### PR TITLE
plugin/bind: tweak error messages

### DIFF
--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -33,7 +33,7 @@ func setup(c *caddy.Controller) error {
 					isIface = true
 					addrs, err := iface.Addrs()
 					if err != nil {
-						return plugin.Error("bind", fmt.Errorf("failed to get the IP(s) of the interface: %s", arg))
+						return plugin.Error("bind", fmt.Errorf("failed to get the IP addresses of the interface: %q", arg))
 					}
 					for _, addr := range addrs {
 						if ipnet, ok := addr.(*net.IPNet); ok {
@@ -44,7 +44,7 @@ func setup(c *caddy.Controller) error {
 			}
 			if !isIface {
 				if net.ParseIP(arg) == nil {
-					return plugin.Error("bind", fmt.Errorf("not a valid IP address: %s", arg))
+					return plugin.Error("bind", fmt.Errorf("not a valid IP address or interface name: %q", arg))
 				}
 				all = append(all, arg)
 			}


### PR DESCRIPTION
When the interface doesn't exist you get:

plugin/bind: not a valid IP address: eth0

Fix the wording that this can also be interface name. Also %q the
argument in the error mesg.

Signed-off-by: Miek Gieben <miek@miek.nl>
