### PR TITLE
Use latest Go version

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -8,8 +8,6 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
-      with:
-        go-version: 1.15
       id: go
 
     - name: Check out code

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -8,8 +8,6 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
-      with:
-        go-version: 1.15
       id: go
 
     - name: Check out code
@@ -31,8 +29,6 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
-      with:
-        go-version: 1.15
       id: go
 
     - name: Check out code
@@ -51,8 +47,6 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
-      with:
-        go-version: 1.15
       id: go
 
     - name: Check out code

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -20,8 +20,6 @@ jobs:
       -
         name: Setup Go
         uses: actions/setup-go@v2
-        with:
-          go-version: '^1.14.1'
       -
         name: Update Docs
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coredns/coredns
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v40.6.0+incompatible


### PR DESCRIPTION
Update go.mod to 1.16 and make the workflows default to the latest
available.

Signed-off-by: Miek Gieben <miek@miek.nl>
