### PR TITLE
plugin/kubernetes: Exclude unready endpoints from endpointslices

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -127,6 +127,9 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
+		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+			continue
+		}
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Records are incorrectly created for unready endpoints received via the Endpointslices watch.
The EndpointSlices API doesn't list unready endpoint addresses in a separate list as the Endpoints API did, so the condition must be explicitly checked.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
