### PR TITLE
Disable CodeCov on commit push

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -1,5 +1,5 @@
 name: Go Coverage
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   test:
     name: Coverage


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

As commit push holds write access of GITHUB_TOKEN, we may
want to limit the scope of third-party test run.

This PR disable CodeCov on commit push. Pull request is still ok.


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>