### PR TITLE
plugin/rewrite: restore 1.8.3 question revert logic; add tests

### DIFF
--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -54,7 +54,10 @@ func (rw Rewrite) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			}
 			wr.ResponseRules = append(wr.ResponseRules, respRules...)
 			if rule.Mode() == Stop {
-				break
+				if !rw.RevertPolicy.DoRevert() {
+					return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, w, r)
+				}
+				return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, wr, r)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

see #4834.  1.8.3 always restored the _question section_ in the response  to the original question.  [1.8.4 stopped doing this](https://github.com/coredns/coredns/pull/4473), resulting in question mismatch errors for most clients (e.g. including `dig`).  

**Note**: This addresses the mismatch between the original question and the  _question section_ in the response.  This is _not_ changing default behavior for the _answer section_ of the response, of which some clients are tolerant of a mismatch (e.g  `dig`).  For clients that are intolerant, a mismatch between the original question and the _answer section_  is resolvable (as it was in 1.8.3), using an `answer` rewrite rule.

### 2. Which issues (if any) are related?

Fixes #4834

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No.