### PR TITLE
plugin/forward : add proxy address as tag

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
+	otext "github.com/opentracing/opentracing-go/ext"
 )
 
 var log = clog.NewWithPlugin("forward")
@@ -120,6 +121,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 		if span != nil {
 			child = span.Tracer().StartSpan("connect", ot.ChildOf(span.Context()))
+			otext.PeerAddress.Set(child, proxy.addr)
 			ctx = ot.ContextWithSpan(ctx, child)
 		}
 


### PR DESCRIPTION
Signed-off-by: Ondrej Benkovsky <ondrej.benkovsky@wandera.com>

Hello, in order to improve the observability of CoreDNS, I would like to know to which upstream DNS nameserver the DNS request was forwarded to, so I can better analyze the issues from opentracing compatible toolings

### 1. Why is this pull request needed and what does it do?
This PR adds to each `connect` span of forward plugin (there can be multiple `connect` spans, depending on [policy](https://coredns.io/plugins/forward/)) a `peer.address` tag  as it is described in [opentracing conventions ](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table) with an proxy address.

example of usage with CoreDNS with Corefile
```
.:53 {
    forward . 8.8.8.8
    trace zipkin 127.0.0.1:9411 {
        service dns-service
    }
    metadata
}
``` 

will produce trace which can be viewed in Zipkin like this
![image](https://user-images.githubusercontent.com/5522817/125933292-4f76677c-9c08-4fe1-b147-06fd728c929f.png)






### 2. Which issues (if any) are related?
no issue related

### 3. Which documentation changes (if any) need to be made?
I think no changes are needed?

### 4. Does this introduce a backward incompatible change or deprecation?
no
