### PR TITLE
Revert "fix: specifiy platform in docker build command"

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build --platform linux/$${arch} -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
+	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
 	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
 	done
 endif


### PR DESCRIPTION
Reverts coredns/coredns#4897 due to release build failure. https://github.com/coredns/coredns/issues/4896#issuecomment-937757989