### PR TITLE
when no response is written, fallback to status of next plugin in prometheus plugin

### DIFF
--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -28,6 +28,9 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 	rc := rw.Rcode
 	if !plugin.ClientWrite(status) {
+		// when no response was written, fallback to status returned from next plugin as this status
+		// is actually used as rcode of DNS response
+		// see https://github.com/coredns/coredns/blob/master/core/dnsserver/server.go#L318
 		rc = status
 	}
 	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), rw.Len, rw.Start)

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -26,7 +26,11 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	rw := dnstest.NewRecorder(w)
 	status, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, rw, r)
 
-	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rw.Rcode), rw.Len, rw.Start)
+	rc := rw.Rcode
+	if !plugin.ClientWrite(status) {
+		rc = status
+	}
+	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), rw.Len, rw.Start)
 
 	return status, err
 }


### PR DESCRIPTION
Signed-off-by: Ondrej Benkovsky <ondrej.benkovsky@wandera.com>

close #4726

### 1. Why is this pull request needed and what does it do?
when no response is written from up the chain of plugins, the default value of dnstest.Recorder for rcode (0) is used as rcode reported to the `coredns_dns_responses_total` metric, which is misleading and wrong. This PR changes the behaviour that when no response is written, the return status of the next plugin is used.

### 2. Which issues (if any) are related?
#4726

### 3. Which documentation changes (if any) need to be made?
I think no changes are needed

### 4. Does this introduce a backward incompatible change or deprecation?
I don't think so, it fixes the behaviour
