### PR TITLE
plugin/file: fix wildcard CNAME answer

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -203,7 +203,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	if wildElem != nil {
 		auth := ap.ns(do)
 
-		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 {
+		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 && qtype != dns.TypeCNAME {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
 			return z.externalLookup(ctx, state, wildElem, rrs)
 		}

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -115,8 +115,21 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			// Only one DNAME is allowed per name. We just pick the first one to synthesize from.
 			dname := dnamerrs[0]
 			if cname := synthesizeCNAME(state.Name(), dname.(*dns.DNAME)); cname != nil {
-				ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
-				answer, ns, extra, rcode := z.externalLookup(ctx, state, elem, []dns.RR{cname})
+				var (
+					answer, ns, extra []dns.RR
+					rcode             Result
+				)
+
+				// We don't need to chase CNAME chain for synthesized CNAME
+				if qtype == dns.TypeCNAME {
+					answer = []dns.RR{cname}
+					ns = ap.ns(do)
+					extra = nil
+					rcode = Success
+				} else {
+					ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
+					answer, ns, extra, rcode = z.externalLookup(ctx, state, elem, []dns.RR{cname})
+				}
 
 				if do {
 					sigs := elem.Type(dns.TypeRRSIG)

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -95,6 +95,20 @@ var dnsTestCases = []test.Case{
 		},
 		Ns: miekAuth,
 	},
+	{
+		Qname: "asterisk.x.miek.nl.", Qtype: dns.TypeCNAME,
+		Answer: []dns.RR{
+			test.CNAME("asterisk.x.miek.nl. 1800    IN      CNAME   www.miek.nl."),
+		},
+		Ns: miekAuth,
+	},
+	{
+		Qname: "asterisk.y.miek.nl.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("asterisk.y.miek.nl.     1800    IN      A       139.162.196.78"),
+		},
+		Ns: miekAuth,
+	},
 }
 
 const (
@@ -191,6 +205,8 @@ a               IN      A       139.162.196.78
                 IN      AAAA    2a01:7e00::f03c:91ff:fef1:6735
 www             IN      CNAME   a
 archive         IN      CNAME   a
+*.x             IN      CNAME   www
+*.y             IN      A       139.162.196.78
 
 srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.`

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -109,6 +109,14 @@ var dnsTestCases = []test.Case{
 		},
 		Ns: miekAuth,
 	},
+	{
+		Qname: "foo.dname.miek.nl.", Qtype: dns.TypeCNAME,
+		Answer: []dns.RR{
+			test.DNAME("dname.miek.nl.     1800    IN      DNAME       x.miek.nl."),
+			test.CNAME("foo.dname.miek.nl.     1800    IN      CNAME       foo.x.miek.nl."),
+		},
+		Ns: miekAuth,
+	},
 }
 
 const (
@@ -207,6 +215,7 @@ www             IN      CNAME   a
 archive         IN      CNAME   a
 *.x             IN      CNAME   www
 *.y             IN      A       139.162.196.78
+dname           IN      DNAME   x
 
 srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.`


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
To fix the issue  https://github.com/coredns/coredns/issues/4398

Currently, we return different answers between wildcard CNAME and non-wildcard CNAME RRs for CNAME query.
When we receive a CNAME query for a wildcard CNAME RR, we try to chase chained names (like we do for A record query). 
For a non-wildcard CNAME RR, we don't chase chained names for a CNAME query because exceptional condition has been added in the same commit, the CNAME chain feature added. https://github.com/coredns/coredns/commit/4ef53081c536a66acf77c7b1e3df15c2fc0ca52b

To fix the inconsistent behavior, I added the same condition and some test cases.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4398

### 3. Which documentation changes (if any) need to be made?
No.

### 4. Does this introduce a backward incompatible change or deprecation?
No.