### PR TITLE
trace plugin can mark traces with error tag

### DIFF
--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
+	otext "github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
 	zipkinot "github.com/openzipkin-contrib/zipkin-go-opentracing"
 	"github.com/openzipkin/zipkin-go"
 	zipkinhttp "github.com/openzipkin/zipkin-go/reporter/http"
@@ -148,6 +150,10 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	span.SetTag(t.tagSet.Proto, req.Proto())
 	span.SetTag(t.tagSet.Remote, req.IP())
 	span.SetTag(t.tagSet.Rcode, rcode.ToString(rw.Rcode))
+	if err != nil {
+		otext.Error.Set(span, true)
+		span.LogFields(otlog.Event("error"), otlog.Error(err))
+	}
 
 	return status, err
 }


### PR DESCRIPTION
Signed-off-by: Ondrej Benkovsky <ondrej.benkovsky@wandera.com>

I would appreciate your feedback and I can adjust PR as needed

### 1. Why is this pull request needed and what does it do?
trace plugin now marks root span with error tag according to [opentracing conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table) in case of when following plugins in the chain returns an error
### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4719

### 3. Which documentation changes (if any) need to be made?
I guess none?

### 4. Does this introduce a backward incompatible change or deprecation?
should be backward compatible
