### PR TITLE
plugin/transfer: only allow outgoing axfr over tcp

### DIFF
--- a/plugin/transfer/failed_write_test.go
+++ b/plugin/transfer/failed_write_test.go
@@ -20,7 +20,7 @@ func (w *badwriter) WriteMsg(res *dns.Msg) error { return fmt.Errorf("failed to 
 func TestWriteMessageFailed(t *testing.T) {
 	transfer := newTestTransfer()
 	ctx := context.TODO()
-	w := &badwriter{ResponseWriter: &test.ResponseWriter{}}
+	w := &badwriter{ResponseWriter: &test.ResponseWriter{TCP: true}}
 	m := &dns.Msg{}
 	m.SetAxfr("example.org.")
 

--- a/plugin/transfer/select_test.go
+++ b/plugin/transfer/select_test.go
@@ -47,7 +47,7 @@ func TestZoneSelection(t *testing.T) {
 	}
 	r := new(dns.Msg)
 	r.SetAxfr("sub.example.org.")
-	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	w := dnstest.NewRecorder(&test.ResponseWriter{TCP: true})
 	_, err := tr.ServeDNS(context.TODO(), w, r)
 	if err == nil {
 		t.Fatal("Expected error, got nil")

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -58,6 +58,10 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
 	}
 
+	if state.Proto() != "tcp" {
+		return dns.RcodeRefused, nil
+	}
+
 	x := longestMatch(t.xfrs, state.QName())
 	if x == nil {
 		return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -91,7 +91,7 @@ func TestTransferNonZone(t *testing.T) {
 	ctx := context.TODO()
 
 	for _, tc := range []string{"sub.example.org.", "example.test."} {
-		w := dnstest.NewRecorder(&test.ResponseWriter{})
+		w := dnstest.NewRecorder(&test.ResponseWriter{TCP: true})
 		m := &dns.Msg{}
 		m.SetAxfr(tc)
 
@@ -114,7 +114,7 @@ func TestTransferNotAXFRorIXFR(t *testing.T) {
 	transfer := newTestTransfer()
 
 	ctx := context.TODO()
-	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	w := dnstest.NewRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetQuestion("test.domain.", dns.TypeA)
 
@@ -136,7 +136,7 @@ func TestTransferAXFRExampleOrg(t *testing.T) {
 	transfer := newTestTransfer()
 
 	ctx := context.TODO()
-	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})
+	w := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetAxfr(transfer.xfrs[0].Zones[0])
 
@@ -152,7 +152,7 @@ func TestTransferAXFRExampleCom(t *testing.T) {
 	transfer := newTestTransfer()
 
 	ctx := context.TODO()
-	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})
+	w := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetAxfr(transfer.xfrs[1].Zones[0])
 
@@ -170,7 +170,7 @@ func TestTransferIXFRCurrent(t *testing.T) {
 	testPlugin := transfer.Transferers[0].(*transfererPlugin)
 
 	ctx := context.TODO()
-	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})
+	w := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetIxfr(transfer.xfrs[0].Zones[0], testPlugin.Serial, "ns.dns."+testPlugin.Zone, "hostmaster.dns."+testPlugin.Zone)
 
@@ -200,7 +200,7 @@ func TestTransferIXFRFallback(t *testing.T) {
 	testPlugin := transfer.Transferers[0].(*transfererPlugin)
 
 	ctx := context.TODO()
-	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})
+	w := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetIxfr(
 		transfer.xfrs[0].Zones[0],
@@ -262,7 +262,7 @@ func TestTransferNotAllowed(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	w := dnstest.NewRecorder(&test.ResponseWriter{TCP: true})
 	m := &dns.Msg{}
 	m.SetAxfr(transfer.xfrs[0].Zones[0])
 

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -100,7 +100,7 @@ func TestIxfrResponse(t *testing.T) {
 		}
 	}`
 
-	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	i, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
@@ -111,9 +111,11 @@ func TestIxfrResponse(t *testing.T) {
 	m.Ns = []dns.RR{test.SOA("example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600")} // copied from exampleOrg
 
 	var r *dns.Msg
+	c := new(dns.Client)
+	c.Net = "tcp"
 	// This is now async; we need to wait for it to be transferred.
 	for i := 0; i < 10; i++ {
-		r, _ = dns.Exchange(m, udp)
+		r, _, _ = c.Exchange(m, tcp)
 		if len(r.Answer) != 0 {
 			break
 		}


### PR DESCRIPTION
Return refused when the query comes in over udp.
No need to add a new test case as the current crop needed to be changed
to use TCP.

Fixes: #4450

Signed-off-by: Miek Gieben <miek@miek.nl>
