### PR TITLE
Fix missing `*` in Go Fmt GitHub Actions

### DIFF
--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
     paths:
-      - '*.go'
+      - '**.go'
 
 jobs:
   fix:


### PR DESCRIPTION
Looks like one `*` is missing in Go Fmt GitHub Actions
and that causes the Actions not being triggered.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
