### PR TITLE
plugin/etcd: Fix inconsistent names of glue records with TargetStrip

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -440,8 +440,8 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 
 		case dns.TypeA, dns.TypeAAAA:
 			serv.Host = msg.Domain(serv.Key)
-			extra = append(extra, newAddress(serv, serv.Host, ip, what))
 			ns := serv.NewNS(state.QName())
+			extra = append(extra, newAddress(serv, ns.Ns, ip, what))
 			if _, ok := seen[ns.Ns]; ok {
 				continue
 			}

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -37,12 +37,16 @@ var services = []*msg.Service{
 	{Host: "sub.server1", Port: 0, Key: "a.sub.region1.skydns.test."},
 	{Host: "sub.server2", Port: 80, Key: "b.sub.region1.skydns.test."},
 	{Host: "10.0.0.1", Port: 8080, Key: "c.sub.region1.skydns.test."},
+	// TargetStrip.
+	{Host: "10.0.0.1", Port: 8080, Key: "a.targetstrip.skydns.test.", TargetStrip: 1},
 	// Cname loop.
 	{Host: "a.cname.skydns.test", Key: "b.cname.skydns.test."},
 	{Host: "b.cname.skydns.test", Key: "a.cname.skydns.test."},
 	// Nameservers.
 	{Host: "10.0.0.2", Key: "a.ns.dns.skydns.test."},
 	{Host: "10.0.0.3", Key: "b.ns.dns.skydns.test."},
+	{Host: "10.0.0.4", Key: "ns1.c.ns.dns.skydns.test.", TargetStrip: 1},
+	{Host: "10.0.0.5", Key: "ns2.c.ns.dns.skydns.test.", TargetStrip: 1},
 	// Zone name as A record (basic, return all)
 	{Host: "10.0.0.2", Key: "x.skydns_zonea.test."},
 	{Host: "10.0.0.3", Key: "y.skydns_zonea.test."},
@@ -123,6 +127,14 @@ var dnsTestCases = []test.Case{
 			test.SRV("sub.region1.skydns.test. 300 IN SRV 10 33 8080 c.sub.region1.skydns.test."),
 		},
 		Extra: []dns.RR{test.A("c.sub.region1.skydns.test. 300 IN A 10.0.0.1")},
+	},
+	// SRV TargetStrip Test
+	{
+		Qname: "targetstrip.skydns.test.", Qtype: dns.TypeSRV,
+		Answer: []dns.RR{
+			test.SRV("targetstrip.skydns.test. 300 IN SRV 10 100 8080 targetstrip.skydns.test."),
+		},
+		Extra: []dns.RR{test.A("targetstrip.skydns.test. 300 IN A 10.0.0.1")},
 	},
 	// CNAME (unresolvable internal name)
 	{
@@ -217,10 +229,13 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{
 			test.NS("skydns.test. 300 NS a.ns.dns.skydns.test."),
 			test.NS("skydns.test. 300 NS b.ns.dns.skydns.test."),
+			test.NS("skydns.test. 300 NS c.ns.dns.skydns.test."),
 		},
 		Extra: []dns.RR{
 			test.A("a.ns.dns.skydns.test. 300 A 10.0.0.2"),
 			test.A("b.ns.dns.skydns.test. 300 A 10.0.0.3"),
+			test.A("c.ns.dns.skydns.test. 300 A 10.0.0.4"),
+			test.A("c.ns.dns.skydns.test. 300 A 10.0.0.5"),
 		},
 	},
 	// NS Record Test
@@ -234,6 +249,8 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{
 			test.A("ns.dns.skydns.test. 300 A 10.0.0.2"),
 			test.A("ns.dns.skydns.test. 300 A 10.0.0.3"),
+			test.A("ns.dns.skydns.test. 300 A 10.0.0.4"),
+			test.A("ns.dns.skydns.test. 300 A 10.0.0.5"),
 		},
 	},
 	{


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

When you use `etcd` plugin and query NS record whose `TargetStrip` > 0, A records in the additional section have unstripped names while NS records in the answer section have stripped names. This response is obviously incorrect.

#### Reproducible Example

* Add records under `/skydns/test/dns/ns`
  ```shell
  $ etcd &
  
  $ etcdctl put /skydns/test/dns/ns/ns1 '{"host":"10.0.0.11","ttl":60}'
  
  $ etcdctl put /skydns/test/dns/ns/ns2/foo '{"host":"10.0.0.22","ttl":60,"targetstrip":1}'
  
  $ etcdctl put /skydns/test/dns/ns/ns2/bar '{"host":"10.0.0.33","ttl":60,"targetstrip":1}'
  ```
* Run CoreDNS with etcd plugin enabled
  ```shell
  $ cat > coredns.cfg << EOF
  test.:10053 {
      etcd
  }
  EOF
  
  $ coredns -conf coredns.cfg &
  ```
* Query NS records
  ```shell
  $ dig -p 10053 ns test. @localhost 
  
  ; <<>> DiG 9.16.8 <<>> -p 10053 ns test. @localhost
  ;; global options: +cmd
  ;; Got answer:
  ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12029
  ;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 4
  ;; WARNING: recursion requested but not available
  
  ;; OPT PSEUDOSECTION:
  ; EDNS: version: 0, flags:; udp: 4096
  ; COOKIE: 849063390ea9c238 (echoed)
  ;; QUESTION SECTION:
  ;test.				IN	NS
  
  ;; ANSWER SECTION:
  test.			60	IN	NS	ns1.ns.dns.test.
  test.			60	IN	NS	ns2.ns.dns.test.
  
  ;; ADDITIONAL SECTION:
  ns1.ns.dns.test.	60	IN	A	10.0.0.11
  bar.ns2.ns.dns.test.	60	IN	A	10.0.0.33
  foo.ns2.ns.dns.test.	60	IN	A	10.0.0.22
  
  ;; Query time: 1 msec
  ;; SERVER: ::1#10053(::1)
  ;; WHEN: Sat May 01 23:13:38 JST 2021
  ;; MSG SIZE  rcvd: 212
  ```

In this example, `ns2.ns.dns.test.` was returned in the answer section, but A records for the same name did not appear in the additional section. Instead, A records for unstripped names (`foo.ns2.ns.dns.test.` and `bar.ns2.ns.dns.test.`) were returned.

### 2. Which issues (if any) are related?

Nothing

### 3. Which documentation changes (if any) need to be made?

Nothing

### 4. Does this introduce a backward incompatible change or deprecation?

Response will be changed in limited cases, but it's inevitable because this is a bugfix.