### PR TITLE
Bump actions use go 1.16

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16'
+        go-version: '^1.16'
       id: go
 
     - name: Check out code

--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -8,6 +8,8 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
       id: go
 
     - name: Check out code

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -8,6 +8,8 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
       id: go
 
     - name: Check out code
@@ -29,6 +31,8 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
       id: go
 
     - name: Check out code
@@ -47,6 +51,8 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
       id: go
 
     - name: Check out code

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16'
+        go-version: '^1.16'
       id: go
 
     - name: Check out code
@@ -32,7 +32,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16'
+        go-version: '^1.16'
       id: go
 
     - name: Check out code
@@ -52,7 +52,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.16'
+        go-version: '^1.16'
       id: go
 
     - name: Check out code

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -15,7 +15,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '^1.16'
       -
         name: Update Docs
         run: |

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -14,6 +14,8 @@ jobs:
       -
         name: Setup Go
         uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
       -
         name: Update Docs
         run: |


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Per recent action logs, looks like go 1.15 is being installed when the go version is not specified in action/setup-go.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
