### PR TITLE
fix: specifiy platform in docker build command

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
+	    docker build --platform linux/$${arch} -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Specifying `--platform` as part of `docker build` command.

### 2. Which issues (if any) are related?

Image architecture is inconsistent with the tag name, e.g.

```
docker manifest inspect --verbose coredns/coredns-arm64:1.8.5                                                                                                  chuwon@Ernests-MBP
{
	"Ref": "docker.io/coredns/coredns-arm64:1.8.5",
	"Descriptor": {
		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
		"digest": "sha256:8ce545320d8c7bc92a065d8b3d3320cf0109410f68d4e794cad790fc3490105f",
		"size": 739,
		"platform": {
			"architecture": "amd64",
			"os": "linux"
		}
	},
	"SchemaV2Manifest": {
		"schemaVersion": 2,
		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
		"config": {
			"mediaType": "application/vnd.docker.container.image.v1+json",
			"size": 1944,
			"digest": "sha256:bb56d1bdf3e91fdca9999d8d1b0ff4ec7b99720f146a0dd7f8a299ba7798d371"
		},
		"layers": [
			{
				"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
				"size": 122221,
				"digest": "sha256:d92bdee797857f997be3c92988a15c196893cbbd6d5db2aadcdffd2a98475d2d"
			},
			{
				"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
				"size": 12188898,
				"digest": "sha256:43fb12d327a634091c8f120f667817380b96857275bd5068e44d57c170a6ed12"
			}
		]
	}
}
```

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No