### PR TITLE
plugin/file: Fix file resource leak in fileParse

### DIFF
--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -121,6 +121,7 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				return Zones{}, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
+		reader.Close()
 	}
 
 	for origin := range z {


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
```reader, err := os.Open(fileName)``` 
reader need to close,when it used over
### 2. Which issues (if any) are related?
No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.