### PR TITLE
Remove deprecated function calls flagged by staticcheck

### DIFF
--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -123,7 +123,7 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 
 		session, err := session.NewSession(&aws.Config{})
 		if err != nil {
-			return plugin.Error("route53", c.Errf("couldn't create aws session: %s", err.Error()))
+			return plugin.Error("route53", err)
 		}
 
 		providers = append(providers, &credentials.EnvProvider{}, sharedProvider, &ec2rolecreds.EC2RoleProvider{

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -120,8 +120,14 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 				return plugin.Error("route53", c.Errf("unknown property '%s'", c.Val()))
 			}
 		}
+
+		session, err := session.NewSession(&aws.Config{})
+		if err != nil {
+			return plugin.Error("route53", c.Errf("couldn't create aws session: %s", err.Error()))
+		}
+
 		providers = append(providers, &credentials.EnvProvider{}, sharedProvider, &ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(session.New(&aws.Config{})),
+			Client: ec2metadata.New(session),
 		})
 		client := f(credentials.NewChainCredentials(providers))
 		ctx := context.Background()

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -22,7 +22,8 @@ func TestGrpc(t *testing.T) {
 	}
 	defer g.Stop()
 
-	conn, err := grpc.Dial(tcp, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
+	ctx, _ := context.WithTimeout(nil, 5*time.Second)
+	conn, err := grpc.DialContext(ctx, tcp, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
 	}

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -22,7 +22,7 @@ func TestGrpc(t *testing.T) {
 	}
 	defer g.Stop()
 
-	ctx, _ := context.WithTimeout(nil, 5*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	conn, err := grpc.DialContext(ctx, tcp, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Removes deprecated function calls flagged by staticcheck in grpc test and route53 setup file.

### 2. Which issues (if any) are related?
fixes #3327 
fixes #3328 

### 3. Which documentation changes (if any) need to be made?
Nothing

### 4. Does this introduce a backward incompatible change or deprecation?
No