### PR TITLE
plugin/trace: Have a consistent spanName

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -28,9 +28,16 @@ Additional features can be enabled with this syntax:
 
 ~~~
 trace [ENDPOINT-TYPE] [ENDPOINT] {
-	every AMOUNT
-	service NAME
-	client_server
+    every AMOUNT
+    service NAME
+    client_server
+}
+~~~
+~~~
+trace datadog {
+    every AMOUNT
+    service NAME
+    datadog_analytics_rate RATE
 }
 ~~~
 
@@ -39,6 +46,8 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
 * `service` **NAME** allows you to specify the service name reported to the tracing server.
   Default is `coredns`.
 * `client_server` will enable the `ClientServerSameSpan` OpenTracing feature.
+* `datadog_analytics_rate` **RATE** will enable [trace analytics](https://docs.datadoghq.com/tracing/app_analytics) on the traces sent
+  from *0* to *1*, *1* being every trace sent will be analyzed. This is a datadog only feature.
 
 ## Zipkin
 You can run Zipkin on a Docker host like this:

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -83,6 +83,21 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 				if err != nil {
 					return nil, err
 				}
+			case "datadog_analytics_rate":
+				args := c.RemainingArgs()
+				if len(args) > 1 {
+					return nil, c.ArgErr()
+				}
+				tr.datadogAnalyticsRate = 0
+				if len(args) == 1 {
+					tr.datadogAnalyticsRate,err = strconv.ParseFloat(args[0], 64)
+				}
+				if err != nil {
+					return nil, err
+				}
+				if tr.datadogAnalyticsRate > 1 || tr.datadogAnalyticsRate < 0 {
+					return nil,fmt.Errorf("datadog analytics rate must be between 0 and 1, '%f' is not supported", tr.datadogAnalyticsRate )
+				}
 			}
 		}
 	}

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -22,6 +22,7 @@ func TestTraceParse(t *testing.T) {
 		{`trace zipkin localhost:1234`, false, "http://localhost:1234/api/v1/spans", 1, `coredns`, false},
 		{`trace datadog localhost`, false, "localhost", 1, `coredns`, false},
 		{`trace datadog http://localhost:8127`, false, "http://localhost:8127", 1, `coredns`, false},
+		{"trace datadog localhost {\n datadog_analytics_rate 0.1\n}", false, "localhost", 1, `coredns`, false},
 		{"trace {\n every 100\n}", false, "http://localhost:9411/api/v1/spans", 100, `coredns`, false},
 		{"trace {\n every 100\n service foobar\nclient_server\n}", false, "http://localhost:9411/api/v1/spans", 100, `foobar`, true},
 		{"trace {\n every 2\n client_server true\n}", false, "http://localhost:9411/api/v1/spans", 2, `coredns`, true},
@@ -29,6 +30,7 @@ func TestTraceParse(t *testing.T) {
 		// fails
 		{`trace footype localhost:4321`, true, "", 1, "", false},
 		{"trace {\n every 2\n client_server junk\n}", true, "", 1, "", false},
+		{"trace datadog localhost {\n datadog_analytics_rate 2\n}", true, "", 1, "", false},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -79,9 +79,10 @@ func TestTrace(t *testing.T) {
 
 			rootSpan := fs[1]
 			req := request.Request{W: w, Req: tc.question}
-			if rootSpan.OperationName != spanName(ctx, req) {
-				t.Errorf("Unexpected span name: rootSpan.Name: want %v, got %v", spanName(ctx, req), rootSpan.OperationName)
+			if rootSpan.OperationName != defaultTopLevelSpanName {
+				t.Errorf("Unexpected span name: rootSpan.Name: want %v, got %v", defaultTopLevelSpanName, rootSpan.OperationName)
 			}
+
 			if rootSpan.Tag(tagName) != req.Name() {
 				t.Errorf("Unexpected span tag: rootSpan.Tag(%v): want %v, got %v", tagName, req.Name(), rootSpan.Tag(tagName))
 			}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
The current trace implementation create too many top level trace.
![image](https://user-images.githubusercontent.com/5513509/66491639-1675a400-ea81-11e9-97d3-07e5cf554ef0.png)

The spans are very varied and so can't be compared against each other.
But also bog down the trace store behind it.

The book [Distributed Tracing in Practice by Austin Parker, Daniel Spoonhower, Jonathan Mace, Ben Sigelman, Rebecca Isaacs](https://www.oreilly.com/library/view/distributed-tracing-in/9781492056621/ch04.html)

Mention that span names do not have to be the name of the function nor be unique

> First, names should be aggregable. In short, you want to avoid span names that are unique to each execution of a service. One antipattern we see, especially in HTTP services, is implementers making the span name the same as the fully matched route (such as GET /api/v2/users/1532492). This pattern makes it difficult to aggregate operations across thousands or millions of executions, severely reducing the utility of your data. Instead, make the route more generic and move parameters to tags, such as GET /api/v2/users/{id} with an associated tag of userId: 1532492.

This allows us to have APM based Graph such as

![image](https://user-images.githubusercontent.com/5513509/93375960-339e1f80-f859-11ea-81f0-a1074c375630.png)

![image](https://user-images.githubusercontent.com/5513509/93375997-4153a500-f859-11ea-9f8d-63d45217c681.png)

![image](https://user-images.githubusercontent.com/5513509/93376064-5597a200-f859-11ea-823a-6768f59e3497.png)

![image](https://user-images.githubusercontent.com/5513509/93376405-d6ef3480-f859-11ea-8d6f-58dda247cc86.png)

![image](https://user-images.githubusercontent.com/5513509/93376518-069e3c80-f85a-11ea-9a7e-0426a3817439.png)

I moved the sampling to the implementation of each trace provider
To let them decide how to best decide when to drop the traces.
It allows the datadog provider to smoothly provide the right effective throughput ( in the UI )

### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
Depends on the answer to the question in 5
Possible removal of `client_server` 
Possible addition of a datadog only option regarding trace analyze 
Possible addition of a `TopLevelSpanName` only option to remain backward compatible

### 4. Does this introduce a backward incompatible change or deprecation?
Depends on the answer to the question in 5
Possible backward incompatible change regarding the `TopLevelSpanName`

### 5. Additional Question.

I have a few additional question.

Apparently the `clientServer` options was zipkin only and has been removed from the init of the zipkin tracer in #4109 
The configuration and documentation still point to it. Should i drop that completely or should i reinstate it ?

The change in traceName create a backward incompatible (UI wise) change.
I'm not that familiar with zipkin to be certain if that's an issue or not.
Should I create a configuration to toggle that on or off ?

Related to the first question, i didn't add it yet in this PR but to get the nice *table* and *graph* showed here, datadog need an additional tags on the trace it sends to analyze the trace further.
The trace getting analyzed have an additional cost for datadog customer which is why i didn't set that up by default.

Is it alright to create a Datadog only option in the plugin configuration like `client_server` used to be ? 

 