### PR TITLE
Add cache eviction metrics to the cache plugin

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -79,6 +79,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_cache_prefetch_total{server}` - Counter of times the cache has prefetched a cached item.
 * `coredns_cache_drops_total{server}` - Counter of responses excluded from the cache due to request/response question name mismatch.
 * `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.
+* `coredns_cache_evictions_total{server, type}` - Counter of cache evictions.
 
 Cache types are either "denial" or "success". `Server` is the server handling the request, see the
 prometheus plugin for documentation.

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -50,4 +50,11 @@ var (
 		Name:      "served_stale_total",
 		Help:      "The number of requests served from stale cache entries.",
 	}, []string{"server"})
+	// evictions is the counter of cache evictions.
+	evictions = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "cache",
+		Name:      "evictions_total",
+		Help:      "The count of cache evictions.",
+	}, []string{"server", "type"})
 )


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds the cache evictions count to the cache plugin. This is a useful metric for determining if your cache capacity is too small.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

Added to the cache plugin readme.

### 4. Does this introduce a backward incompatible change or deprecation?

No
