### PR TITLE
plugin/cache: Add refresh mode setting to serve_stale

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -37,7 +37,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
-    serve_stale [DURATION]
+    serve_stale [DURATION] [REFRESH_MODE]
 }
 ~~~
 
@@ -57,7 +57,10 @@ cache [TTL] [ZONES...] {
 * `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
   available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
   entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default duration is 1h.
+  stale responses as fresh. The default duration is 1h. **REFRESH_MODE** controls whether the attempt to refresh
+  the cache happens `before` or `after` returning a response. This defaults to `after`. Setting this value to
+  `before` could lead to increased latency when serving stale responses for unavailable upstreams, but will
+  reduce served stales specially on infrequent resolution usecases.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -36,7 +36,9 @@ type Cache struct {
 	duration   time.Duration
 	percentage int
 
-	staleUpTo time.Duration
+	// Stale serve
+	staleUpTo        time.Duration
+	staleFetchBefore bool
 
 	// Testing.
 	now func() time.Time

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/coredns/caddy"
@@ -165,11 +166,11 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 
 			case "serve_stale":
 				args := c.RemainingArgs()
-				if len(args) > 1 {
+				if len(args) > 2 {
 					return nil, c.ArgErr()
 				}
 				ca.staleUpTo = 1 * time.Hour
-				if len(args) == 1 {
+				if len(args) > 0 {
 					d, err := time.ParseDuration(args[0])
 					if err != nil {
 						return nil, err
@@ -178,6 +179,14 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, errors.New("invalid negative duration for serve_stale")
 					}
 					ca.staleUpTo = d
+				}
+				ca.staleFetchBefore = false
+				if len(args) > 1 {
+					mode := strings.ToLower(args[1])
+					if mode != "before" && mode != "after" {
+						return nil, fmt.Errorf("invalid value for serve_stale refresh mode: %s", mode)
+					}
+					ca.staleFetchBefore = mode == "before"
 				}
 			default:
 				return nil, c.ArgErr()

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -117,20 +117,25 @@ func TestSetup(t *testing.T) {
 
 func TestServeStale(t *testing.T) {
 	tests := []struct {
-		input     string
-		shouldErr bool
-		staleUpTo time.Duration
+		input            string
+		shouldErr        bool
+		staleUpTo        time.Duration
+		staleFetchBefore bool
 	}{
-		{"serve_stale", false, 1 * time.Hour},
-		{"serve_stale 20m", false, 20 * time.Minute},
-		{"serve_stale 1h20m", false, 80 * time.Minute},
-		{"serve_stale 0m", false, 0},
-		{"serve_stale 0", false, 0},
+		{"serve_stale", false, 1 * time.Hour, false},
+		{"serve_stale 20m", false, 20 * time.Minute, false},
+		{"serve_stale 1h20m", false, 80 * time.Minute, false},
+		{"serve_stale 0m", false, 0, false},
+		{"serve_stale 0", false, 0, false},
+		{"serve_stale 0 before", false, 0, true},
+		{"serve_stale 0 after", false, 0, false},
+		{"serve_stale 0 BEFORE", false, 0, true},
 		// fails
-		{"serve_stale 20", true, 0},
-		{"serve_stale -20m", true, 0},
-		{"serve_stale aa", true, 0},
-		{"serve_stale 1m nono", true, 0},
+		{"serve_stale 20", true, 0, false},
+		{"serve_stale -20m", true, 0, false},
+		{"serve_stale aa", true, 0, false},
+		{"serve_stale 1m nono", true, 0, false},
+		{"serve_stale 0 after nono", true, 0, false},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", fmt.Sprintf("cache {\n%s\n}", test.input))


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR adds an optional `REFRESH_MODE` parameter on the `serve_stale` configuration directive of the cache plugin. For context, please see #4309

### 2. Which issues (if any) are related?

Reasoning and RFC discussed at #4309
Other similar issues are #4097 and #4199.

### 3. Which documentation changes (if any) need to be made?

I updated the cache plugin `README.md` to document the new parameter on the PR.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
