### PR TITLE
plugin/file: Make copies of RRs before returning them to avoid tree mutation 

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -171,7 +171,12 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			return z.externalLookup(ctx, state, elem, rrs)
 		}
 
-		rrs := elem.Type(qtype)
+		treeRRs := elem.Type(qtype)
+		// make a copy of the element RRs to prevent response writers from mutating the tree
+		rrs := make([]dns.RR, len(treeRRs))
+		for i, rr := range treeRRs {
+			rrs[i] = dns.Copy(rr)
+		}
 
 		// NODATA
 		if len(rrs) == 0 {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This PR makes copies of RRs from the tree before writing them to the client.  If the original RRs are written to the client, a mutating response writer (e.g. rewrite's `ResponseReverter`) will mutate the RR elements in the file's in memory tree, affecting the responses to later queries.

### 2. Which issues (if any) are related?

[Reported on slack](https://cloud-native.slack.com/archives/C4DF7FP71/p1611065238019400?thread_ts=1611051481.018900&cid=C4DF7FP71) by @svinther

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
