### PR TITLE
plugin/bind: Discard link-local addresses on binding by interface name

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -13,7 +13,7 @@ If several addresses are provided, a listener will be open on each of the IP pro
 
 Each address has to be an IP or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
 
-If the given argument is an interface name, and that interface has serveral IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for link-local addresses on that interface.
+If the given argument is an interface name, and that interface has serveral IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for IPv6 link-local addresses on that interface.
 
 ## Syntax
 

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -13,7 +13,7 @@ If several addresses are provided, a listener will be open on each of the IP pro
 
 Each address has to be an IP or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
 
-If the given argument is an interface name, and that interface has serveral IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6).
+If the given argument is an interface name, and that interface has serveral IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for link-local addresses on that interface.
 
 ## Syntax
 

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -36,8 +36,10 @@ func setup(c *caddy.Controller) error {
 						return plugin.Error("bind", fmt.Errorf("failed to get the IP(s) of the interface: %s", arg))
 					}
 					for _, addr := range addrs {
-						if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLinkLocalMulticast() && !ipnet.IP.IsLinkLocalUnicast() {
-							all = append(all, ipnet.IP.String())
+						if ipnet, ok := addr.(*net.IPNet); ok {
+							if ipnet.IP.To4() != nil || (!ipnet.IP.IsLinkLocalMulticast() && !ipnet.IP.IsLinkLocalUnicast()) {
+								all = append(all, ipnet.IP.String())
+							}
 						}
 					}
 				}

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -36,7 +36,7 @@ func setup(c *caddy.Controller) error {
 						return plugin.Error("bind", fmt.Errorf("failed to get the IP(s) of the interface: %s", arg))
 					}
 					for _, addr := range addrs {
-						if ipnet, ok := addr.(*net.IPNet); ok {
+						if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLinkLocalMulticast() && !ipnet.IP.IsLinkLocalUnicast() {
 							all = append(all, ipnet.IP.String())
 						}
 					}


### PR DESCRIPTION
Signed-off-by: Mohammad Yosefpor <myusefpur@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Binding doesn't work on link local IPv6 addresses (`fe80::/10`). I found multiple stackoverflow/github issues related to binding on IPv6 link-local (e.g. [this](https://stackoverflow.com/questions/30984656/socket-programming-bind-invalid-argument) or [this](https://github.com/cytopia/pwncat/issues/89) ) explaining why this does not work. It seems we need to also specify scope_id in binding. So it needs changes in coredns/core and caddy parts if we want to be able to bind on link local addresses as well.

So I suggest, we add a `IsLinkLocalUnicast()` check and discard link-local IPv6 addresses, and specify a `except for link-local addresses` in readme.

Without this, bind by interface name feature does not work with interfaces with link local address (which in some distros it has by default), so using those interface names will not work then. We should either discard them (what has been done in this PR), or change caddy code to allow binding on link-local addresses.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4219
https://github.com/coredns/coredns/pull/4522

### 3. Which documentation changes (if any) need to be made?
Changed README.md

### 4. Does this introduce a backward incompatible change or deprecation?
It has backward compatibility.