### PR TITLE
Allow dependabot to check go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

I wouldn't say this pull requested is *needed* per se. Rather it's a nice to have.

This change allows dependabot to check any Go dependency which this projects uses on a weekly basis and submit pull requests with version bumps in order to keep packages up-to-date.

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.