### PR TITLE
introduce new plugin to prevent DNS cache snooping

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -31,6 +31,7 @@ var Directives = []string{
 	"local",
 	"dns64",
 	"acl",
+	"refusenord",
 	"any",
 	"chaos",
 	"loadbalance",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/nsid"
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/ready"
+	_ "github.com/coredns/coredns/plugin/refusenord"
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -40,6 +40,7 @@ dnstap:dnstap
 local:local
 dns64:dns64
 acl:acl
+refusenord:refusenord
 any:any
 chaos:chaos
 loadbalance:loadbalance

--- a/plugin/refusenord/README.md
+++ b/plugin/refusenord/README.md
@@ -1,0 +1,25 @@
+# refusenord
+
+## Name
+
+*refusenord* - enforces that all queries without RD (recursion desired) bit are answered with REFUSED. This prevents DNS cache snooping.
+
+## Description
+
+With `refusenord` enabled, users are able to prevent DNS cache snooping by refusing all DNS queries without RD bit set
+
+## Syntax
+
+```
+refusenord
+```
+
+## Examples
+
+Block all DNS queries without RD bit
+
+~~~ corefile
+. {
+    refusenord
+}
+~~~

--- a/plugin/refusenord/refusenord.go
+++ b/plugin/refusenord/refusenord.go
@@ -1,0 +1,28 @@
+package refusenord
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/miekg/dns"
+)
+
+type handler struct {
+	Next plugin.Handler
+}
+
+func (h handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	if !r.RecursionDesired {
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeRefused)
+		w.WriteMsg(m)
+		return dns.RcodeSuccess, nil
+	}
+
+	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
+}
+
+func (h handler) Name() string {
+	return pluginName
+}

--- a/plugin/refusenord/refusenord_test.go
+++ b/plugin/refusenord/refusenord_test.go
@@ -1,0 +1,91 @@
+package refusenord
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	
+	"github.com/miekg/dns"
+)
+
+type testResponseWriter struct {
+	test.ResponseWriter
+	Rcode int
+}
+
+func (t *testResponseWriter) setRemoteIP(ip string) {
+	t.RemoteIP = ip
+}
+
+// WriteMsg implement dns.ResponseWriter interface.
+func (t *testResponseWriter) WriteMsg(m *dns.Msg) error {
+	t.Rcode = m.Rcode
+	return nil
+}
+
+func Test_handler_ServeDNS(t *testing.T) {
+	type args struct {
+		rd        bool
+		nextRcode int
+		nextErr   error
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      int
+		wantErr   bool
+		wantRcode int
+	}{
+		{
+			name: "DNS query with RD set - next handler fails",
+			args: args{
+				true,
+				dns.RcodeSuccess,
+				errors.New("some error"),
+			},
+			want:    dns.RcodeSuccess,
+			wantErr: true,
+		},
+		{
+			name: "DNS query with RD set - next handler does not fail",
+			args: args{
+				true,
+				dns.RcodeSuccess,
+				nil,
+			},
+			want:    dns.RcodeSuccess,
+			wantErr: false,
+		},
+		{
+			name: "DNS query with RD not set",
+			args: args{
+				false,
+				dns.RcodeSuccess,
+				nil,
+			},
+			want:    dns.RcodeRefused,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := handler{
+				Next: test.NextHandler(tt.args.nextRcode, tt.args.nextErr),
+			}
+			msg := dns.Msg{}
+			msg.SetQuestion("example.com", dns.TypeA)
+			msg.RecursionDesired = tt.args.rd
+			w := testResponseWriter{}
+			_, err := h.ServeDNS(context.Background(), &w, &msg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ServeDNS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if w.Rcode != tt.want {
+				t.Errorf("ServeDNS() Rcode got = %v, want %v", w.Rcode, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/refusenord/setup.go
+++ b/plugin/refusenord/setup.go
@@ -1,0 +1,19 @@
+package refusenord
+
+import (
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+)
+
+const pluginName = "refusenord"
+
+func init() { plugin.Register(pluginName, setup) }
+
+func setup(c *caddy.Controller) error {
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return handler{next}
+	})
+
+	return nil
+}

--- a/plugin/refusenord/setup_test.go
+++ b/plugin/refusenord/setup_test.go
@@ -1,0 +1,29 @@
+package refusenord
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+func TestSetup(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr bool
+	}{
+		{
+			"plugin with no additional options",
+			`refusenord`,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctr := caddy.NewTestController("dns", tt.config)
+			if err := setup(ctr); (err != nil) != tt.wantErr {
+				t.Errorf("Error: setup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

Hello 👋 I would like to circulate an idea for a new CoreDNS plugin, I prepared a draft how it could look like and I would welcome comments

### 1. Why is this pull request needed and what does it do?
This PR adds a new plugin that can to some extent prevent [DNS cache snooping attacks](https://kb.isc.org/docs/aa-00509). This is inspired by the existing module in [Knot Resolver](https://knot-resolver.readthedocs.io/en/stable/modules-refuse_nord.html).

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
mention new plugin in documentation

### 4. Does this introduce a backward incompatible change or deprecation?
no
