### PR TITLE
Makefile.release: Replace manifest-tool with docker manifest

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -44,11 +44,8 @@ EMPTY:=
 SPACE:=$(EMPTY) $(EMPTY)
 COMMA:=$(EMPTY),$(EMPTY)
 
-ifeq (, $(shell which curl))
+ifeq (, $(shell command -v curl))
     $(error "No curl in $$PATH, please install")
-endif
-ifeq (, $(shell which manifest-tool))
-    $(error "No manifest-tool in $$PATH, please install")
 endif
 
 DOCKER:=
@@ -56,8 +53,8 @@ NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-# mips is not in LINUX_ARCH because it's not supported by the manifest-tool.
-LINUX_ARCH:=amd64 arm arm64 ppc64le s390x
+# mips is not in LINUX_ARCH because it's not supported by docker manifest
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
 PLATFORMS:=$(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
 
 all:
@@ -77,8 +74,6 @@ build:
 	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME).exe SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="" BUILDOPTS=""
 	@echo Building: linux/mips - $(VERSION)
 	mkdir -p build/linux/mips  && $(MAKE) coredns BINARY=build/linux/mips/$(NAME) SYSTEM="GOOS=linux GOARCH=mips" CHECKS="" BUILDOPTS=""
-	@echo Building: linux/mips64le - $(VERSION)
-	mkdir -p build/linux/mips64le  && $(MAKE) coredns BINARY=build/linux/mips64le/$(NAME) SYSTEM="GOOS=linux GOARCH=mips64le" CHECKS="" BUILDOPTS=""
 	@echo Building: linux/$(LINUX_ARCH) - $(VERSION) ;\
 	for arch in $(LINUX_ARCH); do \
 	    mkdir -p build/linux/$$arch  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" BUILDOPTS="" ;\
@@ -135,11 +130,11 @@ else
 	@# 2. Copy Dockerfile to build/docker/linux/<arch>
 	@rm -rf build/docker
 	for arch in $(LINUX_ARCH); do \
-	    mkdir -p build/docker/linux/$$arch ;\
-	    tar -xzf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/docker/linux/$$arch ;\
-	    cp Dockerfile build/docker/linux/$$arch ;\
-	    docker build -t coredns build/docker/linux/$$arch ;\
-	    docker tag coredns $(DOCKER_IMAGE_NAME):coredns-$$arch ;\
+	    mkdir -p build/docker/linux/$${arch} ;\
+	    tar -xzf release/$(NAME)_$(VERSION)_linux_$${arch}.tgz -C build/docker/linux/$${arch} ;\
+	    cp Dockerfile build/docker/linux/$${arch} ;\
+	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/linux/$${arch} ;\
+	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif
 
@@ -148,13 +143,27 @@ docker-push:
 ifeq ($(DOCKER),)
 	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
 else
+	@# Experimental CLI is required for docker manifest to work
+	@# Pushes coredns/coredns-$arch:$version images
+	@# Creates manifest for multi-arch image
+	@# Pushes multi-arch image to coredns/coredns:$version
+	export DOCKER_CLI_EXPERIMENTAL=enabled
 	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
 	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
 	for arch in $(LINUX_ARCH); do \
-	    docker push $(DOCKER_IMAGE_NAME):coredns-$$arch ;\
+		docker push $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
+		docker push $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
-	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):$(VERSION)
-	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):latest
+	DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:$(VERSION)~g")
+	DOCKER_IMAGE_LIST_LATEST:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:latest~g")
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_LATEST)
+	for arch in $(LINUX_ARCH); do \
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+	done
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
 endif
 
 .PHONY: version


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This commit replaces `manifest-tool` with `docker manifest`, which should
hopefully provide a better experience for releasing coredns.

In addition it integrates mips64le (since it's supported by `docker
manifest`) in LINUX_ARCHES, so docker images for mips64le are pushed as
well.

### 2. Which issues (if any) are related?
Alternative to https://github.com/coredns/coredns/pull/4415
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
If people use them docker.io/coredns/coredns:$arch tags are not updated anymore and changed to docker.io/coredns/coredns-$arch:$version



I've tested it locally and pushed to my dockerhub namespace.

```
docker manifest inspect mrueg/coredns:1.8.1
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:4e7a16c46bb028aae66635b2131318df3015a32ff0cfee4d4086f9a8d2675af9",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:7a46d6f4fbfc1a0c2443a81f98a709d75d8cdf7da00419f3c697ef9c8d0d35b0",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:c8aba8abbb3478aea65ccc6678e2edbffe113a6298375e5cec99347b16f645d7",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:01019c876f207abb7d868e60728468dafcc678f19323ca221b2ddf31d8d96678",
         "platform": {
            "architecture": "mips64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:4b51c8aa0826f7af32b557eae79849a0a26c351e39d7e85b8115c236b5bb592b",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:d0f3e086c01762d125ac9c78765a60a6a97bd1ef430e4b65d632576cd8e74e04",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```