### PR TITLE
Update cache metrics

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -75,7 +75,8 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 
 * `coredns_cache_entries{server, type}` - Total elements in the cache by cache type.
 * `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
-* `coredns_cache_misses_total{server}` - Counter of cache misses.
+* `coredns_cache_misses_total{server}` - Counter of cache misses. - Deprecated, derive misses from cache hits/requests counters.
+* `coredns_cache_requests_total{server}` - Counter of cache requests.
 * `coredns_cache_prefetch_total{server}` - Counter of times the cache has prefetched a cached item.
 * `coredns_cache_drops_total{server}` - Counter of responses excluded from the cache due to request/response question name mismatch.
 * `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -91,6 +91,7 @@ func (c *Cache) Name() string { return "cache" }
 
 func (c *Cache) get(now time.Time, state request.Request, server string) (*item, bool) {
 	k := hash(state.Name(), state.QType())
+	cacheRequests.WithLabelValues(server).Inc()
 
 	if i, ok := c.ncache.Get(k); ok && i.(*item).ttl(now) > 0 {
 		cacheHits.WithLabelValues(server, Denial).Inc()
@@ -108,6 +109,7 @@ func (c *Cache) get(now time.Time, state request.Request, server string) (*item,
 // getIgnoreTTL unconditionally returns an item if it exists in the cache.
 func (c *Cache) getIgnoreTTL(now time.Time, state request.Request, server string) *item {
 	k := hash(state.Name(), state.QType())
+	cacheRequests.WithLabelValues(server).Inc()
 
 	if i, ok := c.ncache.Get(k); ok {
 		ttl := i.(*item).ttl(now)

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -15,6 +15,13 @@ var (
 		Name:      "entries",
 		Help:      "The number of elements in the cache.",
 	}, []string{"server", "type"})
+	// cacheRequests is a counter of all requests through the cache.
+	cacheRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "cache",
+		Name:      "requests_total",
+		Help:      "The count of cache requests.",
+	}, []string{"server"})
 	// cacheHits is counter of cache hits by cache type.
 	cacheHits = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
@@ -22,12 +29,12 @@ var (
 		Name:      "hits_total",
 		Help:      "The count of cache hits.",
 	}, []string{"server", "type"})
-	// cacheMisses is the counter of cache misses.
+	// cacheMisses is the counter of cache misses. - Deprecated
 	cacheMisses = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "cache",
 		Name:      "misses_total",
-		Help:      "The count of cache misses.",
+		Help:      "The count of cache misses. Deprecated, derive misses from cache hits/requests counters.",
 	}, []string{"server"})
 	// cachePrefetches is the number of time the cache has prefetched a cached item.
 	cachePrefetches = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add a total cache request counter to follow Prometheus conventions[0].
Mark the existing cache miss metric as deprecated.

> Similarly, with hit or miss for caches, it’s better to have one
> metric for total and another for hits.

[0]: https://prometheus.io/docs/instrumenting/writing_exporters/#naming

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Updated plugin README.

### 4. Does this introduce a backward incompatible change or deprecation?

Backwards compatible, but deprecates the cache miss metric.