### PR TITLE
plugin/kubernetes: collect endpoint node name from endpointslices

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -135,7 +135,9 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 			if end.TargetRef != nil {
 				ea.TargetRefName = end.TargetRef.Name
 			}
-			// EndpointSlice does not contain NodeName, leave blank
+			if end.NodeName != nil {
+				ea.NodeName = *end.NodeName
+			}
 			e.Subsets[0].Addresses = append(e.Subsets[0].Addresses, ea)
 			e.IndexIP = append(e.IndexIP, a)
 		}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Collect endpoint node name from endopintslices, as we do from endpoints.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
