### PR TITLE
plugin/k8s_external: fix SRV queries doesn't work with AWS ELB/NLB

### DIFF
--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -97,7 +97,7 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	case dns.TypeAAAA:
 		m.Answer = e.aaaa(ctx, svc, state)
 	case dns.TypeSRV:
-		m.Answer, m.Extra = e.srv(svc, state)
+		m.Answer, m.Extra = e.srv(ctx, svc, state)
 	default:
 		m.Ns = []dns.RR{e.soa(state)}
 	}

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -154,6 +154,12 @@ var tests = []test.Case{
 		},
 	},
 	{
+		Qname: "_http._tcp.svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc12.testns.example.com.	5	IN	SRV	0 100 80 svc12.testns.example.com."),
+		},
+	},
+	{
 		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -156,7 +156,7 @@ var tests = []test.Case{
 	{
 		Qname: "_http._tcp.svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc12.testns.example.com.	5	IN	SRV	0 100 80 svc12.testns.example.com."),
+			test.SRV("_http._tcp.svc12.testns.example.com.	5	IN	SRV	0 100 80 dummy.hostname."),
 		},
 	},
 	{


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

### 1. Why is this pull request needed and what does it do?

1. Fixes https://github.com/coredns/coredns/issues/4927
2. **Tested on AWS cluster**

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/4927

### 3. Which documentation changes (if any) need to be made?

No documentation changes need to be made.

### 4. Does this introduce a backward incompatible change or deprecation?

This change does not introduce a backward-incompatible change of depreciation.


### 5. Comporation with  coredns/coredns:1.8.6

Corefile:
```
.:53 {
    errors
    health {
      lameduck 5s
    }
    ready
    kubernetes cluster.local in-addr.arpa ip6.arpa {
      fallthrough in-addr.arpa ip6.arpa
    }
    prometheus :9153
    forward . /etc/resolv.conf {
      max_concurrent 1000
    }
    k8s_external my.cluster
    loop
    reload
    loadbalance
}
```

k8s services:
```
NAMESPACE     NAME                TYPE           CLUSTER-IP      EXTERNAL-IP                                                               PORT(S)                  AGE
default       kubernetes          ClusterIP      10.100.0.1      <none>                                                                    443/TCP                  3h37m
kube-system   exposed-kube-dns2   LoadBalancer   10.100.57.201   a2fd497e947fe4cbfb99ea8a39525efb-1948346745.us-east-2.elb.amazonaws.com   53:32725/TCP             171m
kube-system   kube-dns            ClusterIP      10.100.0.10     <none>                                                                    53/UDP,53/TCP,9153/TCP   3h37m
```

Query: `dig  @18.216.219.94  _._tcp.exposed-kube-dns2.kube-system.my.cluster +tcp SRV`


**Response from coredns/coredns:1.8.6**
```
; <<>> DiG 9.10.6 <<>> @18.216.219.94 _._tcp.exposed-kube-dns2.kube-system.my.cluster +tcp SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 19182
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;_._tcp.exposed-kube-dns2.kube-system.my.cluster. IN SRV

;; AUTHORITY SECTION:
my.cluster.		5	IN	SOA	ns1.dns.my.cluster. hostmaster.dns.my.cluster. 12345 7200 1800 86400 5

;; Query time: 7348 msec
;; SERVER: 18.216.219.94#53(18.216.219.94)
;; WHEN: Wed Oct 20 16:16:29 MSK 2021
;; MSG SIZE  r
```

**Updated: Response from coredns based on this patch:**

```
; <<>> DiG 9.10.6 <<>> @a5ae6cc6610dc4c8eb324396028858a3-368021828.us-east-2.elb.amazonaws.com. _._tcp.exposed-kube-dns2.kube-system.my.cluster +tcp SRV
; (2 servers found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 20326
;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 3
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;_._tcp.exposed-kube-dns2.kube-system.my.cluster. IN SRV

;; ANSWER SECTION:
_._tcp.exposed-kube-dns2.kube-system.my.cluster. 5 IN SRV 0 100 53 a5ae6cc6610dc4c8eb324396028858a3-368021828.us-east-2.elb.amazonaws.com.

;; ADDITIONAL SECTION:
a5ae6cc6610dc4c8eb324396028858a3-368021828.us-east-2.elb.amazonaws.com.	60 IN A	3.129.123.240
a5ae6cc6610dc4c8eb324396028858a3-368021828.us-east-2.elb.amazonaws.com.	60 IN A	18.117.198.240

;; Query time: 184 msec
;; SERVER: 3.129.123.240#53(3.129.123.240)
;; WHEN: Thu Oct 21 01:53:13 MSK 2021
;; MSG SIZE  rcvd: 385
```