### PR TITLE
plugin/kubernetes: Treat Endpointslices with a nil ready condition as "ready"

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -128,7 +128,7 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+		if !endpointsliceReady(end.Conditions.Ready) {
 			continue
 		}
 		for _, a := range end.Addresses {
@@ -178,7 +178,7 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if end.Conditions.Ready == nil || !*end.Conditions.Ready {
+		if !endpointsliceReady(end.Conditions.Ready) {
 			continue
 		}
 		for _, a := range end.Addresses {
@@ -198,6 +198,15 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	*ends = discoveryV1beta1.EndpointSlice{}
 
 	return e, nil
+}
+
+func endpointsliceReady(ready *bool) bool {
+	// Per API docs: a nil value indicates an unknown state. In most cases consumers
+	// should interpret this unknown state as ready.
+	if ready == nil {
+		return true
+	}
+	return *ready
 }
 
 // CopyWithoutSubsets copies e, without the subsets.


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Per API docs, "Most consumers" should consider an Endpointslice with a nil ready condition as "ready".

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
