### PR TITLE
fix circleci test build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: Run Kubernetes tests
           command: |
             cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/ci/test/kubernetes
-            go mod download
+            go mod tidy
             go test -v ./...
 
 workflows:


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

go 1.16.5 changes the behavior of `go mod download`, such that it no longer updates `go.sum`.
Use `go mod tidy` instead.

### 2. Which issues (if any) are related?

This test started failing in PRs soon after the release of go 1.16.5.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
