### PR TITLE
docker: test makefile and Dockerfile change

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -78,5 +78,8 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Test Makefile
-      run:  make GITHUB_ACCESS_TOKEN=bla -n build github-push -f Makefile.release
+    - name: Test Makefile.release
+      run:  make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
+
+    - name: Test Makefile.docker
+      run:  make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian:stable-slim
 
-RUN sed -i.bak s@stable/update@stable-security/update@g /etc/apt/sources.list
 RUN apt-get update && apt-get -uy upgrade
 RUN apt-get -y install ca-certificates && update-ca-certificates
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -67,7 +67,7 @@ else
 	@# 1. Copy appropriate coredns binary to build/docker/linux/<arch>
 	@# 2. Copy Dockerfile to build/docker/linux/<arch>
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/linux/$${arch} ;\
+	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif


### PR DESCRIPTION
The fix in 4b9bc138d92b90adafeb977913f96e9030507278 breaks docker with

~~~
Step 2/9 : RUN sed -i.bak s@stable/update@stable-security/update@g /etc/apt/sources.list
 ---> Running in 29a0dbae5746
no status provided on response: unknown
~~~

So reverted here. This adds github workflows to test Makefile.docker
syntax as well. And small updates to the docker-coredns over in the
release repo.

Signed-off-by: Miek Gieben <miek@miek.nl>
