### PR TITLE
plugin/cache: add refresh_stale parameter

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -38,6 +38,7 @@ cache [TTL] [ZONES...] {
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
     serve_stale [DURATION]
+    refresh_stale MODE
 }
 ~~~
 
@@ -57,7 +58,9 @@ cache [TTL] [ZONES...] {
 * `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
   available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
   entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default duration is 1h.
+* `refresh_stale` specifies a refresh mode for `serve_stale`. The default is `async`.
+  * `async` mode will return an expired entry and attempt to refresh it asynchronously
+  * `sync` mode will synchronously refresh an expired entry, and will serve an expired entry only after refresh has failed or exceeded the timeout.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,6 +36,7 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
+	refreshMode string
 	staleUpTo time.Duration
 
 	// Testing.
@@ -222,6 +223,10 @@ const (
 	minTTL  = dnsutil.MinimalDefaultTTL
 	maxNTTL = dnsutil.MaximumDefaulTTL / 2
 	minNTTL = dnsutil.MinimalDefaultTTL
+
+	// serve_stale refresh mode.
+	refreshAsync = "async"
+	refreshSync = "sync"
 
 	defaultCap = 10000 // default capacity of the cache.
 

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -38,9 +38,12 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	if i != nil {
 		ttl = i.ttl(now)
 	}
-	if i == nil {
+	if i == nil || (ttl < 0 && c.refreshMode == refreshSync) {
 		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do}
-		return c.doRefresh(ctx, state, crr)
+		rcode, err := c.doRefresh(ctx, state, crr)
+		if i == nil || rcode == dns.RcodeSuccess {
+			return rcode, err
+		}
 	}
 	if ttl < 0 {
 		servedStale.WithLabelValues(server).Inc()

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/coredns/caddy"
@@ -183,6 +184,19 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, errors.New("invalid negative duration for serve_stale")
 					}
 					ca.staleUpTo = d
+				}
+			case "refresh_stale":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				switch x := strings.ToLower(args[0]); x {
+				case "async":
+					ca.refreshMode = refreshAsync
+				case "sync":
+					ca.refreshMode = refreshSync
+				default:
+					return nil, c.Errf("unknown refresh_stale mode '%s'", x)
 				}
 			default:
 				return nil, c.ArgErr()


### PR DESCRIPTION
The `refresh_stale` parameter can be set to `sync` in order
to ensure that TTL is respected when the upstream is available.
This does not negate cache benefits, because refresh will
not occur until the TTL expires. If the upstream is not
responsive, then `sync` will delay the response until the
upstream request has failed. This behavior is useful for
cases where the extra request time introduced by an
unhealthy upstream would be less harmful than it would be
to receive an expired entry which is no longer valid.

* `refresh_stale` specifies a refresh mode for `serve_stale`. The default is `async`.
  * `async` mode will return an expired entry and attempt to refresh it asynchronously
  * `sync` mode will synchronously refresh an expired entry, and will serve an expired entry only after refresh has failed or exceeded the timeout.

See #4097

Signed-off-by: Zac Medico <zmedico@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

It aims to solve #4097, by adding a `refresh_stale sync` setting which ensures that `serve_stale` respects TTL when the upstream is healthy.

### 2. Which issues (if any) are related?

#4097

### 3. Which documentation changes (if any) need to be made?

I've added some documentation to plugin/cache/README.md .

### 4. Does this introduce a backward incompatible change or deprecation?

There is no change unless the new `refresh_stale sync` setting is present.