### PR TITLE
WIP: Reflect truncated state to client, if upstream lookup is truncated

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -67,10 +67,11 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return dns.RcodeRefused, nil
 	}
 
-	answer, ns, extra, result := z.Lookup(ctx, state, qname)
+	answer, ns, extra, result, tc := z.Lookup(ctx, state, qname)
 
 	m := new(dns.Msg)
 	m.SetReply(r)
+	m.Truncated = tc
 	m.Authoritative = true
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -318,7 +318,7 @@ func (h *Azure) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	var result file.Result
 	for _, z := range zones {
 		h.zMu.RLock()
-		m.Answer, m.Ns, m.Extra, result = z.z.Lookup(ctx, state, qname)
+		m.Answer, m.Ns, m.Extra, result, m.Truncated = z.z.Lookup(ctx, state, qname)
 		h.zMu.RUnlock()
 
 		// record type exists for this name (NODATA).

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -116,10 +116,9 @@ func (h *CloudDNS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	m.SetReply(r)
 	m.Authoritative = true
 	var result file.Result
-
 	for _, hostedZone := range z {
 		h.zMu.RLock()
-		m.Answer, m.Ns, m.Extra, result = hostedZone.z.Lookup(ctx, state, qname)
+		m.Answer, m.Ns, m.Extra, result, m.Truncated = hostedZone.z.Lookup(ctx, state, qname)
 		h.zMu.RUnlock()
 
 		// Take the answer if it's non-empty OR if there is another

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -84,10 +84,11 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return dns.RcodeServerFailure, nil
 	}
 
-	answer, ns, extra, result := z.Lookup(ctx, state, qname)
+	answer, ns, extra, result, tc := z.Lookup(ctx, state, qname)
 
 	m := new(dns.Msg)
 	m.SetReply(r)
+	m.Truncated = tc
 	m.Authoritative = true
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -38,14 +38,14 @@ func TestZoneReload(t *testing.T) {
 	r := new(dns.Msg)
 	r.SetQuestion("miek.nl", dns.TypeSOA)
 	state := request.Request{W: &test.ResponseWriter{}, Req: r}
-	if _, _, _, res := z.Lookup(ctx, state, "miek.nl."); res != Success {
+	if _, _, _, res, _:= z.Lookup(ctx, state, "miek.nl."); res != Success {
 		t.Fatalf("Failed to lookup, got %d", res)
 	}
 
 	r = new(dns.Msg)
 	r.SetQuestion("miek.nl", dns.TypeNS)
 	state = request.Request{W: &test.ResponseWriter{}, Req: r}
-	if _, _, _, res := z.Lookup(ctx, state, "miek.nl."); res != Success {
+	if _, _, _, res, _:= z.Lookup(ctx, state, "miek.nl."); res != Success {
 		t.Fatalf("Failed to lookup, got %d", res)
 	}
 

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -91,11 +91,13 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return 0, nil
 	}
 
+	var truncated bool
+
 	switch state.QType() {
 	case dns.TypeA:
-		m.Answer = e.a(ctx, svc, state)
+		m.Answer, truncated = e.a(ctx, svc, state)
 	case dns.TypeAAAA:
-		m.Answer = e.aaaa(ctx, svc, state)
+		m.Answer, truncated = e.aaaa(ctx, svc, state)
 	case dns.TypeSRV:
 		m.Answer, m.Extra = e.srv(svc, state)
 	default:
@@ -106,6 +108,8 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	if len(m.Answer) == 0 {
 		m.Ns = []dns.RR{e.soa(state)}
 	}
+
+	m.Truncated = truncated
 
 	w.WriteMsg(m)
 	return 0, nil

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -119,7 +119,7 @@ func (h *Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	var result file.Result
 	for _, hostedZone := range z {
 		h.zMu.RLock()
-		m.Answer, m.Ns, m.Extra, result = hostedZone.z.Lookup(ctx, state, qname)
+		m.Answer, m.Ns, m.Extra, result, m.Truncated = hostedZone.z.Lookup(ctx, state, qname)
 		h.zMu.RUnlock()
 
 		// Take the answer if it's non-empty OR if there is another


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When responding to a client with records that were obtained from a truncated upstream response, the response to the client should be marked truncated. We can fail to do this for a CNAME to external records, where the response from the upstream providing the records is truncated. If that happens, the answer to the client need to be marked truncated.

Note: Depending on individual record size and size of the truncated upstream response, this issue may or may not manifest. If the total length of CNAME + truncated A records happens to exceed the client's max buffer size, then the response to the client will be truncated at write time.  But if the total length of CNAME + truncated A records does _not_ exceed the clients buffer size, then the answer will be written with the TC bit off, even though the answer is not complete.  Responses are truncated on record boundaries - so this is dependent on the size of the individual records.

This is a big change, we may want to break it into pieces. I've tried to break the commits out per dependent groups.

### 2. Which issues (if any) are related?

_Possibly_ related to #4684, although the symptoms described are different.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
