### PR TITLE
Add field to rewrite plugin to support flag rewrites.

### DIFF
--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -291,6 +291,18 @@ rewrite edns0 subnet set 24 56
 * If the query's source IP address is an IPv4 address, the first 24 bits in the IP will be the network subnet.
 * If the query's source IP address is an IPv6 address, the first 56 bits in the IP will be the network subnet.
 
+### Flag Response Rewrites
+Using the FIELD `flag` you can set or clear the flags in the responses. The syntax of the rule is as follows:
+
+```
+rewrite [continue|stop] flag [set|clear] STRING
+```
+Following example add recursive available flag to the response:
+```
+rewrite flag set ra
+```
+Currently supported flag include `aa`, `ra` and `rd`.
+
 ## Full Syntax
 
 The full plugin usage syntax is harder to digest...

--- a/plugin/rewrite/flag.go
+++ b/plugin/rewrite/flag.go
@@ -1,0 +1,79 @@
+// Package rewrite is a plugin for rewriting requests internally to something different.
+package rewrite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// possible actions for the flags
+const (
+	setAction   = "set"
+	clearAction = "clear"
+)
+
+// current supported flags
+const (
+	authoritative      = "aa"
+	recursionAvailable = "ra"
+	recursionDesired   = "rd"
+)
+
+type flagRule struct {
+	action     string
+	flag       string
+	nextAction string
+}
+
+func newFlagRule(nextAction string, args ...string) (Rule, error) {
+	action := strings.ToLower(args[0])
+	if action != setAction && action != clearAction {
+		return nil, fmt.Errorf("invalid action: %s", action)
+	}
+
+	flag := strings.ToLower(args[1])
+	switch flag {
+	case authoritative:
+	case recursionAvailable:
+	case recursionDesired:
+	default:
+		return nil, fmt.Errorf("invalid flag: %s", flag)
+	}
+	return &flagRule{
+		action:     action,
+		flag:       flag,
+		nextAction: nextAction,
+	}, nil
+}
+
+func (rule *flagRule) Rewrite(ctx context.Context, state request.Request) Result { return RewriteDone }
+
+func (rule *flagRule) Mode() string { return rule.nextAction }
+
+func (rule *flagRule) GetResponseRules() []ResponseRule {
+	return []ResponseRule{
+		{
+			Active: true,
+			Type:   "flag",
+			Flag:   rule,
+		},
+	}
+}
+
+func (rule *flagRule) rewriteFlag(dns *dns.Msg) {
+	actionValue := rule.action == setAction
+	if rule.flag == authoritative && dns.Authoritative != actionValue {
+		dns.Authoritative = actionValue
+	}
+	if rule.flag == recursionAvailable && dns.RecursionAvailable != actionValue {
+		dns.RecursionAvailable = actionValue
+	}
+	if rule.flag == recursionDesired && dns.RecursionDesired != actionValue {
+		dns.RecursionDesired = actionValue
+	}
+}

--- a/plugin/rewrite/flag_test.go
+++ b/plugin/rewrite/flag_test.go
@@ -1,0 +1,118 @@
+package rewrite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestNewFlagRule(t *testing.T) {
+	tests := []struct {
+		next         string
+		args         []string
+		expectedFail bool
+	}{
+		{"stop", []string{"clear", "aa"}, false},
+		{"stop", []string{"clear", "ra"}, false},
+		{"stop", []string{"clear", "rd"}, false},
+		{"stop", []string{"set", "aa"}, false},
+		{"stop", []string{"set", "ra"}, false},
+		{"stop", []string{"set", "rd"}, false},
+		{"continue", []string{"clear", "aa"}, false},
+		{"continue", []string{"set", "rd"}, false},
+		{"stop", []string{"set", "xx"}, true},
+		{"stop", []string{"remove", "aa"}, true},
+	}
+	for i, tc := range tests {
+		failed := false
+		rule, err := newFlagRule(tc.next, tc.args...)
+		if err != nil {
+			failed = true
+		}
+		if !failed && !tc.expectedFail {
+			continue
+		}
+		if failed && tc.expectedFail {
+			continue
+		}
+		t.Fatalf("Test %d: FAIL, expected fail=%t, but received fail=%t: (%s) %s, rule=%v", i, tc.expectedFail, failed, tc.next, tc.args, rule)
+	}
+	for i, tc := range tests {
+		failed := false
+		tc.args = append([]string{tc.next, "flag"}, tc.args...)
+		rule, err := newRule(tc.args...)
+		if err != nil {
+			failed = true
+		}
+		if !failed && !tc.expectedFail {
+			continue
+		}
+		if failed && tc.expectedFail {
+			continue
+		}
+		t.Fatalf("Test %d: FAIL, expected fail=%t, but received fail=%t: (%s) %s, rule=%v", i, tc.expectedFail, failed, tc.next, tc.args, rule)
+	}
+}
+
+func TestFlagRewrite(t *testing.T) {
+
+	ctx, close := context.WithCancel(context.TODO())
+	defer close()
+
+	tests := []struct {
+		next          string
+		args          []string
+		expectedFlag  string
+		expectedValue bool
+	}{
+		{"stop", []string{"clear", "aa"}, authoritative, false},
+		{"stop", []string{"clear", "rd"}, recursionDesired, false},
+		{"stop", []string{"clear", "ra"}, recursionAvailable, false},
+		{"stop", []string{"set", "aa"}, authoritative, true},
+		{"stop", []string{"set", "ra"}, recursionAvailable, true},
+		{"stop", []string{"set", "rd"}, recursionDesired, true},
+	}
+
+	for _, tc := range tests {
+		r, err := newFlagRule(tc.next, tc.args...)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err)
+		}
+
+		rw := Rewrite{
+			Next:     plugin.HandlerFunc(msgPrinter),
+			Rules:    []Rule{r},
+			noRevert: false,
+		}
+
+		m := new(dns.Msg)
+		m.SetQuestion("coredns.rocks", dns.TypeA)
+		m.Question[0].Qclass = dns.ClassINET
+		m.Answer = []dns.RR{test.A("coredns.rocks.  5   IN  A  10.0.0.1")}
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		_, err = rw.ServeDNS(ctx, rec, m)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err)
+		}
+
+		var actual bool
+		switch tc.expectedFlag {
+		case authoritative:
+			actual = rec.Msg.Authoritative
+		case recursionAvailable:
+			actual = rec.Msg.RecursionAvailable
+		case recursionDesired:
+			actual = rec.Msg.RecursionDesired
+		}
+
+		if actual != tc.expectedValue {
+			t.Fatalf("Expected rewrite flag=%s to %v, got %v", tc.expectedFlag, tc.expectedValue, actual)
+		}
+	}
+}

--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -15,6 +15,7 @@ type ResponseRule struct {
 	Pattern     *regexp.Regexp
 	Replacement string
 	TTL         uint32
+	Flag        *flagRule
 }
 
 // ResponseReverter reverses the operations done on the question section of a packet.
@@ -83,7 +84,12 @@ func rewriteResourceRecord(res *dns.Msg, rr dns.RR, r *ResponseReverter) {
 		case "ttl":
 			ttl = rule.TTL
 			isTTLRewritten = true
+		case "flag":
+			if rule.Flag != nil {
+				rule.Flag.rewriteFlag(res)
+			}
 		}
+
 	}
 
 	if isNameRewritten {

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -128,6 +128,11 @@ func newRule(args ...string) (Rule, error) {
 		return newEdns0Rule(mode, args[startArg:]...)
 	case "ttl":
 		return newTTLRule(mode, args[startArg:]...)
+	case "flag":
+		if expectNumArgs != 3 {
+			return nil, fmt.Errorf("%s rules must have exactly two arguments", ruleType)
+		}
+		return newFlagRule(mode, args[startArg:]...)
 	default:
 		return nil, fmt.Errorf("invalid rule type %q", args[0])
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
There are cases where users want to change the response flags to fit their needs. e.g `dnsmasqd` needs `ra` for caching so having a generic way to changes response might be helpful in such cases. 

Also, this is just a draft of an idea I had so I am sure it can be further improved. It would be great if I can please get the maintainers review on this? 
### 2. Which issues (if any) are related?
#4435
### 3. Which documentation changes (if any) need to be made?
The usage for the plugin needs to be added to documentation.
### 4. Does this introduce a backward incompatible change or deprecation?
No