### PR TITLE
Plugin/route53 AWS API MaxRetries parameter

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build --platform linux/$${arch} -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
+	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
+	    docker build --platform linux/$${arch} -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -22,34 +22,38 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 }
 ~~~
 
-*   **ZONE** the name of the domain to be accessed. When there are multiple zones with overlapping
-    domains (private vs. public hosted zone), CoreDNS does the lookup in the given order here.
-    Therefore, for a non-existing resource record, SOA response will be from the rightmost zone.
+* **ZONE** the name of the domain to be accessed. When there are multiple zones with overlapping
+ domains (private vs. public hosted zone), CoreDNS does the lookup in the given order here.
+ Therefore, for a non-existing resource record, SOA response will be from the rightmost zone.
 
-*   **HOSTED\_ZONE\_ID** the ID of the hosted zone that contains the resource record sets to be
-    accessed.
+* **HOSTED\_ZONE\_ID** the ID of the hosted zone that contains the resource record sets to be
+ accessed.
 
-*   **AWS\_ACCESS\_KEY\_ID** and **AWS\_SECRET\_ACCESS\_KEY** the AWS access key ID and secret access key
-    to be used when query AWS (optional). If they are not provided, then coredns tries to access
-    AWS credentials the same way as AWS CLI, e.g., environmental variables, AWS credentials file,
-    instance profile credentials, etc.
+* **AWS\_ACCESS\_KEY\_ID** and **AWS\_SECRET\_ACCESS\_KEY** the AWS access key ID and secret access key
+ to be used when query AWS (optional). If they are not provided, then coredns tries to access
+ AWS credentials the same way as AWS CLI, e.g., environmental variables, AWS credentials file,
+ instance profile credentials, etc.
 
-*   `credentials` is used for reading the credential **FILENAME** and setting the **PROFILE** name for a given
-    zone. **PROFILE** is the AWS account profile name. Defaults to `default`. **FILENAME** is the
-    AWS credentials filename, defaults to `~/.aws/credentials`.
+* `credentials` is used for reading the credential **FILENAME** and setting the **PROFILE** name for a given
+ zone. **PROFILE** is the AWS account profile name. Defaults to `default`. **FILENAME** is the
+ AWS credentials filename, defaults to `~/.aws/credentials`.
 
-*   `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
-    If **ZONES** is omitted, then fallthrough happens for all zones for which the plugin is
-    authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then
-    only queries for those zones will be subject to fallthrough.
+* `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
+ If **ZONES** is omitted, then fallthrough happens for all zones for which the plugin is
+ authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then
+ only queries for those zones will be subject to fallthrough.
 
-*   `refresh` can be used to control how long between record retrievals from Route 53. It requires
-    a duration string as a parameter to specify the duration between update cycles. Each update
-    cycle may result in many AWS API calls depending on how many domains use this plugin and how
-    many records are in each. Adjusting the update frequency may help reduce the potential of API
-    rate-limiting imposed by AWS.
+* `refresh` can be used to control how long between record retrievals from Route 53. It requires
+ a duration string as a parameter to specify the duration between update cycles. Each update
+ cycle may result in many AWS API calls depending on how many domains use this plugin and how
+ many records are in each. Adjusting the update frequency may help reduce the potential of API
+ rate-limiting imposed by AWS.
 
-*   **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
+* `aws_api_max_retries` can be used to retry recoverable errors on the AWS API. By default errors
+    are not retried and thus, in case of throttling on the AWS API, the plugin doesn't update the zone.
+    The default value is 0, meaning that the pluging doesn't retry.
+
+* **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
 
 ## Examples
 
@@ -57,7 +61,7 @@ Enable route53 with implicit AWS credentials and resolve CNAMEs via 10.0.0.1:
 
 ~~~ txt
 example.org {
-	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
+    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
 }
 
 . {
@@ -94,6 +98,7 @@ example.org {
 ~~~
 
 Enable route53 and refresh records every 3 minutes
+
 ~~~ txt
 example.org {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -49,6 +49,10 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
     many records are in each. Adjusting the update frequency may help reduce the potential of API
     rate-limiting imposed by AWS.
 
+*   `max_retries` can be used to retry recoverable errors on the AWS API. By default errors
+    are not retried and thus, in case of throttling on the AWS API, the plugin doesn't update the zone.
+    The default value is 0, meaning that the pluging doesn't retry.
+
 *   **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
 
 ## Examples

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -22,38 +22,34 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 }
 ~~~
 
-* **ZONE** the name of the domain to be accessed. When there are multiple zones with overlapping
- domains (private vs. public hosted zone), CoreDNS does the lookup in the given order here.
- Therefore, for a non-existing resource record, SOA response will be from the rightmost zone.
+*   **ZONE** the name of the domain to be accessed. When there are multiple zones with overlapping
+    domains (private vs. public hosted zone), CoreDNS does the lookup in the given order here.
+    Therefore, for a non-existing resource record, SOA response will be from the rightmost zone.
 
-* **HOSTED\_ZONE\_ID** the ID of the hosted zone that contains the resource record sets to be
- accessed.
+*   **HOSTED\_ZONE\_ID** the ID of the hosted zone that contains the resource record sets to be
+    accessed.
 
-* **AWS\_ACCESS\_KEY\_ID** and **AWS\_SECRET\_ACCESS\_KEY** the AWS access key ID and secret access key
- to be used when query AWS (optional). If they are not provided, then coredns tries to access
- AWS credentials the same way as AWS CLI, e.g., environmental variables, AWS credentials file,
- instance profile credentials, etc.
+*   **AWS\_ACCESS\_KEY\_ID** and **AWS\_SECRET\_ACCESS\_KEY** the AWS access key ID and secret access key
+    to be used when query AWS (optional). If they are not provided, then coredns tries to access
+    AWS credentials the same way as AWS CLI, e.g., environmental variables, AWS credentials file,
+    instance profile credentials, etc.
 
-* `credentials` is used for reading the credential **FILENAME** and setting the **PROFILE** name for a given
- zone. **PROFILE** is the AWS account profile name. Defaults to `default`. **FILENAME** is the
- AWS credentials filename, defaults to `~/.aws/credentials`.
+*   `credentials` is used for reading the credential **FILENAME** and setting the **PROFILE** name for a given
+    zone. **PROFILE** is the AWS account profile name. Defaults to `default`. **FILENAME** is the
+    AWS credentials filename, defaults to `~/.aws/credentials`.
 
-* `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
- If **ZONES** is omitted, then fallthrough happens for all zones for which the plugin is
- authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then
- only queries for those zones will be subject to fallthrough.
+*   `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
+    If **ZONES** is omitted, then fallthrough happens for all zones for which the plugin is
+    authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then
+    only queries for those zones will be subject to fallthrough.
 
-* `refresh` can be used to control how long between record retrievals from Route 53. It requires
- a duration string as a parameter to specify the duration between update cycles. Each update
- cycle may result in many AWS API calls depending on how many domains use this plugin and how
- many records are in each. Adjusting the update frequency may help reduce the potential of API
- rate-limiting imposed by AWS.
+*   `refresh` can be used to control how long between record retrievals from Route 53. It requires
+    a duration string as a parameter to specify the duration between update cycles. Each update
+    cycle may result in many AWS API calls depending on how many domains use this plugin and how
+    many records are in each. Adjusting the update frequency may help reduce the potential of API
+    rate-limiting imposed by AWS.
 
-* `aws_api_max_retries` can be used to retry recoverable errors on the AWS API. By default errors
-    are not retried and thus, in case of throttling on the AWS API, the plugin doesn't update the zone.
-    The default value is 0, meaning that the pluging doesn't retry.
-
-* **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
+*   **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
 
 ## Examples
 
@@ -61,7 +57,7 @@ Enable route53 with implicit AWS credentials and resolve CNAMEs via 10.0.0.1:
 
 ~~~ txt
 example.org {
-    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
+	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
 }
 
 . {
@@ -98,7 +94,6 @@ example.org {
 ~~~
 
 Enable route53 and refresh records every 3 minutes
-
 ~~~ txt
 example.org {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -26,12 +26,12 @@ var log = clog.NewWithPlugin("route53")
 func init() { plugin.Register("route53", setup) }
 
 // exposed for testing
-var f = func(credential *credentials.Credentials, awsApiMaxRetries int) route53iface.Route53API {
+var f = func(credential *credentials.Credentials, maxRetries int) route53iface.Route53API {
 	return route53.New(session.Must(session.NewSessionWithOptions(
 		session.Options{
 			Config: aws.Config{
 				Credentials: credential,
-				MaxRetries:  &awsApiMaxRetries},
+				MaxRetries:  &maxRetries},
 		})))
 }
 
@@ -49,7 +49,7 @@ func setup(c *caddy.Controller) error {
 		sharedProvider := &credentials.SharedCredentialsProvider{}
 		var providers []credentials.Provider
 		var fall fall.F
-		var awsApiMaxRetries int = 0
+		var maxRetries int = 0
 
 		refresh := time.Duration(1) * time.Minute // default update frequency to 1 minute
 
@@ -115,15 +115,15 @@ func setup(c *caddy.Controller) error {
 				} else {
 					return plugin.Error("route53", c.ArgErr())
 				}
-			case "aws_api_max_retries":
+			case "max_retries":
 				if c.NextArg() {
 					var err error
-					awsApiMaxRetries, err = strconv.Atoi(c.Val())
+					maxRetries, err = strconv.Atoi(c.Val())
 					if err != nil {
-						return plugin.Error("route53", c.Errf("Unable to parse aws_api_max_retries: %v", err))
+						return plugin.Error("route53", c.Errf("Unable to parse max_retries: %v", err))
 					}
-					if awsApiMaxRetries <= 0 {
-						return plugin.Error("route53", c.Errf("aws_api_max_retries must be greater than 0: %q", awsApiMaxRetries))
+					if maxRetries <= 0 {
+						return plugin.Error("route53", c.Errf("max_retries must be greater than 0: %q", maxRetries))
 					}
 				} else {
 					return c.ArgErr()
@@ -140,7 +140,7 @@ func setup(c *caddy.Controller) error {
 		}
 
 		providers = append(providers, &credentials.EnvProvider{}, sharedProvider, defaults.RemoteCredProvider(*session.Config, session.Handlers))
-		client := f(credentials.NewChainCredentials(providers), awsApiMaxRetries)
+		client := f(credentials.NewChainCredentials(providers), maxRetries)
 		ctx, cancel := context.WithCancel(context.Background())
 		h, err := New(ctx, client, keys, refresh)
 		if err != nil {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR adds the possibility to tune the MaxRetries parameter of the AWS session created with the AWS SDK.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/4899

### 3. Which documentation changes (if any) need to be made?
I already updated the README for the plugin.

### 4. Does this introduce a backward incompatible change or deprecation?
No, it's a new parameter with a default.
