### PR TITLE
Add verbose log in GitHub Actions CI for make -f Makefile.doc

### DIFF
--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -17,7 +17,7 @@ jobs:
       -
         name: Update Docs
         run: |
-          ./.github/fixup_file_mtime.sh
+          bash -x -e ./.github/fixup_file_mtime.sh
           make -f Makefile.doc
       -
         name: Set up Git
@@ -30,6 +30,7 @@ jobs:
       -
         name: Commit and push changes
         run: |
+          set -x -e
           git add .
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -s -m 'auto make -f Makefile.doc'


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Our GitHub Actions CI is having some issues with `make -f Makefile.doc` as the related changes that should have triggered the build didn't work for the past 3 months (since march).


This PR adds verbose to GitHub Actions CI to see if we can get more information.

Note this PR just add `set -x` to show detailed step. Will not impact anything else.


### 2. Which issues (if any) are related?


See https://github.com/coredns/coredns/pull/4680#issuecomment-856872811 for related discussion.

### 3. Which documentation changes (if any) need to be made?

n/a

### 4. Does this introduce a backward incompatible change or deprecation?

n/a


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>