### PR TITLE
plugins: calling Dispenser itself is a mistake

### DIFF
--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/parse"
 
 	"github.com/caddyserver/caddy"
-	"github.com/caddyserver/caddy/caddyfile"
 )
 
 var log = clog.NewWithPlugin("dnstap")
@@ -30,7 +29,7 @@ type config struct {
 	full   bool
 }
 
-func parseConfig(d *caddyfile.Dispenser) (c config, err error) {
+func parseConfig(d *caddy.Controller) (c config, err error) {
 	d.Next() // directive name
 
 	if !d.Args(&c.target) {
@@ -56,7 +55,7 @@ func parseConfig(d *caddyfile.Dispenser) (c config, err error) {
 }
 
 func setup(c *caddy.Controller) error {
-	conf, err := parseConfig(&c.Dispenser)
+	conf, err := parseConfig(c)
 	if err != nil {
 		return err
 	}

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -21,7 +21,7 @@ func TestConfig(t *testing.T) {
 	}
 	for _, c := range tests {
 		cad := caddy.NewTestController("dns", c.file)
-		conf, err := parseConfig(&cad.Dispenser)
+		conf, err := parseConfig(cad)
 		if c.fail {
 			if err == nil {
 				t.Errorf("%s: %s", c.file, err)

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -13,7 +13,6 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/transport"
 
 	"github.com/caddyserver/caddy"
-	"github.com/caddyserver/caddy/caddyfile"
 )
 
 func init() { plugin.Register("forward", setup) }
@@ -74,7 +73,7 @@ func parseForward(c *caddy.Controller) (*Forward, error) {
 			return nil, plugin.ErrOnce
 		}
 		i++
-		f, err = ParseForwardStanza(&c.Dispenser)
+		f, err = parseStanza(c)
 		if err != nil {
 			return nil, err
 		}
@@ -82,8 +81,7 @@ func parseForward(c *caddy.Controller) (*Forward, error) {
 	return f, nil
 }
 
-// ParseForwardStanza parses one forward stanza
-func ParseForwardStanza(c *caddyfile.Dispenser) (*Forward, error) {
+func parseStanza(c *caddy.Controller) (*Forward, error) {
 	f := New()
 
 	if !c.Args(&f.from) {
@@ -128,7 +126,7 @@ func ParseForwardStanza(c *caddyfile.Dispenser) (*Forward, error) {
 	return f, nil
 }
 
-func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
+func parseBlock(c *caddy.Controller, f *Forward) error {
 	switch c.Val() {
 	case "except":
 		ignore := c.RemainingArgs()

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -11,7 +11,6 @@ import (
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 
 	"github.com/caddyserver/caddy"
-	"github.com/caddyserver/caddy/caddyfile"
 )
 
 func init() { plugin.Register("grpc", setup) }
@@ -50,7 +49,7 @@ func parseGRPC(c *caddy.Controller) (*GRPC, error) {
 			return nil, plugin.ErrOnce
 		}
 		i++
-		g, err = parseGRPCStanza(&c.Dispenser)
+		g, err = parseStanza(c)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +57,7 @@ func parseGRPC(c *caddy.Controller) (*GRPC, error) {
 	return g, nil
 }
 
-func parseGRPCStanza(c *caddyfile.Dispenser) (*GRPC, error) {
+func parseStanza(c *caddy.Controller) (*GRPC, error) {
 	g := newGRPC()
 
 	if !c.Args(&g.from) {
@@ -99,7 +98,7 @@ func parseGRPCStanza(c *caddyfile.Dispenser) (*GRPC, error) {
 	return g, nil
 }
 
-func parseBlock(c *caddyfile.Dispenser, g *GRPC) error {
+func parseBlock(c *caddy.Controller, g *GRPC) error {
 
 	switch c.Val() {
 	case "except":


### PR DESCRIPTION
Remove all these uses and just make them work on caddy.Controller. Also
don't export parsing functions as their should be private to the plugin.