### PR TITLE
plugin/file: Fix print tree error

### DIFF
--- a/plugin/file/tree/print.go
+++ b/plugin/file/tree/print.go
@@ -29,9 +29,9 @@ func (n *Node) print() {
 		}
 		if nodesInCurrentLevel == 0 {
 			fmt.Println()
+			nodesInCurrentLevel = nodesInNextLevel
+			nodesInNextLevel = 0
 		}
-		nodesInCurrentLevel = nodesInNextLevel
-		nodesInNextLevel = 0
 	}
 	fmt.Println()
 }

--- a/plugin/file/tree/print_test.go
+++ b/plugin/file/tree/print_test.go
@@ -1,0 +1,102 @@
+package tree
+
+import (
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestPrint(t *testing.T) {
+	rr1 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server1.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 1),
+	}
+	rr2 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server2.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 2),
+	}
+	rr3 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server3.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 3),
+	}
+	rr4 := dns.A{
+		Hdr: dns.RR_Header{
+			Name:     dns.Fqdn("server4.example.com"),
+			Rrtype:   1,
+			Class:    1,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		A: net.IPv4(10, 0, 1, 4),
+	}
+	tree := Tree{
+		Root:  nil,
+		Count: 0,
+	}
+	tree.Insert(&rr1)
+	tree.Insert(&rr2)
+	tree.Insert(&rr3)
+	tree.Insert(&rr4)
+
+	/**
+	build a LLRB tree, the height of the tree is 3, look like:
+
+				  server2.example.com.
+					/             \
+		server1.example.com.   server4.example.com.
+			   /
+	 server3.example.com.
+
+	*/
+
+	f, err := os.Create("tmp")
+	if err != nil {
+		t.Error(err)
+	}
+	//Redirect the printed results to a tmp file for later comparison
+	os.Stdout = f
+
+	tree.Print()
+	/**
+	  server2.example.com.
+	  server1.example.com. server4.example.com.
+	  server3.example.com.
+	*/
+
+	buf := make([]byte, 256)
+	f.Seek(0, 0)
+	_, er := f.Read(buf)
+	if er != nil {
+		t.Error(err)
+	}
+	height := strings.Count(string(buf), ". \n")
+	//Compare the height of the print with the actual height of the tree
+	if height != 3 {
+		f.Close()
+		os.Remove("tmp")
+		t.Fatal("The number of rows is inconsistent with the actual number of rows in the tree itself.")
+	}
+	f.Close()
+	os.Remove("tmp")
+}


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The print method designed in the coredns is a perfect debugging tool, but I found a small problem. The steps to reproduce this problem:

https://github.com/coredns/coredns/blob/4c0eacb6574786c8b3db1e5f068ebce96f7545e1/plugin/file/lookup_test.go#L135-L141
Just need to add *zone.Tree.Print()* to L140, like following:

```
func TestLookup(t *testing.T) {
	zone, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
	if err != nil {
		t.Fatalf("Expected no error when reading zone, got %q", err)
	}
	zone.Tree.Print() //add this
	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: zone}, Names: []string{testzone}}}
```

Print result before fix,  it just print two row:
```
=== RUN   TestLookup
dname.miek.nl. 
a.miek.nl. www.miek.nl. miek.nl. archive.miek.nl. mx.miek.nl. *.y.miek.nl. ext-cname.miek.nl. srv.miek.nl. *.x.miek.nl. 
```
Print result after fix:
```
=== RUN   TestLookup
dname.miek.nl. 
a.miek.nl. www.miek.nl. 
miek.nl. archive.miek.nl. mx.miek.nl. *.y.miek.nl. 
ext-cname.miek.nl. srv.miek.nl. *.x.miek.nl. 
```
In summary, the print by level of tree can not work correctly,  if the tree has 4 nodes,  it shoud print three row node,  but it print all node in the two row now. 
### 2. Which issues (if any) are related?
No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.