### PR TITLE
[Re-apply #4599]: plugin/file: Fix in wrong answers returned when wildcard and concrete records exist

### DIFF
--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -95,6 +95,12 @@ var dnsTestCases = []test.Case{
 		},
 		Ns: miekAuth,
 	},
+	{
+		Qname: "ent.miek.nl.", Qtype: dns.TypeA,
+		Ns: []dns.RR{
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
 }
 
 const (
@@ -193,4 +199,6 @@ www             IN      CNAME   a
 archive         IN      CNAME   a
 
 srv		IN	SRV     10 10 8080 a.miek.nl.
-mx		IN	MX      10 a.miek.nl.`
+mx		IN	MX      10 a.miek.nl.
+
+test.ent	IN	A	139.162.196.79`

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -266,6 +266,76 @@ func TestLookupMultiWildcard(t *testing.T) {
 	}
 }
 
+var cornerCasesWildcardTestCases = []test.Case{
+	{
+		Qname: "r.c.d.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`r.c.d.example.org. 3600	IN	A 127.0.1.56`)},
+		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+	{
+		Qname: "something.d.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`something.d.example.org.	3600	IN	A	127.0.1.53`)},
+		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+	{
+		Qname: "else.something.d.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`else.something.d.example.org.	3600	IN	A	127.0.1.53`)},
+		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+	{
+		Qname: "something.c.d.example.org.", Qtype: dns.TypeA,
+		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
+		Rcode: dns.RcodeNameError,
+	},
+	{
+		Qname: "something.r.c.d.example.org.", Qtype: dns.TypeA,
+		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
+		Rcode: dns.RcodeNameError,
+	},
+	{
+		Qname: "z.+.d.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`z.+.d.example.org.	3600	IN	A	127.0.1.54`)},
+		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+	{
+		Qname: "x.&.d.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`x.&.d.example.org.	3600	IN	A	127.0.1.55`)},
+		Ns: []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+	{
+		Qname: "something.x.&.d.example.org.", Qtype: dns.TypeA,
+		Ns: []dns.RR{test.SOA(`example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`)},
+		Rcode: dns.RcodeNameError,
+	},
+}
+
+func TestLookupCornerCasesWildcard(t *testing.T) {
+	const name = "example.org."
+	zone, err := Parse(strings.NewReader(cornerCasesWildcard), name, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expect no error when reading zone, got %q", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
+	ctx := context.TODO()
+
+	for _, tc := range cornerCasesWildcardTestCases {
+		m := tc.Msg()
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		_, err := fm.ServeDNS(ctx, rec, m)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+			return
+		}
+
+		resp := rec.Msg
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 const exampleOrg = `; example.org test file
 $TTL 3600
 example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
@@ -295,4 +365,14 @@ example.org.		IN	NS	b.iana-servers.net.
 *.example.org.          IN      A       127.0.0.53
 *.intern.example.org.   IN      A       127.0.1.52
 foo.example.org.        IN      A       127.0.0.54
+`
+
+const cornerCasesWildcard = `; example.org test file with wildcard corner cases
+$TTL 3600
+example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+example.org.		IN	NS	b.iana-servers.net.
+*.d.example.org.        IN      A       127.0.1.53
+z.+.d.example.org.		IN		A		127.0.1.54
+x.&.d.example.org.		IN		A		127.0.1.55
+r.c.d.example.org.      IN      A       127.0.1.56
 `


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It fixes in file plugin wrong answers returned when wildcard and concrete records exist:
```
; example.org test file with wildcard corner cases
$TTL 3600
example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600  
example.org.		IN	NS	b.iana-servers.net.  
*.d.example.org.        IN      A       127.0.1.53  
r.c.d.example.org.      IN      A       127.0.1.52
```

As per RFC 4592, the query `something.r.c.d.example.com.` , A should not match the wildcard record `*.d.example.com.` , A as `r.c.d.example.com.` , A exists. It is considered the closest encloser, and since there is neither something domain nor a wildcard record under it, the answer has to be NXDOMAIN.
CoreDNS exhibit the same behavior even for queries like `something.c.d.example.com.` , A. The expected response is NXDOMAIN, but CoreDNS returns the wildcard record.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4290

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No