### PR TITLE
Enable dependabot scan on github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Since we are using GitHub Actions in CoreDNS repo and we are already
using Dependabot for security/version scans on golang code,
it makes sense to enable security/version scans on GitHub Actions as well.



### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?

n/a

### 4. Does this introduce a backward incompatible change or deprecation?

n/a


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>