### PR TITLE
cache: default to DNSSEC

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -10,6 +10,9 @@ With *cache* enabled, all records except zone transfers and metadata records wil
 3600s. Caching is mostly useful in a scenario when fetching data from the backend (upstream,
 database, etc.) is expensive.
 
+*Cache* will change the query to enable DNSSEC (DNSSEC OK; DO) if it passes through the plugin. If
+the client didn't request any DNSSEC (records), these are filtered out when replying.
+
 This plugin can only be used once per Server Block.
 
 ## Syntax

--- a/plugin/cache/do_test.go
+++ b/plugin/cache/do_test.go
@@ -1,0 +1,60 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestDo(t *testing.T) {
+	// cache sets Do and requests that don't have them.
+	c := New()
+	c.Next = echoHandler()
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	// No DO set
+	c.ServeDNS(context.TODO(), rec, req)
+	reply := rec.Msg
+	opt := reply.Extra[len(reply.Extra)-1]
+	if x, ok := opt.(*dns.OPT); !ok {
+		t.Fatalf("Expected OPT RR, got %T", x)
+	}
+	if !opt.(*dns.OPT).Do() {
+		t.Errorf("Expected DO bit to be set, got false")
+	}
+	if x := opt.(*dns.OPT).UDPSize(); x != defaultUDPBufSize {
+		t.Errorf("Expected %d bufsize, got %d", defaultUDPBufSize, x)
+	}
+
+	// Do set - so left alone
+	const mysize = defaultUDPBufSize * 2
+	setDo(req)
+	// set bufsize to something else than default to see cache doesn't touch it
+	req.Extra[len(req.Extra)-1].(*dns.OPT).SetUDPSize(mysize)
+	c.ServeDNS(context.TODO(), rec, req)
+	reply = rec.Msg
+	opt = reply.Extra[len(reply.Extra)-1]
+	if x, ok := opt.(*dns.OPT); !ok {
+		t.Fatalf("Expected OPT RR, got %T", x)
+	}
+	if !opt.(*dns.OPT).Do() {
+		t.Errorf("Expected DO bit to be set, got false")
+	}
+	if x := opt.(*dns.OPT).UDPSize(); x != mysize {
+		t.Errorf("Expected %d bufsize, got %d", mysize, x)
+	}
+}
+
+func echoHandler() plugin.Handler {
+	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		w.WriteMsg(r)
+		return dns.RcodeSuccess, nil
+	})
+}

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -26,7 +26,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	server := metrics.WithServer(ctx)
 
 	// On cache miss, if the request has the OPT record and the DO bit set we leave the message as-is. If there isn't a DO bit
-	// set we will modify the request to _add_ one. This means we will always do DNSSEC lookups on cache misses. 
+	// set we will modify the request to _add_ one. This means we will always do DNSSEC lookups on cache misses.
 	// When writing to cache, any DNSSEC RRs in the response are written to cache with the response.
 	// When sending a response to a non-DNSSEC client, we remove DNSSEC RRs from the response. We use a 2048 buffer size, which is
 	// less than 4096 (and older default) and more than 1024 which may be too small. We might need to tweaks this

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -140,8 +140,16 @@ func (c *Cache) exists(state request.Request) *item {
 	return nil
 }
 
+// setDo sets the DO bit and UDP buffer size in the message m.
 func setDo(m *dns.Msg) {
-	o := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+	o := m.IsEdns0()
+	if o != nil {
+		o.SetDo()
+		o.SetUDPSize(defaultUDPBufSize)
+		return
+	}
+
+	o = &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
 	o.SetDo()
 	o.SetUDPSize(defaultUDPBufSize)
 	m.Extra = append(m.Extra, o)

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -25,9 +25,10 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	now := c.now().UTC()
 	server := metrics.WithServer(ctx)
 
-	// If the request has the OPT record and the DO bit set we leave the message as-is. If there isn't a DO bit
-	// set we will modify the request to _add_ one. This means we will always do DNSSEC lookups. When the reply
-	// comes back we will remove DNSSEC RRs to make non-DNSSEC clients happy. We use a 2048 buffer size, which is
+	// On cache miss, if the request has the OPT record and the DO bit set we leave the message as-is. If there isn't a DO bit
+	// set we will modify the request to _add_ one. This means we will always do DNSSEC lookups on cache misses. 
+	// When writing to cache, any DNSSEC RRs in the response are written to cache with the response.
+	// When sending a response to a non-DNSSEC client, we remove DNSSEC RRs from the response. We use a 2048 buffer size, which is
 	// less than 4096 (and older default) and more than 1024 which may be too small. We might need to tweaks this
 	// value to be smaller still to prevent UDP fragmentation?
 

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -64,6 +64,9 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool) *dns.Msg {
 	// just set it to true.
 	m1.Authoritative = true
 	m1.AuthenticatedData = i.AuthenticatedData
+	if !do {
+		m1.AuthenticatedData = false // when DNSSEC was not wanted, it can't be authenticated data.
+	}
 	m1.RecursionAvailable = i.RecursionAvailable
 	m1.Rcode = i.Rcode
 

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -111,7 +111,7 @@ func (i *item) ttl(now time.Time) int {
 	return ttl
 }
 
-// isDNSSEC return true id r is a DNSSEC record. NSEC,NSEC3,DS and RRSIG/SIG
+// isDNSSEC returns true if r is a DNSSEC record. NSEC,NSEC3,DS and RRSIG/SIG
 // are DNSSEC records. DNSKEYs are left alone on the assumptions that if they
 // are there the client explictly asked for them.
 func isDNSSEC(r dns.RR) bool {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -111,9 +111,9 @@ func (i *item) ttl(now time.Time) int {
 	return ttl
 }
 
-// filterDNSSEC filters the dns.RR slice and removes DNSSEC records. This removes:
-// NSEC,NSEC3,DS and RRSIG/SIG records. DNSKEYs are left alone on the assumptions that if they are
-// there the client explictly asked for them.
+// isDNSSEC return true id r is a DNSSEC record. NSEC,NSEC3,DS and RRSIG/SIG
+// are DNSSEC records. DNSKEYs are left alone on the assumptions that if they
+// are there the client explictly asked for them.
 func isDNSSEC(r dns.RR) bool {
 	switch r.Header().Rrtype {
 	case dns.TypeNSEC:

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -112,8 +112,8 @@ func (i *item) ttl(now time.Time) int {
 }
 
 // isDNSSEC returns true if r is a DNSSEC record. NSEC,NSEC3,DS and RRSIG/SIG
-// are DNSSEC records. DNSKEYs are left alone on the assumptions that if they
-// are there the client explictly asked for them.
+// are DNSSEC records. DNSKEYs is not in this list on the assumption that the
+// client explictly asked for it.
 func isDNSSEC(r dns.RR) bool {
 	switch r.Header().Rrtype {
 	case dns.TypeNSEC:

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -55,7 +55,7 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 // So we're forced to always set this to 1; regardless if the answer came from the cache or not.
 // On newer systems(e.g. ubuntu 16.04 with glib version 2.23), this issue is resolved.
 // So we may set this bit back to 0 in the future ?
-func (i *item) toMsg(m *dns.Msg, now time.Time) *dns.Msg {
+func (i *item) toMsg(m *dns.Msg, now time.Time, do bool) *dns.Msg {
 	m1 := new(dns.Msg)
 	m1.SetReply(m)
 
@@ -72,23 +72,60 @@ func (i *item) toMsg(m *dns.Msg, now time.Time) *dns.Msg {
 	m1.Extra = make([]dns.RR, len(i.Extra))
 
 	ttl := uint32(i.ttl(now))
-	for j, r := range i.Answer {
+	j := 0
+	for _, r := range i.Answer {
+		if !do && isDNSSEC(r) {
+			continue
+		}
 		m1.Answer[j] = dns.Copy(r)
 		m1.Answer[j].Header().Ttl = ttl
+		j++
 	}
-	for j, r := range i.Ns {
+	m1.Answer = m1.Answer[:j]
+	j = 0
+	for _, r := range i.Ns {
+		if !do && isDNSSEC(r) {
+			continue
+		}
 		m1.Ns[j] = dns.Copy(r)
 		m1.Ns[j].Header().Ttl = ttl
+		j++
 	}
+	m1.Ns = m1.Ns[:j]
 	// newItem skips OPT records, so we can just use i.Extra as is.
-	for j, r := range i.Extra {
+	j = 0
+	for _, r := range i.Extra {
+		if !do && isDNSSEC(r) {
+			continue
+		}
 		m1.Extra[j] = dns.Copy(r)
 		m1.Extra[j].Header().Ttl = ttl
+		j++
 	}
+	m1.Extra = m1.Extra[:j]
 	return m1
 }
 
 func (i *item) ttl(now time.Time) int {
 	ttl := int(i.origTTL) - int(now.UTC().Sub(i.stored).Seconds())
 	return ttl
+}
+
+// filterDNSSEC filters the dns.RR slice and removes DNSSEC records. This removes:
+// NSEC,NSEC3,DS and RRSIG/SIG records. DNSKEYs are left alone on the assumptions that if they are
+// there the client explictly asked for them.
+func isDNSSEC(r dns.RR) bool {
+	switch r.Header().Rrtype {
+	case dns.TypeNSEC:
+		return true
+	case dns.TypeNSEC3:
+		return true
+	case dns.TypeDS:
+		return true
+	case dns.TypeRRSIG:
+		return true
+	case dns.TypeSIG:
+		return true
+	}
+	return false
 }

--- a/request/request.go
+++ b/request/request.go
@@ -144,7 +144,7 @@ func (r *Request) Family() int {
 	return 2
 }
 
-// Do returns if the request has the DO (DNSSEC OK) bit set.
+// Do returns true if the request has the DO (DNSSEC OK) bit set.
 func (r *Request) Do() bool {
 	if r.size != 0 {
 		return r.do


### PR DESCRIPTION
This change does away with the DNS/DNSSEC distinction the cache
currently makes. Cache will always make coredns perform a DNSSEC query
and store that result. If a client just needs plain DNS, the DNSSEC
records are stripped from the response.

It should also be more memory efficient, because we store a reply once
and not one DNS and another for DNSSEC.

Fixes: #3836