### PR TITLE
plugin/loadbalance: remove cname case in roundRobin

### DIFF
--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -26,14 +26,11 @@ func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
 }
 
 func roundRobin(in []dns.RR) []dns.RR {
-	cname := []dns.RR{}
 	address := []dns.RR{}
 	mx := []dns.RR{}
 	rest := []dns.RR{}
 	for _, r := range in {
 		switch r.Header().Rrtype {
-		case dns.TypeCNAME:
-			cname = append(cname, r)
 		case dns.TypeA, dns.TypeAAAA:
 			address = append(address, r)
 		case dns.TypeMX:
@@ -46,9 +43,8 @@ func roundRobin(in []dns.RR) []dns.RR {
 	roundRobinShuffle(address)
 	roundRobinShuffle(mx)
 
-	out := append(cname, rest...)
-	out = append(out, address...)
-	out = append(out, mx...)
+	out := append(address, mx...)
+	out = append(out, rest...)
 	return out
 }
 


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
https://github.com/coredns/coredns/blob/06e3b2e85994c180e1f8febebae1b11370789596/plugin/loadbalance/loadbalance.go#L34-L48

As shown in the code above, the cname record is obtained, but random sorting of cname is meaningless as @chrisohaver said.

### 2. Which issues (if any) are related?
No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.