### PR TITLE
plugin/bind: exclude interface or ip address

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -80,6 +80,7 @@ You can exclude some addresses by their IP or interface name (The following will
         exclude 127.0.0.1
     }
 }
+~~~
 
 ## Bugs
 

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -20,22 +20,22 @@ If the given argument is an interface name, and that interface has serveral IP a
 In its basic form, a simple bind uses this syntax:
 
 ~~~ txt
-bind ADDRESS  ...
+bind ADDRESS|IFACE  ...
 ~~~
 
 You can also exclude some addresses with their IP address or interface name in expanded syntax:
 
 ~~~
-bind ADDRESS ... {
-    except ADDRESS ...
+bind ADDRESS|IFACE ... {
+    except ADDRESS|IFACE ...
 }
 ~~~
 
 
 
-* **ADDRESS** is an IP address or interface name to bind to.
+* **ADDRESS|IFACE** is an IP address or interface name to bind to.
 When several addresses are provided a listener will be opened on each of the addresses. Please read the *Description* for more details.
-* `except`, exclude interfaces or ip addresses to bind to. `except` option only exclude addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
+* `except`, excludes interfaces or ip addresses to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
 ## Examples
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):
@@ -72,12 +72,12 @@ The following server block, binds on localhost with its interface name (both "12
 }
 ~~~
 
-You can exclude some addresses by their IP or interface name (The following will only listen on `::1`):
+You can exclude some addresses by their IP or interface name (The following will only listen on `::1` or whatever addresses have been assigned to the `lo` interface):
 
 ~~~ corefile
 . {
     bind lo {
-        exclude 127.0.0.1
+        except 127.0.0.1
     }
 }
 ~~~

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -17,13 +17,25 @@ If the given argument is an interface name, and that interface has serveral IP a
 
 ## Syntax
 
+In its basic form, a simple bind uses this syntax:
+
 ~~~ txt
 bind ADDRESS  ...
 ~~~
 
-**ADDRESS** is an IP address to bind to.
-When several addresses are provided a listener will be opened on each of the addresses.
+You can also exclude some addresses with their IP address or interface name in expanded syntax:
 
+~~~
+bind ADDRESS ... {
+    except ADDRESS ...
+}
+~~~
+
+
+
+* **ADDRESS** is an IP address or interface name to bind to.
+When several addresses are provided a listener will be opened on each of the addresses. Please read the *Description* for more details.
+* `except`, exclude interfaces or ip addresses to bind to. `except` option only exclude addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
 ## Examples
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):
@@ -59,6 +71,15 @@ The following server block, binds on localhost with its interface name (both "12
     bind lo
 }
 ~~~
+
+You can exclude some addresses by their IP or interface name (The following will only listen on `::1`):
+
+~~~ corefile
+. {
+    bind lo {
+        exclude 127.0.0.1
+    }
+}
 
 ## Bugs
 

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -35,7 +35,7 @@ bind ADDRESS|IFACE ... {
 
 * **ADDRESS|IFACE** is an IP address or interface name to bind to.
 When several addresses are provided a listener will be opened on each of the addresses. Please read the *Description* for more details.
-* `except`, excludes interfaces or ip addresses to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
+* `except`, excludes interfaces or IP addresses to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
 ## Examples
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):

--- a/plugin/bind/bind.go
+++ b/plugin/bind/bind.go
@@ -1,6 +1,17 @@
 // Package bind allows binding to a specific interface instead of bind to all of them.
 package bind
 
-import "github.com/coredns/coredns/plugin"
+import (
+	"github.com/coredns/coredns/plugin"
+)
 
 func init() { plugin.Register("bind", setup) }
+
+type bind struct {
+	Next     plugin.Handler
+	includes []string
+	excludes []string
+}
+
+// Name implements plugin.Handler.
+func (b *bind) Name() string { return "bind" }

--- a/plugin/bind/bind.go
+++ b/plugin/bind/bind.go
@@ -8,9 +8,9 @@ import (
 func init() { plugin.Register("bind", setup) }
 
 type bind struct {
-	Next     plugin.Handler
-	includes []string
-	excludes []string
+	Next   plugin.Handler
+	addrs  []string
+	except []string
 }
 
 // Name implements plugin.Handler.

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -1,6 +1,7 @@
 package bind
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -10,48 +11,101 @@ import (
 )
 
 func setup(c *caddy.Controller) error {
-	config := dnsserver.GetConfig(c)
 
+	config := dnsserver.GetConfig(c)
 	// addresses will be consolidated over all BIND directives available in that BlocServer
 	all := []string{}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return plugin.Error("bind", fmt.Errorf("failed to get interfaces list"))
+	}
+
 	for c.Next() {
-		args := c.RemainingArgs()
-		if len(args) == 0 {
-			return plugin.Error("bind", fmt.Errorf("at least one address or interface name is expected"))
-		}
-
-		ifaces, err := net.Interfaces()
+		b, err := parse(c)
 		if err != nil {
-			return plugin.Error("bind", fmt.Errorf("failed to get interfaces list"))
+			return plugin.Error("bind", err)
 		}
 
-		var isIface bool
-		for _, arg := range args {
-			isIface = false
-			for _, iface := range ifaces {
-				if arg == iface.Name {
-					isIface = true
-					addrs, err := iface.Addrs()
-					if err != nil {
-						return plugin.Error("bind", fmt.Errorf("failed to get the IP addresses of the interface: %q", arg))
-					}
-					for _, addr := range addrs {
-						if ipnet, ok := addr.(*net.IPNet); ok {
-							if ipnet.IP.To4() != nil || (!ipnet.IP.IsLinkLocalMulticast() && !ipnet.IP.IsLinkLocalUnicast()) {
-								all = append(all, ipnet.IP.String())
-							}
+		includes, err := listIP(b.includes, ifaces)
+		if err != nil {
+			return err
+		}
+
+		excludes, err := listIP(b.excludes, ifaces)
+		if err != nil {
+			return err
+		}
+
+		for _, ip := range includes {
+			if !isIn(ip, excludes) {
+				all = append(all, ip)
+			}
+		}
+	}
+
+	config.ListenHosts = all
+	return nil
+}
+
+func parse(c *caddy.Controller) (*bind, error) {
+	b := &bind{}
+	b.includes = c.RemainingArgs()
+	if len(b.includes) == 0 {
+		return nil, plugin.Error("bind", fmt.Errorf("at least one address or interface name is expected"))
+	}
+	for c.NextBlock() {
+		switch c.Val() {
+		case "exclude":
+			b.excludes = c.RemainingArgs()
+			if len(b.excludes) == 0 {
+				return nil, errors.New("at least one exclude must be given to exclude subdirective")
+			}
+		default:
+			return nil, fmt.Errorf("invalid option %q", c.Val())
+		}
+	}
+	return b, nil
+}
+
+// listIP returns a list of IP addresses from a list of arguments which can be either IP-Address or Interface-Name.
+func listIP(args []string, ifaces []net.Interface) ([]string, error) {
+	all := []string{}
+	var isIface bool
+	for _, a := range args {
+		isIface = false
+		for _, iface := range ifaces {
+			if a == iface.Name {
+				isIface = true
+				addrs, err := iface.Addrs()
+				if err != nil {
+					return nil, plugin.Error("bind", fmt.Errorf("failed to get the IP addresses of the interface: %q", a))
+				}
+				for _, addr := range addrs {
+					if ipnet, ok := addr.(*net.IPNet); ok {
+						if ipnet.IP.To4() != nil || (!ipnet.IP.IsLinkLocalMulticast() && !ipnet.IP.IsLinkLocalUnicast()) {
+							all = append(all, ipnet.IP.String())
 						}
 					}
 				}
 			}
-			if !isIface {
-				if net.ParseIP(arg) == nil {
-					return plugin.Error("bind", fmt.Errorf("not a valid IP address or interface name: %q", arg))
-				}
-				all = append(all, arg)
+		}
+		if !isIface {
+			if net.ParseIP(a) == nil {
+				return nil, plugin.Error("bind", fmt.Errorf("not a valid IP address or interface name: %q", a))
 			}
+			all = append(all, a)
 		}
 	}
-	config.ListenHosts = all
-	return nil
+	return all, nil
+}
+
+// isIn checks if a string array contains an element
+func isIn(s string, list []string) bool {
+	is := false
+	for _, l := range list {
+		if s == l {
+			is = true
+		}
+	}
+	return is
 }

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -26,18 +26,18 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("bind", err)
 		}
 
-		includes, err := listIP(b.includes, ifaces)
+		ips, err := listIP(b.addrs, ifaces)
 		if err != nil {
 			return err
 		}
 
-		excludes, err := listIP(b.excludes, ifaces)
+		except, err := listIP(b.except, ifaces)
 		if err != nil {
 			return err
 		}
 
-		for _, ip := range includes {
-			if !isIn(ip, excludes) {
+		for _, ip := range ips {
+			if !isIn(ip, except) {
 				all = append(all, ip)
 			}
 		}
@@ -49,16 +49,16 @@ func setup(c *caddy.Controller) error {
 
 func parse(c *caddy.Controller) (*bind, error) {
 	b := &bind{}
-	b.includes = c.RemainingArgs()
-	if len(b.includes) == 0 {
+	b.addrs = c.RemainingArgs()
+	if len(b.addrs) == 0 {
 		return nil, plugin.Error("bind", fmt.Errorf("at least one address or interface name is expected"))
 	}
 	for c.NextBlock() {
 		switch c.Val() {
-		case "exclude":
-			b.excludes = c.RemainingArgs()
-			if len(b.excludes) == 0 {
-				return nil, errors.New("at least one exclude must be given to exclude subdirective")
+		case "except":
+			b.except = c.RemainingArgs()
+			if len(b.except) == 0 {
+				return nil, errors.New("at least one address or interface must be given to except subdirective")
 			}
 		default:
 			return nil, fmt.Errorf("invalid option %q", c.Val())

--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -20,6 +20,7 @@ func TestSetup(t *testing.T) {
 		{`bind ::1 1.2.3.4 ::5 127.9.9.0`, []string{"::1", "1.2.3.4", "::5", "127.9.9.0"}, false},
 		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, true},
 		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, false},
+		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, false},
 	} {
 		c := caddy.NewTestController("dns", test.config)
 		err := setup(c)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
As per discussions in https://github.com/coredns/coredns/issues/4219 , this PR implements `except` directive for bind plugin.

```
. {
    bind lo {
        except 127.0.0.1
    }
}
```

**IMPORTANT NOTE:** This PR does not currently work with wildcard binding. e.g.

```
. {
  bind :: {
    except 127.0.0.1
  }
```

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4219

### 3. Which documentation changes (if any) need to be made?
README.md has changed.

### 4. Does this introduce a backward incompatible change or deprecation?
No it is backward compatible.
