### PR TITLE
[plugin][forward] - Populate return code on upstream error.

### DIFF
--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -24,11 +24,15 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 	// Record response to get status code and size of the reply.
 	rw := dnstest.NewRecorder(w)
-	status, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, rw, r)
+	rcodeFromNext, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, rw, r)
+	rcodeRet := rcode.ToString(rw.Rcode)
+	if !plugin.ClientWrite(rcodeFromNext) && err != nil {
+		rcodeRet = rcode.ToString(rcodeFromNext)
+	}
 
-	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rw.Rcode), rw.Len, rw.Start)
+	vars.Report(WithServer(ctx), state, zone, rcodeRet, rw.Len, rw.Start)
 
-	return status, err
+	return rcodeFromNext, err
 }
 
 // Name implements the Handler interface.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Following an incident we noticed that the global metrics did not have the right return code when upstream failure were happening.
More specifically `i/o timeout` errors
~Also if the client is patient enough (>30s) the query is returned with a *noerror* code.~

![Graph showing app errors](https://user-images.githubusercontent.com/5513509/104312937-989c1600-54d7-11eb-9295-736fb9e5d900.png)
👆 This is a client metrics showing dns error (timeout / servfail)
![Graph showing apm errors](https://user-images.githubusercontent.com/5513509/104312798-668ab400-54d7-11eb-863d-33232b565e4b.png)
👆 Note the _30s_ timeout
![Graph showing no servfail errors](https://user-images.githubusercontent.com/5513509/104313210-fd577080-54d7-11eb-8044-1745de45ba1d.png)
☝️ Blue is NOERROR , which should have been another color because of a different error code.

~In order to fix that particular issue, i thought of 2 ways to go about it.~
~The one in the PR~
 modifying the [metrics/handler.go:ServeDns](https://github.com/coredns/coredns/blob/master/plugin/metrics/handler.go#L29) function to use the `status` instead of `rw.Rcode`
~Let me know if the second one is better or if you see a better way of doing this.~

### 2. Which issues (if any) are related?
None that i found

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No

### 5. Additional Question / Info

Additionally the [maxDialTimeout](https://github.com/coredns/coredns/blob/master/plugin/forward/persistent.go#L154) seems a bit high at *30s* with client usually having the default *5s* timeout.
It tends to create a queuing problem.
I saw the cancel plugin but did not find the wiring in the forward plugin. 
I'm curious about how you see this working.


Edit: Strikethrough based on comment.
