### PR TITLE
plugin/metrics: support HTTPS qType in requests count metric label

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -30,7 +30,7 @@ Extra labels used are:
 * `proto` which holds the transport of the response ("udp" or "tcp")
 * The address family (`family`) of the transport (1 = IP (IP version 4), 2 = IP6 (IP version 6)).
 * `type` which holds the query type. It holds most common types (A, AAAA, MX, SOA, CNAME, PTR, TXT,
-  NS, SRV, DS, DNSKEY, RRSIG, NSEC, NSEC3, IXFR, AXFR and ANY) and "other" which lumps together all
+  NS, SRV, DS, DNSKEY, RRSIG, NSEC, NSEC3, HTTPS, IXFR, AXFR and ANY) and "other" which lumps together all
   other types.
 
 If monitoring is enabled, queries that do not enter the plugin chain are exported under the fake

--- a/plugin/metrics/vars/monitor.go
+++ b/plugin/metrics/vars/monitor.go
@@ -19,6 +19,7 @@ var monitorType = map[uint16]struct{}{
 	dns.TypeSOA:    {},
 	dns.TypeSRV:    {},
 	dns.TypeTXT:    {},
+	dns.TypeHTTPS:  {},
 	// Meta Qtypes
 	dns.TypeIXFR: {},
 	dns.TypeAXFR: {},
@@ -26,7 +27,7 @@ var monitorType = map[uint16]struct{}{
 }
 
 // qTypeString returns the RR type based on monitorType. It returns the text representation
-// of thosAe types. RR types not in that list will have "other" returned.
+// of those types. RR types not in that list will have "other" returned.
 func qTypeString(qtype uint16) string {
 	if _, known := monitorType[qtype]; known {
 		return dns.Type(qtype).String()

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -21,8 +21,8 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 		RequestDo.WithLabelValues(server, zone).Inc()
 	}
 
-	qtype := qTypeString(req.QType())
-	RequestCount.WithLabelValues(server, zone, net, fam, qtype).Inc()
+	qType := qTypeString(req.QType())
+	RequestCount.WithLabelValues(server, zone, net, fam, qType).Inc()
 
 	RequestDuration.WithLabelValues(server, zone).Observe(time.Since(start).Seconds())
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Since iOS14, apple devices are standardly using the HTTPS query (type 65). It would be beneficial to be able to distinguish the amount of these requests based on the metrics. Therefore I would like to add the HTTPS query type support into the metric labels.


### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
