### PR TITLE
Fix NPE isssue in plugin kubernetes 

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -252,7 +252,10 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (err error) {
 	}
 	// Disable use of endpoint slices for k8s versions 1.18 and earlier. Endpoint slices were
 	// introduced in 1.17 but EndpointSliceMirroring was not added until 1.19.
-	sv, _ := kubeClient.ServerVersion()
+	sv, err := kubeClient.ServerVersion()
+	if err != nil {
+		return err
+	}
 	major, _ := strconv.Atoi(sv.Major)
 	minor, _ := strconv.Atoi(sv.Minor)
 	if k.opts.useEndpointSlices && major <= 1 && minor <= 18 {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
I faced the npe issue . the error log as below。I fixed this issue . add error check before use sv .
`github.com/coredns/coredns/plugin/kubernetes.(*Kubernetes).InitKubeCache(0xc0004a4480, 0x21f3940, 0xc0001080d8, 0x0, 0x1b856c0)
	/Users/xmly/go/src/coredns/plugin/kubernetes/kubernetes.go:256 +0x22d
github.com/coredns/coredns/plugin/kubernetes.setup(0xc000250cf0, 0x3, 0x1da9502)
	/Users/xmly/go/src/coredns/plugin/kubernetes/setup.go:42 +0x190
github.com/coredns/caddy.executeDirectives(0xc000048800, 0x7ffff3e08991, 0x15, 0x30a00e0, 0x2e, 0x2e, 0xc0002c1420, 0x1, 0x1, 0x0, ...)
	/Users/xmly/go/pkg/mod/github.com/coredns/caddy@v1.1.0/caddy.go:656 +0x69e
github.com/coredns/caddy.ValidateAndExecuteDirectives(0x21ebf80, 0xc0000e2640, 0xc000048800, 0x0, 0x1, 0xc000206100)
	/Users/xmly/go/pkg/mod/github.com/coredns/caddy@v1.1.0/caddy.go:612 +0x421
github.com/coredns/caddy.startWithListenerFds(0x21ebf80, 0xc0000e2640, 0xc000048800, 0x0, 0x0, 0x0)
	/Users/xmly/go/pkg/mod/github.com/coredns/caddy@v1.1.0/caddy.go:515 +0x13c
github.com/coredns/caddy.Start(0x21ebf80, 0xc0000e2640, 0x21ebf80, 0xc0000e2640, 0x0)
	/Users/xmly/go/pkg/mod/github.com/coredns/caddy@v1.1.0/caddy.go:472 +0xea
github.com/coredns/coredns/coremain.Run()
	/Users/xmly/go/src/coredns/coremain/run.go:78 +0x27c
main.main()
	/Users/xmly/go/src/coredns/coredns.go:12 +0x20`

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
