### PR TITLE
doh: set http request in writer

### DIFF
--- a/core/dnsserver/https.go
+++ b/core/dnsserver/https.go
@@ -2,6 +2,7 @@ package dnsserver
 
 import (
 	"net"
+	"net/http"
 
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 )
@@ -14,6 +15,9 @@ type DoHWriter struct {
 	raddr net.Addr
 	// laddr is our address. This can be optionally set.
 	laddr net.Addr
+
+	// request is the HTTP request we're currently handling.
+	request *http.Request
 }
 
 // RemoteAddr returns the remote address.
@@ -21,3 +25,6 @@ func (d *DoHWriter) RemoteAddr() net.Addr { return d.raddr }
 
 // LocalAddr returns the local address.
 func (d *DoHWriter) LocalAddr() net.Addr { return d.laddr }
+
+// Request returns the HTTP request
+func (d *DoHWriter) Request() *http.Request { return d.request }

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -140,7 +140,11 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Create a DoHWriter with the correct addresses in it.
 	h, p, _ := net.SplitHostPort(r.RemoteAddr)
 	port, _ := strconv.Atoi(p)
-	dw := &DoHWriter{laddr: s.listenAddr, raddr: &net.TCPAddr{IP: net.ParseIP(h), Port: port}}
+	dw := &DoHWriter{
+		laddr:   s.listenAddr,
+		raddr:   &net.TCPAddr{IP: net.ParseIP(h), Port: port},
+		request: r,
+	}
 
 	// We just call the normal chain handler - all error handling is done there.
 	// We should expect a packet to be returned that we can send to the client.


### PR DESCRIPTION
### Why 

Makes it possible to read the current http request while serving DNS and in turn modify metadata or do other custom processing based on the HTTP request rather than the DNS message.


