### PR TITLE
Fix broken URL link in 1.8.0 release note

### DIFF
--- a/notes/coredns-1.8.0.md
+++ b/notes/coredns-1.8.0.md
@@ -14,7 +14,7 @@ If you are running 1.7.1 you want to upgrade for the *cache* plugin fixes.
 
 This release also adds three backwards incompatible changes. This will only affect you if you have an
 **external plugin** or use **outgoing zone transfers**. If you're using `dnstap` in your plugin,
-you'll need to upgrade to the new API as detailed in it's [documentation](/plugin/dnstap).
+you'll need to upgrade to the new API as detailed in it's [documentation](/plugins/dnstap).
 
 Two, because Caddy is now developing a version 2 and we are using version 1, we've internalized
 Caddy into <https://github.com/coredns/caddy>. This means the `caddy` types change and *all* plugins


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR fixes broken URL link to plugins/dnstap in release note.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
### 2. Which issues (if any) are related?
NONE

### 3. Which documentation changes (if any) need to be made?
NONE

### 4. Does this introduce a backward incompatible change or deprecation?
NONE