### PR TITLE
plugin/transfer: Correct docs for 'to' option

### DIFF
--- a/plugin/transfer/README.md
+++ b/plugin/transfer/README.md
@@ -31,9 +31,29 @@ transfer [ZONE...] {
     `transfer.Transferer`.
 
  *  `to` **ADDRESS...** The hosts *transfer* will transfer to. Use `*` to permit transfers to all
-    addresses. **ADDRESS** must be denoted in CIDR notation (e.g., 127.0.0.1/32) or just as plain
-    addresses. `to` may be specified multiple times.
+    addresses. Zone change notifications are sent to all **ADDRESS** that are an IP address or
+    an IP address and port e.g. `1.2.3.4`, `12:34::56`, `1.2.3.4:5300`, `[12:34::56]:5300`.
+    `to` may be specified multiple times.
+
+You can use the _acl_ plugin to further restrict hosts permitted to receive a zone transfer.
+See example below.
 
 ## Examples
 
-See the specific plugins using this plugin for examples on it's usage.
+Use in conjuction with the _acl_ plugin to restrict access to subnet 10.1.0.0/16.
+
+```
+...
+  acl {
+    allow type AXFR net 10.1.0.0/16
+    allow type IXFR net 10.1.0.0/16
+    block type AXFR net *
+    block type IXFR net *
+  }
+  transfer {
+    to *
+  }
+...
+```
+
+Each plugin that can use _transfer_ includes an example of use in their respective documentation.


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?
Correct `to` docs to not allow CIDRs.
Add mention of notifications sent to IPs listed in `to`
Add example of how to restrict transfer access with _acl_

### 2. Which issues (if any) are related?

Fixes #4690

This is a "no-code" alternative to #4698.  IOW, either #4698 should merge OR this PR, but not both.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
