### PR TITLE
plugin/loadbalance: More consistent shuffling

### DIFF
--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -61,7 +61,7 @@ func roundRobinShuffle(records []dns.RR) {
 			records[0], records[1] = records[1], records[0]
 		}
 	default:
-		for j := 0; j < l*(int(dns.Id())%4+1); j++ {
+		for j := 0; j < l*3; j++ {
 			q := int(dns.Id()) % l
 			p := int(dns.Id()) % l
 			if q == p {

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -61,13 +61,12 @@ func roundRobinShuffle(records []dns.RR) {
 			records[0], records[1] = records[1], records[0]
 		}
 	default:
-		for j := 0; j < l*3; j++ {
-			q := int(dns.Id()) % l
-			p := int(dns.Id()) % l
-			if q == p {
-				p = (p + 1) % l
+		for j := 0; j < l; j++ {
+			p := j + (int(dns.Id()) % (l-j))
+			if j == p {
+				continue
 			}
-			records[q], records[p] = records[p], records[q]
+			records[j], records[p] = records[p], records[j]
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

The random shuffle algorithm is ... 

Given N records: Randomly select two records. Swap them. Repeat for N*(1-4) times ... 

But the randomized loop exit condition gets re-randomized every iteration.  The result is that it will shuffle less than intended - usually exiting after swapping a number of times slightly higher than the number of records (not 1-4 times number of records, closer to 1 time + a few extra swaps).  This would have a more pronounced effect for longer record sets, that few extra swaps being less significant amount of extra shuffling. Under-shuffling results in a higher incident of the first record not being shuffled.

Fixing the random exit condition to be the same for all iterations lessens the problem, but still under-shuffles slightly since 1:4 times it will shuffle only N times for N records (resulting in a high incident of the first record not being shuffled).

Observationally, fixing the the number of shuffles to 3N seems to distribute the records pretty evenly. 2N still favored the first record significantly.

Edit: A simpler algorithm works better and requires less swaps:  iterating through each record once randomly selecting a record in the remainder of the list, and swapping them.

### 2. Which issues (if any) are related?

#4960

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
