### PR TITLE
The IPv4 parser no longer accepts leading zeros

### DIFF
--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -45,16 +45,13 @@ var (
 	singlelinehosts = `127.0.0.2  odin`
 	ipv4hosts       = `# See https://tools.ietf.org/html/rfc1123.
 	#
-	# The literal IPv4 address parser in the net package is a relaxed
-	# one. It may accept a literal IPv4 address in dotted-decimal notation
-	# with leading zeros such as "001.2.003.4".
 
 	# internet address and host name
 	127.0.0.1	localhost	# inline comment separated by tab
-	127.000.000.002	localhost       # inline comment separated by space
+	127.0.0.2	localhost       # inline comment separated by space
 
 	# internet address, host name and aliases
-	127.000.000.003	localhost	localhost.localdomain`
+	127.0.0.3	localhost	localhost.localdomain`
 	ipv6hosts = `# See https://tools.ietf.org/html/rfc5952, https://tools.ietf.org/html/rfc4007.
 
 	# internet address and host name


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Fix test golang-1.17

### 2. Which issues (if any) are related?
Fixes #4843

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
Yes it does.
Any ip4 address with leading zeros will be skipped.