### PR TITLE
Update 1.8.6 release note and prepare for release

### DIFF
--- a/notes/coredns-1.8.6.md
+++ b/notes/coredns-1.8.6.md
@@ -3,7 +3,7 @@ title = "CoreDNS-1.8.6 Release"
 description = "CoreDNS-1.8.6 Release Notes."
 tags = ["Release", "1.8.6", "Notes"]
 release = "1.8.6"
-date = 2021-09-24T00:00:00+00:00
+date = 2021-10-7T00:00:00+00:00
 author = "coredns"
 +++
 
@@ -17,3 +17,4 @@ Miek Gieben.
 ## Noteworthy Changes
 
 * plugin/kubernetes: fix reload panic (https://github.com/coredns/coredns/pull/4881)
+* plugin/kubernetes: Don't use pod names longer than 63 characters as dns labels (https://github.com/coredns/coredns/pull/4908)


### PR DESCRIPTION
Update 1.8.6 release note and prepare for release, part of #4896

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
