### PR TITLE
Corrected detection of K8s minor version

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -257,7 +257,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (err error) {
 		return err
 	}
 	major, _ := strconv.Atoi(sv.Major)
-	minor, _ := strconv.Atoi(sv.Minor)
+	minor, _ := strconv.Atoi(strings.TrimRight(sv.Minor, "+"))
 	if k.opts.useEndpointSlices && major <= 1 && minor <= 18 {
 		log.Info("watching Endpoints instead of EndpointSlices in k8s versions < 1.19")
 		k.opts.useEndpointSlices = false


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

For not-yet-released K8s versions i.e. alpha, rc and local builds the minor version was not detected correctly.

This caused endpoints to be used when endpointslices should be used.

### 2. Which issues (if any) are related?

#4428

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No