### PR TITLE
deprecate Normalize and MustNormalize

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -93,7 +93,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		return f, c.ArgErr()
 	}
 	origFrom := f.from
-	f.from = plugin.Host(f.from).Normalize()[0] // there can only be one here, won't work with non-octet reverse
+	f.from = plugin.Host(f.from).NormalizeExact()[0] // there can only be one here, won't work with non-octet reverse
 
 	if len(f.from) > 1 {
 		log.Warningf("Unsupported CIDR notation: '%s' expands to multiple zones. Using only '%s'.", origFrom, f.from)
@@ -156,7 +156,7 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return c.ArgErr()
 		}
 		for i := 0; i < len(ignore); i++ {
-			f.ignored = append(f.ignored, plugin.Host(ignore[i]).Normalize()...)
+			f.ignored = append(f.ignored, plugin.Host(ignore[i]).NormalizeExact()...)
 		}
 	case "max_fails":
 		if !c.NextArg() {

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -56,7 +56,7 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 	if !c.Args(&g.from) {
 		return g, c.ArgErr()
 	}
-	g.from = plugin.Host(g.from).Normalize()[0] // only the first is used.
+	g.from = plugin.Host(g.from).NormalizeExact()[0] // only the first is used.
 
 	to := c.RemainingArgs()
 	if len(to) == 0 {
@@ -100,7 +100,7 @@ func parseBlock(c *caddy.Controller, g *GRPC) error {
 			return c.ArgErr()
 		}
 		for i := 0; i < len(ignore); i++ {
-			g.ignored = append(g.ignored, plugin.Host(ignore[i]).Normalize()...)
+			g.ignored = append(g.ignored, plugin.Host(ignore[i]).NormalizeExact()...)
 		}
 	case "tls":
 		args := c.RemainingArgs()

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -70,7 +70,7 @@ func parse(c *caddy.Controller) (*Loop, error) {
 		}
 
 		if len(c.ServerBlockKeys) > 0 {
-			zones = plugin.Host(c.ServerBlockKeys[0]).Normalize()
+			zones = plugin.Host(c.ServerBlockKeys[0]).NormalizeExact()
 		}
 	}
 	return New(zones[0]), nil

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -63,8 +63,34 @@ type (
 
 // Normalize will return the host portion of host, stripping
 // of any port or transport. The host will also be fully qualified and lowercased.
+// An empty string is returned on failure
+// Deprecated: use OriginsFromArgsOrServerBlock or NormalizeExact
+func (h Host) Normalize() string {
+	// The error can be ignored here, because this function should only be called after the corefile has already been vetted.
+	host, _ := h.MustNormalize()
+	return host
+}
+
+// MustNormalize will return the host portion of host, stripping
+// of any port or transport. The host will also be fully qualified and lowercased.
+// An error is returned on error
+// Deprecated: use OriginsFromArgsOrServerBlock or NormalizeExact
+func (h Host) MustNormalize() (string, error) {
+	s := string(h)
+	_, s = parse.Transport(s)
+
+	// The error can be ignored here, because this function is called after the corefile has already been vetted.
+	hosts, _, err := SplitHostPort(s)
+	if err != nil {
+		return "", err
+	}
+	return Name(hosts[0]).Normalize(), nil
+}
+
+// NormalizeExact will return the host portion of host, stripping
+// of any port or transport. The host will also be fully qualified and lowercased.
 // An empty slice is returned on failure
-func (h Host) Normalize() []string {
+func (h Host) NormalizeExact() []string {
 	// The error can be ignored here, because this function should only be called after the corefile has already been vetted.
 	s := string(h)
 	_, s = parse.Transport(s)
@@ -126,13 +152,13 @@ func OriginsFromArgsOrServerBlock(args, serverblock []string) []string {
 		s := make([]string, len(serverblock))
 		copy(s, serverblock)
 		for i := range s {
-			s[i] = Host(s[i]).Normalize()[0] // expansion of these already happened in dnsserver/registrer.go
+			s[i] = Host(s[i]).NormalizeExact()[0] // expansion of these already happened in dnsserver/register.go
 		}
 		return s
 	}
 	s := []string{}
 	for i := range args {
-		sx := Host(args[i]).Normalize()
+		sx := Host(args[i]).NormalizeExact()
 		if len(sx) == 0 {
 			continue // silently ignores errors.
 		}

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -77,7 +77,9 @@ func (h Host) Normalize() string {
 // An error is returned on error
 // Deprecated: use OriginsFromArgsOrServerBlock or NormalizeExact
 func (h Host) MustNormalize() (string, error) {
-	log.Warning("Host.Normalize and Host.MustNormalize are Deprecated. Use OriginsFromArgsOrServerBlock or NormalizeExact.")
+	log.Warning("An external plugin is using deprecated functions Normalize or MustNormalize. " +
+		"These will be removed in a future versions of CoreDNS. The plugin should be updated to use " +
+		"OriginsFromArgsOrServerBlock or NormalizeExact instead.")
 	s := string(h)
 	_, s = parse.Transport(s)
 

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/cidr"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/parse"
 
 	"github.com/miekg/dns"
@@ -76,6 +77,7 @@ func (h Host) Normalize() string {
 // An error is returned on error
 // Deprecated: use OriginsFromArgsOrServerBlock or NormalizeExact
 func (h Host) MustNormalize() (string, error) {
+	log.Warning("Host.Normalize and Host.MustNormalize are Deprecated. Use OriginsFromArgsOrServerBlock or NormalizeExact.")
 	s := string(h)
 	_, s = parse.Transport(s)
 

--- a/plugin/normalize_test.go
+++ b/plugin/normalize_test.go
@@ -71,7 +71,7 @@ func TestNameNormalize(t *testing.T) {
 	}
 }
 
-func TestHostNormalize(t *testing.T) {
+func TestHostNormalizeExact(t *testing.T) {
 	tests := []struct {
 		in  string
 		out []string
@@ -85,7 +85,7 @@ func TestHostNormalize(t *testing.T) {
 	}
 
 	for i := range tests {
-		actual := Host(tests[i].in).Normalize()
+		actual := Host(tests[i].in).NormalizeExact()
 		expected := tests[i].out
 		sort.Strings(expected)
 		for j := range expected {

--- a/plugin/pkg/fall/fall.go
+++ b/plugin/pkg/fall/fall.go
@@ -33,7 +33,7 @@ func (f F) Through(qname string) bool {
 func (f *F) setZones(zones []string) {
 	z := []string{}
 	for i := range zones {
-		z = append(z, plugin.Host(zones[i]).Normalize()...)
+		z = append(z, plugin.Host(zones[i]).NormalizeExact()...)
 	}
 	f.Zones = z
 }


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

The recent signature change to `Normalize` (#4621) is not compatible with existing external plugins.
To ease the transition, this PR ...
* Renames the fixed version of `Normalize` to `NormalizeExact`
* Restore the original `Normalize` and `MustNormalize` and documents them as Deprecated.

### 2. Which issues (if any) are related?

#4621

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
