### PR TITLE
core: flag blacklisting not needed anymore

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -35,21 +35,6 @@ func init() {
 // Run is CoreDNS's main() function.
 func Run() {
 	caddy.TrapSignals()
-
-	// Reset flag.CommandLine to get rid of unwanted flags for instance from glog (used in kubernetes).
-	// And read the ones we want to keep.
-	flag.VisitAll(func(f *flag.Flag) {
-		if _, ok := flagsBlacklist[f.Name]; ok {
-			return
-		}
-		flagsToKeep = append(flagsToKeep, f)
-	})
-
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	for _, f := range flagsToKeep {
-		flag.Var(f.Value, f.Name, f.Usage)
-	}
-
 	flag.Parse()
 
 	if len(flag.Args()) > 0 {
@@ -197,16 +182,3 @@ var (
 	// Gitcommit contains the commit where we built CoreDNS from.
 	GitCommit string
 )
-
-// flagsBlacklist removes flags with these names from our flagset.
-var flagsBlacklist = map[string]struct{}{
-	"logtostderr":      {},
-	"alsologtostderr":  {},
-	"v":                {},
-	"stderrthreshold":  {},
-	"vmodule":          {},
-	"log_backtrace_at": {},
-	"log_dir":          {},
-}
-
-var flagsToKeep []*flag.Flag


### PR DESCRIPTION
The glog flag blacklisting doesn't seem to be necessary anymore as k8s
moved to klog. This was added back in the glog days.

Signed-off-by: Miek Gieben <miek@miek.nl>
