### PR TITLE
plugin/etcd+kubernetes: Persist truncated state to client if CNAME lookup response is truncated

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -22,18 +22,19 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	state.Zone = zone
 
 	var (
-		records []dns.RR
-		extra   []dns.RR
-		err     error
+		records   []dns.RR
+		extra     []dns.RR
+		truncated bool
+		err       error
 	)
 
 	switch state.QType() {
 	case dns.TypeA:
-		records, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
+		records, truncated, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
 	case dns.TypeAAAA:
-		records, err = plugin.AAAA(ctx, &k, zone, state, nil, plugin.Options{})
+		records, truncated, err = plugin.AAAA(ctx, &k, zone, state, nil, plugin.Options{})
 	case dns.TypeTXT:
-		records, err = plugin.TXT(ctx, &k, zone, state, nil, plugin.Options{})
+		records, truncated, err = plugin.TXT(ctx, &k, zone, state, nil, plugin.Options{})
 	case dns.TypeCNAME:
 		records, err = plugin.CNAME(ctx, &k, zone, state, plugin.Options{})
 	case dns.TypePTR:
@@ -58,7 +59,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
 		fake := state.NewWithQuestion(state.QName(), dns.TypeA)
 		fake.Zone = state.Zone
-		_, err = plugin.A(ctx, &k, zone, fake, nil, plugin.Options{})
+		_, _, err = plugin.A(ctx, &k, zone, fake, nil, plugin.Options{})
 	}
 
 	if k.IsNameError(err) {
@@ -81,6 +82,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	m := new(dns.Msg)
 	m.SetReply(r)
+	m.Truncated = truncated
 	m.Authoritative = true
 	m.Answer = append(m.Answer, records...)
 	m.Extra = append(m.Extra, extra...)

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -8,48 +8,56 @@ import (
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var dnsTestCases = []test.Case{
+type kubeTestCase struct {
+	Upstream  Upstreamer
+	Truncated bool
+	test.Case
+}
+
+var dnsTestCases = []kubeTestCase{
 	// A Service
-	{
+	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
 		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.")},
 		Extra: []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local.")},
 		Extra: []dns.RR{test.AAAA("svc6.testns.svc.cluster.local.  5       IN      AAAA       1234:abcd::1")},
-	},
+	}},
 	// SRV Service
-	{
+	{Case: test.Case{
+
 		Qname: "_http._tcp.svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -58,8 +66,9 @@ var dnsTestCases = []test.Case{
 		Extra: []dns.RR{
 			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
+
 		Qname: "_http._tcp.svcempty.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -68,9 +77,9 @@ var dnsTestCases = []test.Case{
 		Extra: []dns.RR{
 			test.A("svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
-	},
+	}},
 	// A Service (Headless)
-	{
+	{Case: test.Case{
 		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -79,50 +88,50 @@ var dnsTestCases = []test.Case{
 			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
-	},
+	}},
 	// A Service (Headless and Portless)
-	{
+	{Case: test.Case{
 		Qname: "hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
 		},
-	},
+	}},
 	// An Endpoint with no port
-	{
+	{Case: test.Case{
 		Qname: "172-0-0-20.hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("172-0-0-20.hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
 		},
-	},
+	}},
 	// An Endpoint ip
-	{
+	{Case: test.Case{
 		Qname: "172-0-0-2.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("172-0-0-2.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.2"),
 		},
-	},
+	}},
 	// A Endpoint ip
-	{
+	{Case: test.Case{
 		Qname: "172-0-0-3.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("172-0-0-3.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.3"),
 		},
-	},
+	}},
 	// An Endpoint by name
-	{
+	{Case: test.Case{
 		Qname: "dup-name.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
-	},
+	}},
 	// SRV Service (Headless)
-	{
+	{Case: test.Case{
 		Qname: "_http._tcp.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -140,8 +149,8 @@ var dnsTestCases = []test.Case{
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
-	},
-	{ // An A record query for an existing headless service should return a record for each of its ipv4 endpoints
+	}},
+	{Case: test.Case{ // An A record query for an existing headless service should return a record for each of its ipv4 endpoints
 		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -150,96 +159,120 @@ var dnsTestCases = []test.Case{
 			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
-	},
+	}},
 	// AAAA
-	{
+	{Case: test.Case{
 		Qname: "5678-abcd--2.hdls1.testns.svc.cluster.local", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2")},
-	},
+	}},
 	// CNAME External
-	{
+	{Case: test.Case{
 		Qname: "external.testns.svc.cluster.local.", Qtype: dns.TypeCNAME,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
 		},
+	}},
+	// CNAME External Truncated Lookup
+	{
+		Case: test.Case{
+			Qname: "external.testns.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("ext.interwebs.test.	5	IN	A	1.2.3.4"),
+				test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
+			},
+		},
+		Upstream: &Upstub{
+			Truncated: true,
+			Qclass:    dns.ClassINET,
+			Case: test.Case{
+				Qname: "external.testns.svc.cluster.local.",
+				Qtype: dns.TypeA,
+				Answer: []dns.RR{
+					test.A("ext.interwebs.test.	5	IN	A	1.2.3.4"),
+					test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
+				},
+			},
+		},
+		Truncated: true,
 	},
 	// CNAME External To Internal Service
-	{
+	{Case: test.Case{
 		Qname: "external-to-service.testns.svc.cluster.local", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.CNAME("external-to-service.testns.svc.cluster.local.	5	IN	CNAME	svc1.testns.svc.cluster.local."),
 			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
-	},
+	}},
 	// AAAA Service (with an existing A record, but no AAAA record)
-	{
+	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// AAAA Service (non-existing service)
-	{
+	{Case: test.Case{
 		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// A Service (non-existing service)
-	{
+	{Case: test.Case{
 		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// A Service (non-existing namespace)
-	{
+	{Case: test.Case{
 		Qname: "svc0.svc-nons.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// TXT Schema
-	{
+	{Case: test.Case{
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.TXT("dns-version.cluster.local 28800 IN TXT 1.1.0"),
 		},
-	},
+	}},
 	// A Service (Headless) does not exist
-	{
+	{Case: test.Case{
 		Qname: "bogusendpoint.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// A Service does not exist
-	{
+	{Case: test.Case{
 		Qname: "bogusendpoint.svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// AAAA Service
-	{
+	{Case: test.Case{
 		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.AAAA("svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1"),
 		},
-	},
+	}},
 	// SRV
-	{
+	{Case: test.Case{
 		Qname: "_http._tcp.svc6.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -248,94 +281,94 @@ var dnsTestCases = []test.Case{
 		Extra: []dns.RR{
 			test.AAAA("svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1"),
 		},
-	},
+	}},
 	// AAAA Service (Headless)
-	{
+	{Case: test.Case{
 		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.AAAA("hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1"),
 			test.AAAA("hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2"),
 		},
-	},
+	}},
 	// AAAA Endpoint
-	{
+	{Case: test.Case{
 		Qname: "5678-abcd--1.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::1"),
 		},
-	},
+	}},
 
-	{
+	{Case: test.Case{
 		Qname: "svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// NS query for qname != zone (existing domain)
-	{
+	{Case: test.Case{
 		Qname: "svc.cluster.local.", Qtype: dns.TypeNS,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// NS query for qname != zone (existing domain)
-	{
+	{Case: test.Case{
 		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeNS,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// NS query for qname != zone (non existing domain)
-	{
+	{Case: test.Case{
 		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// NS query for qname != zone (non existing domain)
-	{
+	{Case: test.Case{
 		Qname: "foo.svc.cluster.local.", Qtype: dns.TypeNS,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// Dual Stack ClusterIP Services
-	{
+	{Case: test.Case{
 		Qname: "svc-dual-stack.testns.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc-dual-stack.testns.svc.cluster.local.	5	IN	A	10.0.0.3"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc-dual-stack.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.AAAA("svc-dual-stack.testns.svc.cluster.local.	5	IN	AAAA	10::3"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc-dual-stack.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc-dual-stack.testns.svc.cluster.local.	5	IN	SRV	0 50 80 svc-dual-stack.testns.svc.cluster.local.")},
@@ -343,14 +376,14 @@ var dnsTestCases = []test.Case{
 			test.A("svc-dual-stack.testns.svc.cluster.local.  5       IN      A       10.0.0.3"),
 			test.AAAA("svc-dual-stack.testns.svc.cluster.local.  5       IN      AAAA       10::3"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeSOA,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 }
 
 func TestServeDNS(t *testing.T) {
@@ -361,6 +394,8 @@ func TestServeDNS(t *testing.T) {
 	ctx := context.TODO()
 
 	for i, tc := range dnsTestCases {
+		k.Upstream = tc.Upstream
+
 		r := tc.Msg()
 
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
@@ -379,12 +414,16 @@ func TestServeDNS(t *testing.T) {
 			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
 		}
 
+		if tc.Truncated != resp.Truncated {
+			t.Errorf("Expected truncation %t, got truncation %t", tc.Truncated, resp.Truncated)
+		}
+
 		// Before sorting, make sure that CNAMES do not appear after their target records
 		if err := test.CNAMEOrder(resp); err != nil {
 			t.Errorf("Test %d, %v", i, err)
 		}
 
-		if err := test.SortAndCheck(resp, tc); err != nil {
+		if err := test.SortAndCheck(resp, tc.Case); err != nil {
 			t.Errorf("Test %d, %v", i, err)
 		}
 	}
@@ -515,17 +554,6 @@ func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 }
 
 var svcIndex = map[string][]*object.Service{
-	"kubedns.kube-system": {
-		{
-			Name:       "kubedns",
-			Namespace:  "kube-system",
-			Type:       api.ServiceTypeClusterIP,
-			ClusterIPs: []string{"10.0.0.10"},
-			Ports: []api.ServicePort{
-				{Name: "dns", Protocol: "udp", Port: 53},
-			},
-		},
-	},
 	"svc1.testns": {
 		{
 			Name:       "svc1",
@@ -631,21 +659,6 @@ func (APIConnServeTest) ServiceList() []*object.Service {
 }
 
 var epsIndex = map[string][]*object.Endpoints{
-	"kubedns.kube-system": {{
-		Subsets: []object.EndpointSubset{
-			{
-				Addresses: []object.EndpointAddress{
-					{IP: "172.0.0.100"},
-				},
-				Ports: []object.EndpointPort{
-					{Port: 53, Protocol: "udp", Name: "dns"},
-				},
-			},
-		},
-		Name:      "kubedns",
-		Namespace: "kube-system",
-		Index:     object.EndpointsKey("kubedns", "kube-system"),
-	}},
 	"svc1.testns": {{
 		Subsets: []object.EndpointSubset{
 			{
@@ -738,5 +751,40 @@ func (APIConnServeTest) GetNamespaceByName(name string) (*object.Namespace, erro
 	}
 	return &object.Namespace{
 		Name: name,
+	}, nil
+}
+
+// Upstub implements an Upstreamer that returns a set response for test purposes
+type Upstub struct {
+	test.Case
+	Truncated bool
+	Qclass    uint16
+}
+
+// Lookup returns a set response
+func (t *Upstub) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	var answer []dns.RR
+	// if query type is not CNAME, remove any CNAME with same name as qname from the answer
+	if t.Qtype != dns.TypeCNAME {
+		for _, a := range t.Answer {
+			if c, ok := a.(*dns.CNAME); ok && c.Header().Name == t.Qname {
+				continue
+			}
+			answer = append(answer, a)
+		}
+	} else {
+		answer = t.Answer
+	}
+
+	return &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Response:  true,
+			Truncated: t.Truncated,
+			Rcode:     t.Rcode,
+		},
+		Question: []dns.Question{{Name: t.Qname, Qtype: t.Qtype, Qclass: t.Qclass}},
+		Answer:   answer,
+		Extra:    t.Extra,
+		Ns:       t.Ns,
 	}, nil
 }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -554,6 +554,17 @@ func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 }
 
 var svcIndex = map[string][]*object.Service{
+	"kubedns.kube-system": {
+		{
+			Name:       "kubedns",
+			Namespace:  "kube-system",
+			Type:       api.ServiceTypeClusterIP,
+			ClusterIPs: []string{"10.0.0.10"},
+			Ports: []api.ServicePort{
+				{Name: "dns", Protocol: "udp", Port: 53},
+			},
+		},
+	},
 	"svc1.testns": {
 		{
 			Name:       "svc1",
@@ -659,6 +670,21 @@ func (APIConnServeTest) ServiceList() []*object.Service {
 }
 
 var epsIndex = map[string][]*object.Endpoints{
+	"kubedns.kube-system": {{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "172.0.0.100"},
+				},
+				Ports: []object.EndpointPort{
+					{Port: 53, Protocol: "udp", Name: "dns"},
+				},
+			},
+		},
+		Name:      "kubedns",
+		Namespace: "kube-system",
+		Index:     object.EndpointsKey("kubedns", "kube-system"),
+	}},
 	"svc1.testns": {{
 		Subsets: []object.EndpointSubset{
 			{

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/fall"
-	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -35,7 +34,7 @@ import (
 type Kubernetes struct {
 	Next             plugin.Handler
 	Zones            []string
-	Upstream         *upstream.Upstream
+	Upstream         Upstreamer
 	APIServerList    []string
 	APICertAuth      string
 	APIClientCert    string
@@ -51,6 +50,11 @@ type Kubernetes struct {
 	primaryZoneIndex int
 	localIPs         []net.IP
 	autoPathSearch   []string // Local search path from /etc/resolv.conf. Needed for autopath.
+}
+
+// Upstreamer is used to resolve CNAME or other external targets
+type Upstreamer interface {
+	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
 }
 
 // New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

For backend and backend using plugins _etcd_ and _kubernetes_...
Persists the TC bit to client response if the CNAME lookup response is truncated.
If not done, the client will think it got a complete response when the upstream response was truncated.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
