### PR TITLE
plugin/route53: Add support for aliases

### DIFF
--- a/plugin/route53/alias_resolver.go
+++ b/plugin/route53/alias_resolver.go
@@ -1,0 +1,39 @@
+package route53
+
+import (
+	"context"
+	"github.com/miekg/dns"
+)
+
+// AliasResolver helps us in resolving ALIAS records from AWS.
+type AliasResolver interface {
+	Resolve(ctx context.Context, dnsName string, dnsType uint16, ns string, ttl int64) (rrs []dns.RR, err error)
+}
+
+type authoritativeNsResolver struct{}
+
+func (anr authoritativeNsResolver) Resolve(ctx context.Context, dnsName string, dnsType uint16, ns string, ttl int64) (rrs []dns.RR, err error) {
+	client := new(dns.Client)
+	req := new(dns.Msg)
+
+	req.RecursionDesired = true
+	req.SetQuestion(dnsName, dnsType)
+
+	r, _, err := client.ExchangeContext(ctx, req, ns)
+	if err != nil {
+		return
+	}
+
+	for _, resp := range r.Answer {
+		var rec dns.RR
+		switch response := resp.(type) {
+		case *dns.A:
+			rec, _ = remapDnsAliasRR(dnsName, response, ttl)
+		case *dns.AAAA:
+			rec, _ = remapDnsAliasRR(dnsName, response, ttl)
+		}
+		rrs = append(rrs, rec)
+	}
+
+	return
+}

--- a/plugin/route53/alias_resolver_test.go
+++ b/plugin/route53/alias_resolver_test.go
@@ -1,0 +1,66 @@
+package route53
+
+import (
+	"context"
+	"fmt"
+	"github.com/miekg/dns"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestAuthoritativeNsResolver_Resolve(t *testing.T) {
+	resolver := authoritativeNsResolver{}
+
+	dnsAddr := "127.0.0.1:31726"
+	server := &dns.Server{
+		Addr:      dnsAddr,
+		Net:       "udp",
+		ReusePort: true,
+	}
+
+	dns.HandleFunc("example.dev.", func(w dns.ResponseWriter, r *dns.Msg) {
+		q := r.Question[0]
+		m := new(dns.Msg)
+		m.SetReply(r)
+		var rr dns.RR
+		switch q.Qtype {
+		case dns.TypeA:
+			rr = &dns.A{
+				Hdr: dns.RR_Header{Name: "example.dev.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   net.ParseIP("10.0.0.0"),
+			}
+		case dns.TypeAAAA:
+			rr = &dns.AAAA{
+				Hdr:  dns.RR_Header{Name: "example.dev.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+				AAAA: net.ParseIP("fdf8:f53b:82e4::53"),
+			}
+		}
+		m.Answer = append(m.Answer, rr)
+		_ = w.WriteMsg(m)
+	})
+
+	go func() {
+		err := server.ListenAndServe()
+		fmt.Println(err)
+	}()
+	time.Sleep(time.Millisecond * 50) // so we can start the server
+
+	_, err := resolver.Resolve(context.Background(), "test.example.dev.", dns.TypeA, dnsAddr, 60)
+	if err != nil {
+		t.Fatalf("Failed to resolve A record: %v", err)
+	}
+
+	_, err = resolver.Resolve(context.Background(), "test.example.dev.", dns.TypeAAAA, dnsAddr, 60)
+	if err != nil {
+		t.Fatalf("Failed to resolve AAAA record: %v", err)
+	}
+}
+
+func TestAuthoritativeNsResolver_ResolveInvalidPort(t *testing.T) {
+	resolver := authoritativeNsResolver{}
+	_, err := resolver.Resolve(context.Background(), "test.example.dev.", dns.TypeA, "127.0.0.1:8054", 60)
+	if err == nil {
+		t.Fatalf("Why did it resolve the record, should have failed")
+	}
+}

--- a/plugin/route53/route53_alias_test.go
+++ b/plugin/route53/route53_alias_test.go
@@ -1,0 +1,194 @@
+package route53
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/pkg/fall"
+	"github.com/coredns/coredns/plugin/test"
+	crequest "github.com/coredns/coredns/request"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/miekg/dns"
+)
+
+type fakeAliasResolver struct{}
+
+func (far fakeAliasResolver) Resolve(ctx context.Context, dnsName string, dnsType uint16, ns string, ttl int64) (rrs []dns.RR, err error) {
+	val := "1.2.3.4"
+	rr, _ := rrFromRR(dnsName, "A", ttl, route53.ResourceRecord{Value: &val})
+	rrs = append(rrs, rr)
+	return
+}
+
+type fakeRoute53Alias struct {
+	route53iface.Route53API
+}
+
+func (fakeRoute53Alias) ListHostedZonesByNameWithContext(_ aws.Context, input *route53.ListHostedZonesByNameInput, _ ...request.Option) (*route53.ListHostedZonesByNameOutput, error) {
+	return nil, nil
+}
+
+func (fakeRoute53Alias) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *route53.ListResourceRecordSetsInput, fn func(*route53.ListResourceRecordSetsOutput, bool) bool, _ ...request.Option) error {
+	if aws.StringValue(in.HostedZoneId) == "0987654321" {
+		return errors.New("bad. zone is bad")
+	}
+	rrsResponse := map[string][]*route53.ResourceRecordSet{}
+	for _, r := range []struct {
+		rType, name, value, hostedZoneID string
+		aliasDnsName, aliasHostedZoneId  string
+		alias                            bool
+	}{
+		{"A", "alias.example.dev.", "1.2.3.4", "1234567891", "random.alias.address.", "3234567891", true},
+		{"A", "same-zone-alias.example.dev.", "4.3.2.1", "1234567891", "target.example.dev.", "1234567891", true},
+		{"A", "example.dev.", "1.2.3.4", "1234567891", "", "", false},
+		{"A", "target.example.dev.", "4.3.2.1", "1234567891", "", "", false},
+		{"A", "target.example.dev.", "8.7.6.5", "1234567891", "", "", false},
+		{"SOA", "dev.", "ns-1536.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400", "1234567891", "", "", false},
+		{"NS", "dev.", "ns-1536.awsdns-00.co.uk", "1234567891", "", "", false},
+		// ALIAS record
+	} {
+		rrs, ok := rrsResponse[r.hostedZoneID]
+		if !ok {
+			rrs = make([]*route53.ResourceRecordSet, 0)
+		}
+		record := route53.ResourceRecordSet{Type: aws.String(r.rType),
+			Name: aws.String(r.name),
+			ResourceRecords: []*route53.ResourceRecord{
+				{
+					Value: aws.String(r.value),
+				},
+			},
+			TTL: aws.Int64(300),
+		}
+		if r.alias {
+			record.ResourceRecords = nil // we need to reset it to empty, an alias record would not have data in it
+			dnsName := r.aliasDnsName
+			hostedZone := r.aliasHostedZoneId
+			evaluateTargetHealth := false
+
+			record.AliasTarget = &route53.AliasTarget{
+				DNSName:              &dnsName,
+				EvaluateTargetHealth: &evaluateTargetHealth,
+				HostedZoneId:         &hostedZone,
+			}
+		}
+
+		rrs = append(rrs, &record)
+		rrsResponse[r.hostedZoneID] = rrs
+	}
+
+	if ok := fn(&route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: rrsResponse[aws.StringValue(in.HostedZoneId)],
+	}, true); !ok {
+		return errors.New("paging function return false")
+	}
+	return nil
+}
+
+func TestRoute53WithAlias(t *testing.T) {
+	ctx := context.Background()
+
+	r, err := New(ctx, fakeRoute53Alias{}, map[string][]string{"dev.": {"1234567891"}}, 90*time.Second, fakeAliasResolver{})
+	if err != nil {
+		t.Fatalf("Failed to create Route53: %v", err)
+	}
+	r.Fall = fall.Zero
+	r.Fall.SetZonesFromArgs([]string{"gov."})
+	r.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		state := crequest.Request{W: w, Req: r}
+		qname := state.Name()
+		m := new(dns.Msg)
+		rcode := dns.RcodeServerFailure
+		if qname == "example.gov." {
+			m.SetReply(r)
+			rr, err := dns.NewRR("example.gov.  300 IN  A   2.4.6.8")
+			if err != nil {
+				t.Fatalf("Failed to create Resource Record: %v", err)
+			}
+			m.Answer = []dns.RR{rr}
+
+			m.Authoritative = true
+			rcode = dns.RcodeSuccess
+
+		}
+
+		m.SetRcode(r, rcode)
+		w.WriteMsg(m)
+		return rcode, nil
+	})
+	err = r.Run(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize Route53: %v", err)
+	}
+
+	tests := []struct {
+		qname        string
+		qtype        uint16
+		wantRetCode  int
+		wantAnswer   []string // ownernames for the records in the additional section.
+		wantMsgRCode int
+		wantNS       []string
+		expectedErr  error
+	}{
+		{
+			qname: "example.dev",
+			qtype: dns.TypeA,
+			wantAnswer: []string{
+				"example.dev.	300	IN	A	1.2.3.4",
+			},
+		},
+		// 15. alias.example.dev points to 1.2.3.4.
+		{
+			qname: "alias.example.dev",
+			qtype: dns.TypeA,
+			wantAnswer: []string{
+				"alias.example.dev.	60	IN	A	1.2.3.4",
+			},
+		},
+		// 16. same-zone-alias.example.dev points to 4.3.2.1.
+		{
+			qname: "same-zone-alias.example.dev",
+			qtype: dns.TypeA,
+			wantAnswer: []string{
+				"same-zone-alias.example.dev.	300	IN	A	4.3.2.1",
+				"same-zone-alias.example.dev.	300	IN	A	8.7.6.5",
+			},
+		},
+	}
+
+	for ti, tc := range tests {
+		req := new(dns.Msg)
+		req.SetQuestion(dns.Fqdn(tc.qname), tc.qtype)
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		code, err := r.ServeDNS(ctx, rec, req)
+
+		if err != tc.expectedErr {
+			t.Fatalf("Test %d: Expected error %v, but got %v", ti, tc.expectedErr, err)
+		}
+		if code != int(tc.wantRetCode) {
+			t.Fatalf("Test %d: Expected returned status code %s, but got %s", ti, dns.RcodeToString[tc.wantRetCode], dns.RcodeToString[code])
+		}
+
+		if tc.wantMsgRCode != rec.Msg.Rcode {
+			t.Errorf("Test %d: Unexpected msg status code. Want: %s, got: %s", ti, dns.RcodeToString[tc.wantMsgRCode], dns.RcodeToString[rec.Msg.Rcode])
+		}
+
+		if len(tc.wantAnswer) != len(rec.Msg.Answer) {
+			t.Errorf("Test %d: Unexpected number of Answers. Want: %d, got: %d", ti, len(tc.wantAnswer), len(rec.Msg.Answer))
+		} else {
+			for i, gotAnswer := range rec.Msg.Answer {
+				if gotAnswer.String() != tc.wantAnswer[i] {
+					t.Errorf("Test %d: Unexpected answer.\nWant:\n\t%s\nGot:\n\t%s", ti, tc.wantAnswer[i], gotAnswer)
+				}
+			}
+		}
+	}
+}

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -79,7 +79,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Minute)
+	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Minute, nil)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, 90*time.Second)
+	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, 90*time.Second, nil)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -125,7 +125,7 @@ func setup(c *caddy.Controller) error {
 		})
 		client := f(credentials.NewChainCredentials(providers))
 		ctx := context.Background()
-		h, err := New(ctx, client, keys, refresh)
+		h, err := New(ctx, client, keys, refresh, authoritativeNsResolver{})
 		if err != nil {
 			return plugin.Error("route53", c.Errf("failed to create Route53 plugin: %v", err))
 		}

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -66,7 +66,6 @@ func TestSetupRoute53(t *testing.T) {
 		{`route53 example.org:12345678 {
 	refresh -1m
 }`, true},
-
 		{`route53 example.org {
 	}`, true},
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Allows us to use aliases in route 53
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-alias.html
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html

Based on the documentation ALIAS records can only return A/AAAA, and the TTL is fixed at 60 seconds.
Possible options for health-checks for ALIAS are 15 second and 30 seconds.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3012

### 3. Which documentation changes (if any) need to be made?
Added a new configuration option

### 4. Does this introduce a backward incompatible change or deprecation?
No

I do have some questions on the best way to implement the DNS lookups, I took a look at the Cache plugin which actually does something similar to what I need, the ability to do the query lookups without being in the ServeDNS function.

Are there any thought on how to implement this?
@yongtang @dilyevsky

I've implemented a working version by querying the authoritative server for the domain in question.
