### PR TITLE
add docker in Makefile.docker

### DIFF
--- a/.dreck.yaml
+++ b/.dreck.yaml
@@ -9,3 +9,5 @@ aliases:
     /wai -> /label works as intended
   - |
     /release (.*) -> /exec /opt/bin/release-coredns $1
+  - |
+    /docker (.*) -> /exec /opt/bin/docker-coredns $1

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,97 @@
+# Makefile for creating and uploading CoreDNS docker image.
+#
+# First you should do a release and then call this Makefile to create and upload
+# the image.
+#
+# 1. Reuse the issue for this release
+# 2. In an issue give the command: /docker VERSION
+#    Where VERSION is the version of the release.
+# 3. (to test as release /docker -t VERSION can be used.
+#
+# To release we run, these target from the this Makefile.docker ordered like:
+# * make release
+# * make docker-push
+#
+# Testing docker is done e.g. via:
+#
+#  export DOCKER_PASSWORD=<pass>
+# export DOCKER_LOGIN=miek
+# make DOCKER=miek -f Makefile.release build docker-build docker-push
+
+ifeq (, $(shell which curl))
+    $(error "No curl in $$PATH, please install")
+endif
+
+# VERSION is the version we should download and use.
+VERSION:=
+# DOCKER is the docker image repo we need to push to.
+DOCKER:=
+NAME:=coredns
+GITHUB:=https://github.com/coredns/coredns/releases/download
+# mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
+DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
+DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:$(VERSION)~g")
+DOCKER_IMAGE_LIST_LATEST:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:latest~g")
+
+all:
+	@echo Use the 'release' target to build a release, 'docker' for docker build.
+	echo $(DOCKER_IMAGE_LIST_VERSIONED)
+	echo $(DOCKER_IMAGE_LIST_LATEST)
+
+release: image-download docker-build
+
+.PHONY: image-download
+image-download:
+ifeq ($(VERSION),)
+	$(error "Please specify a version use. Use VERSION=<version>")
+endif
+
+	@rm -rf build/docker
+	@mkdir -p build/docker
+	@# 1. Copy appropriate coredns binary to build/docker/<arch>
+	@# 2. Copy Dockerfile into the correct dir as well.
+	@# 3. Unpack the tgz from github into 'coredns' binary.
+	for arch in $(LINUX_ARCH); do \
+		mkdir build/docker/$${arch}; \
+		curl -L $(GITHUB)/v$(VERSION)/coredns_$(VERSION)_linux_$${arch}.tgz > build/docker/$${arch}/coredns.tgz && \
+			( cd build/docker/$${arch}; tar xf coredns.tgz && rm coredns.tgz ); \
+			cp Dockerfile build/docker/$${arch} ; \
+	done
+
+.PHONY: docker-build
+docker-build:
+ifeq ($(DOCKER),)
+	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
+else
+	@# 1. Copy appropriate coredns binary to build/docker/linux/<arch>
+	@# 2. Copy Dockerfile to build/docker/linux/<arch>
+	for arch in $(LINUX_ARCH); do \
+	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/linux/$${arch} ;\
+	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+	done
+endif
+
+.PHONY: docker-push
+docker-push:
+ifeq ($(DOCKER),)
+	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
+else
+	@# Pushes coredns/coredns-$arch:$version images
+	@# Creates manifest for multi-arch image
+	@# Pushes multi-arch image to coredns/coredns:$version
+	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
+	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
+	for arch in $(LINUX_ARCH); do \
+		docker push $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
+		docker push $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+	done
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_LATEST)
+	for arch in $(LINUX_ARCH); do \
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+	done
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
+endif

--- a/Makefile.release
+++ b/Makefile.release
@@ -40,10 +40,8 @@
 #
 # Testing this is hard-ish as you don't want to accidentially release a coredns. If not executing the github-push target
 # you should be fine.
-
-EMPTY:=
-SPACE:=$(EMPTY) $(EMPTY)
-COMMA:=$(EMPTY),$(EMPTY)
+# The Docker image creation and upload is now a seperate step because it was failing too often. See the Makefile.docker for
+# details.
 
 ifeq (, $(shell which curl))
     $(error "No curl in $$PATH, please install")


### PR DESCRIPTION
This adds the (older) docker stuff back in a new Makefile.docker. Add
.dreck alias to be able to release the docker stuff via a github issue.

See #4858

Signed-off-by: Miek Gieben <miek@miek.nl>
