### PR TITLE
Add Absa to Adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -29,3 +29,4 @@
 * [Hellofresh](https://www.hellofresh.com/) uses CoreDNS in multiple Kubernetes clusters, with Forward plugin.
 * [Render](https://render.com) uses CoreDNS in production across all its Kubernetes clusters.
 * [BackMarket](https://www.backmarket.com) uses CoreDNS within Kubernetes in production, with standard configuration.
+* [Absa Group](https://www.absa.africa) uses CoreDNS as an integral part of Kubernetes Global Balancer project - [k8gb](https://www.k8gb.io/).


### PR DESCRIPTION
Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>

Why is this pull request needed and what does it do?
It adds Absa Group(South African financial service provider) to the list of CoreDNS adopters.

Which issues (if any) are related?
None.

Which documentation changes (if any) need to be made?
None.

Does this introduce a backward incompatible change or deprecation?
No.