### PR TITLE
plugin/kubernetes: do endpoint/slice check in retry loop

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -104,6 +104,20 @@ kubernetes [ZONES...] {
 
 Enabling zone transfer is done by using the *transfer* plugin.
 
+## Startup
+
+When CoreDNS starts with the *kubernetes* plugin enabled, it will delay serving DNS for up to 5 seconds
+until it can connect to the Kubernetes API and synchronize all object watches.  If this cannot happen within
+5 seconds, then CoreDNS will start serving DNS while the *kubernetes* plugin continues to try to connect
+and synchronize all object watches.  CoreDNS will answer SERVFAIL to any request made for a Kubernetes record
+that has not yet been synchronized.
+
+## Monitoring Kubernetes Endpoints
+
+By default the *kubernetes* plugin watches Endpoints via the `discovery.EndpointSlices` API.  However the
+`api.Endpoints` API is used instead if the Kubernetes version does not support the `EndpointSliceProxying`
+feature gate by default (i.e. Kubernetes version < 1.19).
+
 ## Ready
 
 This plugin reports readiness to the ready plugin. This will happen after it has synced to the

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -117,19 +117,6 @@ func newdnsController(ctx context.Context, kubeClient kubernetes.Interface, opts
 		object.DefaultProcessor(object.ToService, nil),
 	)
 
-	if opts.initEndpointsCache {
-		dns.epLister, dns.epController = object.NewIndexerInformer(
-			&cache.ListWatch{
-				ListFunc:  endpointSliceListFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
-				WatchFunc: endpointSliceWatchFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
-			},
-			&discovery.EndpointSlice{},
-			cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
-			cache.Indexers{epNameNamespaceIndex: epNameNamespaceIndexFunc, epIPIndex: epIPIndexFunc},
-			object.DefaultProcessor(object.EndpointSliceToEndpoints, dns.EndpointSliceLatencyRecorder()),
-		)
-	}
-
 	if opts.initPodCache {
 		dns.podLister, dns.podController = object.NewIndexerInformer(
 			&cache.ListWatch{
@@ -140,6 +127,19 @@ func newdnsController(ctx context.Context, kubeClient kubernetes.Interface, opts
 			cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
 			cache.Indexers{podIPIndex: podIPIndexFunc},
 			object.DefaultProcessor(object.ToPod, nil),
+		)
+	}
+
+	if opts.initEndpointsCache {
+		dns.epLister, dns.epController = object.NewIndexerInformer(
+			&cache.ListWatch{
+				ListFunc:  endpointSliceListFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+				WatchFunc: endpointSliceWatchFunc(ctx, dns.client, api.NamespaceAll, dns.selector),
+			},
+			&discovery.EndpointSlice{},
+			cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
+			cache.Indexers{epNameNamespaceIndex: epNameNamespaceIndexFunc, epIPIndex: epIPIndexFunc},
+			object.DefaultProcessor(object.EndpointSliceToEndpoints, dns.EndpointSliceLatencyRecorder()),
 		)
 	}
 

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -18,10 +18,10 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
-	discovery "k8s.io/api/discovery/v1beta1"
 
 	"github.com/miekg/dns"
 	api "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -274,6 +274,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 					return nil
 				}
 			case <-timeout:
+				log.Warning("starting server with unsynced Kubernetes API")
 				return nil
 			}
 		}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin"
@@ -16,6 +18,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
+	discovery "k8s.io/api/discovery/v1beta1"
 
 	"github.com/miekg/dns"
 	api "k8s.io/api/core/v1"
@@ -246,11 +249,66 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context, c *caddy.Controller) (er
 	k.opts.zones = k.Zones
 	k.opts.endpointNameMode = k.endpointNameMode
 
-	k.APIConn = newdnsController(ctx, kubeClient, k.opts)
+	c.OnStartup(func() error {
+		go func() {
+			k.selectEndpointType(kubeClient)
+			k.APIConn = newdnsController(ctx, kubeClient, k.opts)
+			k.APIConn.Run()
+		}()
 
-	k.RegisterKubeCache(c, kubeClient)
+		timeout := time.After(5 * time.Second)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if k.APIConn.HasSynced() {
+					return nil
+				}
+			case <-timeout:
+				return nil
+			}
+		}
+	})
+
+	c.OnShutdown(func() error {
+		return k.APIConn.Stop()
+	})
 
 	return err
+}
+
+// selectEndpointType will select which endpoint object type to watch (endpointslices or endpoints)
+// based on the supportability of endpointslices in the API and server version.
+// If the API supports discovery v1 beta1, and the server versions >= 1.19, endpointslices will be watched.
+// This function should be removed, along with non-slice endpoint watch code, when support for k8s < 1.19 is dropped.
+func (k *Kubernetes) selectEndpointType(kubeClient *kubernetes.Clientset) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			sv, err := kubeClient.ServerVersion()
+			if err != nil {
+				continue
+			}
+			// Enable use of endpoint slices if the API supports the discovery v1 beta1 api
+			if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(discovery.SchemeGroupVersion.String()); err == nil {
+				k.opts.useEndpointSlices = true
+			}
+			// Disable use of endpoint slices for k8s versions 1.18 and earlier. The Endpointslices API was enabled
+			// by default in 1.17 but Service -> Pod proxy continued to use Endpoints by default until 1.19.
+			// DNS results should be built from the same source data that the proxy uses.  This decision assumes
+			// k8s EndpointSliceProxying featuregate is at the default (i.e. only enabled for k8s >= 1.19).
+			major, _ := strconv.Atoi(sv.Major)
+			minor, _ := strconv.Atoi(strings.TrimRight(sv.Minor, "+"))
+			if k.opts.useEndpointSlices && major <= 1 && minor <= 18 {
+				log.Info("Watching Endpoints instead of EndpointSlices in k8s versions < 1.19")
+				k.opts.useEndpointSlices = false
+			}
+			return
+		}
+	}
 }
 
 // Records looks up services in kubernetes.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -65,8 +65,8 @@ func setup(c *caddy.Controller) error {
 // If the API supports discovery v1 beta1, and the server versions >= 1.19, endpointslices will be watched.
 // This function should be removed, along with non-slice endpoint watch code, when support for k8s < 1.19 is dropped.
 func (k *Kubernetes) selectEndpointType(kubeClient *kubernetes.Clientset) {
+	ticker := time.NewTicker(100 * time.Millisecond)
 	for {
-		ticker := time.NewTicker(100 * time.Millisecond)
 		select {
 		case <-ticker.C:
 			sv, err := kubeClient.ServerVersion()

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -86,7 +86,6 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 
 	opts := dnsControlOpts{
 		initEndpointsCache: true,
-		useEndpointSlices:  false,
 		ignoreEmptyService: false,
 	}
 	k8s.opts = opts

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -17,9 +16,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 
 	"github.com/miekg/dns"
-	discovery "k8s.io/api/discovery/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
@@ -58,65 +55,6 @@ func setup(c *caddy.Controller) error {
 	})
 
 	return nil
-}
-
-// selectEndpointType will select which endpoint object type to watch (endpointslices or endpoints)
-// based on the supportability of endpointslices in the API and server version.
-// If the API supports discovery v1 beta1, and the server versions >= 1.19, endpointslices will be watched.
-// This function should be removed, along with non-slice endpoint watch code, when support for k8s < 1.19 is dropped.
-func (k *Kubernetes) selectEndpointType(kubeClient *kubernetes.Clientset) {
-	ticker := time.NewTicker(100 * time.Millisecond)
-	for {
-		select {
-		case <-ticker.C:
-			sv, err := kubeClient.ServerVersion()
-			if err != nil {
-				continue
-			}
-			// Enable use of endpoint slices if the API supports the discovery v1 beta1 api
-			if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(discovery.SchemeGroupVersion.String()); err == nil {
-				k.opts.useEndpointSlices = true
-			}
-			// Disable use of endpoint slices for k8s versions 1.18 and earlier. The Endpointslices API was enabled
-			// by default in 1.17 but Service -> Pod proxy continued to use Endpoints by default until 1.19.
-			// DNS results should be built from the same source data that the proxy uses.  This decision assumes
-			// k8s EndpointSliceProxying featuregate is at the default (i.e. only on for k8s >= 1.19).
-			major, _ := strconv.Atoi(sv.Major)
-			minor, _ := strconv.Atoi(strings.TrimRight(sv.Minor, "+"))
-			if k.opts.useEndpointSlices && major <= 1 && minor <= 18 {
-				log.Info("Watching Endpoints instead of EndpointSlices in k8s versions < 1.19")
-				k.opts.useEndpointSlices = false
-			}
-			return
-		}
-	}
-}
-
-// RegisterKubeCache registers KubeCache start and stop functions with Caddy
-func (k *Kubernetes) RegisterKubeCache(c *caddy.Controller, kubeClient *kubernetes.Clientset) {
-	c.OnStartup(func() error {
-		go func() {
-			k.selectEndpointType(kubeClient)
-			k.APIConn.Run()
-		}()
-
-		timeout := time.After(5 * time.Second)
-		ticker := time.NewTicker(100 * time.Millisecond)
-		for {
-			select {
-			case <-ticker.C:
-				if k.APIConn.HasSynced() {
-					return nil
-				}
-			case <-timeout:
-				return nil
-			}
-		}
-	})
-
-	c.OnShutdown(func() error {
-		return k.APIConn.Stop()
-	})
 }
 
 func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -15,11 +15,11 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
-	discovery "k8s.io/api/discovery/v1beta1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/miekg/dns"
+	discovery "k8s.io/api/discovery/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -38,9 +38,15 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error(pluginName, err)
 	}
 
-	err = k.InitKubeCache(context.Background(), c)
+	onStart, onShut, err := k.InitKubeCache(context.Background())
 	if err != nil {
 		return plugin.Error(pluginName, err)
+	}
+	if onStart != nil {
+		c.OnStartup(onStart)
+	}
+	if onShut != nil {
+		c.OnShutdown(onShut)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

 If the API server is not available when CoreDNS starts, it may [not select the correct endpoint object type to watch](https://github.com/coredns/coredns/pull/4490#issuecomment-786072526).  When the wrong endpoint type is watched, DNS records for endpoints and headless services will be incomplete/missing.

This PR does the following:
- Moves the endpointslice check logic into a retry loop.
- Puts the code into a separate function so it's easier to identify and remove when the time comes.
- Documents reasoning and assumptions for the version check.

### 2. Which issues (if any) are related?

#4490 #4338

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
