### PR TITLE
plugin/forward: fix CIDR multi-zone check

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -93,9 +93,10 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		return f, c.ArgErr()
 	}
 	origFrom := f.from
-	f.from = plugin.Host(f.from).NormalizeExact()[0] // there can only be one here, won't work with non-octet reverse
+	zones := plugin.Host(f.from).NormalizeExact()
+	f.from = zones[0] // there can only be one here, won't work with non-octet reverse
 
-	if len(f.from) > 1 {
+	if len(zones) > 1 {
 		log.Warningf("Unsupported CIDR notation: '%s' expands to multiple zones. Using only '%s'.", origFrom, f.from)
 	}
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Multi reverse zone CIDR warning was incorrectly displayed any time the zone string length length was > 1 (practically speaking, anything other than `.`).
This fix checks the length of the number of zones returned by `NormalizeExact()`.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
