### PR TITLE
plugin/forward Add rcode and rtype to request_duration_seconds metric

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -107,7 +107,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 
 * `coredns_forward_requests_total{to}` - query count per upstream.
 * `coredns_forward_responses_total{to}` - Counter of responses received per upstream.
-* `coredns_forward_request_duration_seconds{to}` - duration per upstream interaction.
+* `coredns_forward_request_duration_seconds{to, rcode, type}` - duration per upstream, RCODE, type
 * `coredns_forward_responses_total{to, rcode}` - count of RCODEs per upstream.
 * `coredns_forward_healthcheck_failures_total{to}` - number of failed health checks per upstream.
 * `coredns_forward_healthcheck_broken_total{}` - counter of when all upstreams are unhealthy,

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -129,9 +130,11 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts options
 		rc = strconv.Itoa(ret.Rcode)
 	}
 
+	qtype := dnsutil.QTypeMonitorLabel(state.QType())
+
 	RequestCount.WithLabelValues(p.addr).Add(1)
 	RcodeCount.WithLabelValues(rc, p.addr).Add(1)
-	RequestDuration.WithLabelValues(p.addr, rc, state.Type()).Observe(time.Since(start).Seconds())
+	RequestDuration.WithLabelValues(p.addr, rc, qtype).Observe(time.Since(start).Seconds())
 
 	return ret, nil
 }

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -131,7 +131,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts options
 
 	RequestCount.WithLabelValues(p.addr).Add(1)
 	RcodeCount.WithLabelValues(rc, p.addr).Add(1)
-	RequestDuration.WithLabelValues(p.addr).Observe(time.Since(start).Seconds())
+	RequestDuration.WithLabelValues(p.addr, rc, state.Type()).Observe(time.Since(start).Seconds())
 
 	return ret, nil
 }

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -27,7 +27,7 @@ var (
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time each request took.",
-	}, []string{"to"})
+	}, []string{"to", "rcode", "type"})
 	HealthcheckFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -3,9 +3,8 @@ package vars
 import (
 	"time"
 
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
-
-	"github.com/miekg/dns"
 )
 
 // Report reports the metrics data associated with request. This function is exported because it is also
@@ -19,45 +18,17 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 		fam = "2"
 	}
 
-	typ := req.QType()
+	qtype := dnsutil.QTypeMonitorLabel(req.QType())
 
 	if req.Do() {
 		RequestDo.WithLabelValues(server, zone).Inc()
 	}
 
-	if _, known := monitorType[typ]; known {
-		RequestCount.WithLabelValues(server, zone, net, fam, dns.Type(typ).String()).Inc()
-		RequestDuration.WithLabelValues(server, zone, dns.Type(typ).String()).Observe(time.Since(start).Seconds())
-	} else {
-		RequestCount.WithLabelValues(server, zone, net, fam, other).Inc()
-		RequestDuration.WithLabelValues(server, zone, other).Observe(time.Since(start).Seconds())
-	}
+	RequestCount.WithLabelValues(server, zone, net, fam, qtype).Inc()
+	RequestDuration.WithLabelValues(server, zone, qtype).Observe(time.Since(start).Seconds())
 
 	ResponseSize.WithLabelValues(server, zone, net).Observe(float64(size))
 	RequestSize.WithLabelValues(server, zone, net).Observe(float64(req.Len()))
 
 	ResponseRcode.WithLabelValues(server, zone, rcode).Inc()
 }
-
-var monitorType = map[uint16]struct{}{
-	dns.TypeAAAA:   {},
-	dns.TypeA:      {},
-	dns.TypeCNAME:  {},
-	dns.TypeDNSKEY: {},
-	dns.TypeDS:     {},
-	dns.TypeMX:     {},
-	dns.TypeNSEC3:  {},
-	dns.TypeNSEC:   {},
-	dns.TypeNS:     {},
-	dns.TypePTR:    {},
-	dns.TypeRRSIG:  {},
-	dns.TypeSOA:    {},
-	dns.TypeSRV:    {},
-	dns.TypeTXT:    {},
-	// Meta Qtypes
-	dns.TypeIXFR: {},
-	dns.TypeAXFR: {},
-	dns.TypeANY:  {},
-}
-
-const other = "other"

--- a/plugin/pkg/dnsutil/monitor.go
+++ b/plugin/pkg/dnsutil/monitor.go
@@ -1,0 +1,37 @@
+package dnsutil
+
+import (
+	"github.com/miekg/dns"
+)
+
+var monitorType = map[uint16]struct{}{
+	dns.TypeAAAA:   {},
+	dns.TypeA:      {},
+	dns.TypeCNAME:  {},
+	dns.TypeDNSKEY: {},
+	dns.TypeDS:     {},
+	dns.TypeMX:     {},
+	dns.TypeNSEC3:  {},
+	dns.TypeNSEC:   {},
+	dns.TypeNS:     {},
+	dns.TypePTR:    {},
+	dns.TypeRRSIG:  {},
+	dns.TypeSOA:    {},
+	dns.TypeSRV:    {},
+	dns.TypeTXT:    {},
+	// Meta Qtypes
+	dns.TypeIXFR: {},
+	dns.TypeAXFR: {},
+	dns.TypeANY:  {},
+}
+
+const other = "other"
+
+// QTypeMonitorLabel returns dns type label based on a list of monitored types.
+// Will return "other" for unmonitored ones.
+func QTypeMonitorLabel(qtype uint16) string {
+	if _, known := monitorType[qtype]; known {
+		return dns.Type(qtype).String()
+	}
+	return other
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This adds the response code (`rcode`) and request type (`type`) to `coredns_forward_request_duration_seconds` metric.

We've been using these extra tags in production for a while to help us debug unexpected behavior. It could be a nice observability addition to CoreDNS.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Documentation updated in forward's README.

### 4. Does this introduce a backward incompatible change or deprecation?

no
