### PR TITLE
Revert "plugin/file: Fix in wrong answers returned when wildcard and concrete records exist (#4599)"

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -56,10 +56,10 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	}
 
 	var (
-		found, shot              bool
-		parts                    string
-		i, maxLabelNum           int
-		elem, wildElem, nextElem *tree.Elem
+		found, shot    bool
+		parts          string
+		i              int
+		elem, wildElem *tree.Elem
 	)
 
 	loop, _ := ctx.Value(dnsserver.LoopKey{}).(int)
@@ -90,12 +90,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 		// We overshot the name, break and check if we previously found something.
 		if shot {
 			break
-		}
-
-		if nextElem, found = tr.Next(parts); found {
-			if dns.IsSubDomain(parts, nextElem.Name()) {
-				maxLabelNum = z.origLen + i
-			}
 		}
 
 		elem, found = tr.Search(parts)
@@ -207,18 +201,8 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 	// Found wildcard.
 	if wildElem != nil {
-		// if the domain's longest matching parent domain is subdomain of the wildcard,
-		// in other words, the domain‘s max number of labels matched is >= number of labels of the wildcard
-		if maxLabelNum >= dns.CountLabel(wildElem.Name()) {
-			ret := ap.soa(do)
-			if do {
-				nsec := typeFromElem(wildElem, dns.TypeNSEC, do)
-				ret = append(ret, nsec...)
-			}
-			return nil, ret, nil, NameError
-		}
-
 		auth := ap.ns(do)
+
 		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
 			return z.externalLookup(ctx, state, wildElem, rrs)

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -95,12 +95,6 @@ var dnsTestCases = []test.Case{
 		},
 		Ns: miekAuth,
 	},
-	{
-		Qname: "ent.miek.nl.", Qtype: dns.TypeA,
-		Ns: []dns.RR{
-			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
-		},
-	},
 }
 
 const (
@@ -199,6 +193,4 @@ www             IN      CNAME   a
 archive         IN      CNAME   a
 
 srv		IN	SRV     10 10 8080 a.miek.nl.
-mx		IN	MX      10 a.miek.nl.
-
-test.ent	IN	A	139.162.196.79`
+mx		IN	MX      10 a.miek.nl.`

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -266,76 +266,6 @@ func TestLookupMultiWildcard(t *testing.T) {
 	}
 }
 
-var cornerCasesWildcardTestCases = []test.Case{
-	{
-		Qname: "r.c.d.example.org.", Qtype: dns.TypeA,
-		Answer: []dns.RR{test.A(`r.c.d.example.org. 3600	IN	A 127.0.1.56`)},
-		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
-	},
-	{
-		Qname: "something.d.example.org.", Qtype: dns.TypeA,
-		Answer: []dns.RR{test.A(`something.d.example.org.	3600	IN	A	127.0.1.53`)},
-		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
-	},
-	{
-		Qname: "else.something.d.example.org.", Qtype: dns.TypeA,
-		Answer: []dns.RR{test.A(`else.something.d.example.org.	3600	IN	A	127.0.1.53`)},
-		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
-	},
-	{
-		Qname: "something.c.d.example.org.", Qtype: dns.TypeA,
-		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
-		Rcode: dns.RcodeNameError,
-	},
-	{
-		Qname: "something.r.c.d.example.org.", Qtype: dns.TypeA,
-		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
-		Rcode: dns.RcodeNameError,
-	},
-	{
-		Qname: "z.+.d.example.org.", Qtype: dns.TypeA,
-		Answer: []dns.RR{test.A(`z.+.d.example.org.	3600	IN	A	127.0.1.54`)},
-		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
-	},
-	{
-		Qname: "x.&.d.example.org.", Qtype: dns.TypeA,
-		Answer: []dns.RR{test.A(`x.&.d.example.org.	3600	IN	A	127.0.1.55`)},
-		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
-	},
-	{
-		Qname: "something.x.&.d.example.org.", Qtype: dns.TypeA,
-		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
-		Rcode: dns.RcodeNameError,
-	},
-}
-
-func TestLookupCornerCasesWildcard(t *testing.T) {
-	const name = "example.org."
-	zone, err := Parse(strings.NewReader(cornerCasesWildcard), name, "stdin", 0)
-	if err != nil {
-		t.Fatalf("Expect no error when reading zone, got %q", err)
-	}
-
-	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
-	ctx := context.TODO()
-
-	for _, tc := range cornerCasesWildcardTestCases {
-		m := tc.Msg()
-
-		rec := dnstest.NewRecorder(&test.ResponseWriter{})
-		_, err := fm.ServeDNS(ctx, rec, m)
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-			return
-		}
-
-		resp := rec.Msg
-		if err := test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
-		}
-	}
-}
-
 const exampleOrg = `; example.org test file
 $TTL 3600
 example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
@@ -365,14 +295,4 @@ example.org.		IN	NS	b.iana-servers.net.
 *.example.org.          IN      A       127.0.0.53
 *.intern.example.org.   IN      A       127.0.1.52
 foo.example.org.        IN      A       127.0.0.54
-`
-
-const cornerCasesWildcard = `; example.org test file with wildcard corner cases
-$TTL 3600
-example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
-example.org.		IN	NS	b.iana-servers.net.
-*.d.example.org.        IN      A       127.0.1.53
-z.+.d.example.org.		IN		A		127.0.1.54
-x.&.d.example.org.		IN		A		127.0.1.55
-r.c.d.example.org.      IN      A       127.0.1.56
 `


### PR DESCRIPTION
reverting as I don't want to release 1.8.4 with this enabled.

This reverts commit fbf3f07f469a99fcbb5985a41c260a3fad26f908.
