### PR TITLE
plugin/log - Support for Metadata

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -61,6 +61,7 @@ The following place holders are supported:
 * `{class}`: qclass of the request
 * `{proto}`: protocol used (tcp or udp)
 * `{remote}`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
+* `{local}`: server's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
 * `{size}`: request size in bytes
 * `{port}`: client's port
 * `{duration}`: response duration
@@ -72,6 +73,10 @@ The following place holders are supported:
 * `{>do}`: is the EDNS0 DO (DNSSEC OK) bit set in the query
 * `{>id}`: query ID
 * `{>opcode}`: query OPCODE
+* `{/[LABEL]}`: any metadata label is accepted as a place holder if it is enclosed between `{/` and  `}`.
+the place holder will be replaced by the corresponding metadata value or the default value `-` if label is not defined.
+
+
 
 The default Common Log Format is:
 

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -57,7 +57,7 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		// If we don't set up a class in config, the default "all" will be added
 		// and we shouldn't have an empty rule.Class.
 		if rule.Class[response.All] || rule.Class[class] {
-			rep := replacer.New(r, rrw, CommonLogEmptyValue)
+			rep := replacer.New(ctx, r, rrw, CommonLogEmptyValue)
 			clog.Infof(rep.Replace(rule.Format))
 		}
 

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -1,10 +1,12 @@
 package replacer
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/request"
 
@@ -21,6 +23,7 @@ type Replacer interface {
 }
 
 type replacer struct {
+	ctx          context.Context
 	replacements map[string]string
 	emptyValue   string
 }
@@ -31,18 +34,20 @@ type replacer struct {
 // values into the replacer. rr may be nil if it is not
 // available. emptyValue should be the string that is used
 // in place of empty string (can still be empty string).
-func New(r *dns.Msg, rr *dnstest.Recorder, emptyValue string) Replacer {
+func New(ctx context.Context, r *dns.Msg, rr *dnstest.Recorder, emptyValue string) Replacer {
 	req := request.Request{W: rr, Req: r}
 	rep := replacer{
+		ctx: ctx,
 		replacements: map[string]string{
-			"{type}":   req.Type(),
-			"{name}":   req.Name(),
-			"{class}":  req.Class(),
-			"{proto}":  req.Proto(),
+			"{type}":  req.Type(),
+			"{name}":  req.Name(),
+			"{class}": req.Class(),
+			"{proto}": req.Proto(),
 			"{when}":   "", // made a noop
 			"{size}":   strconv.Itoa(req.Len()),
 			"{remote}": addrToRFC3986(req.IP()),
 			"{port}":   req.Port(),
+			"{local}":  addrToRFC3986(req.LocalIP()),
 		},
 		emptyValue: emptyValue,
 	}
@@ -71,22 +76,35 @@ func New(r *dns.Msg, rr *dnstest.Recorder, emptyValue string) Replacer {
 // Replace performs a replacement of values on s and returns
 // the string with the replaced values.
 func (r replacer) Replace(s string) string {
-	// Header replacements - these are case-insensitive, so we can't just use strings.Replace()
-	for strings.Contains(s, headerReplacer) {
-		idxStart := strings.Index(s, headerReplacer)
-		endOffset := idxStart + len(headerReplacer)
-		idxEnd := strings.Index(s[endOffset:], "}")
-		if idxEnd > -1 {
-			placeholder := strings.ToLower(s[idxStart : endOffset+idxEnd+1])
-			replacement := r.replacements[placeholder]
-			if replacement == "" {
-				replacement = r.emptyValue
+
+	// declare a function that replace based on header matching
+	fscanAndReplace := func(s string, header string, replace func(string) string) string {
+		b := strings.Builder{}
+		for strings.Contains(s, header) {
+			idxStart := strings.Index(s, header)
+			endOffset := idxStart + len(header)
+			idxEnd := strings.Index(s[endOffset:], "}")
+			if idxEnd > -1 {
+				placeholder := strings.ToLower(s[idxStart : endOffset+idxEnd+1])
+				replacement := replace(placeholder)
+				if replacement == "" {
+					replacement = r.emptyValue
+				}
+				b.WriteString(s[:idxStart])
+				b.WriteString(replacement)
+				s = s[endOffset+idxEnd+1:]
+			} else {
+				break
 			}
-			s = s[:idxStart] + replacement + s[endOffset+idxEnd+1:]
-		} else {
-			break
 		}
+		b.WriteString(s)
+		return b.String()
 	}
+
+	// Header replacements - these are case-insensitive, so we can't just use strings.Replace()
+	s = fscanAndReplace(s, headerReplacer, func(placeholder string) string {
+		return r.replacements[placeholder]
+	})
 
 	// Regular replacements - these are easier because they're case-sensitive
 	for placeholder, replacement := range r.replacements {
@@ -95,6 +113,16 @@ func (r replacer) Replace(s string) string {
 		}
 		s = strings.Replace(s, placeholder, replacement, -1)
 	}
+
+	// Metadata label replacements
+	s = fscanAndReplace(s, headerLabelReplacer, func(placeholder string) string {
+		// label place holder has the format {/<label>}
+		fm := metadata.ValueFunc(r.ctx, placeholder[len(headerLabelReplacer):len(placeholder)-1])
+		if fm != nil {
+			return fm()
+		}
+		return ""
+	})
 
 	return s
 }
@@ -161,4 +189,7 @@ func addrToRFC3986(addr string) string {
 	return addr
 }
 
-const headerReplacer = "{>"
+const (
+	headerReplacer      = "{>"
+	headerLabelReplacer = "{/"
+)

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -39,10 +39,10 @@ func New(ctx context.Context, r *dns.Msg, rr *dnstest.Recorder, emptyValue strin
 	rep := replacer{
 		ctx: ctx,
 		replacements: map[string]string{
-			"{type}":  req.Type(),
-			"{name}":  req.Name(),
-			"{class}": req.Class(),
-			"{proto}": req.Proto(),
+			"{type}":   req.Type(),
+			"{name}":   req.Name(),
+			"{class}":  req.Class(),
+			"{proto}":  req.Proto(),
 			"{when}":   "", // made a noop
 			"{size}":   strconv.Itoa(req.Len()),
 			"{remote}": addrToRFC3986(req.IP()),

--- a/plugin/rewrite/condition.go
+++ b/plugin/rewrite/condition.go
@@ -1,6 +1,7 @@
 package rewrite
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -22,7 +23,7 @@ const (
 	NotMatch   = "not_match"
 )
 
-func newReplacer(r *dns.Msg) replacer.Replacer { return replacer.New(r, nil, "") }
+func newReplacer(r *dns.Msg) replacer.Replacer { return replacer.New(context.TODO(), r, nil, "") }
 
 // condition is a rewrite condition.
 type condition func(string, string) bool


### PR DESCRIPTION
- add metadata support to Log and introduce laze init for replacer

### 1. Why is this pull request needed and what does it do?

**Support of Metadata for plugin Log**
Any place holder with a valid metadata label format : {<plugin>/<label>} we be accepted and replaced by the value of the corresponding metadata.
If metadata does not exist or provide an empty value, the default "emptyvalue" will be applied.

**Lazy initialization**
All Placeholder values are now given with a function that will be called ONLY of the placeholder is defined in the log. It allows lazy initialization.

**parsing the log format**
The process of replacement is now changed into a scan of {} and replacement placeholder by placeholder instead of the former try to replace for each possible placeholders.
(side-effect of lazy-initialization)

### 2. Which issues (if any) are related?
#2250 

NOTE: 3 place holders added recently within PR #2240 are removed:
- one was already a metadata and will be interpreted directly
- the 2 other are counting the number of A and AAAA records. Considered as very specific, and can now be added as metadata by who needs it. (@drazhanski : I proposed a PR for plugin AtepMonitor that can handle thoseMetadata specifics for your logging).

NOTE: this PR does not transform into Metadata the standard place holders of Log. That can be done later if we wish.

### 3. Which documentation changes (if any) need to be made?
Updated the README of plugin/log
