### PR TITLE
plugin/cache: Unset AD flag when DO is not set for cache miss

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -181,6 +181,10 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	res.Ns = filterRRSlice(res.Ns, ttl, w.do, false)
 	res.Extra = filterRRSlice(res.Extra, ttl, w.do, false)
 
+	if !w.do {
+		res.AuthenticatedData = false // unset AD bit if client is not OK with DNSSEC
+	}
+
 	return w.ResponseWriter.WriteMsg(res)
 }
 

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -29,14 +29,15 @@ func (p RRSet) Less(i, j int) bool { return p[i].String() < p[j].String() }
 // Case represents a test case that encapsulates various data from a query and response.
 // Note that is the TTL of a record is 303 we don't compare it with the TTL.
 type Case struct {
-	Qname  string
-	Qtype  uint16
-	Rcode  int
-	Do     bool
-	Answer []dns.RR
-	Ns     []dns.RR
-	Extra  []dns.RR
-	Error  error
+	Qname             string
+	Qtype             uint16
+	Rcode             int
+	Do                bool
+	AuthenticatedData bool
+	Answer            []dns.RR
+	Ns                []dns.RR
+	Extra             []dns.RR
+	Error             error
 }
 
 // Msg returns a *dns.Msg embedded in c.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Unset AD header flag when DO is not set in request.
This is [already done for cache hits](https://github.com/coredns/coredns/blob/master/plugin/cache/item.go#L68-L70), but was not for cache miss.

### 2. Which issues (if any) are related?

related to #4735 

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
