### PR TITLE
workflow: move committing workflows to schedule

### DIFF
--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -1,11 +1,8 @@
 name: Go Fmt
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - '**.go'
+  schedule:
+    - cron: '22 10 * * 1'
 
 jobs:
   fix:
@@ -23,8 +20,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "coredns-auto-go-fmt[bot]"
-          git config user.email "coredns-auto-go-fmt[bot]@users.noreply.github.com"
+          git config user.name "coredns[bot]"
+          git config user.email "bot@bot.coredns.io"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes

--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -1,13 +1,8 @@
 name: Go Tidy
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - '.github/workflows/go.tidy.yml'
-      - 'go.mod'
-      - 'go.sum'
+  schedule:
+    - cron: '22 10 * * 3'
 
 jobs:
   fix:
@@ -26,8 +21,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "coredns-auto-go-mod-tidy[bot]"
-          git config user.email "coredns-auto-go-mod-tidy[bot]@users.noreply.github.com"
+          git config user.name "coredns[bot]"
+          git config user.email "bot@bot.coredns.io"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -1,14 +1,8 @@
 name: Make Doc
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - '.github/workflows/make.doc.yml'
-      - 'coredns.1.md'
-      - 'corefile.5.md'
-      - 'plugin/*/README.md'
+  schedule:
+    - cron: '22 10 * * 0'
 
 jobs:
   fix:
@@ -30,8 +24,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "coredns-auto-go-mod-tidy[bot]"
-          git config user.email "coredns-auto-go-mod-tidy[bot]@users.noreply.github.com"
+          git config user.name "coredns[bot]"
+          git config user.email "bot@bot.coredns.io"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -1,11 +1,8 @@
 name: Remove Trailing Whitespaces
 
 on:
-  push:
-    branches:
-      - 'master'
-    paths-ignore:
-      - '**.go'
+  schedule:
+    - cron: '22 10 * * 2'
 
 jobs:
   fix:
@@ -23,8 +20,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "coredns-auto-trailing-whitespaces[bot]"
-          git config user.email "coredns-auto-trailing-whitespaces[bot]@users.noreply.github.com"
+          git config user.name "coredns[bot]"
+          git config user.email "bot@bot.coredns.io"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes

--- a/Makefile.release
+++ b/Makefile.release
@@ -203,5 +203,5 @@ prs:
 authors:
 	@echo "## Brought to You By"
 	@echo
-	@git log --pretty=format:'%an' $$(git describe --tags --abbrev=0)..master | sort -u | grep -v '^coredns-auto' | grep -v '^dependabot-preview' | \
+	@git log --pretty=format:'%an' $$(git describe --tags --abbrev=0)..master | sort -u | grep -v '^coredns-auto' | grep -v '^coredns\[bot\]' | grep -v '^dependabot-preview' | \
 	    tac | cat -n | sed -e 's/^[[:space:]]\+1[[:space:]]\+\(.*\)/\1./' | sed -e 's/^[[:space:]]\+[[:digit:]]\+[[:space:]]\+\(.*\)/\1,/' | tac # comma separate, with dot at the end


### PR DESCRIPTION
This moves all workflows that commit to a schedule, so that it _doesn't_
push into peoples PRs as that enlarges them and is just non-obvious.

They run throughout the week.

Also change the "user" we use for this, so that DCO believes it a real
email address (DCO is pretty stupid here). Update the authors target to
filter out this bot as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
