### PR TITLE
Fix docker build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:stable-slim
 
+RUN sed -i.bak s@stable/update@stable-security/update@g /etc/apt/sources.list
 RUN apt-get update && apt-get -uy upgrade
 RUN apt-get -y install ca-certificates && update-ca-certificates
 


### PR DESCRIPTION
This PR fixes docker build issue, as it looks like
debian changed `stable/update` to `stable-security/update`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
