### PR TITLE
plugin/kubernetes: Only answer transfer requests for authoritative zones

### DIFF
--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -18,6 +18,10 @@ import (
 
 // Transfer implements the transfer.Transfer interface.
 func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	match := plugin.Zones(k.Zones).Matches(zone)
+	if match == "" {
+		return nil, transfer.ErrNotAuthoritative
+	}
 	// state is not used here, hence the empty request.Request{]
 	soa, err := plugin.SOA(context.TODO(), k, zone, request.Request{}, plugin.Options{})
 	if err != nil {

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -6,7 +6,24 @@ import (
 	"testing"
 
 	"github.com/miekg/dns"
+
+	"github.com/coredns/coredns/plugin/transfer"
 )
+
+func TestKubernetesTransferNonAuthZone(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Namespaces = map[string]struct{}{"testns": {}, "kube-system": {}}
+	k.localIPs = []net.IP{net.ParseIP("10.0.0.10")}
+
+	dnsmsg := &dns.Msg{}
+	dnsmsg.SetAxfr("example.com")
+
+	_, err := k.Transfer("example.com", 0)
+	if err != transfer.ErrNotAuthoritative {
+		t.Error(err)
+	}
+}
 
 func TestKubernetesAXFR(t *testing.T) {
 	k := New([]string{"cluster.local."})

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/miekg/dns"
-
 	"github.com/coredns/coredns/plugin/transfer"
+
+	"github.com/miekg/dns"
 )
 
 func TestKubernetesTransferNonAuthZone(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Checks for zone match before doing a zone transfer, so the _kubernetes_ plugin only answers transfers for the zones it is authoritative for.

### 2. Which issues (if any) are related?

#4801

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
