### PR TITLE
FreeBSD Support Patch

### DIFF
--- a/.presubmit/context
+++ b/.presubmit/context
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/filename-hyphen
+++ b/.presubmit/filename-hyphen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/import-testing
+++ b/.presubmit/import-testing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/test-lowercase
+++ b/.presubmit/test-lowercase
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/trailing-whitespace
+++ b/.presubmit/trailing-whitespace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 


### PR DESCRIPTION
FreeBSD does not ship Bash in their `/bin` directory and via their standard installation processes, Bash is installed to /usr/local/bin. Due to hard-coded shebangs for `/bin/bash` for files in .presubmit, `make` (well, `gmake`) on FreeBSD will fail as it cannot find `/bin/bash`.

This patch updates the .presubmit/ scripts to use `/usr/bin/env` to locate Bash, which allows these scripts to be platform-neutral.

