### PR TITLE
plugin/forward: CNAME resolution support

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -52,6 +52,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec]
     max_concurrent MAX
+    upstream [max_depth MAX]
 }
 ~~~
 
@@ -93,6 +94,11 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `upstream` If upstream support is enabled the plugin will try to resolve CNAMEs and only return the resulting A or AAAA address.
+  If no A or AAAA record can be resolved the original (first) answer from a forwarder will be returned to the client. Circular dependencies are
+  detected and an error will be logged accordingly. In that case the original (first) answer from a forwarder will be returned to the client as well.
+  * `max_depth` **MAX** to limit the maximum calls to resolve a CNAME chain to the final A or AAAA record, a value `> 0` can be specified.
+    If the maximum depth is reached and no A or AAAA record could be found, the the original (first) from a forwarder answer will be returned to the client.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -183,11 +183,11 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			return 0, nil
 		}
 
-		rr := ret.Answer[0]
-		if f.upstream != nil && rr.Header().Rrtype == dns.TypeCNAME {
+		if f.upstream != nil && ret.Answer != nil || len(ret.Answer) > 0 && ret.Answer[0].Header().Rrtype == dns.TypeCNAME {
 			// emulate hashset in go; https://emersion.fr/blog/2017/sets-in-go/
 			cnameVisited := make(map[string]struct{})
 			cnt := 0
+			rr := ret.Answer[0]
 
 		resolveCname:
 			log.Debugf("Trying to resolve CNAME [%+v] via upstream", rr)

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -183,7 +183,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			return 0, nil
 		}
 
-		if f.upstream != nil && ret.Answer != nil || len(ret.Answer) > 0 && ret.Answer[0].Header().Rrtype == dns.TypeCNAME {
+		if f.upstream != nil && ret.Answer != nil && len(ret.Answer) > 0 && ret.Answer[0].Header().Rrtype == dns.TypeCNAME {
 			// emulate hashset in go; https://emersion.fr/blog/2017/sets-in-go/
 			cnameVisited := make(map[string]struct{})
 			cnt := 0

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/parse"
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/pkg/transport"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 )
 
 func init() { plugin.Register("forward", setup) }
@@ -258,7 +259,9 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		}
 		f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
-
+	case "upstream":
+		c.RemainingArgs() // eats args
+		f.Upstream = upstream.New()
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}

--- a/plugin/forward/upstream_test.go
+++ b/plugin/forward/upstream_test.go
@@ -1,0 +1,302 @@
+package forward
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+type testZoneEntry struct {
+	question  string
+	zoneEntry string
+}
+type testConfig struct {
+	zone    string
+	entries []testZoneEntry
+}
+
+type testPlugin struct {
+	handler dns.HandlerFunc
+}
+
+func (tp testPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	tp.handler(w, r)
+	return 0, nil
+}
+
+func (tp testPlugin) Name() string { return "testplugin" }
+
+func newTestServer(testConfig testConfig) (*dnsserver.Server, error) {
+	c := &dnsserver.Config{
+		Zone:      testConfig.zone,
+		Transport: "dns",
+		Debug:     false,
+	}
+
+	p := testPlugin{
+		handler: func(w dns.ResponseWriter, r *dns.Msg) {
+			ret := new(dns.Msg)
+			ret.SetReply(r)
+			for _, c := range testConfig.entries {
+				if strings.HasPrefix(r.Question[0].Name, c.question) {
+					rr, _ := dns.NewRR(c.zoneEntry)
+					ret.Answer = append(ret.Answer, rr)
+					break
+				}
+			}
+			w.WriteMsg(ret)
+		},
+	}
+	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
+
+	s, err := dnsserver.NewServer("dns://:0", []*dnsserver.Config{c})
+	if err != nil {
+		return nil, err
+	}
+	l, err := s.Listen()
+	if err != nil {
+		return nil, err
+	}
+
+	go s.Serve(l)
+
+	s.Addr = l.Addr().String()
+	return s, nil
+}
+
+func TestUpstreamSingleCNAME(t *testing.T) {
+	s, err := newTestServer(testConfig{
+		zone: "example.com.",
+		entries: []testZoneEntry{
+			{
+				question:  "addr.example.com.",
+				zoneEntry: "cname.example.com. IN CNAME test.example.com.",
+			},
+			{
+				question:  "test.example.com.",
+				zoneEntry: "test.example.com. IN A 127.0.0.1",
+			},
+		},
+	})
+
+	defer s.Stop()
+	if err != nil {
+		t.Fatalf("Failed to create test DNS server, %+v", err)
+	}
+	c := caddy.NewTestController("dns",
+		fmt.Sprintf(`forward . %s {
+			force_tcp
+			upstream
+		}`, s.Addr))
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Failed to create forwarder: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("addr.example.com.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, s)
+	if _, err := f.ServeDNS(ctx, rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if rec.Msg.Answer == nil || len(rec.Msg.Answer) <= 0 {
+		t.Error("Expected to receive valid answer, but didn't")
+	}
+
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected dns.TypeA(%d), got %d", dns.TypeA, rec.Msg.Answer[0].Header().Rrtype)
+	}
+
+	a := rec.Msg.Answer[0].(*dns.A)
+	if a.A.String() != "127.0.0.1" {
+		t.Errorf("Expected address 127.0.0.1, got %s", a.A.String())
+	}
+}
+
+func TestUpstreamMultipleCNAME(t *testing.T) {
+	s, err := newTestServer(testConfig{
+		zone: "example.com.",
+		entries: []testZoneEntry{
+			{
+				question:  "addr.example.com.",
+				zoneEntry: "cname.example.com. IN CNAME test1.example.com.",
+			},
+			{
+				question:  "test1.example.com.",
+				zoneEntry: "test1.example.com. IN CNAME test2.example.com.",
+			},
+			{
+				question:  "test2.example.com.",
+				zoneEntry: "test2.example.com. IN A 127.0.0.1",
+			},
+		},
+	})
+
+	defer s.Stop()
+	if err != nil {
+		t.Fatalf("Failed to create test DNS server, %+v", err)
+	}
+	c := caddy.NewTestController("dns",
+		fmt.Sprintf(`forward . %s {
+			force_tcp
+			upstream
+		}`, s.Addr))
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Failed to create forwarder: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("addr.example.com.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, s)
+	if _, err := f.ServeDNS(ctx, rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if rec.Msg.Answer == nil || len(rec.Msg.Answer) <= 0 {
+		t.Error("Expected to receive valid answer, but didn't")
+	}
+
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected dns.TypeA(%d), got %d", dns.TypeA, rec.Msg.Answer[0].Header().Rrtype)
+	}
+
+	a := rec.Msg.Answer[0].(*dns.A)
+	if a.A.String() != "127.0.0.1" {
+		t.Errorf("Expected address 127.0.0.1, got %s", a.A.String())
+	}
+}
+
+func TestUpstreamFailMaxDepth(t *testing.T) {
+	s, err := newTestServer(testConfig{
+		zone: "example.com.",
+		entries: []testZoneEntry{
+			{
+				question:  "addr.example.com.",
+				zoneEntry: "cname.example.com. IN CNAME test1.example.com.",
+			},
+			{
+				question:  "test1.example.com.",
+				zoneEntry: "test1.example.com. IN CNAME test2.example.com.",
+			},
+			{
+				question:  "test2.example.com.",
+				zoneEntry: "test2.example.com. IN A 127.0.0.1",
+			},
+		},
+	})
+
+	defer s.Stop()
+	if err != nil {
+		t.Fatalf("Failed to create test DNS server, %+v", err)
+	}
+	c := caddy.NewTestController("dns",
+		fmt.Sprintf(`forward . %s {
+			force_tcp
+			upstream max_depth 1
+		}`, s.Addr))
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Failed to create forwarder: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("addr.example.com.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, s)
+	if _, err := f.ServeDNS(ctx, rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if rec.Msg.Answer == nil || len(rec.Msg.Answer) <= 0 {
+		t.Error("Expected to receive valid answer, but didn't")
+	}
+
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeCNAME {
+		t.Errorf("Expected dns.TypeCNAME(%d), got %d", dns.TypeCNAME, rec.Msg.Answer[0].Header().Rrtype)
+	}
+
+	cname := rec.Msg.Answer[0].(*dns.CNAME)
+	if cname.Target != "test1.example.com." {
+		t.Errorf("Expected CNAME test1.example.com., got %s", cname.Target)
+	}
+}
+
+func TestUpstreamFailOnCircularReference(t *testing.T) {
+	s, err := newTestServer(testConfig{
+		zone: "example.com.",
+		entries: []testZoneEntry{
+			{
+				question:  "addr.example.com.",
+				zoneEntry: "cname.example.com. IN CNAME test1.example.com.",
+			},
+			{
+				question:  "test1.example.com.",
+				zoneEntry: "test1.example.com. IN CNAME test2.example.com.",
+			},
+			{
+				question:  "test2.example.com.",
+				zoneEntry: "test2.example.com. IN CNAME test1.example.com.",
+			},
+		},
+	})
+
+	defer s.Stop()
+	if err != nil {
+		t.Fatalf("Failed to create test DNS server, %+v", err)
+	}
+	c := caddy.NewTestController("dns",
+		fmt.Sprintf(`forward . %s {
+			force_tcp
+			upstream
+		}`, s.Addr))
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Failed to create forwarder: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("addr.example.com.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, s)
+	if _, err := f.ServeDNS(ctx, rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+
+	if rec.Msg.Answer == nil || len(rec.Msg.Answer) <= 0 {
+		t.Error("Expected to receive valid answer, but didn't")
+	}
+
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeCNAME {
+		t.Errorf("Expected dns.TypeCNAME(%d), got %d", dns.TypeCNAME, rec.Msg.Answer[0].Header().Rrtype)
+	}
+
+	cname := rec.Msg.Answer[0].(*dns.CNAME)
+	if cname.Target != "test1.example.com." {
+		t.Errorf("Expected CNAME test1.example.com., got %s", cname.Target)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

**Description**
The PR contains upstream i.e CNAME resolution support for the `forward` plugin. With upstream support enabled the forward plugin will try to resolve CNAMEs and only return the resulting A or AAAA address to the client.

**Use case**

Azure provides so called private endpoints for PaaS services, which will bind those services to IP addresses of a virtual (private) network in Azure. Along with this support, additional CNAME records are then created in Azure's Public DNS for the affected service instances. Clients that are then bound to appropriately configured DNS servers then receive the IP address of the endpoint from the virtual network and not the public address of the Azure service. This strategy creates additional traffic between the clients and the involved DNS Servers.

![image](https://user-images.githubusercontent.com/14177833/128762824-b0729367-dcc6-4128-9d75-b006b59c5d98.png)

Using coredns and the forward plugin with upstream (CNAME resolution) support enabled will resolve the CNAME chain inside the dns server and thus reducing the traffic generated by the involved clients. With caching enabled this will speedup the resolution of addresses of private endpoints for clients as well.

[Azure Private Endpoint DNS configuration](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns)
[Virtual network and on-premises workloads using a DNS forwarder](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#virtual-network-and-on-premises-workloads-using-a-dns-forwarder)

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

Documentation for the upstream support for the `forward` plugin has already been added

### 4. Does this introduce a backward incompatible change or deprecation?

No