### PR TITLE
plugin/header: run go gen and small doc updates

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -36,6 +36,7 @@ var Directives = []string{
 	"loadbalance",
 	"cache",
 	"rewrite",
+	"header",
 	"dnssec",
 	"autopath",
 	"minimal",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/forward"
 	_ "github.com/coredns/coredns/plugin/geoip"
 	_ "github.com/coredns/coredns/plugin/grpc"
+	_ "github.com/coredns/coredns/plugin/header"
 	_ "github.com/coredns/coredns/plugin/health"
 	_ "github.com/coredns/coredns/plugin/hosts"
 	_ "github.com/coredns/coredns/plugin/k8s_external"

--- a/plugin/chaos/zowners.go
+++ b/plugin/chaos/zowners.go
@@ -1,4 +1,4 @@
 package chaos
 
 // Owners are all GitHub handlers of all maintainers.
-var Owners = []string{"bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "fastest963", "greenpau", "ihac", "inigohu", "isolus", "johnbelamaric", "miekg", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang", "zouyee"}
+var Owners = []string{"bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "fastest963", "greenpau", "ihac", "inigohu", "isolus", "johnbelamaric", "miekg", "mqasimsarfraz", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "snebel29", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang", "zouyee"}

--- a/plugin/header/README.md
+++ b/plugin/header/README.md
@@ -2,11 +2,11 @@
 
 ## Name
 
-*header* - modifies the header for all the responses.
+*header* - modifies the header for responses.
 
 ## Description
 
-It ensures that the flags are in the desired state for all the responses. The modifications are made transparently for
+*header* ensures that the flags are in the desired state for responses. The modifications are made transparently for
 the client.
 
 ## Syntax
@@ -18,12 +18,12 @@ header {
 }
 ~~~
 
-* **ACTION** defines the state for dns flags. Actions are evaluated in the order they are defined so last one has the
+* **ACTION** defines the state for DNS message header flags. Actions are evaluated in the order they are defined so last one has the
   most precedence. Allowed values are:
     * `set`
     * `clear`
-* **FLAGS** are the dns flags that will be modified. Current supported flags include:
-    * `aa` - Authoritative
+* **FLAGS** are the DNS header flags that will be modified. Current supported flags include:
+    * `aa` - Authoritative(Answer)
     * `ra` - RecursionAvailable
     * `rd` - RecursionDesired
 
@@ -39,13 +39,12 @@ Make sure recursive available `ra` flag is set in all the responses:
 }
 ~~~
 
-Make sure recursive available `ra` and authoritative `aa` flags are set and recursive desired is cleared in all the
-responses:
+Make sure "recursive available" `ra` and "authoritative answer" `aa` flags are set and "recursive desired" is cleared in all responses:
 
 ~~~ corefile
 . {
     header {
-        set ra aa 
+        set ra aa
         clear rd
     }
 }

--- a/plugin/header/README.md
+++ b/plugin/header/README.md
@@ -39,7 +39,7 @@ Make sure recursive available `ra` flag is set in all the responses:
 }
 ~~~
 
-Make sure "recursive available" `ra` and "authoritative answer" `aa` flags are set and "recursive desired" is cleared in all responses:
+Make sure "recursion available" `ra` and "authoritative answer" `aa` flags are set and "recursion desired" is cleared in all responses:
 
 ~~~ corefile
 . {

--- a/plugin/header/setup.go
+++ b/plugin/header/setup.go
@@ -3,9 +3,9 @@ package header
 import (
 	"fmt"
 
+	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/caddy"
 )
 
 func init() { plugin.Register("header", setup) }


### PR DESCRIPTION
Run go gen to enable the new plugin, this should fix the CI failures.
Small tweaks to the docs.

Signed-off-by: Miek Gieben <miek@miek.nl>
