### PR TITLE
plugin/kubernetes: copy unready endpointslice exclusion to v1beta1

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -178,6 +178,9 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
+		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+			continue
+		}
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Copies the unready endpointslice exclusion condition to the v1beta1 version of the endpointslice object conversion function.

### 2. Which issues (if any) are related?

#4570
#4580

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
