### PR TITLE
Update Project Lead's term

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# @miekg, miek@miek.nl, project lead: 11/11/2020
+# @miekg, miek@miek.nl, project lead: 11/11/2021
 
 *                       @bradbeam @chrisohaver @dilyevsky @fastest963 @greenpau @isolus @johnbelamaric @miekg @pmoroney @rajansandeep @stp-ip @superq @yongtang
 


### PR DESCRIPTION
Base on the [GOVERNANCE.md] of CoreDNS, we will need to update project lead's term:
1) Any PR should only be opened no earlier than 6 weeks before the end of current lead's term
2) PR can only be merged after it has been opened for 4 weeks.
3) See [GOVERNANCE.md] for more details on how votes are counted.

Since it is less than 6 weeks before 11/11/2020, this PR:
1) propose to extend project lead's term from 11/11/2020 to 11/11/2021.
2) will keep open until at least to 10/28/2020 (4 weeks), so that community has a chance to voice opinions

Please specify +1/-1 for agree/disagree.

Note: Alternative PRs could be opened concurrently, as long as it following the rules specified in [GOVERNANCE.md].

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>