### PR TITLE
plugin/error: use warning instead of warn

### DIFF
--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -27,7 +27,7 @@ errors {
 ~~~
 
 Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
-log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warn`,`error`,`info` and `debug`.
+log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.
 ~~~
 2 errors like '^read udp .* i/o timeout$' occurred in last 30s
 ~~~

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -92,7 +92,7 @@ func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ..
 	}
 
 	switch args[2] {
-	case "warn":
+	case "warning":
 		return log.Warningf, nil
 	case "error":
 		return log.Errorf, nil
@@ -101,6 +101,6 @@ func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ..
 	case "debug":
 		return log.Debugf, nil
 	default:
-		return nil, c.Err("unknown log level argument in consolidate")
+		return nil, c.Errf("unknown log level argument in consolidate: %s", args[2])
 	}
 }

--- a/plugin/errors/setup_test.go
+++ b/plugin/errors/setup_test.go
@@ -79,9 +79,9 @@ func TestProperLogCallbackIsSet(t *testing.T) {
 		wantLogLevel     string
 	}{
 		{
-			name: "warn is parsed properly",
+			name: "warning is parsed properly",
 			inputErrorsRules: `errors {
-		        consolidate 1m .* warn
+		        consolidate 1m .* warning
 		    }`,
 			wantLogLevel: "[WARNING]",
 		},


### PR DESCRIPTION
We use the 'WARNING' in the logs, instead of warn, so make the change
here as well for consistency sake.

Signed-off-by: Miek Gieben <miek@miek.nl>
