### PR TITLE
add DIAL_CHAN_SIZE to fix system freeze on high load

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -50,7 +50,12 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 		proto = "tcp-tls"
 	}
 
-	t.dial <- proto
+    select {
+	    case t.dial <- proto:
+	    default:
+	        return nil, false, ErrSocketRequestsLimit
+	}
+
 	pc := <-t.ret
 
 	if pc != nil {

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -227,6 +227,8 @@ var (
 	ErrNoForward = errors.New("no forwarder defined")
 	// ErrCachedClosed means cached connection was closed by peer.
 	ErrCachedClosed = errors.New("cached connection was closed by peer")
+	// ErrSocketRequestsLimit means transport is too busy to serve socket request.
+	ErrSocketRequestsLimit = errors.New("can't serve all socket requests")
 )
 
 // options holds various options that can be set.

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -8,6 +8,9 @@ import (
 	"github.com/miekg/dns"
 )
 
+// dial channel size.
+var DIAL_CHAN_SIZE = 1000
+
 // a persistConn hold the dns.Conn and the last used time.
 type persistConn struct {
 	c    *dns.Conn
@@ -34,7 +37,7 @@ func newTransport(addr string) *Transport {
 		conns:       [typeTotalCount][]*persistConn{},
 		expire:      defaultExpire,
 		addr:        addr,
-		dial:        make(chan string),
+		dial:        make(chan string, DIAL_CHAN_SIZE),
 		yield:       make(chan *persistConn),
 		ret:         make(chan *persistConn),
 		stop:        make(chan bool),


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?
On a very high load (more than 30k rps in my case), one goroutine is not able to read all requests for a socket from dial channel in Transport. Because new forward goroutines continue to appear, more memory and cpu is used. Finally, system consume all available memory and freezes.

### 2. Which issues (if any) are related?
No.

### 3. Which documentation changes (if any) need to be made?
No.

### 4. Does this introduce a backward incompatible change or deprecation?
