### PR TITLE
plugin/transfer: remove unused error format

### DIFF
--- a/plugin/transfer/setup.go
+++ b/plugin/transfer/setup.go
@@ -94,7 +94,7 @@ func parse(c *caddy.Controller) (*Transfer, error) {
 			}
 		}
 		if len(x.to) == 0 {
-			return nil, plugin.Error("transfer", c.Errf("'to' is required", c.Val()))
+			return nil, plugin.Error("transfer", c.Err("'to' is required"))
 		}
 		t.xfrs = append(t.xfrs, x)
 	}


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

remove unused error format in setup.go.

### 2. Which issues (if any) are related?

saw the error in lint check PR #3638.  figured I'd clean it up.

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no