### PR TITLE
make kubernetes plugin kubeconfig argument 'context' optional

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -33,7 +33,7 @@ all the zones the plugin should be authoritative for.
 kubernetes [ZONES...] {
     endpoint URL
     tls CERT KEY CACERT
-    kubeconfig KUBECONFIG CONTEXT
+    kubeconfig KUBECONFIG [CONTEXT]
     namespaces NAMESPACE...
     labels EXPRESSION
     pods POD-MODE
@@ -49,7 +49,10 @@ kubernetes [ZONES...] {
    If omitted, it will connect to k8s in-cluster using the cluster service account.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
-* `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+* `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file.
+   **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
+   It supports TLS, username and password, or token-based authentication.
+   This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
 * `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -253,15 +253,18 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			}
 		case "kubeconfig":
 			args := c.RemainingArgs()
-			if len(args) == 2 {
-				config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-					&clientcmd.ClientConfigLoadingRules{ExplicitPath: args[0]},
-					&clientcmd.ConfigOverrides{CurrentContext: args[1]},
-				)
-				k8s.ClientConfig = config
-				continue
+			if len(args) != 1 && len(args) != 2 {
+				return nil, c.ArgErr()
 			}
-			return nil, c.ArgErr()
+			overrides := &clientcmd.ConfigOverrides{}
+			if len(args) == 2 {
+				overrides.CurrentContext = args[1]
+			}
+			config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+				&clientcmd.ClientConfigLoadingRules{ExplicitPath: args[0]},
+				overrides,
+			)
+			k8s.ClientConfig = config
 		default:
 			return nil, c.Errf("unknown property '%s'", c.Val())
 		}

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -329,6 +329,19 @@ kubernetes cluster.local`,
 		},
 		{
 			`kubernetes coredns.local {
+	kubeconfig file
+}`,
+			false,
+			"",
+			1,
+			0,
+			"",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
 	kubeconfig file context
 }`,
 			false,


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Make kubernetes plugin kubeconfig argument 'context' optional.

This corefile should also work fine:
```bash
kubernetes coredns.local {
	kubeconfig file
}
```

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

kubernetes plugin document.

### 4. Does this introduce a backward incompatible change or deprecation?

None.
