### PR TITLE
Cache reduce insert metrics cost

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -38,7 +38,8 @@ type Cache struct {
 
 	staleUpTo time.Duration
 
-	mMgr *MetricsManager
+	mMgr            *MetricsManager
+	metricsInterval time.Duration
 
 	// Testing.
 	now func() time.Time
@@ -48,19 +49,20 @@ type Cache struct {
 // caller to set the Next handler.
 func New() *Cache {
 	return &Cache{
-		Zones:      []string{"."},
-		pcap:       defaultCap,
-		pcache:     cache.New(defaultCap),
-		pttl:       maxTTL,
-		minpttl:    minTTL,
-		ncap:       defaultCap,
-		ncache:     cache.New(defaultCap),
-		nttl:       maxNTTL,
-		minnttl:    minNTTL,
-		prefetch:   0,
-		duration:   1 * time.Minute,
-		percentage: 10,
-		now:        time.Now,
+		Zones:           []string{"."},
+		pcap:            defaultCap,
+		pcache:          cache.New(defaultCap),
+		pttl:            maxTTL,
+		minpttl:         minTTL,
+		ncap:            defaultCap,
+		ncache:          cache.New(defaultCap),
+		nttl:            maxNTTL,
+		minnttl:         minNTTL,
+		prefetch:        0,
+		duration:        1 * time.Minute,
+		percentage:      10,
+		metricsInterval: defaultMetricsInterval,
+		now:             time.Now,
 	}
 }
 
@@ -244,4 +246,8 @@ const (
 	Success = "success"
 	// Denial is the class defined for negative caching.
 	Denial = "denial"
+)
+
+const (
+	defaultMetricsInterval = time.Duration(10) * time.Second
 )

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -38,6 +38,8 @@ type Cache struct {
 
 	staleUpTo time.Duration
 
+	mMgr *MetricsManager
+
 	// Testing.
 	now func() time.Time
 }
@@ -175,8 +177,6 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	if hasKey && duration > 0 {
 		if w.state.Match(res) {
 			w.set(res, key, mt, duration)
-			cacheSize.WithLabelValues(w.server, Success).Set(float64(w.pcache.Len()))
-			cacheSize.WithLabelValues(w.server, Denial).Set(float64(w.ncache.Len()))
 		} else {
 			// Don't log it, but increment counter
 			cacheDrops.WithLabelValues(w.server).Inc()

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -15,7 +15,7 @@ type MetricsManager struct {
 
 func newMetricsManager(server string, c *Cache) *MetricsManager {
 	m := &MetricsManager{
-		interval: defaultInterval,
+		interval: c.metricsInterval,
 		server:   server,
 		c:        c,
 		stop:     make(chan bool),
@@ -49,7 +49,3 @@ func (m *MetricsManager) Start() { go m.metricsManager() }
 
 // Stop stops the metrics updater.
 func (m *MetricsManager) Stop() { close(m.stop) }
-
-const (
-	defaultInterval = time.Duration(10) * time.Second
-)

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -1,0 +1,55 @@
+package cache
+
+import (
+	"time"
+)
+
+// MetricsManager updates expensive count stats on an interval.
+type MetricsManager struct {
+	interval time.Duration
+	server   string
+	c        *Cache
+
+	stop chan bool
+}
+
+func newMetricsManager(server string, c *Cache) *MetricsManager {
+	m := &MetricsManager{
+		interval: defaultInterval,
+		server:   server,
+		c:        c,
+		stop:     make(chan bool),
+	}
+	return m
+}
+
+func (m *MetricsManager) metricsManager() {
+	ticker := time.NewTicker(m.interval)
+
+	for {
+		select {
+		case <-ticker.C:
+			// Calculating cache size requires reading the size of all shards
+			// Reading the size of the shards requires obtaining a ReadLock
+			// on each shard.  If called after adding an item that turns every
+			// writer into a reader, which serializes each write effectively twice.
+			// Additionally, ristretto with ttlEvict enabled can update cache sizes
+			// outside of adding items.
+			cacheSize.WithLabelValues(m.server, Success).Set(float64(m.c.pcache.Len()))
+			cacheSize.WithLabelValues(m.server, Denial).Set(float64(m.c.ncache.Len()))
+
+		case <-m.stop:
+			return
+		}
+	}
+}
+
+// Start starts the metrics updater.
+func (m *MetricsManager) Start() { go m.metricsManager() }
+
+// Stop stops the metrics updater.
+func (m *MetricsManager) Stop() { close(m.stop) }
+
+const (
+	defaultInterval = time.Duration(10) * time.Second
+)

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -204,6 +204,21 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 					}
 					ca.staleUpTo = d
 				}
+
+			case "metrics_interval":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				d, err := time.ParseDuration(args[0])
+				if err != nil {
+					return nil, err
+				}
+				if d < 0 {
+					return nil, errors.New("invalid negative duration for metrics_interval")
+				}
+				ca.metricsInterval = d
+
 			default:
 				return nil, c.ArgErr()
 			}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -33,6 +33,17 @@ func setup(c *caddy.Controller) error {
 		metrics.MustRegister(c,
 			cacheSize, cacheHits, cacheMisses,
 			cachePrefetches, cacheDrops, servedStale)
+
+		// Create the metrics manager to periodically update
+		// expensive metrics
+		ca.mMgr = newMetricsManager(c.Key, ca)
+		ca.mMgr.Start()
+
+		return nil
+	})
+
+	c.OnShutdown(func() error {
+		ca.mMgr.Stop()
 		return nil
 	})
 

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -48,6 +48,9 @@ func TestSetup(t *testing.T) {
 		{`cache	{
 				prefetch 10
 			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 10},
+		{`cache	{
+				metrics_interval 1s
+			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 
 		// fails
 		{`cache example.nl {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -153,7 +153,9 @@ google.com:0 {
 	forward . 8.8.8.8:53 {
        force_tcp
     }
-	cache
+	cache {
+		metrics_interval 10ms
+	}
 }
 `, addrMetrics, addrMetrics)
 
@@ -170,6 +172,9 @@ google.com:0 {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
+	// wait for cache size metrics to update
+	time.Sleep(time.Duration(10) * time.Millisecond)
+
 	beginCacheSize := test.ScrapeMetricAsInt(addrMetrics, cacheSizeMetricName, "", 0)
 
 	// send an query, different from initial to ensure we have another add to the cache
@@ -179,6 +184,9 @@ google.com:0 {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+
+	// wait for cache size metrics to update
+	time.Sleep(time.Duration(10) * time.Millisecond)
 
 	endCacheSize := test.ScrapeMetricAsInt(addrMetrics, cacheSizeMetricName, "", 0)
 	if err != nil {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Reduces lock contention on cache inserts.  Each insert would need to obtain a ReadLock on *all* of the Shards, one at a time, on the builtin cache to compute the overall positive *and* negative cache sizes (regardless of which one was actually updated).  The cache is pretty carefully implemented to only need to lock one shard, but the metrics update caused every write to need a lock on every shard, which partially defeats the purpose of using shards.

### 2. Which issues (if any) are related?

#3703 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

None.

### 5. Benchmarks

#### Baseline - Metrics Updated After Every Add

```
BenchmarkBuiltinReads-8                           712930              1547 ns/op             566 B/op         14 allocs/op
BenchmarkBuiltinParallelReads-8                  2479280               487 ns/op             566 B/op         14 allocs/op
BenchmarkBuiltinBalanced-8                        262920              4256 ns/op             815 B/op         19 allocs/op
BenchmarkBuiltinInserts-8                         323592              3568 ns/op             706 B/op         16 allocs/op
BenchmarkBuiltinParallelInserts-8                 131554              7640 ns/op            2472 B/op         58 allocs/op
BenchmarkBuiltinParallelInsertsRead-8             193125             29294 ns/op            1255 B/op         30 allocs/op
```

#### Metrics Updated in GoRoutine

```
BenchmarkBuiltinReads-8                           751372              1552 ns/op             566 B/op         14 allocs/op
BenchmarkBuiltinParallelReads-8                  2354401               507 ns/op             566 B/op         14 allocs/op
BenchmarkBuiltinBalanced-8                        286875              4217 ns/op             790 B/op         18 allocs/op
BenchmarkBuiltinInserts-8                         443962              2617 ns/op             688 B/op         16 allocs/op
BenchmarkBuiltinParallelInserts-8                 414012              2693 ns/op            1804 B/op         40 allocs/op
BenchmarkBuiltinParallelInsertsRead-8             200334             28704 ns/op            1247 B/op         30 allocs/op
```