### PR TITLE
Use latest go 1.x available for go tidy action

### DIFF
--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Install Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: '^1.16'
+          id: go
+      -
         name: Checkout
         uses: actions/checkout@v2
       -


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

go tidy action has been failing due to go 1.15 being installed, but go 1.16 is required.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
