### PR TITLE
plugin/dns64: Persist truncated state to client if AAAA response is truncated

### DIFF
--- a/plugin/dns64/dns64.go
+++ b/plugin/dns64/dns64.go
@@ -130,6 +130,9 @@ func (d *DNS64) Synthesize(origReq, origResponse, resp *dns.Msg) *dns.Msg {
 	ret := dns.Msg{}
 	ret.SetReply(origReq)
 
+	// persist truncated state of AAAA response
+	ret.Truncated = resp.Truncated
+
 	// 5.3.2: DNS64 MUST pass the additional section unchanged
 	ret.Extra = resp.Extra
 	ret.Ns = resp.Ns

--- a/plugin/dns64/dns64_test.go
+++ b/plugin/dns64/dns64_test.go
@@ -382,6 +382,61 @@ func TestDNS64(t *testing.T) {
 				},
 			},
 		},
+		{
+			// no AAAA records, A record response truncated.
+			name: "truncated A response",
+			req: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Id:               42,
+					RecursionDesired: true,
+					Opcode:           dns.OpcodeQuery,
+				},
+				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+			},
+			initResp: &dns.Msg{ //success, no answers
+				MsgHdr: dns.MsgHdr{
+					Id:               42,
+					Opcode:           dns.OpcodeQuery,
+					RecursionDesired: true,
+					Rcode:            dns.RcodeSuccess,
+					Response:         true,
+				},
+				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Ns:       []dns.RR{test.SOA("example.com. 70 IN SOA foo bar 1 1 1 1 1")},
+			},
+			aResp: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Id:               43,
+					Opcode:           dns.OpcodeQuery,
+					RecursionDesired: true,
+					Truncated:        true,
+					Rcode:            dns.RcodeSuccess,
+					Response:         true,
+				},
+				Question: []dns.Question{{"example.com.", dns.TypeA, dns.ClassINET}},
+				Answer: []dns.RR{
+					test.A("example.com. 60 IN A 192.0.2.42"),
+					test.A("example.com. 5000 IN A 192.0.2.43"),
+				},
+			},
+
+			resp: &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Id:               42,
+					Opcode:           dns.OpcodeQuery,
+					RecursionDesired: true,
+					Truncated:        true,
+					Rcode:            dns.RcodeSuccess,
+					Response:         true,
+				},
+				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Answer: []dns.RR{
+					test.AAAA("example.com. 60 IN AAAA 64:ff9b::192.0.2.42"),
+					// override RR ttl to SOA ttl, since it's lower
+					test.AAAA("example.com. 70 IN AAAA 64:ff9b::192.0.2.43"),
+				},
+			},
+		},
 	}
 
 	_, pfx, _ := net.ParseCIDR("64:ff9b::/96")


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Persists the TC bit to the client response if the `AAAA` lookup response is truncated.
If not done, the client will think it got a complete response when the upstream response was truncated, _resulting in a wrong answer given to the client_.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
