### PR TITLE
plugin/k8s_external: fix external nsAddrs when CoreDNS Service has no External IPs

### DIFF
--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -15,8 +15,9 @@ func isDefaultNS(name, zone string) bool {
 // it returns a record for the local address of the machine we're running on.
 func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 	var (
-		svcNames []string
-		svcIPs   []net.IP
+		svcNames     []string
+		svcIPs       []net.IP
+		foundService bool
 	)
 
 	// Find the CoreDNS Endpoints
@@ -27,6 +28,7 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 		for _, endpoint := range endpoints {
 			svcs := k.APIConn.SvcIndex(endpoint.Index)
 			for _, svc := range svcs {
+				foundService = true
 				if external {
 					svcName := strings.Join([]string{svc.Name, svc.Namespace, zone}, ".")
 					for _, exIP := range svc.ExternalIPs {
@@ -54,8 +56,8 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 		}
 	}
 
-	// If no local IPs matched any endpoints, use the localIPs directly
-	if len(svcIPs) == 0 {
+	// If no CoreDNS services were found, use the localIPs directly
+	if !foundService {
 		svcIPs = make([]net.IP, len(k.localIPs))
 		svcNames = make([]string, len(k.localIPs))
 		for i, localIP := range k.localIPs {

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -15,9 +15,9 @@ func isDefaultNS(name, zone string) bool {
 // it returns a record for the local address of the machine we're running on.
 func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 	var (
-		svcNames     []string
-		svcIPs       []net.IP
-		foundService bool
+		svcNames      []string
+		svcIPs        []net.IP
+		foundEndpoint bool
 	)
 
 	// Find the CoreDNS Endpoints
@@ -26,9 +26,9 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 
 		// Collect IPs for all Services of the Endpoints
 		for _, endpoint := range endpoints {
+			foundEndpoint = true
 			svcs := k.APIConn.SvcIndex(endpoint.Index)
 			for _, svc := range svcs {
-				foundService = true
 				if external {
 					svcName := strings.Join([]string{svc.Name, svc.Namespace, zone}, ".")
 					for _, exIP := range svc.ExternalIPs {
@@ -56,8 +56,8 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 		}
 	}
 
-	// If no CoreDNS services were found, use the localIPs directly
-	if !foundService {
+	// If no CoreDNS endpoints were found, use the localIPs directly
+	if !foundEndpoint {
 		svcIPs = make([]net.IP, len(k.localIPs))
 		svcNames = make([]string, len(k.localIPs))
 		for i, localIP := range k.localIPs {

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -35,24 +35,25 @@ func (a APIConnTest) SvcIndex(s string) []*object.Service {
 	return nil
 }
 
+var svcs = []*object.Service{
+	{
+		Name:       "dns-service",
+		Namespace:  "kube-system",
+		ClusterIPs: []string{"10.0.0.111"},
+	},
+	{
+		Name:       "hdls-dns-service",
+		Namespace:  "kube-system",
+		ClusterIPs: []string{api.ClusterIPNone},
+	},
+	{
+		Name:       "dns6-service",
+		Namespace:  "kube-system",
+		ClusterIPs: []string{"10::111"},
+	},
+}
+
 func (APIConnTest) ServiceList() []*object.Service {
-	svcs := []*object.Service{
-		{
-			Name:       "dns-service",
-			Namespace:  "kube-system",
-			ClusterIPs: []string{"10.0.0.111"},
-		},
-		{
-			Name:       "hdls-dns-service",
-			Namespace:  "kube-system",
-			ClusterIPs: []string{api.ClusterIPNone},
-		},
-		{
-			Name:       "dns6-service",
-			Namespace:  "kube-system",
-			ClusterIPs: []string{"10::111"},
-		},
-	}
 	return svcs
 }
 
@@ -135,4 +136,38 @@ func TestNsAddrs(t *testing.T) {
 	if cdr.Header().Name != expected {
 		t.Errorf("Expected AAAA Header Name to be %q, got %q", expected, cdr.Header().Name)
 	}
+}
+
+func TestNsAddrsExternal(t *testing.T) {
+
+	k := New([]string{"example.com."})
+	k.APIConn = &APIConnTest{}
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
+
+	// initially no services have an external IP ...
+	cdrs := k.nsAddrs(true, k.Zones[0])
+
+	if len(cdrs) != 0 {
+		t.Fatalf("Expected 0 results, got %v", len(cdrs))
+
+	}
+
+	// Add an external IP to one of the services ...
+	svcs[0].ExternalIPs = []string{"1.2.3.4"}
+	cdrs = k.nsAddrs(true, k.Zones[0])
+
+	if len(cdrs) != 1 {
+		t.Fatalf("Expected 1 results, got %v", len(cdrs))
+
+	}
+	cdr := cdrs[0]
+	expected := "1.2.3.4"
+	if cdr.(*dns.A).A.String() != expected {
+		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "dns-service.kube-system.example.com."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Context _k8s_external_: When CoreDNS is running _in cluster_, but has no external IPs defined for its Service object, the additional section in an NS response should be empty - since there are no valid IP address to return.  Currently, we incorrectly fallback to returning local IP addresses, as if the CoreDNS instance was running outside of the cluster.

### 2. Which issues (if any) are related?

Closes #4887

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
