### PR TITLE
Plugin/file: add minInterval avoid cpu load too high

### DIFF
--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -108,11 +108,19 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 		for c.NextBlock() {
 			switch c.Val() {
 			case "reload":
-				d, err := time.ParseDuration(c.RemainingArgs()[0])
-				if err != nil {
+				args := c.RemainingArgs()
+				if len(args) > 0 {
+					d, err := time.ParseDuration(args[0])
+					if err != nil {
+						return Zones{}, plugin.Error("file", err)
+					}
+					reload = d
+				}
+
+				if reload != 0 && reload < minInterval {
 					return Zones{}, plugin.Error("file", err)
 				}
-				reload = d
+
 			case "upstream":
 				// remove soon
 				c.RemainingArgs()
@@ -138,3 +146,5 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 	}
 	return Zones{Z: z, Names: names}, nil
 }
+
+const minInterval = 2 * time.Second


### PR DESCRIPTION
Signed-off-by: vanceli <vanceli@tencent.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
when plugin `file` reload duration is too low:
the CPU: 
![image](https://user-images.githubusercontent.com/17512778/139621768-d63f86d8-802c-4e8c-ab27-47b70d55290c.png)

![wecom-temp-65bfbd4e2a0ed182c01534f267feb5cd](https://user-images.githubusercontent.com/17512778/139621662-71ac6748-65e9-4d80-a023-8b8e83ff2e7f.png)

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
we should notify users when they set these args

https://github.com/coredns/coredns/blob/master/plugin/file/README.md#syntax

### 4. Does this introduce a backward incompatible change or deprecation?
No