### PR TITLE
upstream lookups are done with original EDNS options

### DIFF
--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -25,11 +25,9 @@ func (u *Upstream) Lookup(ctx context.Context, state request.Request, name strin
 		return nil, fmt.Errorf("no full server is running")
 	}
 
-	size := state.Size()
-	do := state.Do()
-	req := new(dns.Msg)
+	req := state.Req.Copy()
+	// overwrite copied ID to a new one
 	req.SetQuestion(name, typ)
-	req.SetEdns0(uint16(size), do)
 
 	nw := nonwriter.New(state.W)
 	server.ServeDNS(ctx, nw, req)

--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -24,13 +24,10 @@ func (u *Upstream) Lookup(ctx context.Context, state request.Request, name strin
 	if !ok {
 		return nil, fmt.Errorf("no full server is running")
 	}
-
-	req := state.Req.Copy()
-	// overwrite copied ID to a new one
-	req.SetQuestion(name, typ)
+	req := state.NewWithQuestion(name, typ)
 
 	nw := nonwriter.New(state.W)
-	server.ServeDNS(ctx, nw, req)
+	server.ServeDNS(ctx, nw, req.Req)
 
 	return nw.Msg, nil
 }


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
copy whole original DNS request with all EDNS options to make lookups against upstream with all original EDNS0 options

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4825

### 3. Which documentation changes (if any) need to be made?
I guess none

### 4. Does this introduce a backward incompatible change or deprecation?
no

close #4825