### PR TITLE
cleanup deprecated package io/ioutil

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -4,7 +4,6 @@ package coremain
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -96,7 +95,7 @@ func confLoader(serverType string) (caddy.Input, error) {
 		return caddy.CaddyfileFromPipe(os.Stdin, serverType)
 	}
 
-	contents, err := ioutil.ReadFile(conf)
+	contents, err := os.ReadFile(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +108,7 @@ func confLoader(serverType string) (caddy.Input, error) {
 
 // defaultLoader loads the Corefile from the current working directory.
 func defaultLoader(serverType string) (caddy.Input, error) {
-	contents, err := ioutil.ReadFile(caddy.DefaultConfigFile)
+	contents, err := os.ReadFile(caddy.DefaultConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/directives_generate.go
+++ b/directives_generate.go
@@ -5,7 +5,6 @@ package main
 import (
 	"bufio"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -101,7 +100,7 @@ func formatAndWrite(file string, data string) error {
 		return err
 	}
 
-	if err = ioutil.WriteFile(file, res, 0644); err != nil {
+	if err = os.WriteFile(file, res, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/owners_generate.go
+++ b/owners_generate.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -35,7 +34,7 @@ var Owners = []string{`
 	// to prevent `No newline at end of file` with gofmt
 	golist += "\n"
 
-	if err := ioutil.WriteFile("plugin/chaos/zowners.go", []byte(golist), 0644); err != nil {
+	if err := os.WriteFile("plugin/chaos/zowners.go", []byte(golist), 0644); err != nil {
 		log.Fatal(err)
 	}
 	return

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -1,7 +1,6 @@
 package auto
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -67,13 +66,13 @@ func TestWalkNonExistent(t *testing.T) {
 }
 
 func createFiles() (string, error) {
-	dir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	dir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		return dir, err
 	}
 
 	for _, name := range dbFiles {
-		if err := ioutil.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
 			return dir, err
 		}
 	}

--- a/plugin/dnssec/setup_test.go
+++ b/plugin/dnssec/setup_test.go
@@ -1,7 +1,6 @@
 package dnssec
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -10,19 +9,19 @@ import (
 )
 
 func TestSetupDnssec(t *testing.T) {
-	if err := ioutil.WriteFile("Kcluster.local.key", []byte(keypub), 0644); err != nil {
+	if err := os.WriteFile("Kcluster.local.key", []byte(keypub), 0644); err != nil {
 		t.Fatalf("Failed to write pub key file: %s", err)
 	}
 	defer func() { os.Remove("Kcluster.local.key") }()
-	if err := ioutil.WriteFile("Kcluster.local.private", []byte(keypriv), 0644); err != nil {
+	if err := os.WriteFile("Kcluster.local.private", []byte(keypriv), 0644); err != nil {
 		t.Fatalf("Failed to write private key file: %s", err)
 	}
 	defer func() { os.Remove("Kcluster.local.private") }()
-	if err := ioutil.WriteFile("ksk_Kcluster.local.key", []byte(kskpub), 0644); err != nil {
+	if err := os.WriteFile("ksk_Kcluster.local.key", []byte(kskpub), 0644); err != nil {
 		t.Fatalf("Failed to write pub key file: %s", err)
 	}
 	defer func() { os.Remove("ksk_Kcluster.local.key") }()
-	if err := ioutil.WriteFile("ksk_Kcluster.local.private", []byte(kskpriv), 0644); err != nil {
+	if err := os.WriteFile("ksk_Kcluster.local.private", []byte(kskpriv), 0644); err != nil {
 		t.Fatalf("Failed to write private key file: %s", err)
 	}
 	defer func() { os.Remove("ksk_Kcluster.local.private") }()

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -56,7 +55,7 @@ func TestZoneReload(t *testing.T) {
 	if len(rrs) != 5 {
 		t.Fatalf("Expected 5 RRs, got %d", len(rrs))
 	}
-	if err := ioutil.WriteFile(fileName, []byte(reloadZone2Test), 0644); err != nil {
+	if err := os.WriteFile(fileName, []byte(reloadZone2Test), 0644); err != nil {
 		t.Fatalf("Failed to write new zone data: %s", err)
 	}
 	// Could still be racy, but we need to wait a bit for the event to be seen

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -1,7 +1,6 @@
 package forward
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -126,7 +125,7 @@ func TestSetupTLS(t *testing.T) {
 
 func TestSetupResolvconf(t *testing.T) {
 	const resolv = "resolv.conf"
-	if err := ioutil.WriteFile(resolv,
+	if err := os.WriteFile(resolv,
 		[]byte(`nameserver 10.10.255.252
 nameserver 10.10.255.253`), 0666); err != nil {
 		t.Fatalf("Failed to write resolv.conf file: %s", err)

--- a/plugin/grpc/setup_test.go
+++ b/plugin/grpc/setup_test.go
@@ -1,7 +1,6 @@
 package grpc
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -105,7 +104,7 @@ tls
 
 func TestSetupResolvconf(t *testing.T) {
 	const resolv = "resolv.conf"
-	if err := ioutil.WriteFile(resolv,
+	if err := os.WriteFile(resolv,
 		[]byte(`nameserver 10.10.255.252
 nameserver 10.10.255.253`), 0666); err != nil {
 		t.Fatalf("Failed to write resolv.conf file: %s", err)

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -2,7 +2,7 @@ package health
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -25,7 +25,7 @@ func TestHealth(t *testing.T) {
 	if response.StatusCode != 200 {
 		t.Errorf("Invalid status code: expecting '200', got '%d'", response.StatusCode)
 	}
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("Unable to get response body from %s: %v", address, err)
 	}

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -3,7 +3,7 @@ package log
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -240,7 +240,7 @@ func TestLogged(t *testing.T) {
 }
 
 func BenchmarkLogged(b *testing.B) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	rule := Rule{
 		NameScope: ".",

--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/miekg/dns"
@@ -93,7 +92,7 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 }
 
 func toMsg(r io.ReadCloser) (*dns.Msg, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -10,7 +10,7 @@ package log
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	golog "log"
 	"os"
 	"sync"
@@ -102,7 +102,7 @@ func Fatal(v ...interface{}) { log(fatal, v...); os.Exit(1) }
 func Fatalf(format string, v ...interface{}) { logf(fatal, format, v...); os.Exit(1) }
 
 // Discard sets the log output to /dev/null.
-func Discard() { golog.SetOutput(ioutil.Discard) }
+func Discard() { golog.SetOutput(io.Discard) }
 
 const (
 	debug   = "[DEBUG] "

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -1,7 +1,6 @@
 package parse
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestHostPortOrFile(t *testing.T) {
 		},
 	}
 
-	err := ioutil.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)
+	err := os.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)
 	if err != nil {
 		t.Fatalf("Failed to write test resolv.conf")
 	}

--- a/plugin/pkg/tls/tls.go
+++ b/plugin/pkg/tls/tls.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -95,7 +95,7 @@ func loadRoots(caPath string) (*x509.CertPool, error) {
 	}
 
 	roots := x509.NewCertPool()
-	pem, err := ioutil.ReadFile(caPath)
+	pem, err := os.ReadFile(caPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %s", caPath, err)
 	}

--- a/plugin/root/root_test.go
+++ b/plugin/root/root_test.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +23,7 @@ func TestRoot(t *testing.T) {
 
 	nonExistingDir := filepath.Join(existingDirPath, "highly_unlikely_to_exist_dir")
 
-	existingFile, err := ioutil.TempFile("", "root_test")
+	existingFile, err := os.CreateTemp("", "root_test")
 	if err != nil {
 		t.Fatalf("BeforeTest: Failed to create temp file for testing! Error was: %v", err)
 	}

--- a/plugin/sign/file.go
+++ b/plugin/sign/file.go
@@ -3,7 +3,6 @@ package sign
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -15,7 +14,7 @@ import (
 
 // write writes out the zone file to a temporary file which is then moved into the correct place.
 func (s *Signer) write(z *file.Zone) error {
-	f, err := ioutil.TempFile(s.directory, "signed-")
+	f, err := os.CreateTemp(s.directory, "signed-")
 	if err != nil {
 		return err
 	}

--- a/plugin/sign/keys.go
+++ b/plugin/sign/keys.go
@@ -5,7 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -70,7 +70,7 @@ func readKeyPair(public, private string) (Pair, error) {
 	if err != nil {
 		return Pair{}, err
 	}
-	b, err := ioutil.ReadAll(rk)
+	b, err := io.ReadAll(rk)
 	if err != nil {
 		return Pair{}, err
 	}

--- a/plugin/sign/signer_test.go
+++ b/plugin/sign/signer_test.go
@@ -1,7 +1,6 @@
 package sign
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ $ORIGIN example.org.
 @       IN      SOA     linode miek.miek.nl. ( 1282630060 4H 1H 7D 4H )
         IN      NS      linode
 `
-	if err := ioutil.WriteFile("db.apex-test.example.org", []byte(apex), 0644); err != nil {
+	if err := os.WriteFile("db.apex-test.example.org", []byte(apex), 0644); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove("db.apex-test.example.org")

--- a/plugin/test/file.go
+++ b/plugin/test/file.go
@@ -1,18 +1,17 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
 // TempFile will create a temporary file on disk and returns the name and a cleanup function to remove it later.
 func TempFile(dir, content string) (string, func(), error) {
-	f, err := ioutil.TempFile(dir, "go-test-tmpfile")
+	f, err := os.CreateTemp(dir, "go-test-tmpfile")
 	if err != nil {
 		return "", nil, err
 	}
-	if err := ioutil.WriteFile(f.Name(), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(content), 0644); err != nil {
 		return "", nil, err
 	}
 	rmFunc := func() { os.Remove(f.Name()) }
@@ -21,7 +20,7 @@ func TempFile(dir, content string) (string, func(), error) {
 
 // WritePEMFiles creates a tmp dir with ca.pem, cert.pem, and key.pem and the func to remove it
 func WritePEMFiles(dir string) (string, func(), error) {
-	tempDir, err := ioutil.TempDir(dir, "go-test-pemfiles")
+	tempDir, err := os.MkdirTemp(dir, "go-test-pemfiles")
 	if err != nil {
 		return "", nil, err
 	}
@@ -45,7 +44,7 @@ xGbtCkhVk2VQ+BiCWnjYXJ6ZMzabP7wiOFDP9Pvr2ik22PRItsW/TLfHFXM1jDmc
 I1rs/VUGKzcJGVIWbHrgjP68CTStGAvKgbsTqw7aLXTSqtPw88N9XVSyRg==
 -----END CERTIFICATE-----`
 	path := filepath.Join(tempDir, "ca.pem")
-	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
 		return "", nil, err
 	}
 	data = `-----BEGIN CERTIFICATE-----
@@ -66,7 +65,7 @@ zhDEPP4FhY+Sz+y1yWirphl7A1aZwhXVPcfWIGqpQ3jzNwUeocbH27kuLh+U4hQo
 qeg10RdFnw==
 -----END CERTIFICATE-----`
 	path = filepath.Join(tempDir, "cert.pem")
-	if err = ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+	if err = os.WriteFile(path, []byte(data), 0644); err != nil {
 		return "", nil, err
 	}
 
@@ -98,7 +97,7 @@ E/WObVJXDnBdViu0L9abE9iaTToBVri4cmlDlZagLuKVR+TFTCN/DSlVZTDkqkLI
 8chzqtkH6b2b2R73hyRysWjsomys34ma3mEEPTX/aXeAF2MSZ/EWT9yL
 -----END RSA PRIVATE KEY-----`
 	path = filepath.Join(tempDir, "key.pem")
-	if err = ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+	if err = os.WriteFile(path, []byte(data), 0644); err != nil {
 		return "", nil, err
 	}
 

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,7 @@ import (
 
 func TestAuto(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func TestAuto(t *testing.T) {
 	}
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +70,7 @@ func TestAuto(t *testing.T) {
 
 func TestAutoNonExistentZone(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +109,7 @@ func TestAutoNonExistentZone(t *testing.T) {
 func TestAutoAXFR(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +137,7 @@ func TestAutoAXFR(t *testing.T) {
 	defer i.Stop()
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,7 @@ import (
 )
 
 func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +23,7 @@ google.com. IN A 172.217.25.110
 `
 
 	path := filepath.Join(tmpdir, "file")
-	if err = ioutil.WriteFile(path, []byte(content), 0644); err != nil {
+	if err = os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("Could not write to temp file: %s", err)
 	}
 	defer os.Remove(path)

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -45,7 +45,7 @@ func TestZoneReload(t *testing.T) {
 	}
 
 	// Remove RR from the Apex
-	ioutil.WriteFile(name, []byte(exampleOrgUpdated), 0644)
+	os.WriteFile(name, []byte(exampleOrgUpdated), 0644)
 
 	time.Sleep(20 * time.Millisecond) // reload time, with some race insurance
 

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func TestMetricsRefused(t *testing.T) {
 }
 
 func TestMetricsAuto(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +94,7 @@ func TestMetricsAuto(t *testing.T) {
 	defer i.Stop()
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(110 * time.Millisecond) // wait for it to be picked up

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -56,10 +55,10 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 }
 
 func createKeyFile(t *testing.T) func() {
-	ioutil.WriteFile(base+".key",
+	os.WriteFile(base+".key",
 		[]byte(`example.org. IN DNSKEY 256 3 13 tDyI0uEIDO4SjhTJh1AVTFBLpKhY3He5BdAlKztewiZ7GecWj94DOodg ovpN73+oJs+UfZ+p9zOSN5usGAlHrw==`),
 		0644)
-	ioutil.WriteFile(base+".private",
+	os.WriteFile(base+".private",
 		[]byte(`Private-key-format: v1.3
 Algorithm: 13 (ECDSAP256SHA256)
 PrivateKey: HPmldSNfrkj/aDdUMFwuk/lgzaC5KIsVEG3uoYvF4pQ=

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -52,7 +51,7 @@ func TestReadme(t *testing.T) {
 	defer remove(contents)
 
 	middle := filepath.Join("..", "plugin")
-	dirs, err := ioutil.ReadDir(middle)
+	dirs, err := os.ReadDir(middle)
 	if err != nil {
 		t.Fatalf("Could not read %s: %q", middle, err)
 	}
@@ -173,7 +172,7 @@ func sectionsFromReadme(readme string) error {
 
 func create(c map[string]string) {
 	for name, content := range c {
-		ioutil.WriteFile(name, []byte(content), 0644)
+		os.WriteFile(name, []byte(content), 0644)
 	}
 }
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -105,7 +105,7 @@ func TestReloadMetricsHealth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ok, _ := ioutil.ReadAll(resp.Body)
+	ok, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if string(ok) != http.StatusText(http.StatusOK) {
 		t.Errorf("Failed to receive OK, got %s", ok)
@@ -117,7 +117,7 @@ func TestReloadMetricsHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 	const proc = "coredns_build_info"
-	metrics, _ := ioutil.ReadAll(resp.Body)
+	metrics, _ := io.ReadAll(resp.Body)
 	if !bytes.Contains(metrics, []byte(proc)) {
 		t.Errorf("Failed to see %s in metric output", proc)
 	}
@@ -129,7 +129,7 @@ func collectMetricsInfo(addr string, procs ...string) error {
 	if err != nil {
 		return err
 	}
-	metrics, _ := ioutil.ReadAll(resp.Body)
+	metrics, _ := io.ReadAll(resp.Body)
 	for _, p := range procs {
 		if !bytes.Contains(metrics, []byte(p)) {
 			return fmt.Errorf("failed to see %s in metric output \n%s", p, metrics)


### PR DESCRIPTION
Signed-off-by: Zou Nengren <zouyee1989@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

io/ioutil package has been deprecated in Go 1.16 (xref https://golang.org/doc/go1.16#ioutil), replaces the existing io/ioutil functions with os packages.

### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
none