### PR TITLE
plugin/forward: Add option for local address

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -51,7 +51,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec]
     max_concurrent MAX
-    local_address IP [to TO]
+    local_addr IP [to TO]
 }
 ~~~
 
@@ -93,9 +93,9 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
-* `local_address` **IP** `to` **TO** will send forwarded requests to the upstream **TO** using the local address **IP**,
+* `local_addr` **IP** `to` **TO** will send forwarded requests to the upstream **TO** using the local address **IP**,
   instead of letting the system select the local address.  **TO** must be in the form of `ip-address:port`.
-  If **TO** is omitted, the local address is used for all upstreams, providing that another `local_address` is not
+  If **TO** is omitted, the local address is used for all upstreams, providing that another `local_addr` is not
   defined for a given upstream.  This may be used more than once do define different local addresses for different upstreams.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -51,6 +51,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec]
     max_concurrent MAX
+    local_address IP [to TO]
 }
 ~~~
 
@@ -92,6 +93,10 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `local_address` **IP** `to` **TO** will send forwarded requests to the upstream **TO** using the local address **IP**,
+  instead of letting the system select the local address.  **TO** must be in the form of `ip-address:port`.
+  If **TO** is omitted, the local address is used for all upstreams, providing that another `local_address` is not
+  defined for a given upstream.  This may be used more than once do define different local addresses for different upstreams.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net"
 	"sync/atomic"
 	"time"
 
@@ -41,7 +42,8 @@ type Forward struct {
 	maxfails      uint32
 	expire        time.Duration
 	maxConcurrent int64
-
+	localAddr     net.IP
+	localAddrs     map[string]net.IP
 	opts options // also here for testing
 
 	// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -42,7 +42,6 @@ type Forward struct {
 	maxfails      uint32
 	expire        time.Duration
 	maxConcurrent int64
-	localAddr     net.IP
 	localAddrs    map[string]net.IP
 	opts          options // also here for testing
 
@@ -58,6 +57,7 @@ type Forward struct {
 // New returns a new Forward.
 func New() *Forward {
 	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true}}
+	f.localAddrs = make(map[string]net.IP)
 	return f
 }
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -43,8 +43,8 @@ type Forward struct {
 	expire        time.Duration
 	maxConcurrent int64
 	localAddr     net.IP
-	localAddrs     map[string]net.IP
-	opts options // also here for testing
+	localAddrs    map[string]net.IP
+	opts          options // also here for testing
 
 	// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
 	// the maximum allowed (maxConcurrent)

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"crypto/tls"
+	"net"
 	"sync/atomic"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 type HealthChecker interface {
 	Check(*Proxy) error
 	SetTLSConfig(*tls.Config)
+	SetLocalAddr(net.IP)
 	SetRecursionDesired(bool)
 	GetRecursionDesired() bool
 }
@@ -22,6 +24,7 @@ type HealthChecker interface {
 type dnsHc struct {
 	c                *dns.Client
 	recursionDesired bool
+	localAddr        net.IP
 }
 
 var (
@@ -48,6 +51,10 @@ func NewHealthChecker(trans string, recursionDesired bool) HealthChecker {
 func (h *dnsHc) SetTLSConfig(cfg *tls.Config) {
 	h.c.Net = "tcp-tls"
 	h.c.TLSConfig = cfg
+}
+
+func (h *dnsHc) SetLocalAddr(ip net.IP) {
+	h.localAddr = ip
 }
 
 func (h *dnsHc) SetRecursionDesired(recursionDesired bool) {

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -21,7 +21,7 @@ type Transport struct {
 	conns       [typeTotalCount][]*persistConn // Buckets for udp, tcp and tcp-tls.
 	expire      time.Duration                  // After this duration a connection is expired.
 	addr        string
-	localAddr	net.IP
+	localAddr   net.IP
 	tlsConfig   *tls.Config
 
 	dial  chan string

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"crypto/tls"
+	"net"
 	"sort"
 	"time"
 
@@ -20,6 +21,7 @@ type Transport struct {
 	conns       [typeTotalCount][]*persistConn // Buckets for udp, tcp and tcp-tls.
 	expire      time.Duration                  // After this duration a connection is expired.
 	addr        string
+	localAddr	net.IP
 	tlsConfig   *tls.Config
 
 	dial  chan string
@@ -147,6 +149,9 @@ func (t *Transport) SetExpire(expire time.Duration) { t.expire = expire }
 
 // SetTLSConfig sets the TLS config in transport.
 func (t *Transport) SetTLSConfig(cfg *tls.Config) { t.tlsConfig = cfg }
+
+// SetLocalAddr sets the local address in transport.
+func (t *Transport) SetLocalAddr(ip net.IP) { t.localAddr = ip }
 
 const (
 	defaultExpire  = 10 * time.Second

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"crypto/tls"
+	"net"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -38,6 +39,12 @@ func NewProxy(addr, trans string) *Proxy {
 func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 	p.transport.SetTLSConfig(cfg)
 	p.health.SetTLSConfig(cfg)
+}
+
+// SetLocalAddr sets the local address in the lower p.transport and in the healthchecking client.
+func (p *Proxy) SetLocalAddr(ip net.IP) {
+	p.transport.SetLocalAddr(ip)
+	p.health.SetLocalAddr(ip)
 }
 
 // SetExpire sets the expire duration in the lower p.transport.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

An upstream DNS service might not be accessible via all local addresses that have a route to the upstream IP (e.g. the upstream might employ an ACL of some sort, or other some intervening network restriction).  In the case that more than one interface can route to the upstream, the system may automatically select an interface that is prevented from accessing the upstream DNS.

This PR adds an option to control which local address is used when forwarding requests upstream.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Included

### 4. Does this introduce a backward incompatible change or deprecation?
