### PR TITLE
Add `requests_total` metric to `hosts` plugin

### DIFF
--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -69,6 +69,7 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	m.Answer = answers
 
 	w.WriteMsg(m)
+	RequestCount.WithLabelValues().Add(1)
 	return dns.RcodeSuccess, nil
 }
 

--- a/plugin/hosts/metrics.go
+++ b/plugin/hosts/metrics.go
@@ -22,4 +22,11 @@ var (
 		Name:      "reload_timestamp_seconds",
 		Help:      "The timestamp of the last reload of hosts file.",
 	})
+	// RequestCount is the amount of requests served from hosts-file/s
+	RequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "hosts",
+		Name:      "requests_total",
+		Help:      "Counter of requests made per upstream.",
+	}, []string{})
 )

--- a/plugin/hosts/metrics.go
+++ b/plugin/hosts/metrics.go
@@ -27,6 +27,6 @@ var (
 		Namespace: plugin.Namespace,
 		Subsystem: "hosts",
 		Name:      "requests_total",
-		Help:      "Counter of requests made per upstream.",
+		Help:      "Counter of requests made to hosts plugin.",
 	}, []string{})
 )


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It adds a new Metric for RequestsCount similar to all other plugins that serve requests to monitor the amount of requests being served from hosts file

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
Potentially add newly exposed metric to docs, however I dont see the current metrics being listed there either.
So likely N/A

### 4. Does this introduce a backward incompatible change or deprecation?
No