### PR TITLE
plugin/cache: Set min TTL default to zero

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -41,10 +41,10 @@ cache [TTL] [ZONES...] {
 * **TTL**  and **ZONES** as above.
 * `success`, override the settings for caching successful responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (*randomly*). **TTL** overrides the cache maximum TTL.
-  **MINTTL** overrides the cache minimum TTL, which can be useful to limit queries to the backend.
+  **MINTTL** overrides the cache minimum TTL (default 0), which can be useful to limit queries to the backend.
 * `denial`, override the settings for caching denial of existence responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (LRU). **TTL** overrides the cache maximum TTL.
-  **MINTTL** overrides the cache minimum TTL, which can be useful to limit queries to the backend.
+  **MINTTL** overrides the cache minimum TTL (default 0), which can be useful to limit queries to the backend.
   There is a third category (`error`) but those responses are never cached.
 * `prefetch` will prefetch popular items when they are about to be expunged from the cache.
   Popular means **AMOUNT** queries have been seen with no gaps of **DURATION** or more between them.

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -239,9 +239,9 @@ func (w *ResponseWriter) Write(buf []byte) (int, error) {
 
 const (
 	maxTTL  = dnsutil.MaximumDefaulTTL
-	minTTL  = dnsutil.MinimalDefaultTTL
+	minTTL  = 0
 	maxNTTL = dnsutil.MaximumDefaulTTL / 2
-	minNTTL = dnsutil.MinimalDefaultTTL
+	minNTTL = 0
 
 	defaultCap = 10000 // default capacity of the cache.
 

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -43,17 +43,28 @@ func TestLookupCache(t *testing.T) {
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
-	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	t.Run("Long TTL", func(t *testing.T) {
+		testCase(t, state, p, "example.org.", 2, 10)
+	})
+
+	t.Run("Short TTL", func(t *testing.T) {
+		testCase(t, state, p, "short.example.org.", 1, 1)
+	})
+
+}
+
+func testCase(t *testing.T, state request.Request, p proxy.Proxy, name string, expectAnsLen int, expectTTL uint32) {
+	resp, err := p.Lookup(state, name, dns.TypeA)
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")
 	}
-	// expect answer section with A record in it
-	if len(resp.Answer) == 0 {
-		t.Fatal("Expected to at least one RR in the answer section, got none")
+
+	if len(resp.Answer) != expectAnsLen {
+		t.Fatalf("Expected %v RR in the answer section, got %v.", expectAnsLen, len(resp.Answer))
 	}
 
 	ttl := resp.Answer[0].Header().Ttl
-	if ttl != 10 { // as set in the Corefile
-		t.Errorf("Expected TTL to be %d, got %d", 10, ttl)
+	if ttl != expectTTL {
+		t.Errorf("Expected TTL to be %d, got %d", expectTTL, ttl)
 	}
 }

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -7,6 +7,7 @@ example.org.		IN	NS	b.iana-servers.net.
 example.org.		IN	NS	a.iana-servers.net.
 example.org.		IN	A	127.0.0.1
 example.org.		IN	A	127.0.0.2
+short.example.org.	1	IN	A	127.0.0.3
 *.w.example.org.        IN      TXT     "Wildcard"
 a.b.c.w.example.org.    IN      TXT     "Not a wildcard"
 cname.example.org.      IN      CNAME   www.example.net.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

IIUC, #2055 changed default behavior of caching:

Before #2055, we used the message TTL when caching, even if the message had a TTL below the `MinimalDefaultTTL`.  `MinimalDefaultTTL` was only used in cache when synthesizing TTLs for negative responses that had no SOA record.

After #2055, if any message has a TTL below the `MinimalDefaultTTL`, the cache uses the `MinimalDefaultTTL` value instead of the message TTL.

Setting the default values for `minTTL` and `minNTTL` to 0 instead of `MinimalDefaultTTL` should restore the original default behavior.

### 2. Which issues (if any) are related?

#2189

### 3. Which documentation changes (if any) need to be made?