### PR TITLE
1.8.5 release note for cache miss metric deprecation

### DIFF
--- a/notes/coredns-1.8.5.md
+++ b/notes/coredns-1.8.5.md
@@ -13,6 +13,9 @@ a bunch of plugins and not one, but two new plugins. A *geoip* plugin that can r
 query came from and a *header* plugin that allows you to fiddle with (some of) the header bits in a
 DNS message.
 
+With this release, the `coredns_cache_misses_total` metric is deprecated.  It will be removed in a later release.
+Users should migrate forumlas to use `coredns_cache_requests_total - coredns_cache_hits_total`.
+
 ## Brought to You By
 
 Ben Kochie,

--- a/notes/coredns-1.8.5.md
+++ b/notes/coredns-1.8.5.md
@@ -14,7 +14,7 @@ query came from and a *header* plugin that allows you to fiddle with (some of) t
 DNS message.
 
 With this release, the `coredns_cache_misses_total` metric is deprecated.  It will be removed in a later release.
-Users should migrate forumlas to use `coredns_cache_requests_total - coredns_cache_hits_total`.
+Users should migrate their promQL  to use `coredns_cache_requests_total - coredns_cache_hits_total`.
 
 ## Brought to You By
 


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

Add note for cache miss metric deprecation in 1.8.5 release.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
