### PR TITLE
release: remove manifest tool

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -47,17 +47,13 @@ COMMA:=$(EMPTY),$(EMPTY)
 ifeq (, $(shell which curl))
     $(error "No curl in $$PATH, please install")
 endif
-ifeq (, $(shell which manifest-tool))
-    $(error "No manifest-tool in $$PATH, please install")
-endif
 
 DOCKER:=
 NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-# mips is not in LINUX_ARCH because it's not supported by the manifest-tool.
-LINUX_ARCH:=amd64 arm arm64 ppc64le s390x
+LINUX_ARCH:=amd64 arm arm64 ppc64le s390x mips mips64le
 PLATFORMS:=$(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
 
 all:
@@ -75,10 +71,6 @@ build:
 	mkdir -p build/darwin/amd64 && $(MAKE) coredns BINARY=build/darwin/amd64/$(NAME) SYSTEM="GOOS=darwin GOARCH=amd64" CHECKS="" BUILDOPTS=""
 	@echo Building: windows/amd64 - $(VERSION)
 	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME).exe SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="" BUILDOPTS=""
-	@echo Building: linux/mips - $(VERSION)
-	mkdir -p build/linux/mips  && $(MAKE) coredns BINARY=build/linux/mips/$(NAME) SYSTEM="GOOS=linux GOARCH=mips" CHECKS="" BUILDOPTS=""
-	@echo Building: linux/mips64le - $(VERSION)
-	mkdir -p build/linux/mips64le  && $(MAKE) coredns BINARY=build/linux/mips64le/$(NAME) SYSTEM="GOOS=linux GOARCH=mips64le" CHECKS="" BUILDOPTS=""
 	@echo Building: linux/$(LINUX_ARCH) - $(VERSION) ;\
 	for arch in $(LINUX_ARCH); do \
 	    mkdir -p build/linux/$$arch  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" BUILDOPTS="" ;\
@@ -90,8 +82,6 @@ tar:
 	@rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_amd64.tgz -C build/darwin/amd64 $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_windows_amd64.tgz -C build/windows/amd64 $(NAME).exe
-	tar -zcf release/$(NAME)_$(VERSION)_linux_mips.tgz -C build/linux/mips $(NAME)
-	tar -zcf release/$(NAME)_$(VERSION)_linux_mips64le.tgz -C build/linux/mips64le $(NAME)
 	for arch in $(LINUX_ARCH); do \
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done
@@ -153,8 +143,6 @@ else
 	for arch in $(LINUX_ARCH); do \
 	    docker push $(DOCKER_IMAGE_NAME):coredns-$$arch ;\
 	done
-	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):$(VERSION)
-	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):latest
 endif
 
 .PHONY: version


### PR DESCRIPTION
Also include mips and mips64le in the list LINUX_ARCH, that docker can't
deal with this is not our problem; unify and simplify our stuff.

This simple stops using the manifest-tool; I don't know what will break
for those poor souls that actually use non-amd64 arches and docker.

Docker still warns that the manifest tool support is experimental, so
going forward we will highly likely only publish amd64 images.

See #4369 for context on how badly this is working

Signed-off-by: Miek Gieben <miek@miek.nl>
