### PR TITLE
plugin/errors: Update example description to match example

### DIFF
--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -47,7 +47,9 @@ example.org {
 }
 ~~~
 
-Use the *forward* to resolve queries via 8.8.8.8 and print consolidated error messages for errors with suffix " i/o timeout" or with prefix "Failed to ".
+Use the *forward* plugin to resolve queries via 8.8.8.8 and print consolidated messages
+for errors with suffix " i/o timeout" as warnings,
+and errors with prefix "Failed to " as errors.
 
 ~~~ corefile
 . {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Minor doc fix to update example description to match the example, which changed in #4718.

### 2. Which issues (if any) are related?

#4718

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
