### PR TITLE
plugin:Reset dns question name if NS loopkup fail

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -422,13 +422,13 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 	old := state.QName()
 
 	state.Clear()
-	state.Req.Question[0].Name = dnsutil.Join("ns.dns.", zone)
+	state.Req.Question[0].Name = dnsutil.Join("ns.dns", zone)
 	services, err := b.Services(ctx, state, false, opt)
+	// ... and reset
+	state.Req.Question[0].Name = old
 	if err != nil {
 		return nil, nil, err
 	}
-	// ... and reset
-	state.Req.Question[0].Name = old
 
 	seen := map[string]bool{}
 


### PR DESCRIPTION
### **1. Why is this pull request needed and what does it do?**
When I used both etcd plugin and forward plugin, It cannot resolve the NS record of the root domain name.

cmd `dig -t NS .`
resolve time out.

At this time, I found two phenomena：

- coredns logs print "NS: dns: bad rdata".
- it still in loop until defaultTimeout，causing high cpu usage

The reason of this question is that the question section of packet which forwarded by forward plugin is` ns.dns..`  Instead of` . `. 
So the forward plugin print bad rdata Error.

Question section is setted in backend_lookup.go,  I think if NS lookup fail ,  it should reset this question section.

so I commit this PR.

### **2. Which issues (if any) are related?**
forward causing high cpu usage #4544
I use the etcd plug-in to forward all the analysis, and I encountered a CPU usage of 300% #4649 


### **3. Which documentation changes (if any) need to be made?**
No.

### **4. Does this introduce a backward incompatible change or deprecation?**
No.

I verified in our test environment that this commit  is  work.

