### PR TITLE
plugin/rewrite: copy msg before rewritting

### DIFF
--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -36,7 +36,10 @@ func NewResponseReverter(w dns.ResponseWriter, r *dns.Msg) *ResponseReverter {
 }
 
 // WriteMsg records the status code and calls the underlying ResponseWriter's WriteMsg method.
-func (r *ResponseReverter) WriteMsg(res *dns.Msg) error {
+func (r *ResponseReverter) WriteMsg(res1 *dns.Msg) error {
+	// Deep copy 'res' as to not (e.g). rewrite a message that's also stored in the cache.
+	res := res1.Copy()
+
 	res.Question[0] = r.originalQuestion
 	if r.ResponseRewrite {
 		for _, rr := range res.Answer {


### PR DESCRIPTION
Copy the msg to prevent messing with the (via the pointer) original
created message that may be stored in the cache or anything other data
store.

Signed-off-by: Miek Gieben <miek@miek.nl>
