### PR TITLE
plugin/dnssec, plugin/sign: ed25519 support

### DIFF
--- a/plugin/dnssec/dnskey.go
+++ b/plugin/dnssec/dnskey.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/request"
-
 	"github.com/miekg/dns"
 
 	"golang.org/x/crypto/ed25519"

--- a/plugin/dnssec/dnskey.go
+++ b/plugin/dnssec/dnskey.go
@@ -11,6 +11,8 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // DNSKEY holds a DNSSEC public and private key used for on-the-fly signing.
@@ -53,6 +55,9 @@ func ParseKeyFile(pubFile, privFile string) (*DNSKEY, error) {
 		return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: s, tag: dk.KeyTag()}, nil
 	}
 	if s, ok := p.(*ecdsa.PrivateKey); ok {
+		return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: s, tag: dk.KeyTag()}, nil
+	}
+	if s, ok := p.(ed25519.PrivateKey); ok {
 		return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: s, tag: dk.KeyTag()}, nil
 	}
 	return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: nil, tag: 0}, errors.New("no private key found")

--- a/plugin/sign/keys.go
+++ b/plugin/sign/keys.go
@@ -97,7 +97,7 @@ func readKeyPair(public, private string) (Pair, error) {
 	switch signer := privkey.(type) {
 	case *ecdsa.PrivateKey:
 		return Pair{Public: dnskey.(*dns.DNSKEY), KeyTag: dnskey.(*dns.DNSKEY).KeyTag(), Private: signer}, nil
-	case *ed25519.PrivateKey:
+	case ed25519.PrivateKey:
 		return Pair{Public: dnskey.(*dns.DNSKEY), KeyTag: dnskey.(*dns.DNSKEY).KeyTag(), Private: signer}, nil
 	case *rsa.PrivateKey:
 		return Pair{Public: dnskey.(*dns.DNSKEY), KeyTag: dnskey.(*dns.DNSKEY).KeyTag(), Private: signer}, nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
adds support for ed25519 keys to plugin/dnssec,  and corrects plugin/sign ed25519 type assertion

### 2. Which issues (if any) are related?
#3379 

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no