### PR TITLE
Fix timestamp issue for doc generating

### DIFF
--- a/.github/fixup_file_mtime.sh
+++ b/.github/fixup_file_mtime.sh
@@ -9,7 +9,7 @@ if [[ ! -f 'coredns.1.md' ]]; then
   exit 1
 fi
 
-for file in coredns.1.md corefile.5.md plugin/*/README.md; do
+for file in coredns.1.md corefile.5.md plugin/*/README.md man/*.1 man/*.5 man/*.7; do
   time=$(git log --pretty=format:%cd -n 1 --date='format:%Y%m%d%H%M.%S' "${file}")
   touch -m -t "${time}" "${file}"
 done


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR will fix the issue of doc is not automated rendered
through GitHub Actions anymore.

It looks the issue is cause by the fact that in `fixup_file_mtime.sh`
is only fixing files on source (.md) side, not on target (man/*.[1|5|7])
side. As a result Makefile will skip the rendering of doc as
it assume everything will be update to date.

This should fix the issue we were facing.

### 2. Which issues (if any) are related?


See https://github.com/coredns/coredns/pull/4680#issuecomment-856872811 for related discussion.

### 3. Which documentation changes (if any) need to be made?
n/a

### 4. Does this introduce a backward incompatible change or deprecation?

n/a

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>