### PR TITLE
Enable HTTP/2 in gRPC service

### DIFF
--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -40,6 +40,11 @@ func NewServergRPC(addr string, group []*Config) (*ServergRPC, error) {
 		// Should we error if some configs *don't* have TLS?
 		tlsConfig = conf.TLSConfig
 	}
+	// http/2 is required when using gRPC. We need to specify it in next protos
+	// or the upgrade won't happen.
+	if tlsConfig != nil {
+		tlsConfig.NextProtos = []string{"h2"}
+	}
 
 	return &ServergRPC{Server: s, tlsConfig: tlsConfig}, nil
 }


### PR DESCRIPTION
### What

Same as for #4182, add "h2" in "Next Protos" when configuring tls.

### Why

This is required for being able to upgrade the connection to http/2 which in turn is what gRPC is built upon.
Without this, I was unable to use gRPC in this setup:

- coredns with the grpc plugin -> google cloud http/2 load balancer -> coredns grpc server