### PR TITLE
plugin/forward: Document and warn for unsupported FROM CIDR notations

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -29,7 +29,8 @@ In its most basic form, a simple forwarder uses this syntax:
 forward FROM TO...
 ~~~
 
-* **FROM** is the base domain to match for the request to be forwarded.
+* **FROM** is the base domain to match for the request to be forwarded. Domains using CIDR notation
+  that expand to multiple reverse zones are not supported.
 * **TO...** are the destination endpoints to forward to. The **TO** syntax allows you to specify
   a protocol, `tls://9.9.9.9` or `dns://` (or no protocol) for plain DNS. The number of upstreams is
   limited to 15.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -30,7 +30,7 @@ forward FROM TO...
 ~~~
 
 * **FROM** is the base domain to match for the request to be forwarded. Domains using CIDR notation
-  that expand to multiple reverse zones are not supported.
+  that expand to multiple reverse zones are not fully supported; only the first expanded zone is used.
 * **TO...** are the destination endpoints to forward to. The **TO** syntax allows you to specify
   a protocol, `tls://9.9.9.9` or `dns://` (or no protocol) for plain DNS. The number of upstreams is
   limited to 15.

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -96,7 +96,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	f.from = plugin.Host(f.from).Normalize()[0] // there can only be one here, won't work with non-octet reverse
 
 	if len(f.from) > 1 {
-		return f, fmt.Errorf("Unsupported CIDR notation: '%s' expands to multiple zones", origFrom)
+		log.Warningf("Unsupported CIDR notation: '%s' expands to multiple zones. Using only '%s'.", origFrom, f.from)
 	}
 
 	to := c.RemainingArgs()

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -92,7 +92,12 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	if !c.Args(&f.from) {
 		return f, c.ArgErr()
 	}
+	origFrom := f.from
 	f.from = plugin.Host(f.from).Normalize()[0] // there can only be one here, won't work with non-octet reverse
+
+	if len(f.from) > 1 {
+		return f, fmt.Errorf("Unsupported CIDR notation: '%s' expands to multiple zones", origFrom)
+	}
 
 	to := c.RemainingArgs()
 	if len(to) == 0 {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -38,6 +38,7 @@ func TestSetup(t *testing.T) {
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
 		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
+		{"forward 10.0.0.0/18 127.0.0.1", true, "", nil, 2, options{hcRecursionDesired: true}, ""},
 	}
 
 	for i, test := range tests {
@@ -50,7 +51,7 @@ func TestSetup(t *testing.T) {
 
 		if err != nil {
 			if !test.shouldErr {
-				t.Errorf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
+				t.Fatalf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
 			}
 
 			if !strings.Contains(err.Error(), test.expectedErr) {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -32,13 +32,13 @@ func TestSetup(t *testing.T) {
 		{"forward . [::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . [2003::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . 127.0.0.1 \n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward 10.9.3.0/18 127.0.0.1", false, "0.9.10.in-addr.arpa.", nil, 2, options{hcRecursionDesired: true}, ""},
 		// negative
 		{"forward . a27.0.0.1", true, "", nil, 0, options{hcRecursionDesired: true}, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true}, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
 		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
-		{"forward 10.0.0.0/18 127.0.0.1", true, "", nil, 2, options{hcRecursionDesired: true}, ""},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Document that CIDR notations which expand to > 1 rev zone are not fully supported by forward.
Warn at setup if FROM is a CIDR that expands to > 1 zone.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
