### PR TITLE
Add backmarket.com to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -28,3 +28,4 @@
 * [Hualala](https://www.hualala.com)  uses CoreDNS in Kubernetes using default configuration, in its Lab. Expected to be in production soon.
 * [Hellofresh](https://www.hellofresh.com/) uses CoreDNS in multiple Kubernetes clusters, with Forward plugin.
 * [Render](https://render.com) uses CoreDNS in production across all its Kubernetes clusters.
+* [BackMarket](https://www.backmarket.com) uses CoreDNS within Kubernetes in production, with standard configuration.


### PR DESCRIPTION
1. Why is this pull request needed and what does it do?
It adds BackMarket (a retail marketplace for refurbished devices) to the list of CoreDNS adopters.

2. Which issues (if any) are related?
None.

3. Which documentation changes (if any) need to be made?
None.

4. Does this introduce a backward incompatible change or deprecation?
No.