### PR TITLE
Fix import ordering presubmit test

### DIFF
--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/cache/freq"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 	test "github.com/coredns/coredns/plugin/test"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
 )

--- a/plugin/dnstap/writer.go
+++ b/plugin/dnstap/writer.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
 )

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/parse"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/pkg/trace/trace.go
+++ b/plugin/pkg/trace/trace.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"github.com/coredns/coredns/plugin"
+
 	ot "github.com/opentracing/opentracing-go"
 )
 

--- a/test/presubmit_test.go
+++ b/test/presubmit_test.go
@@ -293,7 +293,7 @@ func (w *testImportOrderingWalker) walk(path string, info os.FileInfo, _ error) 
 
 	// Ok, now that we have the type, let's see if all members adhere to it.
 	// After that we check if the are in the right order.
-	for i := 0; i < bl; i++ {
+	for i := 0; i <= bl; i++ {
 		for _, p := range blocks[i] {
 			t := importtype(p.Path.Value)
 			if t != ip[i] {


### PR DESCRIPTION
1 char change: '<' -> '<=', i.e. off by one error. This flagged a number
of intree files that had the wrong import ordering. Fix those as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
