### PR TITLE
chore: use multi-stage to build docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ buildCoreDNSImage: &buildCoreDNSImage
       command: |
         cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
         make coredns SYSTEM="GOOS=linux" && \
-        docker build -t coredns . && \
+        docker build -t coredns --build-arg=BUILD_TYPE=outside . && \
         kind load docker-image coredns
 
 jobs:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
-*
-!coredns
+# Docker
+Dockerfile
+.dockerignore
+
+# don't send git context
+#.git (GITCOMMIT isn't a ARG for the moment)
+
+# Don't send configuration changes
+*.md
+*.yaml

--- a/Makefile.release
+++ b/Makefile.release
@@ -158,6 +158,7 @@ else
 			--pull \
 			--load \
 			--platform linux/$$arch \
+			--build-arg=BUILD_TYPE=outside \
 			-t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) \
 			build/docker/linux/$${arch} ;\
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Simplify build process by only needing a `docker build .`

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

Building image from outside binary need a `--build-arg=BUILD_TYPE=outside`.
