### PR TITLE
add metrics for total of log messages per log level

### DIFF
--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -20,6 +20,14 @@ import (
 // it can not be unset.
 var D = &d{}
 
+var levelToLabel = map[string]string{
+	debug:   debugLabel,
+	info:    infoLabel,
+	warning: warningLabel,
+	err:     errorLabel,
+	fatal:   fatalLabel,
+}
+
 type d struct {
 	on bool
 	sync.RWMutex
@@ -50,11 +58,13 @@ func (d *d) Value() bool {
 // logf calls log.Printf prefixed with level.
 func logf(level, format string, v ...interface{}) {
 	golog.Print(level, fmt.Sprintf(format, v...))
+	LogMessagesTotal.WithLabelValues(levelToLabel[level]).Inc()
 }
 
 // log calls log.Print prefixed with level.
 func log(level string, v ...interface{}) {
 	golog.Print(level, fmt.Sprint(v...))
+	LogMessagesTotal.WithLabelValues(levelToLabel[level]).Inc()
 }
 
 // Debug is equivalent to log.Print(), but prefixed with "[DEBUG] ". It only outputs something

--- a/plugin/pkg/log/metrics.go
+++ b/plugin/pkg/log/metrics.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	debugLabel   = "debug"
+	infoLabel    = "info"
+	warningLabel = "warning"
+	errorLabel   = "error"
+	fatalLabel   = "fatal"
+)
+
+// Variables declared for monitoring.
+var (
+	LogMessagesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "coredns", // using plugin.Namespace would cause import loop here
+		Name:      "log_messages_total",
+		Help:      "Counter of logged messages.",
+	}, []string{"level"})
+)

--- a/plugin/pkg/log/plugin.go
+++ b/plugin/pkg/log/plugin.go
@@ -19,7 +19,7 @@ func (p P) logf(level, format string, v ...interface{}) {
 }
 
 func (p P) log(level string, v ...interface{}) {
-	log(level+p.plugin, v...)
+	log(level, p.plugin, fmt.Sprint(v...))
 }
 
 // Debug logs as log.Debug.


### PR DESCRIPTION
Signed-off-by: Ondrej Benkovsky <ondrej.benkovsky@wandera.com>


### 1. Why is this pull request needed and what does it do?
This PR adds a new Prometheus counter `coredns_log_messages_total{level}` which counts the number of logged messages per log level globally (across all plugins), for example how many errors were logged, how many warnings, etc. 

Example of new metrics
```
# HELP coredns_log_messages_total Counter of logged messages.
# TYPE coredns_log_messages_total counter
coredns_log_messages_total{level="error"} 2
coredns_log_messages_total{level="info"} 2
```

This enables us to monitor if there are any error logs being produced by the CoreDNS (we can set up an alert in Prometheus Alertmanager on this and if it fires, we can go to check the logs) or if there are too many warnings, etc.

### 2. Which issues (if any) are related?
no issue related

### 3. Which documentation changes (if any) need to be made?
I guess none

### 4. Does this introduce a backward incompatible change or deprecation?
no
