### PR TITLE
Fix coredns/ci kubernetes test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           name: Run Kubernetes tests
           command: |
             cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/ci/test/kubernetes
+            go mod download
             go test -v ./...
 
 workflows:


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

With go 1.16, reconciliation of module dependencies is no longer automatic with build/test.
This adds that manual step before the ci test, which _should_ let the test compile successfully.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
