### PR TITLE
Revert "pkg/reuseport: Remove pre-go1.11 impl"

### DIFF
--- a/plugin/pkg/reuseport/listen_go111.go
+++ b/plugin/pkg/reuseport/listen_go111.go
@@ -1,3 +1,6 @@
+// +build go1.11
+// +build aix darwin dragonfly freebsd linux netbsd openbsd
+
 package reuseport
 
 import (

--- a/plugin/pkg/reuseport/listen_go_not111.go
+++ b/plugin/pkg/reuseport/listen_go_not111.go
@@ -1,0 +1,13 @@
+// +build !go1.11 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+
+package reuseport
+
+import "net"
+
+// Listen is a wrapper around net.Listen.
+func Listen(network, addr string) (net.Listener, error) { return net.Listen(network, addr) }
+
+// ListenPacket is a wrapper around net.ListenPacket.
+func ListenPacket(network, addr string) (net.PacketConn, error) {
+	return net.ListenPacket(network, addr)
+}


### PR DESCRIPTION
Looks like coredns/coredns#4795 caused windows builds to fail.