### PR TITLE
plugin/pkg/cache: fix data race

### DIFF
--- a/plugin/pkg/cache/cache.go
+++ b/plugin/pkg/cache/cache.go
@@ -136,8 +136,8 @@ func (s *shard) Len() int {
 
 // Walk walks the shard for each element the function f is executed while holding a write lock.
 func (s *shard) Walk(f func(map[uint64]interface{}, uint64) bool) {
-	items := make([]uint64, len(s.items))
 	s.RLock()
+	items := make([]uint64, len(s.items))
 	i := 0
 	for k := range s.items {
 		items[i] = k


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

`items := make([]uint64, len(s.items))` reads `s.items`, and is not protected by `s.RWMutex`.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

No change needed.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
