### PR TITLE
Makefile to use existing CGO_ENABLED variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CHECKS:=check
 BUILDOPTS:=-v
 GOPATH?=$(HOME)/go
 MAKEPWD:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-CGO_ENABLED:=0
+CGO_ENABLED?=0
 
 .PHONY: all
 all: coredns


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Currently, if you want to build coredns with CGO_ENABLED then you have to edit the `Makefile`.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
