### PR TITLE
plugin/forward: Extensible Forwarding Policies

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -41,7 +41,7 @@ type Forward struct {
 	expire        time.Duration
 	maxConcurrent int64
 
-	policies map[string]Policy
+	extPolicy string
 
 	opts options // also here for testing
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -92,7 +92,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	var upstreamErr error
 	span = ot.SpanFromContext(ctx)
 	i := 0
-	list := f.List()
+	list := f.List(r)
 	deadline := time.Now().Add(defaultTimeout)
 	start := time.Now()
 	for time.Now().Before(deadline) {
@@ -112,7 +112,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			// All upstream proxies are dead, assume healthcheck is completely broken and randomly
 			// select an upstream to connect to.
 			r := new(random)
-			proxy = r.List(f.proxies)[0]
+			proxy = r.List(f.proxies, state.Req)[0]
 
 			HealthcheckBrokenCount.Add(1)
 		}
@@ -211,7 +211,7 @@ func (f *Forward) ForceTCP() bool { return f.opts.forceTCP }
 func (f *Forward) PreferUDP() bool { return f.opts.preferUDP }
 
 // List returns a set of proxies to be used for this client depending on the policy in f.
-func (f *Forward) List() []*Proxy { return f.p.List(f.proxies) }
+func (f *Forward) List(req *dns.Msg) []*Proxy { return f.p.List(f.proxies, req) }
 
 var (
 	// ErrNoHealthy means no healthy proxies left.

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -11,7 +11,7 @@ func TestList(t *testing.T) {
 	}
 
 	expect := []*Proxy{{addr: "2.2.2.2:53"}, {addr: "1.1.1.1:53"}, {addr: "3.3.3.3:53"}}
-	got := f.List(nil)
+	got := f.List(nil,nil)
 
 	if len(got) != len(expect) {
 		t.Fatalf("Expected: %v results, got: %v", len(expect), len(got))

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -11,7 +11,7 @@ func TestList(t *testing.T) {
 	}
 
 	expect := []*Proxy{{addr: "2.2.2.2:53"}, {addr: "1.1.1.1:53"}, {addr: "3.3.3.3:53"}}
-	got := f.List()
+	got := f.List(nil)
 
 	if len(got) != len(expect) {
 		t.Fatalf("Expected: %v results, got: %v", len(expect), len(got))

--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -1,15 +1,16 @@
 package forward
 
 import (
+	"context"
 	"math/rand"
 	"sync/atomic"
 
-	"github.com/miekg/dns"
+	"github.com/coredns/coredns/request"
 )
 
 // Policy defines a policy we use for selecting upstreams.
 type Policy interface {
-	List([]*Proxy, *dns.Msg) []*Proxy
+	List(context.Context, []*Proxy, *request.Request) []*Proxy
 	String() string
 }
 
@@ -18,7 +19,7 @@ type random struct{}
 
 func (r *random) String() string { return "random" }
 
-func (r *random) List(p []*Proxy, req *dns.Msg) []*Proxy {
+func (r *random) List(ctx context.Context, p []*Proxy, state *request.Request) []*Proxy {
 	switch len(p) {
 	case 1:
 		return p
@@ -45,7 +46,7 @@ type roundRobin struct {
 
 func (r *roundRobin) String() string { return "round_robin" }
 
-func (r *roundRobin) List(p []*Proxy, req *dns.Msg) []*Proxy {
+func (r *roundRobin) List(ctx context.Context, p []*Proxy, state *request.Request) []*Proxy {
 	poolLen := uint32(len(p))
 	i := atomic.AddUint32(&r.robin, 1) % poolLen
 
@@ -61,6 +62,6 @@ type sequential struct{}
 
 func (r *sequential) String() string { return "sequential" }
 
-func (r *sequential) List(p []*Proxy, req *dns.Msg) []*Proxy {
+func (r *sequential) List(ctx context.Context, p []*Proxy, state *request.Request) []*Proxy {
 	return p
 }

--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -3,11 +3,13 @@ package forward
 import (
 	"math/rand"
 	"sync/atomic"
+
+	"github.com/miekg/dns"
 )
 
 // Policy defines a policy we use for selecting upstreams.
 type Policy interface {
-	List([]*Proxy) []*Proxy
+	List([]*Proxy, *dns.Msg) []*Proxy
 	String() string
 }
 
@@ -16,7 +18,7 @@ type random struct{}
 
 func (r *random) String() string { return "random" }
 
-func (r *random) List(p []*Proxy) []*Proxy {
+func (r *random) List(p []*Proxy, req *dns.Msg) []*Proxy {
 	switch len(p) {
 	case 1:
 		return p
@@ -43,7 +45,7 @@ type roundRobin struct {
 
 func (r *roundRobin) String() string { return "round_robin" }
 
-func (r *roundRobin) List(p []*Proxy) []*Proxy {
+func (r *roundRobin) List(p []*Proxy, req *dns.Msg) []*Proxy {
 	poolLen := uint32(len(p))
 	i := atomic.AddUint32(&r.robin, 1) % poolLen
 
@@ -59,6 +61,6 @@ type sequential struct{}
 
 func (r *sequential) String() string { return "sequential" }
 
-func (r *sequential) List(p []*Proxy) []*Proxy {
+func (r *sequential) List(p []*Proxy, req *dns.Msg) []*Proxy {
 	return p
 }

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -69,6 +69,7 @@ func (f *Forward) OnShutdown() error {
 
 func (f *Forward) initPolicies(c *caddy.Controller) {
 	// default policies
+	f.policies = make(map[string]Policy, 3)
 	for _, pol := range []Policy{&random{}, &roundRobin{}, &sequential{}} {
 		f.policies[pol.String()] = pol
 	}

--- a/plugin/forward/setup_policy_test.go
+++ b/plugin/forward/setup_policy_test.go
@@ -18,8 +18,6 @@ func TestSetupPolicy(t *testing.T) {
 		{"forward . 127.0.0.1 {\npolicy random\n}\n", false, "random", ""},
 		{"forward . 127.0.0.1 {\npolicy round_robin\n}\n", false, "round_robin", ""},
 		{"forward . 127.0.0.1 {\npolicy sequential\n}\n", false, "sequential", ""},
-		// negative
-		{"forward . 127.0.0.1 {\npolicy random2\n}\n", true, "random", "unknown policy"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR enables the _forward_ plugin to load forwarding policies defined in other plugins.  My thinking is that it would be useful for others that need to have forwarding policies which may not be appropriate for merging in tree.

An example of such a plugin: a conditional forwarding policy, https://github.com/chrisohaver/conditional

### 2. Which issues (if any) are related?

with the example conditional plugin: #2833

### 3. Which documentation changes (if any) need to be made?

ToDo: document interface in readme.

### 4. Does this introduce a backward incompatible change or deprecation?
