### PR TITLE
plugin/metrics Add rcode to request_duration_seconds metric

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -13,7 +13,7 @@ The following metrics are exported:
 * `coredns_build_info{version, revision, goversion}` - info about CoreDNS itself.
 * `coredns_panics_total{}` - total number of panics.
 * `coredns_dns_requests_total{server, zone, proto, family, type}` - total query count.
-* `coredns_dns_request_duration_seconds{server, zone, type}` - duration to process each query.
+* `coredns_dns_request_duration_seconds{server, zone, type, rcode}` - duration to process each query.
 * `coredns_dns_request_size_bytes{server, zone, proto}` - size of the request in bytes.
 * `coredns_dns_do_requests_total{server, zone}` -  queries that have the DO bit set
 * `coredns_dns_response_size_bytes{server, zone, proto}` - response size in bytes.

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -27,10 +27,10 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 
 	if _, known := monitorType[typ]; known {
 		RequestCount.WithLabelValues(server, zone, net, fam, dns.Type(typ).String()).Inc()
-		RequestDuration.WithLabelValues(server, zone, dns.Type(typ).String()).Observe(time.Since(start).Seconds())
+		RequestDuration.WithLabelValues(server, zone, dns.Type(typ).String(), rcode).Observe(time.Since(start).Seconds())
 	} else {
 		RequestCount.WithLabelValues(server, zone, net, fam, other).Inc()
-		RequestDuration.WithLabelValues(server, zone, other).Observe(time.Since(start).Seconds())
+		RequestDuration.WithLabelValues(server, zone, other, rcode).Observe(time.Since(start).Seconds())
 	}
 
 	ResponseSize.WithLabelValues(server, zone, net).Observe(float64(size))

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -22,7 +22,7 @@ var (
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time (in seconds) each request took.",
-	}, []string{"server", "zone", "type"})
+	}, []string{"server", "zone", "type", "rcode"})
 
 	RequestSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This adds the response code (`rcode`) to `coredns_dns_request_duration_seconds` metric.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Documentation updated in metrics's README.


### 4. Does this introduce a backward incompatible change or deprecation?

no