### PR TITLE
fix: reload metrics failed count

### DIFF
--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -70,7 +70,7 @@ func setup(c *caddy.Controller) error {
 	r.setUsage(used)
 	once.Do(func() {
 		caddy.RegisterEventHook("reload", hook)
-		c.OnRestart(func() error {
+		c.OnStartup(func() error {
 			metrics.MustRegister(c, reloadInfo, failedCount)
 			return nil
 		})


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
When I check the reload failed count metrics in my local cluster, it is not shown.

### 2. Which issues (if any) are related?
After some investigation, it may be a bug.

https://pkg.go.dev/github.com/inverse-inc/packetfence/go/caddy/caddy#Controller.OnRestart

It was only called when caddy restarts.
Reload is not `restart`?


### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
None