### PR TITLE
Use distroless base and also run coredns as nonroot.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ initWorkingDir: &initWorkingDir
 
 integrationDefaults: &integrationDefaults
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202010-01
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
     - K8S_VERSION: v1.19.1
@@ -36,7 +36,7 @@ buildCoreDNSImage: &buildCoreDNSImage
       command: |
         cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
         make coredns SYSTEM="GOOS=linux" && \
-        docker build -t coredns . && \
+        DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --load -t coredns . && \
         kind load docker-image coredns
 
 jobs:

--- a/Makefile.release
+++ b/Makefile.release
@@ -145,7 +145,7 @@ else
 	    mkdir -p build/docker/linux/$${arch} ;\
 	    tar -xzf release/$(NAME)_$(VERSION)_linux_$${arch}.tgz -C build/docker/linux/$${arch} ;\
 	    cp Dockerfile build/docker/linux/$${arch} ;\
-	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/linux/$${arch} ;\
+	    DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --load --platform linux/$${arch} -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/linux/$${arch} ;\
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
To run coredns as nonroot using the nonroot distroless base image.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
nope

### How tested:
1. I created an alternative Dockerfile as shown below. This dockerfile uses debian:stable-slim so that I could exec into the container and run /bin/bash to see if the coredns is running as non-root and what capabilities it has on it.
```
FROM --platform=linux/$BUILDARCH k8s.gcr.io/build-image/setcap:buster-v1.4.0
COPY coredns /coredns
# We apply cap_net_bind_service so that coredns can be run as
# non-root and still listen on port less than 1024
RUN setcap cap_net_bind_service=+ep /coredns


FROM debian:stable-slim

RUN apt-get update && apt-get -uy upgrade
RUN apt-get -y install ca-certificates && update-ca-certificates
RUN apt-get -y install procps libcap2-bin

COPY --from=0 /coredns /coredns

USER 1000:1000
EXPOSE 53 53/udp
ENTRYPOINT ["/coredns"]
```
2. I built the image 
```
docker buildx build -t gcr.io/vinaygo/coredns --platform linux/amd64 --load .
```
3.  Ran the image
```
docker run -d gcr.io/vinaygo/coredns
```
4. Let's see what the container is
```
docker container ls                                                      
CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS                       NAMES
cdcc8a0a825b   gcr.io/vinaygo/coredns   "/coredns"               33 minutes ago   Up 33 minutes   53/tcp, 53/udp              dazzling_ardinghelli
```
5. Exec into that container
```
docker exec -it dazzling_ardinghelli  /bin/bash 
```
6.  lets see whats running
```
I have no name!@cdcc8a0a825b:/$ ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
1000           1  0.4  0.0 748648 39428 ?        Ssl  15:56   0:00 /coredns
1000          20  0.6  0.0   3872  3268 pts/0    Ss   15:56   0:00 /bin/bash
1000          27  0.0  0.0   7644  2688 pts/0    R+   15:57   0:00 ps -aux
```
7. lets see what capabilities does coredns have
```
I have no name!@cdcc8a0a825b:/$ getcap coredns 
coredns = cap_net_bind_service+ep
```

Questions you might have:
Why do we need buildx?
buildx preserves xargs across build stages. Meaning that if we apply capabilities to a binary using setcap in one buildstage and then copy that binary to another then the capabilities stay intact. 
