### PR TITLE
plugin/route53: Fix bug when retrieving implicit AWS credentials on ECS Fargate

### DIFF
--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -15,8 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -120,9 +119,7 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("route53", err)
 		}
 
-		providers = append(providers, &credentials.EnvProvider{}, sharedProvider, &ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(session),
-		})
+		providers = append(providers, &credentials.EnvProvider{}, sharedProvider, defaults.RemoteCredProvider(*session.Config, session.Handlers))
 		client := f(credentials.NewChainCredentials(providers))
 		ctx, cancel := context.WithCancel(context.Background())
 		h, err := New(ctx, client, keys, refresh)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This enables Route53 plugin to retrieve implicit AWS credentials on ECS Fargate. Tested on both EC2 instance and ECS Fargate.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4668

### 3. Which documentation changes (if any) need to be made?
We don't need to change any documentation.

### 4. Does this introduce a backward incompatible change or deprecation?
No, this does not.