### PR TITLE
metrics: remove RR type

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -130,11 +129,9 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts options
 		rc = strconv.Itoa(ret.Rcode)
 	}
 
-	qtype := dnsutil.QTypeMonitorLabel(state.QType())
-
 	RequestCount.WithLabelValues(p.addr).Add(1)
 	RcodeCount.WithLabelValues(rc, p.addr).Add(1)
-	RequestDuration.WithLabelValues(p.addr, rc, qtype).Observe(time.Since(start).Seconds())
+	RequestDuration.WithLabelValues(p.addr, rc).Observe(time.Since(start).Seconds())
 
 	return ret, nil
 }

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -27,7 +27,7 @@ var (
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time each request took.",
-	}, []string{"to", "rcode", "type"})
+	}, []string{"to", "rcode"})
 	HealthcheckFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",

--- a/plugin/metrics/vars/monitor.go
+++ b/plugin/metrics/vars/monitor.go
@@ -1,4 +1,4 @@
-package dnsutil
+package vars
 
 import (
 	"github.com/miekg/dns"
@@ -25,13 +25,11 @@ var monitorType = map[uint16]struct{}{
 	dns.TypeANY:  {},
 }
 
-const other = "other"
-
-// QTypeMonitorLabel returns dns type label based on a list of monitored types.
-// Will return "other" for unmonitored ones.
-func QTypeMonitorLabel(qtype uint16) string {
+// qTypeString returns the RR type based on monitorType. It returns the text representation
+// of thosAe types. RR types not in that list will have "other" returned.
+func qTypeString(qtype uint16) string {
 	if _, known := monitorType[qtype]; known {
 		return dns.Type(qtype).String()
 	}
-	return other
+	return "other"
 }

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -3,7 +3,6 @@ package vars
 import (
 	"time"
 
-	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 )
 
@@ -18,14 +17,14 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 		fam = "2"
 	}
 
-	qtype := dnsutil.QTypeMonitorLabel(req.QType())
-
 	if req.Do() {
 		RequestDo.WithLabelValues(server, zone).Inc()
 	}
 
+	qtype := qTypeString(req.QType())
 	RequestCount.WithLabelValues(server, zone, net, fam, qtype).Inc()
-	RequestDuration.WithLabelValues(server, zone, qtype).Observe(time.Since(start).Seconds())
+
+	RequestDuration.WithLabelValues(server, zone).Observe(time.Since(start).Seconds())
 
 	ResponseSize.WithLabelValues(server, zone, net).Observe(float64(size))
 	RequestSize.WithLabelValues(server, zone, net).Observe(float64(req.Len()))

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -21,14 +21,14 @@ var (
 		Subsystem: subsystem,
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
-		Help:      "Histogram of the time (in seconds) each request took.",
-	}, []string{"server", "zone", "type"})
+		Help:      "Histogram of the time (in seconds) each request took per zone.",
+	}, []string{"server", "zone"})
 
 	RequestSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: subsystem,
 		Name:      "request_size_bytes",
-		Help:      "Size of the EDNS0 UDP buffer in bytes (64K for TCP).",
+		Help:      "Size of the EDNS0 UDP buffer in bytes (64K for TCP) per zone and protocol.",
 		Buckets:   []float64{0, 100, 200, 300, 400, 511, 1023, 2047, 4095, 8291, 16e3, 32e3, 48e3, 64e3},
 	}, []string{"server", "zone", "proto"})
 


### PR DESCRIPTION
To combat label cardinality explosions remove the type from metrics.
This was most severe in the histogram for request duration, but remove
it everywhere. This also allow for the removal of dnsutil metric type
stuff; signaling "this is probably not a good idea".

It's also highlighted difference between grpc and forward code, where
forward did use type and grpc didn't; getting rid of all that "fixes"
that discrepancy

Fixes: #4507

Signed-off-by: Miek Gieben <miek@miek.nl>
