### PR TITLE
Add error check to avoid panic

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -117,11 +117,14 @@ func (h *Hostsfile) readHosts() {
 	defer file.Close()
 
 	stat, err := file.Stat()
+	if err != nil {
+		return
+	}
 	h.RLock()
 	size := h.size
 	h.RUnlock()
 
-	if err == nil && h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
+	if h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
 		return
 	}
 

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -117,11 +117,15 @@ func (h *Hostsfile) readHosts() {
 	defer file.Close()
 
 	stat, err := file.Stat()
+	if err != nil {
+		log.Warningf("Failed to get file info: %v", err)
+		return
+	}
 	h.RLock()
 	size := h.size
 	h.RUnlock()
 
-	if err == nil && h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
+	if h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add error check to avoid panic
If err is not nil, the `stat` will be nil. So the following code calling other method will cause panic.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
