### PR TITLE
plugin/forward: Configure dial timeout values

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -52,6 +52,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec]
     max_concurrent MAX
+    min_max_dial_timeout DURATION DURATION
 }
 ~~~
 
@@ -93,13 +94,17 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `min_max_dial_timeout` **DURATION** **DURATION** defines the lower (first) and upper (second) bound 
+   timeout values used to automatically configure the transport dialer timeout. When this option is not set 
+   its default values are `1s` for min and `30s` for max.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.
 
 On each endpoint, the timeouts for communication are set as follows:
 
-* The dial timeout by default is 30s, and can decrease automatically down to 100ms based on early results.
+* The dial timeout starts at max dial timeout, and can decrease automatically down to min dial timeout based on 
+  early results but always within the limits of min_max_dial_timeout.
 * The read timeout is static at 2s.
 
 ## Metadata

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -36,7 +36,7 @@ func averageTimeout(currentAvg *int64, observedDuration time.Duration, weight in
 }
 
 func (t *Transport) dialTimeout() time.Duration {
-	return limitTimeout(&t.avgDialTime, minDialTimeout, maxDialTimeout)
+	return limitTimeout(&t.avgDialTime, t.minDialTimeout, t.maxDialTimeout)
 }
 
 func (t *Transport) updateDialTimeout(newDialTime time.Duration) {

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -36,11 +36,13 @@ type Forward struct {
 	from    string
 	ignored []string
 
-	tlsConfig     *tls.Config
-	tlsServerName string
-	maxfails      uint32
-	expire        time.Duration
-	maxConcurrent int64
+	tlsConfig      *tls.Config
+	tlsServerName  string
+	maxfails       uint32
+	expire         time.Duration
+	maxConcurrent  int64
+	minDialTimeout time.Duration
+	maxDialTimeout time.Duration
 
 	opts options // also here for testing
 
@@ -55,7 +57,8 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true}}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval,
+		minDialTimeout: defaultMinDialTimeout, maxDialTimeout: defaultMaxDialTimeout, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true}}
 	return f
 }
 

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -92,9 +92,9 @@ func TestCleanupAll(t *testing.T) {
 
 	tr := newTransport(s.Addr)
 
-	c1, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
-	c2, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
-	c3, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
+	c1, _ := dns.DialTimeout("udp", tr.addr, defaultMaxDialTimeout)
+	c2, _ := dns.DialTimeout("udp", tr.addr, defaultMaxDialTimeout)
+	c3, _ := dns.DialTimeout("udp", tr.addr, defaultMaxDialTimeout)
 
 	tr.conns[typeUDP] = []*persistConn{{c1, time.Now()}, {c2, time.Now()}, {c3, time.Now()}}
 

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -43,6 +43,12 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
 
+// SetMinDialTimeout sets the min dial timeout in the lower p.transport.
+func (p *Proxy) SetMinDialTimeout(min time.Duration) { p.transport.SetMinDialTimeout(min) }
+
+// SetMaxDialTimeout sets the max dial timeout in the lower p.transport.
+func (p *Proxy) SetMaxDialTimeout(max time.Duration) { p.transport.SetMaxDialTimeout(max) }
+
 // Healthcheck kicks of a round of health checks for this proxy.
 func (p *Proxy) Healthcheck() {
 	if p.health == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Allow users to configure min and max dial timeouts in the forward plugin.

> Note: Since the addition of this feature request wasn't officially accepted (yet) by any core developer, I completely understand and assume this PR could go straight to the bin. Yet I felt motivated to create this draft as an excuse to get in touch with the code base.

### 2. Which issues (if any) are related?
It addresses the feature request described in https://github.com/coredns/coredns/issues/4626 

### 3. Which documentation changes (if any) need to be made?
I changed `README.md` in the forward plugin directory using my best understanding.

### 4. Does this introduce a backward incompatible change or deprecation?
Trying to use the new `min_max_dial_timeout` parameter in previous `coredns` version will cause the server failing to start.
