### PR TITLE
Add a serve_stale option for plugin/cache

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -51,9 +51,10 @@ cache [TTL] [ZONES...] {
   **DURATION** defaults to 1m. Prefetching will happen when the TTL drops below **PERCENTAGE**,
   which defaults to `10%`, or latest 1 second before TTL expiration. Values should be in the range `[10%, 90%]`.
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
-* `serve_expired`, when set to yes, it will serve expired responses from cache when there are no healthy
-  upstream backends. The responses have a TTL of 0.  **DURATION** is how far back to consider stale
-  responses as fresh. The default is: 'serve\_expired no 1h'. Hint: the bigger the **CAPACITY** the more
+* `serve_expired`, when serve\_expired is set, CoreDNS always will serve an expired cache to a client if an
+  expired cache entry exists. When this happens, CoreDNS will attempt to refresh the cache entry after sending
+  the expired cache entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
+  stale responses as fresh. The default is: 'serve\_expired no 1h'. Hint: the bigger the **CAPACITY** the more
   expired responses there will be in the cache.
 
 ## Capacity and Eviction

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -34,7 +34,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
-    serve_expired yes|no [DURATION]
+    serve_stale DURATION
 }
 ~~~
 
@@ -51,11 +51,10 @@ cache [TTL] [ZONES...] {
   **DURATION** defaults to 1m. Prefetching will happen when the TTL drops below **PERCENTAGE**,
   which defaults to `10%`, or latest 1 second before TTL expiration. Values should be in the range `[10%, 90%]`.
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
-* `serve_expired`, when serve\_expired is set, CoreDNS always will serve an expired cache to a client if an
-  expired cache entry exists. When this happens, CoreDNS will attempt to refresh the cache entry after sending
-  the expired cache entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default is: 'serve\_expired no 1h'. Hint: the bigger the **CAPACITY** the more
-  expired responses there will be in the cache.
+* `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
+  available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
+  entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
+  stale responses as fresh. The default is: 'serve\_stale 0h'.
 
 ## Capacity and Eviction
 
@@ -75,6 +74,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
 * `coredns_cache_misses_total{server}` - Counter of cache misses.
 * `coredns_cache_drops_total{server}` - Counter of dropped messages.
+* `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.
 
 Cache types are either "denial" or "success". `Server` is the server handling the request, see the
 metrics plugin for documentation.

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -34,7 +34,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
-    serve_stale DURATION
+    serve_stale [DURATION]
 }
 ~~~
 
@@ -54,7 +54,7 @@ cache [TTL] [ZONES...] {
 * `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
   available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
   entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default is: 'serve\_stale 0h'.
+  stale responses as fresh. The default duration is 1h.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -34,6 +34,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
+    serve_expired yes|no [DURATION]
 }
 ~~~
 
@@ -50,6 +51,10 @@ cache [TTL] [ZONES...] {
   **DURATION** defaults to 1m. Prefetching will happen when the TTL drops below **PERCENTAGE**,
   which defaults to `10%`, or latest 1 second before TTL expiration. Values should be in the range `[10%, 90%]`.
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
+* `serve_expired`, when set to yes, it will serve expired responses from cache when there are no healthy
+  upstream backends. The responses have a TTL of 0.  **DURATION** is how far back to consider stale
+  responses as fresh. The default is: 'serve\_expired no 1h'. Hint: the bigger the **CAPACITY** the more
+  expired responses there will be in the cache.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,6 +36,9 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
+	// Whether to serve cache stale records when upstream is down.
+	serveExpired bool
+
 	// Testing.
 	now func() time.Time
 }

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,8 +36,8 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
-	serveExpired bool
-	expiredUpTo  time.Duration
+	serveStale bool
+	staleUpTo  time.Duration
 
 	// Testing.
 	now func() time.Time

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,8 +36,7 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
-	serveStale bool
-	staleUpTo  time.Duration
+	staleUpTo time.Duration
 
 	// Testing.
 	now func() time.Time

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,8 +36,8 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
-	// Whether to serve cache stale records when upstream is down.
 	serveExpired bool
+	expiredUpTo  time.Duration
 
 	// Testing.
 	now func() time.Time

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -2,10 +2,12 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
@@ -233,7 +235,7 @@ func TestCacheZeroTTL(t *testing.T) {
 	c := New()
 	c.minpttl = 0
 	c.minnttl = 0
-	c.Next = zeroTTLBackend()
+	c.Next = ttlBackend(0)
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.org.", dns.TypeA)
@@ -245,6 +247,56 @@ func TestCacheZeroTTL(t *testing.T) {
 	}
 	if c.ncache.Len() != 0 {
 		t.Errorf("Msg with 0 TTL should not have been cached")
+	}
+}
+
+func TestServeFromStaleCache(t *testing.T) {
+	c := New()
+	c.Next = ttlBackend(60)
+
+	req := new(dns.Msg)
+	req.SetQuestion("cached.org.", dns.TypeA)
+	ctx := context.TODO()
+
+	// Cache example.org.
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	c.serveExpired = false
+	c.expiredUpTo = 1 * time.Hour
+	c.ServeDNS(ctx, rec, req)
+	if c.pcache.Len() != 1 {
+		t.Fatalf("Msg with > 0 TTL should have been cached")
+	}
+
+	// No more backend resolutions, just from cache if available.
+	c.Next = plugin.HandlerFunc(func(context.Context, dns.ResponseWriter, *dns.Msg) (int, error) {
+		return 255, nil // Below, a 255 means we tried querying upstream.
+	})
+
+	tests := []struct {
+		name           string
+		serveExpired   bool
+		futureMinutes  int
+		expectedResult int
+	}{
+		{"cached.org.", true, 30, 0},
+		{"cached.org.", true, 70, 255},
+		{"cached.org.", false, 30, 255},
+		{"cached.org.", false, 70, 255},
+
+		{"notcached.org.", true, 30, 255},
+		{"notcached.org.", true, 70, 255},
+		{"notcached.org.", false, 30, 255},
+		{"notcached.org.", false, 70, 255},
+	}
+
+	for i, tt := range tests {
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		c.now = func() time.Time { return time.Now().Add(time.Duration(tt.futureMinutes) * time.Minute) }
+		c.serveExpired = tt.serveExpired
+		req.SetQuestion(tt.name, dns.TypeA)
+		if ret, _ := c.ServeDNS(ctx, rec, req); ret != tt.expectedResult {
+			t.Errorf("Test %d: expecting %v; got %v", i, tt.expectedResult, ret)
+		}
 	}
 }
 
@@ -286,13 +338,13 @@ func BackendHandler() plugin.Handler {
 	})
 }
 
-func zeroTTLBackend() plugin.Handler {
+func ttlBackend(ttl int) plugin.Handler {
 	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true
 
-		m.Answer = []dns.RR{test.A("example.org. 0 IN A 127.0.0.53")}
+		m.Answer = []dns.RR{test.A(fmt.Sprintf("example.org. %d IN A 127.0.0.53", ttl))}
 		w.WriteMsg(m)
 		return dns.RcodeSuccess, nil
 	})

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -260,8 +260,8 @@ func TestServeFromStaleCache(t *testing.T) {
 
 	// Cache example.org.
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
-	c.serveExpired = false
-	c.expiredUpTo = 1 * time.Hour
+	c.serveStale = false
+	c.staleUpTo = 1 * time.Hour
 	c.ServeDNS(ctx, rec, req)
 	if c.pcache.Len() != 1 {
 		t.Fatalf("Msg with > 0 TTL should have been cached")
@@ -274,7 +274,7 @@ func TestServeFromStaleCache(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		serveExpired   bool
+		serveStale     bool
 		futureMinutes  int
 		expectedResult int
 	}{
@@ -292,7 +292,7 @@ func TestServeFromStaleCache(t *testing.T) {
 	for i, tt := range tests {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		c.now = func() time.Time { return time.Now().Add(time.Duration(tt.futureMinutes) * time.Minute) }
-		c.serveExpired = tt.serveExpired
+		c.serveStale = tt.serveStale
 		r := req.Copy()
 		r.SetQuestion(tt.name, dns.TypeA)
 		if ret, _ := c.ServeDNS(ctx, rec, r); ret != tt.expectedResult {

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -293,8 +293,9 @@ func TestServeFromStaleCache(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		c.now = func() time.Time { return time.Now().Add(time.Duration(tt.futureMinutes) * time.Minute) }
 		c.serveExpired = tt.serveExpired
-		req.SetQuestion(tt.name, dns.TypeA)
-		if ret, _ := c.ServeDNS(ctx, rec, req); ret != tt.expectedResult {
+		r := req.Copy()
+		r.SetQuestion(tt.name, dns.TypeA)
+		if ret, _ := c.ServeDNS(ctx, rec, r); ret != tt.expectedResult {
 			t.Errorf("Test %d: expecting %v; got %v", i, tt.expectedResult, ret)
 		}
 	}

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -29,8 +29,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	i, found := c.get(now, state, server)
 	if i == nil || !found {
 		if c.serveExpired {
-			//TODO: make 1h configurable.
-			i, found = c.get(now.Add(-1*time.Hour), state, server)
+			i, found = c.get(now.Add(-c.expiredUpTo), state, server)
 		}
 		if !found {
 			crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -176,6 +176,15 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 					ca.percentage = num
 				}
 
+			case "serve_expired":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				if args[0] != "yes" && args[0] != "no" {
+					return nil, c.ArgErr()
+				}
+				ca.serveExpired = args[0] == "yes"
 			default:
 				return nil, c.ArgErr()
 			}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -180,10 +180,10 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 			case "serve_expired":
 				args := c.RemainingArgs()
 				if len(args) != 1 && len(args) != 2 {
-					return nil, c.ArgErr()
+					return nil, errors.New("syntax is: serve_expired (yes|no) [<duration>]")
 				}
 				if args[0] != "yes" && args[0] != "no" {
-					return nil, c.ArgErr()
+					return nil, errors.New("syntax is: serve_expired (yes|no) [<duration>]")
 				}
 				ca.serveExpired = args[0] == "yes"
 				ca.expiredUpTo = time.Duration(1 * time.Hour) // default 1h

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -31,7 +31,7 @@ func setup(c *caddy.Controller) error {
 	c.OnStartup(func() error {
 		metrics.MustRegister(c,
 			cacheSize, cacheHits, cacheMisses,
-			cachePrefetches, cacheDrops)
+			cachePrefetches, cacheDrops, servedExpired)
 		return nil
 	})
 

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -182,7 +182,6 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 				if len(args) > 1 {
 					return nil, c.ArgErr()
 				}
-				ca.serveStale = true
 				ca.staleUpTo = 1 * time.Hour
 				if len(args) == 1 {
 					d, err := time.ParseDuration(args[0])
@@ -190,7 +189,7 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, err
 					}
 					if d < 0 {
-						return nil, errors.New("invalid negative duration for server_stale")
+						return nil, errors.New("invalid negative duration for serve_stale")
 					}
 					ca.staleUpTo = d
 				}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -178,13 +179,24 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 
 			case "serve_expired":
 				args := c.RemainingArgs()
-				if len(args) != 1 {
+				if len(args) != 1 && len(args) != 2 {
 					return nil, c.ArgErr()
 				}
 				if args[0] != "yes" && args[0] != "no" {
 					return nil, c.ArgErr()
 				}
 				ca.serveExpired = args[0] == "yes"
+				ca.expiredUpTo = time.Duration(1 * time.Hour) // default 1h
+				if len(args) == 2 {
+					d, err := time.ParseDuration(args[1])
+					if err != nil {
+						return nil, err
+					}
+					if d < 0 {
+						return nil, errors.New("negative duration does not make sense")
+					}
+					ca.expiredUpTo = d
+				}
 			default:
 				return nil, c.ArgErr()
 			}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -179,17 +179,21 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 
 			case "serve_stale":
 				args := c.RemainingArgs()
-				if len(args) != 1 {
-					return nil, errors.New("syntax is: serve_stale <duration>")
+				if len(args) > 1 {
+					return nil, c.ArgErr()
 				}
-				d, err := time.ParseDuration(args[0])
-				if err != nil {
-					return nil, fmt.Errorf("invalid duration: %v", args[0])
+				ca.serveStale = true
+				ca.staleUpTo = 1 * time.Hour
+				if len(args) == 1 {
+					d, err := time.ParseDuration(args[0])
+					if err != nil {
+						return nil, err
+					}
+					if d < 0 {
+						return nil, errors.New("invalid negative duration for server_stale")
+					}
+					ca.staleUpTo = d
 				}
-				if d < 0 {
-					return nil, errors.New("negative duration does not make sense")
-				}
-				ca.staleUpTo = d
 			default:
 				return nil, c.ArgErr()
 			}

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -120,34 +121,19 @@ func TestServeStale(t *testing.T) {
 		shouldErr bool
 		staleUpTo time.Duration
 	}{
-		{`cache	{
-				serve_stale 20m
-			}`, false, 20 * time.Minute},
-		{`cache	{
-				serve_stale 1h20m
-			}`, false, 80 * time.Minute},
-		{`cache	{
-				serve_stale 0m
-			}`, false, 0},
-		{`cache	{
-				serve_stale 0
-			}`, false, 0},
+		{"serve_stale", false, 1 * time.Hour},
+		{"serve_stale 20m", false, 20 * time.Minute},
+		{"serve_stale 1h20m", false, 80 * time.Minute},
+		{"serve_stale 0m", false, 0},
+		{"serve_stale 0", false, 0},
 		// fails
-		{`cache	{
-				serve_stale
-			}`, true, 0},
-		{`cache	{
-				serve_stale 20
-			}`, true, 0},
-		{`cache	{
-				serve_stale aa
-			}`, true, 0},
-		{`cache	{
-				serve_stale 1m nono
-			}`, true, 0},
+		{"serve_stale 20", true, 0},
+		{"serve_stale -20m", true, 0},
+		{"serve_stale aa", true, 0},
+		{"serve_stale 1m nono", true, 0},
 	}
 	for i, test := range tests {
-		c := caddy.NewTestController("dns", test.input)
+		c := caddy.NewTestController("dns", fmt.Sprintf("cache {\n%s\n}", test.input))
 		ca, err := cacheParse(c)
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %v: Expected error but found nil", i)

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -9,101 +9,72 @@ import (
 
 func TestSetup(t *testing.T) {
 	tests := []struct {
-		input                string
-		shouldErr            bool
-		expectedNcap         int
-		expectedPcap         int
-		expectedNttl         time.Duration
-		expectedMinNttl      time.Duration
-		expectedPttl         time.Duration
-		expectedMinPttl      time.Duration
-		expectedPrefetch     int
-		expectedServeExpired bool
-		expectedExpiredUpTo  time.Duration
+		input            string
+		shouldErr        bool
+		expectedNcap     int
+		expectedPcap     int
+		expectedNttl     time.Duration
+		expectedMinNttl  time.Duration
+		expectedPttl     time.Duration
+		expectedMinPttl  time.Duration
+		expectedPrefetch int
 	}{
-		{`cache`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+		{`cache`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10
-			}`, false, defaultCap, 10, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, false, defaultCap, 10, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10 1800 30
-			}`, false, defaultCap, 10, maxNTTL, minNTTL, 1800 * time.Second, 30 * time.Second, 0, false, 0},
+			}`, false, defaultCap, 10, maxNTTL, minNTTL, 1800 * time.Second, 30 * time.Second, 0},
 		{`cache example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, false, 10, 10, 15 * time.Second, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10
 				denial 10 15 2
-			}`, false, 10, 10, 15 * time.Second, 2 * time.Second, maxTTL, minTTL, 0, false, 0},
+			}`, false, 10, 10, 15 * time.Second, 2 * time.Second, maxTTL, minTTL, 0},
 		{`cache 25 example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, minNTTL, 25 * time.Second, minTTL, 0, false, 0},
+			}`, false, 10, 10, 15 * time.Second, minNTTL, 25 * time.Second, minTTL, 0},
 		{`cache 25 example.nl {
 				success 10
 				denial 10 15 5
-			}`, false, 10, 10, 15 * time.Second, 5 * time.Second, 25 * time.Second, minTTL, 0, false, 0},
-		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, false, 10, 10, 15 * time.Second, 5 * time.Second, 25 * time.Second, minTTL, 0},
+		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache	{
 				prefetch 10
-			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 10, false, 0},
-		{`cache	{
-				serve_expired no
-			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 1 * time.Hour},
-		{`cache	{
-				serve_expired no 35m
-			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, false, 35 * time.Minute},
-		{`cache	{
-				serve_expired yes
-			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, true, 1 * time.Hour},
-		{`cache	{
-				serve_expired yes 20m
-			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0, true, 20 * time.Minute},
+			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 10},
 
 		// fails
 		{`cache example.nl {
 				success
 				denial 10 15
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 15
 				denial aaa
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				positive 15
 				negative aaa
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
 				prefetch -1
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				prefetch 0 blurp
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache
-		  cache`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache	{
-				serve_expired non
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache	{
-				serve_expired no 35ma
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache	{
-				serve_expired y
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache	{
-				serve_expired
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
-		{`cache	{
-				serve_expired yes -20m
-			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0, false, 0},
+		  cache`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
@@ -140,11 +111,56 @@ func TestSetup(t *testing.T) {
 		if ca.prefetch != test.expectedPrefetch {
 			t.Errorf("Test %v: Expected prefetch %v but found: %v", i, test.expectedPrefetch, ca.prefetch)
 		}
-		if ca.serveExpired != test.expectedServeExpired {
-			t.Errorf("Test %v: Expected serve_expired %v but found: %v", i, test.expectedServeExpired, ca.serveExpired)
+	}
+}
+
+func TestServeStale(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		staleUpTo time.Duration
+	}{
+		{`cache	{
+				serve_stale 20m
+			}`, false, 20 * time.Minute},
+		{`cache	{
+				serve_stale 1h20m
+			}`, false, 80 * time.Minute},
+		{`cache	{
+				serve_stale 0m
+			}`, false, 0},
+		{`cache	{
+				serve_stale 0
+			}`, false, 0},
+		// fails
+		{`cache	{
+				serve_stale
+			}`, true, 0},
+		{`cache	{
+				serve_stale 20
+			}`, true, 0},
+		{`cache	{
+				serve_stale aa
+			}`, true, 0},
+		{`cache	{
+				serve_stale 1m nono
+			}`, true, 0},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		ca, err := cacheParse(c)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+			continue
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			continue
 		}
-		if ca.expiredUpTo != test.expectedExpiredUpTo {
-			t.Errorf("Test %v: Expected expiredUpTo %v but found: %v", i, test.expectedExpiredUpTo, ca.expiredUpTo)
+		if test.shouldErr && err != nil {
+			continue
+		}
+		if ca.staleUpTo != test.staleUpTo {
+			t.Errorf("Test %v: Expected stale %v but found: %v", i, test.staleUpTo, ca.staleUpTo)
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Implements #3158 by adding a _serve_stale_ option to the cache directive.
From unbound's man page:
>  serve-expired: <yes or no>
>               If  enabled,  unbound attempts to serve old responses from cache with a TTL of 0 in
>               the response without waiting for the  actual  resolution  to  finish.   The  actual
>               resolution answer ends up in the cache later on.  Default is "no".

### 2. Which issues (if any) are related?
#3158 

### 3. Which documentation changes (if any) need to be made?
Yes, the PR includes a documentation update.

### 4. Does this introduce a backward incompatible change or deprecation?
No.
