### PR TITLE
coredns now need golang 1.16 to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ out-of-tree plugins.
 To compile CoreDNS, we assume you have a working Go setup. See various tutorials if you don’t have
 that already configured.
 
-First, make sure your golang version is 1.12 or higher as `go mod` support is needed.
+First, make sure your golang version is 1.16 or higher as `go mod` support and other api is needed.
 See [here](https://github.com/golang/go/wiki/Modules) for `go mod` details.
 Then, check out the project and run `make` to compile the binary:
 
@@ -87,7 +87,7 @@ and starts listening on port 53 (override with `-dns.port`), it should show the 
 ~~~ txt
 .:53
 CoreDNS-1.6.6
-linux/amd64, go1.13.5, aa8c32
+linux/amd64, go1.16.10, aa8c32
 ~~~
 
 The following could be used to query the CoreDNS server that is running now:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Coredns now nned golang 1.16 to compile
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
This is a doc change.
### 4. Does this introduce a backward incompatible change or deprecation?
Not involving