### PR TITLE
Fix go mod tidy workflow indentation

### DIFF
--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       -
         name: Install Go
-          uses: actions/setup-go@v2
-          with:
-            go-version: '^1.16'
-          id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+        id: go
       -
         name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Fix indentation in `go mod tidy` action workflow.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
