### PR TITLE
Makefile: add `go get` to install external plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ check: core/plugin/zplugin.go core/dnsserver/zdirectives.go
 
 core/plugin/zplugin.go core/dnsserver/zdirectives.go: plugin.cfg
 	go generate coredns.go
+	go get
 
 .PHONY: gen
 gen:
 	go generate coredns.go
+	go get
 
 .PHONY: pb
 pb:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add a `go get` step to the makefile.

As `go generate coredns.go` may add new modules (if external plugins are added to `plugin.cfg`), and since with Go 1.16, `go build` fails if modules not in `go.mod` are required, this commit adds the execution of `go get` to add the modules to `go.mod`.

### 2. Which issues (if any) are related?

Fixes #4845

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No
