### PR TITLE
Fix obsure crash in Corefile parsing

### DIFF
--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -132,7 +132,11 @@ func OriginsFromArgsOrServerBlock(args, serverblock []string) []string {
 	}
 	s := []string{}
 	for i := range args {
-		s = append(s, Host(args[i]).Normalize()...)
+		sx := Host(args[i]).Normalize()
+		if len(sx) == 0 {
+			continue // silently ignores errors.
+		}
+		s = append(s, sx...)
 	}
 
 	return s

--- a/test/corefile_test.go
+++ b/test/corefile_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestCorefile1(t *testing.T) {
+	corefile := `ȶ
+acl
+`
+	// this crashed, now it should return an error.
+	i, _, _, err := CoreDNSServerAndPorts(corefile)
+	if err == nil {
+		defer i.Stop()
+		t.Fatalf("Expected an error got none")
+	}
+}


### PR DESCRIPTION
This was found by fuzzing.

We need to make this a fully qualified domain name to catch all errors
in dnsserver/register.go and not later when plugin.Normalize() is called again on these
strings, with the prime difference being that the domain name is fully
qualified. This was found by fuzzing where "ȶ" is deemed OK, but "ȶ." is
not (might be a bug in miekg/dns actually). But here we were checking ȶ,
which is OK, and later we barf in ȶ. leading to "index out of range".

Added a tests and check manually if it would crash with the current code
(yes), and fail with an error in this PR (yes).

Signed-off-by: Miek Gieben <miek@miek.nl>
