### PR TITLE
plugin/k8s_external: Persist tc bit from lookup to client response

### DIFF
--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -99,9 +99,9 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 	switch state.QType() {
 	case dns.TypeA:
-		m.Answer = e.a(ctx, svc, state)
+		m.Answer, m.Truncated = e.a(ctx, svc, state)
 	case dns.TypeAAAA:
-		m.Answer = e.aaaa(ctx, svc, state)
+		m.Answer, m.Truncated = e.aaaa(ctx, svc, state)
 	case dns.TypeSRV:
 		m.Answer, m.Extra = e.srv(ctx, svc, state)
 	default:

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -43,7 +44,7 @@ type External struct {
 	apex       string
 	ttl        uint32
 
-	upstream Upstreamer
+	upstream *upstream.Upstream
 
 	externalFunc         func(request.Request) ([]msg.Service, int)
 	externalAddrFunc     func(request.Request) []dns.RR
@@ -118,8 +119,3 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 // Name implements the Handler interface.
 func (e *External) Name() string { return "k8s_external" }
-
-// Upstreamer is used to resolve CNAME or other external targets
-type Upstreamer interface {
-	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
-}

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
-	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -44,7 +43,7 @@ type External struct {
 	apex       string
 	ttl        uint32
 
-	upstream *upstream.Upstream
+	upstream Upstreamer
 
 	externalFunc         func(request.Request) ([]msg.Service, int)
 	externalAddrFunc     func(request.Request) []dns.RR
@@ -119,3 +118,8 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 // Name implements the Handler interface.
 func (e *External) Name() string { return "k8s_external" }
+
+// Upstreamer is used to resolve CNAME or other external targets
+type Upstreamer interface {
+	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
+}

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -31,6 +31,8 @@ func TestExternal(t *testing.T) {
 		r := tc.Msg()
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
+		e.upstream = tc.Upstream
+
 		_, err := e.ServeDNS(ctx, w, r)
 		if err != tc.Error {
 			t.Errorf("Test %d expected no error, got %v", i, err)
@@ -45,34 +47,45 @@ func TestExternal(t *testing.T) {
 		if resp == nil {
 			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
 		}
-		if err = test.SortAndCheck(resp, tc); err != nil {
+
+		if resp.Truncated != tc.Truncated {
+			t.Errorf("Test %d expected TC=%v, got TC=%v", i, tc.Truncated, resp.Truncated)
+		}
+
+		if err = test.SortAndCheck(resp, tc.Case); err != nil {
 			t.Error(err)
 		}
 	}
 }
 
-var tests = []test.Case{
+type kubeTestCase struct {
+	Upstream  Upstreamer
+	Truncated bool
+	test.Case
+}
+
+var tests = []kubeTestCase{
 	// A Service
-	{
+	{Case: test.Case{
 		Qname: "svc1.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc1.testns.example.com.	5	IN	A	1.2.3.4"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc1.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
-		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
-	},
+		Extra:  []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+	}},
 	// SRV Service Not udp/tcp
-	{
+	{Case: test.Case{
 		Qname: "*._not-udp-or-tcp.svc1.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// SRV Service
-	{
+	{Case: test.Case{
 		Qname: "_http._tcp.svc1.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com."),
@@ -80,44 +93,44 @@ var tests = []test.Case{
 		Extra: []dns.RR{
 			test.A("svc1.testns.example.com.	5	IN	A	1.2.3.4"),
 		},
-	},
+	}},
 	// AAAA Service (with an existing A record, but no AAAA record)
-	{
+	{Case: test.Case{
 		Qname: "svc1.testns.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// AAAA Service (non-existing service)
-	{
+	{Case: test.Case{
 		Qname: "svc0.testns.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// A Service (non-existing service)
-	{
+	{Case: test.Case{
 		Qname: "svc0.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// A Service (non-existing namespace)
-	{
+	{Case: test.Case{
 		Qname: "svc0.svc-nons.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// AAAA Service
-	{
+	{Case: test.Case{
 		Qname: "svc6.testns.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
 		},
-	},
+	}},
 	// SRV
-	{
+	{Case: test.Case{
 		Qname: "_http._tcp.svc6.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc6.testns.example.com.	5	IN	SRV	0 100 80 svc6.testns.example.com."),
@@ -125,9 +138,9 @@ var tests = []test.Case{
 		Extra: []dns.RR{
 			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
 		},
-	},
+	}},
 	// SRV
-	{
+	{Case: test.Case{
 		Qname: "svc6.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("svc6.testns.example.com.	5	IN	SRV	0 100 80 svc6.testns.example.com."),
@@ -135,27 +148,27 @@ var tests = []test.Case{
 		Extra: []dns.RR{
 			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "testns.example.com.", Qtype: dns.TypeSOA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
-	},
+	}},
 	// svc11
-	{
+	{Case: test.Case{
 		Qname: "svc11.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "_http._tcp.svc11.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
@@ -163,8 +176,8 @@ var tests = []test.Case{
 		Extra: []dns.RR{
 			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc11.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
@@ -172,26 +185,44 @@ var tests = []test.Case{
 		Extra: []dns.RR{
 			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
 		},
-	},
+	}},
+
 	// svc12
-	{
+	{Case: test.Case{
 		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
+			test.A("dummy.hostname.	300	IN	A	1.2.3.4"),
 			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
 		},
 	},
-	{
+		Truncated: false,
+		Upstream:  &UpTrunc{Trunc: false},
+	},
+	{Case: test.Case{
+		Qname: "_http._tcp.svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+	}},
+	{Case: test.Case{
+		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("dummy.hostname.	300	IN	A	1.2.3.4"),
+			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
+		},
+	},
+		Truncated: true,
+		Upstream:  &UpTrunc{Trunc: true},
+	},
+	{Case: test.Case{
 		Qname: "_http._tcp.svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc12.testns.example.com.	5	IN	SRV	0 100 80 dummy.hostname."),
 		},
-	},
-	{
+	}},
+	{Case: test.Case{
 		Qname: "svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("svc12.testns.example.com.	5	IN	SRV	0 100 80 dummy.hostname."),
 		},
-	},
+	}},
 }
 
 type external struct{}
@@ -270,4 +301,22 @@ func externalAddress(state request.Request) []dns.RR {
 
 func externalSerial(string) uint32 {
 	return 1499347823
+}
+
+// UpTrunc implements an Upstreamer that controls truncation bit for test purposes
+type UpTrunc struct {
+	Trunc bool
+}
+
+// Lookup returns a hard-coded response with TC bit set to Trunc
+func (t *UpTrunc) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Response:  true,
+			Truncated: t.Trunc,
+			Rcode:     dns.RcodeSuccess,
+		},
+		Question: []dns.Question{{Name: "dummy.hostname.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+		Answer:   []dns.RR{test.A("dummy.hostname.	300	IN	A	1.2.3.4")},
+	}, nil
 }

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -55,11 +55,11 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 			if svcs[i].TargetStrip == 0 {
 				// Add Service A/AAAA records
 				s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
-				as := e.a(ctx, []msg.Service{svcs[i]}, s)
+				as, _ := e.a(ctx, []msg.Service{svcs[i]}, s)
 				if len(as) > 0 {
 					ch <- as
 				}
-				aaaas := e.aaaa(ctx, []msg.Service{svcs[i]}, s)
+				aaaas, _ := e.aaaa(ctx, []msg.Service{svcs[i]}, s)
 				if len(aaaas) > 0 {
 					ch <- aaaas
 				}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Persists the TC bit to client response if the CNAME lookup response is truncated.
If not done, the client will think it got a complete response when the upstream response was truncated.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
