### PR TITLE
Reduce the cardinality of health endpoint metrics

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -50,11 +50,13 @@ Doing this is supported but both endpoints ":8080" and ":8081" will export the e
 
 If monitoring is enabled (via the *prometheus* plugin) then the following metric is exported:
 
- *  `coredns_health_request_duration_seconds{}` - duration to process a HTTP query to the local
+ * `coredns_health_request_duration_seconds{}` - duration to process a HTTP query to the local
     `/health` endpoint. As this a local operation it should be fast. A (large) increase in this
     duration indicates the CoreDNS process is having trouble keeping up with its query load.
+ * `coredns_health_request_failures_total{}` - The number of times the internal health check loop
+    failed to query `/health`.
 
-Note that this metric *does not* have a `server` label, because being overloaded is a symptom of
+Note that these metrics *do not* have a `server` label, because being overloaded is a symptom of
 the running process, *not* a specific server.
 
 ## Examples

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -105,5 +105,8 @@ const Namespace = "coredns"
 // TimeBuckets is based on Prometheus client_golang prometheus.DefBuckets
 var TimeBuckets = prometheus.ExponentialBuckets(0.00025, 2, 16) // from 0.25ms to 8 seconds
 
+// SlimTimeBuckets is low cardinality set of duration buckets.
+var SlimTimeBuckets = prometheus.ExponentialBuckets(0.00025, 10, 5) // from 0.25ms to 2.5 seconds
+
 // ErrOnce is returned when a plugin doesn't support multiple setups per server.
 var ErrOnce = errors.New("this plugin can only be used once per Server Block")


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The health endpoint histogram has a large amount of cardinality for a
simple endpoint. Introduce a new "Slim" set of buckets for `/health` to
reduce the metrics load on large deployments. Especially those that have
per-node DNS caching services.

Add a metric to count internal health check failures rather than use the
timeout value as side effect monitor of the check error. This avoids
incorrectly recording the timeout value if there is an error that is not
a timeout (ex. refused)

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Updated health plugin README.

### 4. Does this introduce a backward incompatible change or deprecation?

No