### PR TITLE
Spun out docker

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -79,4 +79,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test Makefile
-      run:  make DOCKER=bla GITHUB_ACCESS_TOKEN=bla -n build docker github-push docker-push -f Makefile.release
+      run:  make GITHUB_ACCESS_TOKEN=bla -n build github-push -f Makefile.release

--- a/Makefile.release
+++ b/Makefile.release
@@ -36,17 +36,10 @@
 #
 # To release we run, these target from the this Makefile.release ordered like:
 # * make release
-# * make docker
 # * make github-push
-# * make docker-push
 #
 # Testing this is hard-ish as you don't want to accidentially release a coredns. If not executing the github-push target
-# and using a non-coredns docker repo you should be fine.
-# Testing docker is done e.g. via:
-#
-#  export DOCKER_PASSWORD=<pass>
-# export DOCKER_LOGIN=miek
-# make DOCKER=miek -f Makefile.release build docker-build docker-push
+# you should be fine.
 
 EMPTY:=
 SPACE:=$(EMPTY) $(EMPTY)
@@ -56,28 +49,15 @@ ifeq (, $(shell which curl))
     $(error "No curl in $$PATH, please install")
 endif
 
-# DOCKER is the docker image repo we need to push to.
-DOCKER:=
 NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
-# mips is not in LINUX_ARCH because it's not supported by docker manifest
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
-DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-PLATFORMS:=$(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
-DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:$(VERSION)~g")
-DOCKER_IMAGE_LIST_LATEST:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:latest~g")
-QEMUVERSION=5.2.0-2
-
-# Experimental CLI is required for docker buildx/manifest to work
-export DOCKER_CLI_EXPERIMENTAL=enabled
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips
 
 all:
-	@echo Use the 'release' target to build a release, 'docker' for docker build.
+	@echo Use the 'release' target to build a release
 
 release: build tar
-
-docker: docker-build
 
 .PHONY: build
 build:
@@ -88,8 +68,6 @@ build:
 	mkdir -p build/darwin/amd64 && $(MAKE) coredns BINARY=build/darwin/amd64/$(NAME) SYSTEM="GOOS=darwin GOARCH=amd64" CHECKS="" BUILDOPTS=""
 	@echo Building: windows/amd64 - $(VERSION)
 	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME).exe SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="" BUILDOPTS=""
-	@echo Building: linux/mips - $(VERSION)
-	mkdir -p build/linux/mips  && $(MAKE) coredns BINARY=build/linux/mips/$(NAME) SYSTEM="GOOS=linux GOARCH=mips" CHECKS="" BUILDOPTS=""
 	@echo Building: linux/$(LINUX_ARCH) - $(VERSION) ;\
 	for arch in $(LINUX_ARCH); do \
 	    mkdir -p build/linux/$$arch  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" BUILDOPTS="" ;\
@@ -101,8 +79,6 @@ tar:
 	@rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_amd64.tgz -C build/darwin/amd64 $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_windows_amd64.tgz -C build/windows/amd64 $(NAME).exe
-	tar -zcf release/$(NAME)_$(VERSION)_linux_mips.tgz -C build/linux/mips $(NAME)
-	tar -zcf release/$(NAME)_$(VERSION)_linux_mips64le.tgz -C build/linux/mips64le $(NAME)
 	for arch in $(LINUX_ARCH); do \
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done
@@ -134,60 +110,6 @@ else
 	      --data-binary "@$$asset" \
 	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}" ; \
 	done )
-endif
-
-.PHONY: docker-build
-docker-build: tar
-ifeq ($(DOCKER),)
-	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
-else
-	@# Steps:
-	@# 1. Copy appropriate coredns binary to build/docker/linux/<arch>
-	@# 2. Copy Dockerfile to build/docker/linux/<arch>
-	@rm -rf build/docker
-
-	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
-	docker buildx version
-	BUILDER=$(shell docker buildx create --use)
-
-	for arch in $(LINUX_ARCH); do \
-	    mkdir -p build/docker/linux/$${arch} ;\
-	    tar -xzf release/$(NAME)_$(VERSION)_linux_$${arch}.tgz -C build/docker/linux/$${arch} ;\
-	    cp Dockerfile build/docker/linux/$${arch} ;\
-	    docker buildx build \
-			--pull \
-			--load \
-			--platform linux/$$arch \
-			-t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) \
-			build/docker/linux/$${arch} ;\
-	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
-	done
-
-	docker buildx rm $$BUILDER
-endif
-
-.PHONY: docker-push
-docker-push:
-ifeq ($(DOCKER),)
-	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
-else
-	@# Pushes coredns/coredns-$arch:$version images
-	@# Creates manifest for multi-arch image
-	@# Pushes multi-arch image to coredns/coredns:$version
-	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
-	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
-	for arch in $(LINUX_ARCH); do \
-		docker push $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
-		docker push $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
-	done
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_LATEST)
-	for arch in $(LINUX_ARCH); do \
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
-	done
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
 endif
 
 .PHONY: version


### PR DESCRIPTION
Remove docker from Makefile.release so we can actually release.
Unify the mips stuff, now that docker is gone.
Update the docs to reflect this.

See #4858

Signed-off-by: Miek Gieben <miek@miek.nl>
