### PR TITLE
Point to github discussion in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,4 +4,7 @@ about: A question related to CoreDNS
 labels: question
 
 ---
-<!-- Please only use this template for submitting a generic question -->
+<!--
+Please only use this template for submitting a generic question.
+Or consider using a GitHub discussion https://github.com/coredns/coredns/discussions
+-->


### PR DESCRIPTION
A generic question might be more suited for a discussion, add pointer to
the issue template.

Signed-off-by: Miek Gieben <miek@miek.nl>
