### PR TITLE
Metrics: expand coredns_dns_responses_total with plugin label

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -328,7 +328,7 @@ func errorAndMetricsFunc(server string, w dns.ResponseWriter, r *dns.Msg, rc int
 	answer.SetRcode(r, rc)
 	state.SizeAndDo(answer)
 
-	vars.Report(server, state, vars.Dropped, rcode.ToString(rc), answer.Len(), time.Now())
+	vars.Report(server, state, vars.Dropped, rcode.ToString(rc), "", answer.Len(), time.Now())
 
 	w.WriteMsg(answer)
 }

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -328,7 +328,7 @@ func errorAndMetricsFunc(server string, w dns.ResponseWriter, r *dns.Msg, rc int
 	answer.SetRcode(r, rc)
 	state.SizeAndDo(answer)
 
-	vars.Report(server, state, vars.Dropped, rcode.ToString(rc), "", answer.Len(), time.Now())
+	vars.Report(server, state, vars.Dropped, rcode.ToString(rc), "" /* plugin */, answer.Len(), time.Now())
 
 	w.WriteMsg(answer)
 }

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -17,7 +17,7 @@ The following metrics are exported:
 * `coredns_dns_request_size_bytes{server, zone, proto}` - size of the request in bytes.
 * `coredns_dns_do_requests_total{server, zone}` -  queries that have the DO bit set
 * `coredns_dns_response_size_bytes{server, zone, proto}` - response size in bytes.
-* `coredns_dns_responses_total{server, zone, rcode}` - response per zone and rcode.
+* `coredns_dns_responses_total{server, zone, rcode, plugin}` - response per zone, rcode and plugin.
 * `coredns_plugin_enabled{server, zone, name}` - indicates whether a plugin is enabled on per server and zone basis.
 
 Each counter has a label `zone` which is the zonename used for the request/response.
@@ -32,6 +32,8 @@ Extra labels used are:
 * `type` which holds the query type. It holds most common types (A, AAAA, MX, SOA, CNAME, PTR, TXT,
   NS, SRV, DS, DNSKEY, RRSIG, NSEC, NSEC3, IXFR, AXFR and ANY) and "other" which lumps together all
   other types.
+* the `plugin` label holds the name of the plugin that made the write to the client. If the server
+  did the write (on error for instance), the value is empty.
 
 If monitoring is enabled, queries that do not enter the plugin chain are exported under the fake
 name "dropped" (without a closing dot - this is never a valid domain name).

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -2,10 +2,10 @@ package metrics
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
-	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 	"github.com/coredns/coredns/request"
 
@@ -23,7 +23,7 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	}
 
 	// Record response to get status code and size of the reply.
-	rw := dnstest.NewRecorder(w)
+	rw := NewRecorder(w)
 	status, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, rw, r)
 
 	rc := rw.Rcode
@@ -33,10 +33,32 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		// see https://github.com/coredns/coredns/blob/master/core/dnsserver/server.go#L318
 		rc = status
 	}
-	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), rw.Len, rw.Start)
+	plugin := m.authoritativePlugin(rw.Caller1, rw.Caller2, rw.Caller3)
+	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), plugin, rw.Len, rw.Start)
 
 	return status, err
 }
 
 // Name implements the Handler interface.
 func (m *Metrics) Name() string { return "prometheus" }
+
+// authoritativePlugin returns which of made the write, if none is found the empty string is returned.
+func (m *Metrics) authoritativePlugin(a, b, c string) string {
+	// a b and c contain the full path of the caller, the plugin name 2nd last elements
+	// .../coredns/plugin/whoami/whoami.go --> whoami
+	// this is likely FS specific, so use filepath.
+	plug := filepath.Base(filepath.Dir(a))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+	plug = filepath.Base(filepath.Dir(b))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+	plug = filepath.Base(filepath.Dir(c))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+
+	return ""
+}

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -52,7 +52,6 @@ func (m *Metrics) authoritativePlugin(caller [3]string) string {
 		if _, ok := m.plugins[plug]; ok {
 			return plug
 		}
-
 	}
 	return ""
 }

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
@@ -33,10 +34,32 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		// see https://github.com/coredns/coredns/blob/master/core/dnsserver/server.go#L318
 		rc = status
 	}
-	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), rw.Len, rw.Start)
+	plugin := m.authoritativePlugin(rw.Caller1, rw.Caller2, rw.Caller3)
+	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rc), plugin, rw.Len, rw.Start)
 
 	return status, err
 }
 
 // Name implements the Handler interface.
 func (m *Metrics) Name() string { return "prometheus" }
+
+// authoritativePlugin returns which of made the write, if none is found the empty string is returned.
+func (m *Metrics) authoritativePlugin(a, b, c string) string {
+	// a b and c contain the full path of the caller, the plugin name 2nd last elements
+	// .../coredns/plugin/whoami/whoami.go --> whoami
+	// this is likely FS specific, so use filepath.
+	plug := filepath.Base(filepath.Dir(a))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+	plug = filepath.Base(filepath.Dir(b))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+	plug = filepath.Base(filepath.Dir(c))
+	if _, ok := m.plugins[plug]; ok {
+		return plug
+	}
+
+	return ""
+}

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 
@@ -31,6 +32,8 @@ type Metrics struct {
 	zoneNames []string
 	zoneMap   map[string]struct{}
 	zoneMu    sync.RWMutex
+
+	plugins map[string]struct{} // all available plugins, used to determine which plugin made the client write
 }
 
 // New returns a new instance of Metrics with the given address.
@@ -39,6 +42,7 @@ func New(addr string) *Metrics {
 		Addr:    addr,
 		Reg:     prometheus.DefaultRegisterer.(*prometheus.Registry),
 		zoneMap: make(map[string]struct{}),
+		plugins: pluginList(caddy.ListPlugins()),
 	}
 
 	return met
@@ -138,6 +142,19 @@ func keys(m map[string]struct{}) []string {
 		sx = append(sx, k)
 	}
 	return sx
+}
+
+// pluginList iterates over the returned plugin map from caddy and removes the "dns." prefix from them.
+func pluginList(m map[string][]string) map[string]struct{} {
+	pm := map[string]struct{}{}
+	for _, p := range m["others"] {
+		// only add 'dns.' plugins
+		if len(p) > 3 {
+			pm[p[4:]] = struct{}{}
+			continue
+		}
+	}
+	return pm
 }
 
 // ListenAddr is assigned the address of the prometheus listener. Its use is mainly in tests where

--- a/plugin/metrics/recorder.go
+++ b/plugin/metrics/recorder.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/metrics/recorder.go
+++ b/plugin/metrics/recorder.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"runtime"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/miekg/dns"
+)
+
+// Recorder is a dnstest.Recorder specific to the metrics plugin.
+type Recorder struct {
+	*dnstest.Recorder
+	// CallerN holds the string return value of the call to runtime.Caller(N)
+	Caller1 string
+	Caller2 string
+	Caller3 string
+}
+
+// NewRecorder makes and returns a new Recorder.
+func NewRecorder(w dns.ResponseWriter) *Recorder { return &Recorder{Recorder: dnstest.NewRecorder(w)} }
+
+// WriteMsg records the status code and calls the
+// underlying ResponseWriter's WriteMsg method.
+func (r *Recorder) WriteMsg(res *dns.Msg) error {
+	_, r.Caller1, _, _ = runtime.Caller(1)
+	_, r.Caller2, _, _ = runtime.Caller(2)
+	_, r.Caller3, _, _ = runtime.Caller(3)
+	r.Len += res.Len()
+	r.Msg = res
+	return r.ResponseWriter.WriteMsg(res)
+}

--- a/plugin/metrics/recorder.go
+++ b/plugin/metrics/recorder.go
@@ -10,10 +10,8 @@ import (
 // Recorder is a dnstest.Recorder specific to the metrics plugin.
 type Recorder struct {
 	*dnstest.Recorder
-	// CallerN holds the string return value of the call to runtime.Caller(N)
-	Caller1 string
-	Caller2 string
-	Caller3 string
+	// CallerN holds the string return value of the call to runtime.Caller(N+1)
+	Caller [3]string
 }
 
 // NewRecorder makes and returns a new Recorder.
@@ -22,9 +20,9 @@ func NewRecorder(w dns.ResponseWriter) *Recorder { return &Recorder{Recorder: dn
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
-	_, r.Caller1, _, _ = runtime.Caller(1)
-	_, r.Caller2, _, _ = runtime.Caller(2)
-	_, r.Caller3, _, _ = runtime.Caller(3)
+	_, r.Caller[0], _, _ = runtime.Caller(1)
+	_, r.Caller[1], _, _ = runtime.Caller(2)
+	_, r.Caller[2], _, _ = runtime.Caller(3)
 	r.Len += res.Len()
 	r.Msg = res
 	return r.ResponseWriter.WriteMsg(res)

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -9,7 +9,7 @@ import (
 // Report reports the metrics data associated with request. This function is exported because it is also
 // called from core/dnsserver to report requests hitting the server that should not be handled and are thus
 // not sent down the plugin chain.
-func Report(server string, req request.Request, zone, rcode string, size int, start time.Time) {
+func Report(server string, req request.Request, zone, rcode, plugin string, size int, start time.Time) {
 	// Proto and Family.
 	net := req.Proto()
 	fam := "1"
@@ -29,5 +29,5 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 	ResponseSize.WithLabelValues(server, zone, net).Observe(float64(size))
 	RequestSize.WithLabelValues(server, zone, net).Observe(float64(req.Len()))
 
-	ResponseRcode.WithLabelValues(server, zone, rcode).Inc()
+	ResponseRcode.WithLabelValues(server, zone, rcode, plugin).Inc()
 }

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -52,7 +52,7 @@ var (
 		Subsystem: subsystem,
 		Name:      "responses_total",
 		Help:      "Counter of response status codes.",
-	}, []string{"server", "zone", "rcode"})
+	}, []string{"server", "zone", "rcode", "plugin"})
 
 	Panic = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -36,6 +36,7 @@ func NewRecorder(w dns.ResponseWriter) *Recorder {
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
+	r.Rcode = res.Rcode
 	// We may get called multiple times (axfr for instance).
 	// Save the last message, but add the sizes.
 	r.Len += res.Len()

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -20,7 +20,7 @@ type Recorder struct {
 	Len   int
 	Msg   *dns.Msg
 	Start time.Time
-	// CallerN holds string parameters of a call to runtime.Caller(N)
+	// CallerN holds string return value of the call to runtime.Caller(N)
 	Caller1 string
 	Caller2 string
 	Caller3 string

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -2,7 +2,6 @@
 package dnstest
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/miekg/dns"
@@ -20,10 +19,6 @@ type Recorder struct {
 	Len   int
 	Msg   *dns.Msg
 	Start time.Time
-	// CallerN holds string return value of the call to runtime.Caller(N)
-	Caller1 string
-	Caller2 string
-	Caller3 string
 }
 
 // NewRecorder makes and returns a new Recorder,
@@ -41,9 +36,6 @@ func NewRecorder(w dns.ResponseWriter) *Recorder {
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
-	_, r.Caller1, _, _ = runtime.Caller(1)
-	_, r.Caller2, _, _ = runtime.Caller(2)
-	_, r.Caller3, _, _ = runtime.Caller(3)
 	// We may get called multiple times (axfr for instance).
 	// Save the last message, but add the sizes.
 	r.Len += res.Len()

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -2,6 +2,7 @@
 package dnstest
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/miekg/dns"
@@ -19,6 +20,10 @@ type Recorder struct {
 	Len   int
 	Msg   *dns.Msg
 	Start time.Time
+	// CallerN holds string parameters of a call to runtime.Caller(N)
+	Caller1 string
+	Caller2 string
+	Caller3 string
 }
 
 // NewRecorder makes and returns a new Recorder,
@@ -36,7 +41,9 @@ func NewRecorder(w dns.ResponseWriter) *Recorder {
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
-	r.Rcode = res.Rcode
+	_, r.Caller1, _, _ = runtime.Caller(1)
+	_, r.Caller2, _, _ = runtime.Caller(2)
+	_, r.Caller3, _, _ = runtime.Caller(3)
 	// We may get called multiple times (axfr for instance).
 	// Save the last message, but add the sizes.
 	r.Len += res.Len()

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -2,6 +2,7 @@
 package dnstest
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/miekg/dns"
@@ -19,6 +20,10 @@ type Recorder struct {
 	Len   int
 	Msg   *dns.Msg
 	Start time.Time
+	// CallerN holds string return value of the call to runtime.Caller(N)
+	Caller1 string
+	Caller2 string
+	Caller3 string
 }
 
 // NewRecorder makes and returns a new Recorder,
@@ -36,7 +41,9 @@ func NewRecorder(w dns.ResponseWriter) *Recorder {
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
-	r.Rcode = res.Rcode
+	_, r.Caller1, _, _ = runtime.Caller(1)
+	_, r.Caller2, _, _ = runtime.Caller(2)
+	_, r.Caller3, _, _ = runtime.Caller(3)
 	// We may get called multiple times (axfr for instance).
 	// Save the last message, but add the sizes.
 	r.Len += res.Len()

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -53,6 +53,7 @@ func TestMetricsRefused(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	data := test.Scrape("http://" + metrics.ListenAddr + "/metrics")
 	got, labels := test.MetricValue(metricName, data)
@@ -87,6 +88,7 @@ func TestMetricsPlugin(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	data := test.Scrape("http://" + metrics.ListenAddr + "/metrics")
 	_, labels := test.MetricValue(metricName, data)
@@ -134,6 +136,7 @@ func TestMetricsAuto(t *testing.T) {
 	if _, err := dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	metricName := "coredns_dns_requests_total" // {zone, proto, family, type}
 
@@ -192,6 +195,7 @@ func TestMetricsSeveralBlocs(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	beginCacheSize := test.ScrapeMetricAsInt(addrMetrics, cacheSizeMetricName, "", 0)
 
@@ -277,6 +281,7 @@ func TestMetricsAvailable(t *testing.T) {
 	if _, _, err := cl.Exchange(m, tcp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
+	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	// we should have metrics from forward, cache, and metrics itself
 	if err := collectMetricsInfo(metrics.ListenAddr, procMetric, procCache, procCacheMiss, procForward); err != nil {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -53,7 +53,6 @@ func TestMetricsRefused(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
-	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	data := test.Scrape("http://" + metrics.ListenAddr + "/metrics")
 	got, labels := test.MetricValue(metricName, data)
@@ -88,7 +87,6 @@ func TestMetricsPlugin(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
-	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	data := test.Scrape("http://" + metrics.ListenAddr + "/metrics")
 	_, labels := test.MetricValue(metricName, data)
@@ -136,7 +134,6 @@ func TestMetricsAuto(t *testing.T) {
 	if _, err := dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
-	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	metricName := "coredns_dns_requests_total" // {zone, proto, family, type}
 
@@ -195,7 +192,6 @@ func TestMetricsSeveralBlocs(t *testing.T) {
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
-	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	beginCacheSize := test.ScrapeMetricAsInt(addrMetrics, cacheSizeMetricName, "", 0)
 
@@ -281,7 +277,6 @@ func TestMetricsAvailable(t *testing.T) {
 	if _, _, err := cl.Exchange(m, tcp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
-	time.Sleep(100 * time.Millisecond) // sleep a bit to allow actual metrics to be updated for sure.
 
 	// we should have metrics from forward, cache, and metrics itself
 	if err := collectMetricsInfo(metrics.ListenAddr, procMetric, procCache, procCacheMiss, procForward); err != nil {


### PR DESCRIPTION
This adds (somewhat hacky?) code to add a plugin label to the
coredns_dns_responses_total metric. It's completely obvlious to the
plugin as we just check who called the *recorder.WriteMsg method. We use
runtime.Caller( 1 2 3) to get multiple levels of callers, this should be
deep enough, but it depends on the dns.ResponseWriter wrapping that's
occuring.

README.md of metrics updates and test added in test/metrics_test.go to
check for the label being set.

I went through the plugin to see what metrics could be removed, but
actually didn't find any, the plugin push out metrics that make sense.

Due to the path fiddling to figure out the plugin name I doubt this
works (out-of-the-box) for external plugins, but I haven't tested that.

Signed-off-by: Miek Gieben <miek@miek.nl>
