### PR TITLE
plugin/kubernetes: Don't use pod names longer than 63 characters as dns labels

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -87,7 +87,7 @@ kubernetes [ZONES...] {
    If this directive is included, then name selection for endpoints changes as
    follows: Use the hostname of the endpoint, or if hostname is not set, use the
    pod name of the pod targeted by the endpoint. If there is no pod targeted by
-   the endpoint, use the dashed IP address form.
+   the endpoint or pod name is longer than 63, use the dashed IP address form.
 * `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -136,7 +136,8 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname
 			}
-			if end.TargetRef != nil {
+			// ignore pod names that are too long to be a valid label
+			if end.TargetRef != nil && len(end.TargetRef.Name) < 64 {
 				ea.TargetRefName = end.TargetRef.Name
 			}
 			if end.NodeName != nil {
@@ -186,7 +187,8 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname
 			}
-			if end.TargetRef != nil {
+			// ignore pod names that are too long to be a valid label
+			if end.TargetRef != nil && len(end.TargetRef.Name) < 64 {
 				ea.TargetRefName = end.TargetRef.Name
 			}
 			// EndpointSlice does not contain NodeName, leave blank


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

When the `endpoint_pod_names` option is used, only use Pod names shorter than 64 characters.  For longer pod names, fallback to standard endpoint name convention.

### 2. Which issues (if any) are related?

https://kubernetes.slack.com/archives/C09QYUH5W/p1633514843299500

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
