### PR TITLE
plugin/route53: fix multiple route 53 zones issue

### DIFF
--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -140,7 +140,7 @@ func (h *Route53) updateZones(ctx context.Context) error {
 	errc := make(chan error)
 	defer close(errc)
 	for zName, z := range h.zones {
-		go func(zName string) {
+		go func(zName string, z *zone) {
 			var err error
 			defer func() {
 				errc <- err
@@ -170,7 +170,7 @@ func (h *Route53) updateZones(ctx context.Context) error {
 			h.zMu.Lock()
 			z.z = newZ
 			h.zMu.Unlock()
-		}(zName)
+		}(zName, z)
 	}
 	// Collect errors (if any). This will also sync on all zones updates
 	// completion.

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -71,7 +71,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string]string{"org.": "1234567890"}, &upstream.Upstream{})
+	r, err = New(ctx, fakeRoute53{}, map[string]string{"org.": "1234567890", "gov.": "Z098765432"}, &upstream.Upstream{})
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}


### PR DESCRIPTION
When we pass multiple Route 53 Hosted Zones, only the last zone from the list returns answers. 