### PR TITLE
plugin/kubernetes: bump kind/k8s version for coredns/ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ integrationDefaults: &integrationDefaults
     image: ubuntu-1604:201903-01
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
-    - K8S_VERSION: v1.19.1
-    - KIND_VERSION: v0.9.0
+    - K8S_VERSION: v1.22.0
+    - KIND_VERSION: v0.11.1
     - KUBECONFIG: /home/circleci/.kube/kind-config-kind
 
 setupKubernetes: &setupKubernetes


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Bumps kind to latest release, and k8s version for coredns/ci PR tests. 

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
