### PR TITLE
plugin/acl: add the ability to filter records

### DIFF
--- a/plugin/acl/README.md
+++ b/plugin/acl/README.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-With `acl` enabled, users are able to block suspicious DNS queries by configuring IP filter rule sets, i.e. allowing authorized queries to recurse or blocking unauthorized queries.
+With `acl` enabled, users are able to block or filter suspicious DNS queries by configuring IP filter rule sets, i.e. allowing authorized queries to recurse or blocking unauthorized queries.
 
 This plugin can be used multiple times per Server Block.
 
@@ -19,7 +19,7 @@ acl [ZONES...] {
 ```
 
 - **ZONES** zones it should be authoritative for. If empty, the zones from the configuration block are used.
-- **ACTION** (*allow* or *block*) defines the way to deal with DNS queries matched by this rule. The default action is *allow*, which means a DNS query not matched by any rules will be allowed to recurse.
+- **ACTION** (*allow*, *block*, or *filter*) defines the way to deal with DNS queries matched by this rule. The default action is *allow*, which means a DNS query not matched by any rules will be allowed to recurse. The difference between *block* and *filter* is that block returns status code of *REFUSED* while filter returns an empty set *NOERROR*
 - **QTYPE** is the query type to match for the requests to be allowed or blocked. Common resource record types are supported. `*` stands for all record types. The default behavior for an omitted `type QTYPE...` is to match all kinds of DNS queries (same as `type *`).
 - **SOURCE** is the source IP address to match for the requests to be allowed or blocked. Typical CIDR notation and single IP address are supported. `*` stands for all possible source IP addresses.
 
@@ -33,6 +33,16 @@ Block all DNS queries with record type A from 192.168.0.0/16：
 . {
     acl {
         block type A net 192.168.0.0/16
+    }
+}
+~~~
+
+Filter all DNS queries with record type A from 192.168.0.0/16：
+
+~~~ corefile
+. {
+    acl {
+        filter type A net 192.168.0.0/16
     }
 }
 ~~~

--- a/plugin/acl/acl_test.go
+++ b/plugin/acl/acl_test.go
@@ -146,6 +146,34 @@ func TestACLServeDNS(t *testing.T) {
 			false,
 		},
 		{
+			"Filter 1 FILTERED",
+			`acl example.org {
+				filter type A net 192.168.0.0/16
+			}`,
+			[]string{},
+			args{
+				"www.example.org.",
+				"192.168.0.2",
+				dns.TypeA,
+			},
+			dns.RcodeSuccess,
+			false,
+		},
+		{
+			"Filter 1 ALLOWED",
+			`acl example.org {
+				filter type A net 192.168.0.0/16
+			}`,
+			[]string{},
+			args{
+				"www.example.org.",
+				"192.167.0.2",
+				dns.TypeA,
+			},
+			dns.RcodeSuccess,
+			false,
+		},
+		{
 			"Whitelist 1 ALLOWED",
 			`acl example.org {
 				allow net 192.168.0.0/16

--- a/plugin/acl/metrics.go
+++ b/plugin/acl/metrics.go
@@ -15,6 +15,13 @@ var (
 		Name:      "blocked_requests_total",
 		Help:      "Counter of DNS requests being blocked.",
 	}, []string{"server", "zone"})
+	// RequestFilterCount is the number of DNS requests being filtered.
+	RequestFilterCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "filtered_requests_total",
+		Help:      "Counter of DNS requests being filtered.",
+	}, []string{"server", "zone"})
 	// RequestAllowCount is the number of DNS requests being Allowed.
 	RequestAllowCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,

--- a/plugin/acl/setup.go
+++ b/plugin/acl/setup.go
@@ -61,8 +61,10 @@ func parse(c *caddy.Controller) (ACL, error) {
 				p.action = actionAllow
 			} else if action == "block" {
 				p.action = actionBlock
+			} else if action == "filter" {
+				p.action = actionFilter
 			} else {
-				return a, c.Errf("unexpected token %q; expect 'allow' or 'block'", c.Val())
+				return a, c.Errf("unexpected token %q; expect 'allow', 'block', or 'filter'", c.Val())
 			}
 
 			p.qtypes = make(map[uint16]struct{})

--- a/plugin/acl/setup_test.go
+++ b/plugin/acl/setup_test.go
@@ -43,6 +43,13 @@ func TestSetup(t *testing.T) {
 			false,
 		},
 		{
+			"Filter 1",
+			`acl {
+				filter type A net 192.168.0.0/16
+			}`,
+			false,
+		},
+		{
 			"Whitelist 1",
 			`acl {
 				allow type * net 192.168.0.0/16
@@ -150,6 +157,13 @@ func TestSetup(t *testing.T) {
 			`acl {
 				allow net 2001:db8:abcd:0012::0/64
 				block net 2001:db8:abcd:0012::0/48
+			}`,
+			false,
+		},
+		{
+			"Filter 1 IPv6",
+			`acl {
+				filter type A net 2001:0db8:85a3:0000:0000:8a2e:0370:7334
 			}`,
 			false,
 		},


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Currently ACLs only allow for allow and block, however it isn't
always desirable to set the status code to REFUSED. Often times
you want to completely hide the fact that those records even exist.

Adding the ability to acl to filter results makes it significantly
harder for a third party to know that the records are being masked.

### 2. Which issues (if any) are related?
None
### 3. Which documentation changes (if any) need to be made?
I made a few in this module, but maybe more?

### 4. Does this introduce a backward incompatible change or deprecation?
None