### PR TITLE
DNSSEC check for two days of remaining validity

### DIFF
--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -31,7 +31,7 @@ func periodicClean(c *cache.Cache, stop <-chan struct{}) {
 		case <-tick.C:
 			// we sign for 8 days, check if a signature in the cache reached 75% of that (i.e. 6), if found delete
 			// the signature
-			is75 := time.Now().UTC().Add(sixDays)
+			is75 := time.Now().UTC().Add(twoDays)
 			c.Walk(func(items map[uint64]interface{}, key uint64) bool {
 				sig := items[key].(*dns.RRSIG)
 				if !sig.ValidityPeriod(is75) {

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -131,7 +131,7 @@ func (d Dnssec) set(key uint64, sigs []dns.RR) { d.cache.Add(key, sigs) }
 func (d Dnssec) get(key uint64, server string) ([]dns.RR, bool) {
 	if s, ok := d.cache.Get(key); ok {
 		// we sign for 8 days, check if a signature in the cache reached 3/4 of that
-		is75 := time.Now().UTC().Add(sixDays)
+		is75 := time.Now().UTC().Add(twoDays)
 		for _, rr := range s.([]dns.RR) {
 			if !rr.(*dns.RRSIG).ValidityPeriod(is75) {
 				cacheMisses.WithLabelValues(server).Inc()
@@ -154,6 +154,6 @@ func incepExpir(now time.Time) (uint32, uint32) {
 
 const (
 	eightDays  = 8 * 24 * time.Hour
-	sixDays    = 6 * 24 * time.Hour
+	twoDays    = 2 * 24 * time.Hour
 	defaultCap = 10000 // default capacity of the cache.
 )


### PR DESCRIPTION
Signed-off-by: Keith C <keith@fraudmarc.com>

### 1. Why is this pull request needed and what does it do?
This should allow cached signatures to be cached for the intended six day duration.
### 2. Which issues (if any) are related?
fix #4605 
### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No