### PR TITLE
publish trace id as metadata from trace plugin

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -93,6 +93,13 @@ trace tracinghost:9411 {
 }
 ~~~
 
+## Metadata
+
+The trace plugin will publish the following metadata, if the *metadata*
+plugin is also enabled:
+
+* `trace/traceid`: identifier of (zipkin/datadog) trace of processed request 
+
 ## See Also
 
 See the *debug* plugin for more information about debug logging.


### PR DESCRIPTION
Signed-off-by: Ondrej Benkovsky <ondrej.benkovsky@wandera.com>

Hello, I would appreciate your input/comments regarding this enhancement of trace plugin.

### 1. Why is this pull request needed and what does it do?
It adds zipkin/datadog trace identifier to the metadata published by `trace` plugin so that the trace ID can be reused from different plugins (like `log` plugin). By publishing trace ID as metadata, it can be used from `log` plugin => it can be logged as part of query logging and therefore enables correlating logs of CoreDNS with traces in tracing systems (like Zipkin) and enables better debugging of problematic DNS queries.

For example, let's have a CoreDNS instance with Corefile
```
.:53 {
    forward . 8.8.8.8
    log . "[{/trace/traceid}] '{type} {class} {name} {proto}:{port} {size} {>do} {>bufsize}' {rcode} {>rflags} {rsize} {duration}"
    trace zipkin 127.0.0.1:9411 {
        service dns-service
    }
    metadata
}
```

and Zipkin running in docker container
```
docker run -d -p 9411:9411 openzipkin/zipkin
```

when I run DNS query against this CoreDNS instance
```
dig @127.0.0.1 example.com
```

the CoreDNS will log
```
[INFO] [019bfc0577fd9975] 'A IN example.com. udp:64410 52 false 4096' NOERROR qr,rd,ra,ad 67 0.010437056s
```

and by taking the trace Id from the log `019bfc0577fd9975`, I can now directly view trace in Zipkin UI http://localhost:9411/zipkin/traces/019bfc0577fd9975 without the need to search for the related trace

![image](https://user-images.githubusercontent.com/5522817/125353644-1942ae80-e363-11eb-93a6-3e02234fa161.png)


### 2. Which issues (if any) are related?
no issue related

### 3. Which documentation changes (if any) need to be made?
I have enhanced the README of the trace plugin

### 4. Does this introduce a backward incompatible change or deprecation?
no
