### PR TITLE
https plugin (DoH proxying)

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -53,6 +53,7 @@ var Directives = []string{
 	"loop",
 	"forward",
 	"grpc",
+	"https",
 	"erratic",
 	"whoami",
 	"on",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/grpc"
 	_ "github.com/coredns/coredns/plugin/health"
 	_ "github.com/coredns/coredns/plugin/hosts"
+	_ "github.com/coredns/coredns/plugin/https"
 	_ "github.com/coredns/coredns/plugin/k8s_external"
 	_ "github.com/coredns/coredns/plugin/kubernetes"
 	_ "github.com/coredns/coredns/plugin/loadbalance"

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.21.0
+	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200306183522-221f0cc107cb
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,9 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8 h1:ndzgwNDnKIqyCvHTXaCqh9KlOWKvBry6nuXMJmonVsE=

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -62,6 +62,7 @@ etcd:etcd
 loop:loop
 forward:forward
 grpc:grpc
+https:https
 erratic:erratic
 whoami:whoami
 on:github.com/coredns/caddy/onevent

--- a/plugin/https/README.md
+++ b/plugin/https/README.md
@@ -2,11 +2,11 @@
 
 ## Name
 
-*https* - facilitates proxying DNS messages to upstream resolvers via DoH protocol.
+*https* - facilitates proxying DNS messages to upstream resolvers using DoH.
 
 ## Description
 
-The *https* plugin supports DoH.
+The *https* plugin performs DNS-over-HTTPS proxying. See [RFC 8484](https://tools.ietf.org/html/rfc8484).
 
 This plugin can only be used once per Server Block.
 
@@ -51,8 +51,6 @@ https FROM TO... {
 
 * `policy` specifies the policy to use for selecting upstream servers. The default is `random`.
 
-Also note the TLS config is "global" for the whole https proxy if you need a different
-`tls` for different upstreams you're out of luck.
 
 ## Metrics
 

--- a/plugin/https/README.md
+++ b/plugin/https/README.md
@@ -1,0 +1,103 @@
+# https
+
+## Name
+
+*https* - facilitates proxying DNS messages to upstream resolvers via DoH protocol.
+
+## Description
+
+The *https* plugin supports DoH.
+
+This plugin can only be used once per Server Block.
+
+## Syntax
+
+In its most basic form:
+
+~~~
+https FROM TO...
+~~~
+
+* **FROM** is the base domain to match for the request to be proxied.
+* **TO...** are the destination endpoints to proxy to. The number of upstreams is
+  limited to 15.
+
+Multiple upstreams are randomized (see `policy`) on first use. When a proxy returns an error
+the next upstream in the list is tried.
+
+Extra knobs are available with an expanded syntax:
+
+~~~
+https FROM TO... {
+    except IGNORED_NAMES...
+    tls CERT KEY CA
+    tls_servername NAME
+    policy random|round_robin|sequential
+}
+~~~
+
+* **FROM** and **TO...** as above.
+* **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
+  Requests that match none of these names will be passed through.
+* `tls` **CERT** **KEY** **CA** define the TLS properties for TLS connection. From 0 to 3 arguments can be
+  provided with the meaning as described below
+
+  * `tls` - no client authentication is used, and the system CAs are used to verify the server certificate (by default)
+  * `tls` **CA** - no client authentication is used, and the file CA is used to verify the server certificate
+  * `tls` **CERT** **KEY** - client authentication is used with the specified cert/key pair.
+    The server certificate is verified with the system CAs
+  * `tls` **CERT** **KEY**  **CA** - client authentication is used with the specified cert/key pair.
+    The server certificate is verified using the specified CA file
+
+* `policy` specifies the policy to use for selecting upstream servers. The default is `random`.
+
+Also note the TLS config is "global" for the whole https proxy if you need a different
+`tls` for different upstreams you're out of luck.
+
+## Metrics
+
+If monitoring is enabled (via the *prometheus* plugin) then the following metric are exported:
+
+* `coredns_https_request_duration_seconds{to}` - duration per upstream interaction.
+* `coredns_https_requests_total{to}` - query count per upstream.
+* `coredns_https_responses_total{to, rcode}` - count of RCODEs per upstream.
+  and we are randomly (this always uses the `random` policy) spraying to an upstream.
+
+## Examples
+
+Proxy all requests within `example.org.` to a DoH nameserver:
+
+~~~ corefile
+example.org {
+    https . cloudflare-dns.com/dns-query
+}
+~~~
+
+Forward everything except requests to `example.org`
+
+~~~ corefile
+. {
+    https . dns.quad9.net/dns-query {
+        except example.org
+    }
+}
+~~~
+
+Load balance all requests between multiple upstreams
+
+~~~ corefile
+. {
+    https . dns.quad9.net/dns-query cloudflare-dns.com:443/dns-query dns.google/dns-query
+}
+~~~
+
+Internal DoH server:
+
+~~~ corefile
+. {
+    https . 10.0.0.10:853/dns-query {
+      tls ca.crt
+      tls_servername internal.domain
+    }
+}
+~~~

--- a/plugin/https/https.go
+++ b/plugin/https/https.go
@@ -1,0 +1,98 @@
+// Package https implements a plugin that performs DNS-over-HTTPS proxying.
+//
+// See: RFC 8484 (https://tools.ietf.org/html/rfc8484)
+package https
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/debug"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+// HTTPS represents a plugin instance that can proxy requests to another (DNS) server via DoH protocol.
+// It has a list of proxies each representing one upstream proxy
+type HTTPS struct {
+	from   string
+	except []string
+	client dnsClient
+	Next   plugin.Handler
+}
+
+type httpsOption func(h *HTTPS)
+
+func withExcept(except []string) httpsOption {
+	return func(h *HTTPS) {
+		h.except = except
+	}
+}
+
+// newHTTPS returns a new HTTPS.
+func newHTTPS(from string, client dnsClient, opts ...httpsOption) *HTTPS {
+	h := &HTTPS{from: from, client: client}
+	for _, o := range opts {
+		o(h)
+	}
+	return h
+}
+
+// Assert that HTTPS struct conforms to the plugin.Handler interface
+var _ plugin.Handler = (*HTTPS)(nil)
+
+// Name implements plugin.Handler.
+func (h *HTTPS) Name() string { return "https" }
+
+// ServeDNS implements plugin.Handler.
+func (h *HTTPS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (status int, err error) {
+	state := request.Request{W: w, Req: r}
+	if !h.match(state) {
+		return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
+	}
+
+	dnsreq, err := r.Pack()
+	if err != nil {
+		return dns.RcodeServerFailure, err
+	}
+	result, err := h.client.Query(ctx, dnsreq)
+	if err != nil {
+		return dns.RcodeServerFailure, err
+	}
+
+	// Check if the reply is correct; if not return FormErr.
+	// maybe useful to extract this logic from forward, grpc and https plugins to common place
+	if !state.Match(result) {
+		debug.Hexdumpf(result, "Wrong reply for id: %d, %s %d", result.Id, state.QName(), state.QType())
+
+		formerr := new(dns.Msg)
+		formerr.SetRcode(state.Req, dns.RcodeFormatError)
+		err = w.WriteMsg(formerr)
+		return
+	}
+
+	err = w.WriteMsg(result)
+	return
+}
+
+// TODO extract this logic from forward, grpc and https plugins to common place
+func (h *HTTPS) match(state request.Request) bool {
+	if !plugin.Name(h.from).Matches(state.Name()) || !h.isAllowedDomain(state.Name()) {
+		return false
+	}
+
+	return true
+}
+
+func (h *HTTPS) isAllowedDomain(name string) bool {
+	if dns.Name(name) == dns.Name(h.from) {
+		return true
+	}
+
+	for _, ignore := range h.except {
+		if plugin.Name(ignore).Matches(name) {
+			return false
+		}
+	}
+	return true
+}

--- a/plugin/https/https_test.go
+++ b/plugin/https/https_test.go
@@ -1,0 +1,130 @@
+package https
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+const from = "."
+
+func newRequestDNSMsg() *dns.Msg {
+	return &dns.Msg{Question: []dns.Question{
+		{
+			Name:   "example.com.",
+			Qtype:  dns.TypeA,
+			Qclass: dns.ClassINET,
+		},
+	}}
+}
+
+func TestHTTPS(t *testing.T) {
+	t.Parallel()
+	dnsMsg := newRequestDNSMsg()
+	dnsdata, err := dnsMsg.Pack()
+	require.NoError(t, err)
+	dnsClient := &mockDNSClient{reqBody: dnsdata, t: t}
+	h := newHTTPS(from, dnsClient)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	status, err := h.ServeDNS(context.Background(), rec, dnsMsg)
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeSuccess, status)
+	require.Equal(t, 1, dnsClient.callCount, "dnsClient call count is wrong")
+	require.Equal(t, newExpectedDNSMsg(), rec.Msg)
+}
+
+type mockDNSClientFunc func(ctx context.Context, dnsreq []byte) (*dns.Msg, error)
+
+func (f mockDNSClientFunc) Query(ctx context.Context, dnsreq []byte) (*dns.Msg, error) {
+	return f(ctx, dnsreq)
+}
+
+type mockDNSResponseWriter struct {
+	dns.ResponseWriter
+	writeFunc func(*dns.Msg) error
+}
+
+func (w *mockDNSResponseWriter) WriteMsg(msg *dns.Msg) error {
+	return w.writeFunc(msg)
+}
+
+func TestHTTPSMsgPackError(t *testing.T) {
+	t.Parallel()
+	dnsMsg := &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: 0xFFFFF}}
+	dnsClient := mockDNSClientFunc(func(_ context.Context, _ []byte) (result *dns.Msg, err error) {
+		t.Fatal("dns client must not be called")
+		return
+	})
+	h := newHTTPS(from, dnsClient)
+	w := &mockDNSResponseWriter{
+		ResponseWriter: &test.ResponseWriter{},
+		writeFunc: func(*dns.Msg) (err error) {
+			t.Fatal("dns response writer must not be called")
+			return
+		},
+	}
+
+	status, err := h.ServeDNS(context.Background(), w, dnsMsg)
+	require.Error(t, err)
+	require.Equal(t, dns.RcodeServerFailure, status)
+}
+
+func TestHTTPSDNSClientError(t *testing.T) {
+	t.Parallel()
+	dnsMsg := newRequestDNSMsg()
+	dnsClient := mockDNSClientFunc(func(_ context.Context, _ []byte) (*dns.Msg, error) {
+		return newExpectedDNSMsg(), errors.New("dns client error")
+	})
+	h := newHTTPS(from, dnsClient)
+	w := &mockDNSResponseWriter{
+		ResponseWriter: &test.ResponseWriter{},
+		writeFunc: func(*dns.Msg) (err error) {
+			t.Fatal("dns response writer must not be called")
+			return
+		},
+	}
+
+	status, err := h.ServeDNS(context.Background(), w, dnsMsg)
+	require.Error(t, err)
+	require.Equal(t, dns.RcodeServerFailure, status)
+}
+
+func TestHTTPSResponseWriterError(t *testing.T) {
+	t.Parallel()
+	dnsMsg := newRequestDNSMsg()
+	dnsClient := mockDNSClientFunc(func(_ context.Context, _ []byte) (*dns.Msg, error) {
+		return newExpectedDNSMsg(), nil
+	})
+	h := newHTTPS(from, dnsClient)
+	w := &mockDNSResponseWriter{
+		ResponseWriter: &test.ResponseWriter{},
+		writeFunc: func(*dns.Msg) (err error) {
+			return errors.New("response writer error")
+		},
+	}
+
+	_, err := h.ServeDNS(context.Background(), w, dnsMsg)
+	require.Error(t, err)
+}
+
+func TestHTTPSDNSResponseStateNotMatch(t *testing.T) {
+	t.Parallel()
+	dnsMsg := newRequestDNSMsg()
+	dnsClient := mockDNSClientFunc(func(_ context.Context, _ []byte) (*dns.Msg, error) {
+		result := newExpectedDNSMsg()
+		result.Question[0].Name = "other.domain."
+		return result, nil
+	})
+	h := newHTTPS(from, dnsClient)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err := h.ServeDNS(context.Background(), rec, dnsMsg)
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeFormatError, rec.Rcode)
+}

--- a/plugin/https/metrics.go
+++ b/plugin/https/metrics.go
@@ -1,0 +1,31 @@
+package https
+
+import (
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Variables declared for monitoring.
+var (
+	RequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "https",
+		Name:      "requests_total",
+		Help:      "Counter of requests made per upstream.",
+	}, []string{"to"})
+	RcodeCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "https",
+		Name:      "responses_total",
+		Help:      "Counter of requests made per upstream.",
+	}, []string{"rcode", "to"})
+	RequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "https",
+		Name:      "request_duration_seconds",
+		Buckets:   plugin.TimeBuckets,
+		Help:      "Histogram of the time each request took.",
+	}, []string{"to"})
+)

--- a/plugin/https/policy.go
+++ b/plugin/https/policy.go
@@ -1,0 +1,68 @@
+package https
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+)
+
+// policy defines a policy we use for selecting upstreams.
+type policy interface {
+	List(poolLen int) []int
+}
+
+// randomPolicy is a policy that implements random upstream selection.
+type randomPolicy struct{}
+
+func newRandomPolicy() *randomPolicy {
+	return &randomPolicy{}
+}
+
+func (*randomPolicy) List(poolLen int) []int {
+	if poolLen <= 0 {
+		return nil
+	}
+	return rand.Perm(poolLen)
+}
+
+// roundRobinPolicy is a policy that selects hosts based on round robin ordering.
+type roundRobinPolicy struct {
+	robin uint32
+}
+
+func newRoundRobinPolicy() *roundRobinPolicy {
+	return &roundRobinPolicy{robin: math.MaxUint32}
+}
+
+func (p *roundRobinPolicy) List(poolLen int) (result []int) {
+	if poolLen <= 0 {
+		return
+	}
+	result = make([]int, 0, poolLen)
+	i := int(atomic.AddUint32(&p.robin, 1) % uint32(poolLen))
+	for j := i; j < poolLen; j++ {
+		result = append(result, j)
+	}
+	for j := 0; j < i; j++ {
+		result = append(result, j)
+	}
+	return
+}
+
+// sequentialPolicy is a policy that selects hosts based on sequential ordering.
+type sequentialPolicy struct{}
+
+func newSequentialPolicy() *sequentialPolicy {
+	return &sequentialPolicy{}
+}
+
+func (*sequentialPolicy) List(poolLen int) (result []int) {
+	if poolLen <= 0 {
+		return
+	}
+	result = make([]int, poolLen)
+	for i := 0; i < poolLen; i++ {
+		result[i] = i
+	}
+	return
+}

--- a/plugin/https/policy_test.go
+++ b/plugin/https/policy_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestRandomPolicy(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		poolLen  int
@@ -69,7 +68,6 @@ func TestRandomPolicy(t *testing.T) {
 }
 
 func TestRoundRobinPolicy(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		poolLen  int
@@ -130,7 +128,6 @@ func TestRoundRobinPolicy(t *testing.T) {
 }
 
 func TestSequentialPolicy(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		poolLen  int

--- a/plugin/https/policy_test.go
+++ b/plugin/https/policy_test.go
@@ -1,0 +1,188 @@
+package https
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		poolLen  int
+		expected [][]int
+	}{
+		{
+			name:    "NegativeLength",
+			poolLen: -1,
+			expected: [][]int{
+				nil,
+			},
+		},
+		{
+			name:    "ZeroElements",
+			poolLen: 0,
+			expected: [][]int{
+				nil,
+				nil,
+			},
+		},
+		{
+			name:    "OneElement",
+			poolLen: 1,
+			expected: [][]int{
+				[]int{0},
+				[]int{0},
+			},
+		},
+		{
+			name:    "TwoElements",
+			poolLen: 2,
+		},
+		{
+			name:    "ThreeElements",
+			poolLen: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRandomPolicy()
+			if tt.poolLen < 2 {
+				for i, expected := range tt.expected {
+					result := r.List(len(expected))
+					require.Equal(t, expected, result, "iteration %d", i)
+				}
+			} else {
+				result := r.List(tt.poolLen)
+				require.Equal(t, tt.poolLen, len(result))
+				// verify all elements
+				visited := make([]bool, tt.poolLen)
+				for i := 0; i < tt.poolLen; i++ {
+					require.Less(t, result[i], tt.poolLen)
+					require.False(t, visited[result[i]], "element %d is duplicated", result[i])
+					visited[result[i]] = true
+				}
+			}
+		})
+	}
+}
+
+func TestRoundRobinPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		poolLen  int
+		expected [][]int
+	}{
+		{
+			name:    "NegativeLength",
+			poolLen: -1,
+			expected: [][]int{
+				nil,
+			},
+		},
+		{
+			name:    "ZeroElements",
+			poolLen: 0,
+			expected: [][]int{
+				nil,
+				nil,
+			},
+		},
+		{
+			name:    "OneElement",
+			poolLen: 1,
+			expected: [][]int{
+				[]int{0},
+				[]int{0},
+			},
+		},
+		{
+			name:    "TwoElements",
+			poolLen: 2,
+			expected: [][]int{
+				[]int{0, 1},
+				[]int{1, 0},
+				[]int{0, 1},
+			},
+		},
+		{
+			name:    "ThreeElements",
+			poolLen: 3,
+			expected: [][]int{
+				[]int{0, 1, 2},
+				[]int{1, 2, 0},
+				[]int{2, 0, 1},
+				[]int{0, 1, 2},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRoundRobinPolicy()
+			for i, expected := range tt.expected {
+				result := r.List(len(expected))
+				require.Equal(t, expected, result, "iteration %d", i)
+			}
+		})
+	}
+}
+
+func TestSequentialPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		poolLen  int
+		expected [][]int
+	}{
+		{
+			name:    "NegativeLength",
+			poolLen: -1,
+			expected: [][]int{
+				nil,
+			},
+		},
+		{
+			name:    "ZeroElements",
+			poolLen: 0,
+			expected: [][]int{
+				nil,
+				nil,
+			},
+		},
+		{
+			name:    "OneElement",
+			poolLen: 1,
+			expected: [][]int{
+				[]int{0},
+				[]int{0},
+			},
+		},
+		{
+			name:    "TwoElements",
+			poolLen: 2,
+			expected: [][]int{
+				[]int{0, 1},
+				[]int{0, 1},
+			},
+		},
+		{
+			name:    "ThreeElements",
+			poolLen: 3,
+			expected: [][]int{
+				[]int{0, 1, 2},
+				[]int{0, 1, 2},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newSequentialPolicy()
+			for i, expected := range tt.expected {
+				result := p.List(len(expected))
+				require.Equal(t, expected, result, "iteration %d", i)
+			}
+		})
+	}
+}

--- a/plugin/https/proxy.go
+++ b/plugin/https/proxy.go
@@ -1,0 +1,145 @@
+package https
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	dnsMessageMimeType = "application/dns-message"
+
+	// typical Ethernet MTU (1500 bytes) - min IP header size (20 bytes) - UDP header (8 bytes).
+	// It seems like a reasonable limitation for DoH protocol.
+	// However, if you know RFCs that specify this limit, update it.
+	maxDNSMessageSize     = 1472
+	defaultRequestTimeout = 2 * time.Second
+)
+
+var (
+	dnsMessageMimeTypeHeader = []string{dnsMessageMimeType}
+
+	errResponseTooLarge = errors.New("dns response size is too large")
+	errResponseStatus   = errors.New("invalid http response status code")
+)
+
+// dnsClient is the client API for DNS service
+type dnsClient interface {
+	Query(ctx context.Context, dnsreq []byte) (result *dns.Msg, err error)
+}
+
+// newDoHDNSClient creates a new instance of dohDNSClient service.
+// url must be a full URL to send DoH requests to like "https://example.com/dns-query"
+func newDoHDNSClient(client httpRequestDoer, url string) *dohDNSClient {
+	return &dohDNSClient{client, url}
+}
+
+type httpRequestDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// dohDNSClient is a DNS client that proxies requests to the upstream server using DoH protocol.
+type dohDNSClient struct {
+	client httpRequestDoer
+	url    string
+}
+
+func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.Msg, err error) {
+	var req *http.Request
+	if req, err = http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewReader(dnsreq)); err != nil {
+		return
+	}
+	req.Header["Accept"] = dnsMessageMimeTypeHeader
+	req.Header["Content-Type"] = dnsMessageMimeTypeHeader
+
+	var resp *http.Response
+	if resp, err = c.client.Do(req); err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	// RFC8484 Section 4.2.1:
+	// A successful HTTP response with a 2xx status code is used for any valid DNS response,
+	// regardless of the DNS response code.
+	// HTTP responses with non-successful HTTP status codes do not contain
+	// replies to the original DNS question in the HTTP request.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errResponseStatus
+	}
+
+	// limit the number of bytes read to avoid potential DoS attacks.
+	// it would be better to add (*dns.Msg) Unpack(io.Reader) method to avoid byte slice allocation
+	var body []byte
+	if body, err = io.ReadAll(io.LimitReader(resp.Body, maxDNSMessageSize+1)); err != nil {
+		return
+	}
+	if len(body) > maxDNSMessageSize {
+		return nil, errResponseTooLarge
+	}
+	result = new(dns.Msg)
+	err = result.Unpack(body)
+	return
+}
+
+func newLoadBalanceDNSClient(clients []dnsClient, opts ...lbDNSClientOption) *lbDNSClient {
+	c := &lbDNSClient{
+		p:        newRandomPolicy(),
+		maxFails: len(clients),
+		timeout:  defaultRequestTimeout,
+		clients:  clients,
+	}
+	// option pattern
+	for _, o := range opts {
+		o(c)
+	}
+	if len(clients) < c.maxFails {
+		c.maxFails = len(clients)
+	}
+	return c
+}
+
+// lbDNSClient is a DNS client that load balances DNS requests between the list of DNS clients.
+type lbDNSClient struct {
+	p        policy
+	timeout  time.Duration
+	maxFails int
+	clients  []dnsClient
+}
+
+type lbDNSClientOption func(c *lbDNSClient)
+
+func withLbPolicy(p policy) lbDNSClientOption {
+	return func(c *lbDNSClient) {
+		c.p = p
+	}
+}
+
+func withLbRequestTimeout(timeout time.Duration) lbDNSClientOption {
+	return func(c *lbDNSClient) {
+		c.timeout = timeout
+	}
+}
+
+func withLbMaxFails(maxFails int) lbDNSClientOption {
+	return func(c *lbDNSClient) {
+		c.maxFails = maxFails
+	}
+}
+
+func (c *lbDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.Msg, err error) {
+	ids := c.p.List(len(c.clients))
+	for i := 0; i < c.maxFails; i++ {
+		ctx, cancel := context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+		if result, err = c.clients[ids[i]].Query(ctx, dnsreq); err == nil {
+			return
+		}
+		cancel()
+	}
+	return
+}

--- a/plugin/https/proxy.go
+++ b/plugin/https/proxy.go
@@ -49,7 +49,7 @@ type dohDNSClient struct {
 	url    string
 }
 
-func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.Msg, err error) {
+func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (r *dns.Msg, err error) {
 	var req *http.Request
 	if req, err = http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewReader(dnsreq)); err != nil {
 		return
@@ -81,8 +81,8 @@ func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.Ms
 	if len(body) > maxDNSMessageSize {
 		return nil, errResponseTooLarge
 	}
-	result = new(dns.Msg)
-	err = result.Unpack(body)
+	r = new(dns.Msg)
+	err = r.Unpack(body)
 	return
 }
 

--- a/plugin/https/proxy_test.go
+++ b/plugin/https/proxy_test.go
@@ -1,0 +1,326 @@
+package https
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+const upstreamURL = "https://example.com/dns-query"
+
+type mockHTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (f mockHTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newExpectedDNSMsg() *dns.Msg {
+	return &dns.Msg{
+		MsgHdr: dns.MsgHdr{Response: true},
+		Question: []dns.Question{
+			{
+				Name:   "example.com.",
+				Qtype:  dns.TypeA,
+				Qclass: dns.ClassINET,
+			},
+		},
+		Answer: []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+				A:   net.IPv4(1, 1, 1, 1),
+			},
+		},
+	}
+}
+
+func packMsg(t *testing.T, msg *dns.Msg) []byte {
+	t.Helper()
+	data, err := msg.Pack()
+	require.NoError(t, err)
+	return data
+}
+
+func TestDNSClient(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	expectedMsg := newExpectedDNSMsg()
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		callCount++
+		acceptHdrs := req.Header["Accept"]
+		require.NotEmpty(t, acceptHdrs, "Accept header is empty")
+		require.Equal(t, dnsMessageMimeType, acceptHdrs[0], "invalid accept header")
+
+		contentTypeHdrs := req.Header["Content-Type"]
+		require.NotEmpty(t, contentTypeHdrs, "Content-Type header is empty")
+		require.Equal(t, dnsMessageMimeType, contentTypeHdrs[0], "invalid Content-Type header")
+
+		require.Equal(t, upstreamURL, req.URL.String(), "invalid request URL")
+		require.Equal(t, "POST", req.Method, "invalid request method")
+
+		buf, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abc"), buf, "invalid request body")
+
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewReader(packMsg(t, expectedMsg))),
+			StatusCode: http.StatusOK,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	result, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount, "invalid http client call count")
+	require.True(t, result.MsgHdr.Response)
+	require.Equal(t, len(expectedMsg.Answer), len(result.Answer))
+	require.Equal(t, expectedMsg.Answer[0].String(), result.Answer[0].String())
+}
+
+func TestDNSClientNewRequestError(t *testing.T) {
+	t.Parallel()
+	invalidURL := "https://example.com/\t\n"
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		t.Fatal("http client must not be called")
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, invalidURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+func TestDNSClientHttpClientError(t *testing.T) {
+	t.Parallel()
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		err = errors.New("http error")
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewReader(packMsg(t, newExpectedDNSMsg()))),
+			StatusCode: http.StatusOK,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+func TestDNSClientHttpStatusError(t *testing.T) {
+	t.Parallel()
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewReader(packMsg(t, newExpectedDNSMsg()))),
+			StatusCode: http.StatusInternalServerError,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+type errReader struct {
+	delegate io.Reader
+	err      error
+}
+
+// return err instead of io.EOF after the last piece of data is read
+func (r *errReader) Read(p []byte) (n int, err error) {
+	n, err = r.delegate.Read(p)
+	if err == io.EOF {
+		err = r.err
+	}
+	return
+}
+
+func TestDNSClientResponseReadError(t *testing.T) {
+	t.Parallel()
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		reader := &errReader{
+			delegate: bytes.NewReader(packMsg(t, newExpectedDNSMsg())),
+			err:      errors.New("io error"),
+		}
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(reader),
+			StatusCode: http.StatusOK,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+func TestDNSClientMsgUnpackError(t *testing.T) {
+	t.Parallel()
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(strings.NewReader("def")),
+			StatusCode: http.StatusOK,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+func TestDNSClientLargeResponseError(t *testing.T) {
+	t.Parallel()
+
+	//create large buffer with the correct DNS message at the beginning
+	var buf bytes.Buffer
+	dnsMsg := packMsg(t, newExpectedDNSMsg())
+	buf.Write(dnsMsg)
+	buf.WriteString(strings.Repeat("a", maxDNSMessageSize))
+
+	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
+		resp = &http.Response{
+			Body:       ioutil.NopCloser(&buf),
+			StatusCode: http.StatusOK,
+		}
+		return
+	})
+	dnsClient := newDoHDNSClient(httpClient, upstreamURL)
+
+	_, err := dnsClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+}
+
+type mockDNSClient struct {
+	callCount int
+	reqBody   []byte
+	t         *testing.T
+	err       error
+}
+
+func (c *mockDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.Msg, err error) {
+	c.t.Helper()
+	c.callCount++
+	require.NotNil(c.t, ctx)
+	require.Equal(c.t, c.reqBody, dnsreq, "invalid request body")
+	return newExpectedDNSMsg(), c.err
+}
+
+func TestLoadBalanceDNSClient(t *testing.T) {
+	t.Parallel()
+	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	clients := []dnsClient{client1}
+	lbClient := newLoadBalanceDNSClient(clients)
+
+	result, err := lbClient.Query(context.Background(), []byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 1, client1.callCount)
+	require.Equal(t, newExpectedDNSMsg(), result)
+}
+
+func TestLoadBalanceDNSClientError(t *testing.T) {
+	t.Parallel()
+	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
+	clients := []dnsClient{client1}
+	lbClient := newLoadBalanceDNSClient(clients)
+
+	_, err := lbClient.Query(context.Background(), []byte("abc"))
+	require.Error(t, err)
+	require.Equal(t, 1, client1.callCount)
+}
+
+func TestLoadBalanceDNSClientRetry(t *testing.T) {
+	t.Parallel()
+	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
+	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	clients := []dnsClient{client1, client2}
+	lbClient := newLoadBalanceDNSClient(clients, withLbPolicy(newSequentialPolicy()))
+
+	result, err := lbClient.Query(context.Background(), []byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 1, client1.callCount)
+	require.Equal(t, 1, client2.callCount)
+	require.Equal(t, newExpectedDNSMsg(), result)
+}
+
+func TestLoadBalanceDNSClientPolicy(t *testing.T) {
+	t.Parallel()
+	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	clients := []dnsClient{client1, client2}
+	lbClient := newLoadBalanceDNSClient(clients, withLbPolicy(newRoundRobinPolicy()))
+
+	result, err := lbClient.Query(context.Background(), []byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 1, client1.callCount)
+	require.Equal(t, 0, client2.callCount)
+	require.Equal(t, newExpectedDNSMsg(), result)
+
+	result, err = lbClient.Query(context.Background(), []byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 1, client1.callCount)
+	require.Equal(t, 1, client2.callCount)
+	require.Equal(t, newExpectedDNSMsg(), result)
+}
+
+func TestLoadBalanceDNSClientMaxFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		maxFails         int
+		callCountClient1 int
+		callCountClient2 int
+	}{
+		{
+			name:             "OneMaxFail",
+			maxFails:         1,
+			callCountClient1: 1,
+			callCountClient2: 0,
+		},
+		{
+			name:             "TenMaxFails",
+			maxFails:         10,
+			callCountClient1: 1,
+			callCountClient2: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client1 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
+			client2 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
+			clients := []dnsClient{client1, client2}
+
+			lbClient := newLoadBalanceDNSClient(clients,
+				withLbPolicy(newSequentialPolicy()),
+				withLbMaxFails(tt.maxFails))
+
+			result, err := lbClient.Query(context.Background(), []byte("abc"))
+			require.Error(t, err)
+			require.Equal(t, tt.callCountClient1, client1.callCount)
+			require.Equal(t, tt.callCountClient2, client2.callCount)
+			require.Equal(t, newExpectedDNSMsg(), result)
+		})
+	}
+}
+
+func TestDefaultNewLoadBalanceDNSClient(t *testing.T) {
+	t.Parallel()
+	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
+	clients := []dnsClient{client1, client2}
+
+	lbClient := newLoadBalanceDNSClient(clients)
+	require.Equal(t, 2, lbClient.maxFails)
+	require.Equal(t, defaultRequestTimeout, lbClient.timeout)
+}

--- a/plugin/https/proxy_test.go
+++ b/plugin/https/proxy_test.go
@@ -50,7 +50,6 @@ func packMsg(t *testing.T, msg *dns.Msg) []byte {
 }
 
 func TestDNSClient(t *testing.T) {
-	t.Parallel()
 	callCount := 0
 	expectedMsg := newExpectedDNSMsg()
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
@@ -87,7 +86,6 @@ func TestDNSClient(t *testing.T) {
 }
 
 func TestDNSClientNewRequestError(t *testing.T) {
-	t.Parallel()
 	invalidURL := "https://example.com/\t\n"
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
 		t.Fatal("http client must not be called")
@@ -100,7 +98,6 @@ func TestDNSClientNewRequestError(t *testing.T) {
 }
 
 func TestDNSClientHttpClientError(t *testing.T) {
-	t.Parallel()
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
 		err = errors.New("http error")
 		resp = &http.Response{
@@ -116,7 +113,6 @@ func TestDNSClientHttpClientError(t *testing.T) {
 }
 
 func TestDNSClientHttpStatusError(t *testing.T) {
-	t.Parallel()
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
 		resp = &http.Response{
 			Body:       ioutil.NopCloser(bytes.NewReader(packMsg(t, newExpectedDNSMsg()))),
@@ -145,7 +141,6 @@ func (r *errReader) Read(p []byte) (n int, err error) {
 }
 
 func TestDNSClientResponseReadError(t *testing.T) {
-	t.Parallel()
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
 		reader := &errReader{
 			delegate: bytes.NewReader(packMsg(t, newExpectedDNSMsg())),
@@ -164,7 +159,6 @@ func TestDNSClientResponseReadError(t *testing.T) {
 }
 
 func TestDNSClientMsgUnpackError(t *testing.T) {
-	t.Parallel()
 	httpClient := mockHTTPClientFunc(func(req *http.Request) (resp *http.Response, err error) {
 		resp = &http.Response{
 			Body:       ioutil.NopCloser(strings.NewReader("def")),
@@ -179,8 +173,6 @@ func TestDNSClientMsgUnpackError(t *testing.T) {
 }
 
 func TestDNSClientLargeResponseError(t *testing.T) {
-	t.Parallel()
-
 	//create large buffer with the correct DNS message at the beginning
 	var buf bytes.Buffer
 	dnsMsg := packMsg(t, newExpectedDNSMsg())
@@ -216,7 +208,6 @@ func (c *mockDNSClient) Query(ctx context.Context, dnsreq []byte) (result *dns.M
 }
 
 func TestLoadBalanceDNSClient(t *testing.T) {
-	t.Parallel()
 	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	clients := []dnsClient{client1}
 	lbClient := newLoadBalanceDNSClient(clients)
@@ -228,7 +219,6 @@ func TestLoadBalanceDNSClient(t *testing.T) {
 }
 
 func TestLoadBalanceDNSClientError(t *testing.T) {
-	t.Parallel()
 	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
 	clients := []dnsClient{client1}
 	lbClient := newLoadBalanceDNSClient(clients)
@@ -239,7 +229,6 @@ func TestLoadBalanceDNSClientError(t *testing.T) {
 }
 
 func TestLoadBalanceDNSClientRetry(t *testing.T) {
-	t.Parallel()
 	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t, err: errors.New("client error")}
 	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	clients := []dnsClient{client1, client2}
@@ -253,7 +242,6 @@ func TestLoadBalanceDNSClientRetry(t *testing.T) {
 }
 
 func TestLoadBalanceDNSClientPolicy(t *testing.T) {
-	t.Parallel()
 	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	clients := []dnsClient{client1, client2}
@@ -273,8 +261,6 @@ func TestLoadBalanceDNSClientPolicy(t *testing.T) {
 }
 
 func TestLoadBalanceDNSClientMaxFails(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name             string
 		maxFails         int
@@ -315,7 +301,6 @@ func TestLoadBalanceDNSClientMaxFails(t *testing.T) {
 }
 
 func TestDefaultNewLoadBalanceDNSClient(t *testing.T) {
-	t.Parallel()
 	client1 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	client2 := &mockDNSClient{reqBody: []byte("abc"), t: t}
 	clients := []dnsClient{client1, client2}

--- a/plugin/https/setup.go
+++ b/plugin/https/setup.go
@@ -25,7 +25,7 @@ func setup(c *caddy.Controller) error {
 	dnsClient := setupDNSClient(conf)
 	h := newHTTPS(conf.from, dnsClient, withExcept(conf.except))
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		h.Next = next // Set the Next field, so the plugin chaining works.
+		h.Next = next
 		return h
 	})
 

--- a/plugin/https/setup.go
+++ b/plugin/https/setup.go
@@ -1,0 +1,173 @@
+package https
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
+)
+
+const maxUpstreams = 15
+
+func init() { plugin.Register("https", setup) }
+
+func setup(c *caddy.Controller) error {
+	conf, err := parseConfig(c)
+	if err != nil {
+		return plugin.Error("https", err)
+	}
+
+	dnsClient := setupDNSClient(conf)
+	h := newHTTPS(conf.from, dnsClient, withExcept(conf.except))
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		h.Next = next // Set the Next field, so the plugin chaining works.
+		return h
+	})
+
+	return nil
+}
+
+func setupDNSClient(conf *httpsConfig) dnsClient {
+	tr := &http.Transport{
+		TLSClientConfig:   conf.tlsConfig,
+		ForceAttemptHTTP2: true,
+	}
+	httpClient := &http.Client{
+		Transport: tr,
+	}
+
+	clients := make([]dnsClient, len(conf.toURLs))
+	for i, toURL := range conf.toURLs {
+		clients[i] = newDoHDNSClient(httpClient, toURL)
+	}
+
+	var opts []lbDNSClientOption
+	if conf.policy != nil {
+		opts = append(opts, withLbPolicy(conf.policy))
+	}
+
+	// TODO request timeout, max_fail options
+	return newLoadBalanceDNSClient(clients, opts...)
+}
+
+type httpsConfig struct {
+	from          string
+	toURLs        []string
+	except        []string
+	tlsConfig     *tls.Config
+	tlsServerName string
+	policy        policy
+}
+
+func parseConfig(c *caddy.Controller) (*httpsConfig, error) {
+	conf := &httpsConfig{}
+	if !c.Next() {
+		return conf, c.ArgErr()
+	}
+	if !c.Args(&conf.from) {
+		return conf, c.ArgErr()
+	}
+	conf.from = plugin.Host(conf.from).Normalize()
+
+	toURLs := c.RemainingArgs()
+	if len(toURLs) == 0 {
+		return conf, c.ArgErr()
+	}
+	if len(toURLs) > maxUpstreams {
+		return conf, fmt.Errorf("more than %d TOs configured: %d", maxUpstreams, len(toURLs))
+	}
+	conf.toURLs = make([]string, 0, len(toURLs))
+	for _, to := range toURLs {
+		toURL := "https://" + to
+		if _, err := url.ParseRequestURI(toURL); err != nil {
+			return conf, err
+		}
+		conf.toURLs = append(conf.toURLs, toURL)
+	}
+
+	for c.NextBlock() {
+		if err := parseBlock(c, conf); err != nil {
+			return conf, err
+		}
+	}
+
+	if conf.tlsServerName != "" {
+		if conf.tlsConfig == nil {
+			conf.tlsConfig = new(tls.Config)
+		}
+		conf.tlsConfig.ServerName = conf.tlsServerName
+	}
+
+	return conf, nil
+}
+
+func parseBlock(c *caddy.Controller, conf *httpsConfig) (err error) {
+	f, ok := parseBlockMap[c.Val()]
+	if !ok {
+		return c.Errf("unknown property '%s'", c.Val())
+	}
+	return f(c, conf)
+}
+
+type parseBlockFunc func(*caddy.Controller, *httpsConfig) error
+
+var parseBlockMap = map[string]parseBlockFunc{
+	"except":         parseExcept,
+	"tls":            parseTLS,
+	"tls_servername": parseTLSServerName,
+	"policy":         parsePolicy,
+}
+
+func parseExcept(c *caddy.Controller, conf *httpsConfig) error {
+	except := c.RemainingArgs()
+	if len(except) == 0 {
+		return c.ArgErr()
+	}
+	for i := 0; i < len(except); i++ {
+		except[i] = plugin.Host(except[i]).Normalize()
+	}
+	conf.except = except
+	return nil
+}
+
+func parseTLS(c *caddy.Controller, conf *httpsConfig) error {
+	args := c.RemainingArgs()
+	tlsConfig, err := pkgtls.NewTLSConfigFromArgs(args...)
+	if err != nil {
+		return err
+	}
+	conf.tlsConfig = tlsConfig
+	return nil
+}
+
+func parseTLSServerName(c *caddy.Controller, conf *httpsConfig) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+	conf.tlsServerName = args[0]
+	return nil
+}
+
+func parsePolicy(c *caddy.Controller, conf *httpsConfig) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+	switch args[0] {
+	case "random":
+		conf.policy = newRandomPolicy()
+	case "round_robin":
+		conf.policy = newRoundRobinPolicy()
+	case "sequential":
+		conf.policy = newSequentialPolicy()
+	default:
+		return c.Errf("unknown policy '%s'", args[0])
+	}
+	return nil
+}

--- a/plugin/https/setup.go
+++ b/plugin/https/setup.go
@@ -43,7 +43,7 @@ func setupDNSClient(conf *httpsConfig) dnsClient {
 
 	clients := make([]dnsClient, len(conf.toURLs))
 	for i, toURL := range conf.toURLs {
-		clients[i] = newDoHDNSClient(httpClient, toURL)
+		clients[i] = newMetricDNSClient(newDoHDNSClient(httpClient, toURL), toURL)
 	}
 
 	var opts []lbDNSClientOption

--- a/plugin/https/setup_test.go
+++ b/plugin/https/setup_test.go
@@ -1,0 +1,176 @@
+package https
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		input          string
+		expectedConfig *httpsConfig
+	}{
+		{
+			name:  "FromAndOneToURL",
+			input: "https . example.com/dns-query",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+			},
+		},
+		{
+			name:  "FromAndTwoToURLs",
+			input: "https . example.com/dns-query example.org/dns-query",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query", "https://example.org/dns-query"},
+			},
+		},
+		{
+			name:  "ExceptProperty",
+			input: "https . example.com/dns-query {\nexcept domain.com\n}\n",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+				except: []string{"domain.com."},
+			},
+		},
+		{
+			name:  "ExceptPropertyTwoDomains",
+			input: "https . example.com/dns-query {\nexcept domain1.com domain2.com\n}\n",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+				except: []string{"domain1.com.", "domain2.com."},
+			},
+		},
+		{
+			name:  "TLSProperty",
+			input: "https . example.com/dns-query {\ntls\n}\n",
+			expectedConfig: &httpsConfig{
+				from:      ".",
+				toURLs:    []string{"https://example.com/dns-query"},
+				tlsConfig: &tls.Config{},
+			},
+		},
+		{
+			name:  "TLSServerNameProperty",
+			input: "https . 10.1.1.1:853/dns-query {\ntls_servername internal.domain\n}\n",
+			expectedConfig: &httpsConfig{
+				from:          ".",
+				toURLs:        []string{"https://10.1.1.1:853/dns-query"},
+				tlsConfig:     &tls.Config{ServerName: "internal.domain"},
+				tlsServerName: "internal.domain",
+			},
+		},
+		{
+			name:  "PolicyPropertyRandom",
+			input: "https . example.com/dns-query {\npolicy random\n}\n",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+				policy: newRandomPolicy(),
+			},
+		},
+		{
+			name:  "PolicyPropertyRoundRobin",
+			input: "https . example.com/dns-query {\npolicy round_robin\n}\n",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+				policy: newRoundRobinPolicy(),
+			},
+		},
+		{
+			name:  "PolicyPropertySequential",
+			input: "https . example.com/dns-query {\npolicy sequential\n}\n",
+			expectedConfig: &httpsConfig{
+				from:   ".",
+				toURLs: []string{"https://example.com/dns-query"},
+				policy: newSequentialPolicy(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := caddy.NewTestController("https", tt.input)
+			conf, err := parseConfig(c)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedConfig, conf)
+		})
+	}
+}
+
+func TestParseConfigError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "EmptyLine",
+			input: "",
+		},
+		{
+			name:  "EmptyFrom",
+			input: "https",
+		},
+		{
+			name:  "EmptyToURLs",
+			input: "https .",
+		},
+		{
+			name:  "InvalidToURL",
+			input: "https . abc:&",
+		},
+		{
+			name:  "TooManyToURLs",
+			input: "https . " + strings.Repeat("example.com/dns-query ", maxUpstreams+1),
+		},
+		{
+			name:  "UnknownProperty",
+			input: "https . example.com/dns-query {\nabc\n}\n",
+		},
+		{
+			name:  "ExceptPropertyZeroArgs",
+			input: "https . example.com/dns-query {\nexcept\n}\n",
+		},
+		{
+			name:  "TLSPropertyTooManyArgs",
+			input: "https . example.com/dns-query {\ntls abc def ghi qwe\n}\n",
+		},
+		{
+			name:  "TLSServerNamePropertyZeroArgs",
+			input: "https . example.com/dns-query {\ntls_servername\n}\n",
+		},
+		{
+			name:  "TLSServerNamePropertyTooManyArgs",
+			input: "https . example.com/dns-query {\ntls_servername abc.com def.com\n}\n",
+		},
+		{
+			name:  "PolicyPropertyZeroArgs",
+			input: "https . example.com/dns-query {\npolicy\n}\n",
+		},
+		{
+			name:  "PolicyPropertyTooManyArgs",
+			input: "https . example.com/dns-query {\npolicy random round_robin\n}\n",
+		},
+		{
+			name:  "PolicyPropertyUnknownArg",
+			input: "https . example.com/dns-query {\npolicy abc\n}\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := caddy.NewTestController("https", tt.input)
+			_, err := parseConfig(c)
+			require.Error(t, err)
+		})
+	}
+}

--- a/plugin/https/setup_test.go
+++ b/plugin/https/setup_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name           string
 		input          string
@@ -108,7 +107,6 @@ func TestParseConfig(t *testing.T) {
 }
 
 func TestParseConfigError(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name  string
 		input string


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Hi there! This pull request adds **https** plugin that performs DNS-over-HTTPS proxying. I implemented the functionality in accordance with [RFC8484](https://tools.ietf.org/html/rfc8484).  Almost every line of the source code is written using TDD. I have already tested these changes on the cloudflare, google and quad9  DoH servers. 

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/4147

### 3. Which documentation changes (if any) need to be made?

I added documentation in the same style as the forward and grpc plugins. But if you have any comments, feel free to tell me, I'll correct them.

### 4. Does this introduce a backward incompatible change or deprecation?

No
