### PR TITLE
plugin/health: add logging for local health request

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -27,7 +27,7 @@ health [ADDRESS] {
 ~~~
 
 * Where `lameduck` will delay shutdown for **DURATION**. /health will still answer 200 OK.
-  Note: The *ready* plugin will not answer OK while CoreDNS is in lameduck mode prior to shutdown.
+  Note: The *ready* plugin will not answer OK while CoreDNS is in lame duck mode prior to shutdown.
 
 If you have multiple Server Blocks, *health* can only be enabled in one of them (as it is process
 wide). If you really need multiple endpoints, you must run health endpoints on different ports:
@@ -67,7 +67,7 @@ Run another health endpoint on http://localhost:8091.
 }
 ~~~
 
-Set a lameduck duration of 1 second:
+Set a lame duck duration of 1 second:
 
 ~~~ corefile
 . {


### PR DESCRIPTION
This adds some logging if the local health process errors or takes too
long. Too long here is 1s (which is random-ish). The timeout has been
set to 3s. It will log something like:

[WARNING] plugin/health: Local health request to "http://:8080/health" took more than 1s: 2.001739243s

Signed-off-by: Miek Gieben <miek@miek.nl>
