### PR TITLE
plugin/file: Fix print tree error

### DIFF
--- a/plugin/file/tree/print.go
+++ b/plugin/file/tree/print.go
@@ -29,9 +29,9 @@ func (n *Node) print() {
 		}
 		if nodesInCurrentLevel == 0 {
 			fmt.Println()
+			nodesInCurrentLevel = nodesInNextLevel
+			nodesInNextLevel = 0
 		}
-		nodesInCurrentLevel = nodesInNextLevel
-		nodesInNextLevel = 0
 	}
 	fmt.Println()
 }

--- a/plugin/file/tree/print_test.go
+++ b/plugin/file/tree/print_test.go
@@ -1,0 +1,78 @@
+package tree
+
+import (
+	"github.com/miekg/dns"
+	"net"
+	"testing"
+)
+
+func TestPrint(t *testing.T) {
+	rr1 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server1.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 1),
+	}
+	rr2 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server2.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 2),
+	}
+	rr3 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server3.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 3),
+	}
+	rr4 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server4.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 4),
+	}
+	//构造一颗树
+	tree := Tree{
+		Root:  nil,
+		Count: 0,
+	}
+	tree.Insert(&rr1)
+	tree.Insert(&rr2)
+	tree.Insert(&rr3)
+	tree.Insert(&rr4)
+
+	/**
+	 the LLRB tree:
+
+				  server2.example.com.
+					/             \
+		server1.example.com.   server4.example.com.
+			   /
+	 server3.example.com.
+
+	*/
+	tree.Print()
+	/**
+	  server2.example.com.
+	  server1.example.com. server4.example.com.
+	  server3.example.com.
+	*/
+
+	t.Log("tree.Print run this successful")
+}


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
the print  by level of tree can not work correctly, if the tree has 4 nodes, it shoud print three line node , but it will print all node contain in the two line.
### 2. Which issues (if any) are related?
No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.