### PR TITLE
test: Fix rare race condition in TestZoneReload

### DIFF
--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -47,7 +47,7 @@ func TestZoneReload(t *testing.T) {
 	// Remove RR from the Apex
 	ioutil.WriteFile(name, []byte(exampleOrgUpdated), 0644)
 
-	time.Sleep(10 * time.Millisecond) // reload time
+	time.Sleep(20 * time.Millisecond) // reload time, with some race insurance
 
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {
@@ -55,7 +55,7 @@ func TestZoneReload(t *testing.T) {
 	}
 
 	if len(resp.Answer) != 1 {
-		t.Fatalf("Expected two RR in answer section got %d", len(resp.Answer))
+		t.Fatalf("Expected one RR in answer section got %d", len(resp.Answer))
 	}
 }
 


### PR DESCRIPTION
The following test failure for `TestZoneReload` can be observed
periodically:

`file_reload_test.go:58: Expected two RR in answer section got 2`

This failure can be consistently reproduced using the following command
(on my machine, at least):

`( cd test ; go test -v -race -run "TestZoneReload" ./... -count=500)`

test/file_reload_test.go:

Address a typo in a test failure message.

Sleep for double the file reload interval to avoid a rare
race condition between test code and the file plugin's reload code,
which is presumably a result of the time it takes to actually reload.

Signed-off-by: Stephen Greene <sgreene@redhat.com>

---

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This Pull request attempts to fix a race condition in the `TestZoneReload` unit test.
### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A

I am new to the CoreDNS codebase, so if somebody can think of a better approach (or if they are unable to reproduce the test failure), please let me know.