### PR TITLE
A noop target to Makefile.release and run it in CI

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -65,3 +65,14 @@ jobs:
       run: |
         go install github.com/fatih/faillint
         ( cd test; go test -race ./... )
+
+  test-makefile-release:
+    name: Test Makefile.release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Test Makefile
+      run: make -f Makefile.release noop

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -79,4 +79,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test Makefile
-      run: make -f Makefile.release noop
+      run: make -f Makefile.release build

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -71,6 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+   - name: Install dependencies
+      run: |
+        sudo apt-get install make curl
+
     - name: Check out code
       uses: actions/checkout@v2
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -195,7 +195,3 @@ authors:
 	@echo
 	@git log --pretty=format:'%an' $$(git describe --tags --abbrev=0)..master | sort -u | grep -v '^coredns-auto' | grep -v '^dependabot-preview' | \
 	    tac | cat -n | sed -e 's/^[[:space:]]\+1[[:space:]]\+\(.*\)/\1./' | sed -e 's/^[[:space:]]\+[[:digit:]]\+[[:space:]]\+\(.*\)/\1,/' | tac # comma separate, with dot at the end
-
-.PHONY: noop
-noop:
-	@echo noop target is to check the syntax of Makefile.release

--- a/Makefile.release
+++ b/Makefile.release
@@ -195,3 +195,7 @@ authors:
 	@echo
 	@git log --pretty=format:'%an' $$(git describe --tags --abbrev=0)..master | sort -u | grep -v '^coredns-auto' | grep -v '^dependabot-preview' | \
 	    tac | cat -n | sed -e 's/^[[:space:]]\+1[[:space:]]\+\(.*\)/\1./' | sed -e 's/^[[:space:]]\+[[:digit:]]\+[[:space:]]\+\(.*\)/\1,/' | tac # comma separate, with dot at the end
+
+.PHONY: noop
+noop:
+	@echo noop target is to check the syntax of Makefile.release


### PR DESCRIPTION
This tests the Makefile.release (at least on the CI) to be correct and
executes some of the init code. This is to catch problems early and
before we actually release and enter some half released state.

Signed-off-by: Miek Gieben <miek@miek.nl>
