### PR TITLE
Fix go-test yaml

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-   - name: Install dependencies
+    - name: Install dependencies
       run: |
         sudo apt-get install make curl
 


### PR DESCRIPTION
unsure why this only pops up, but the yaml was not correct for this
workflow. Randomly added whitespace until it parsed as proper yaml

Signed-off-by: Miek Gieben <miek@miek.nl>
