### PR TITLE
plugin/k8s_external: implement zone transfers

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -83,6 +83,18 @@ spec:
  type: ClusterIP
 ~~~
 
+The *k8s_external* plugin can be used in conjunction with the *transfer* plugin to enable
+zone transfers.
+
+ ~~~
+     . {
+         transfer example.org {
+             to *
+         }
+         kubernetes cluster.local
+         k8s_external example.org
+     }
+ ~~~
 
 # See Also
 

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -84,7 +84,7 @@ spec:
 ~~~
 
 The *k8s_external* plugin can be used in conjunction with the *transfer* plugin to enable
-zone transfers.
+zone transfers.  Notifies are not supported.
 
  ~~~
      . {

--- a/plugin/k8s_external/apex.go
+++ b/plugin/k8s_external/apex.go
@@ -93,7 +93,7 @@ func (e *External) soa(state request.Request) *dns.SOA {
 	soa := &dns.SOA{Hdr: header,
 		Mbox:    dnsutil.Join(e.hostmaster, e.apex, state.Zone),
 		Ns:      dnsutil.Join("ns1", e.apex, state.Zone),
-		Serial:  12345, // Also dynamic?
+		Serial:  e.externalSerialFunc(state.Zone),
 		Refresh: 7200,
 		Retry:   1800,
 		Expire:  86400,

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -20,7 +20,8 @@ func TestApex(t *testing.T) {
 	e.Zones = []string{"example.com."}
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External
-	e.externalAddrFunc = externalAddress // internal test function
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
 
 	ctx := context.TODO()
 	for i, tc := range testsApex {
@@ -43,6 +44,16 @@ func TestApex(t *testing.T) {
 		if err := test.SortAndCheck(resp, tc); err != nil {
 			t.Error(err)
 		}
+		for i, rr := range tc.Ns {
+			expectsoa := rr.(*dns.SOA)
+			gotsoa, ok := resp.Ns[i].(*dns.SOA)
+			if !ok {
+				t.Fatalf("Unexpected record type in Authority section")
+			}
+			if expectsoa.Serial != gotsoa.Serial {
+				t.Fatalf("Expected soa serial %d, got %d", expectsoa.Serial, gotsoa.Serial)
+			}
+		}
 	}
 }
 
@@ -50,7 +61,7 @@ var testsApex = []test.Case{
 	{
 		Qname: "example.com.", Qtype: dns.TypeSOA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
@@ -65,37 +76,37 @@ var testsApex = []test.Case{
 	{
 		Qname: "example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "dns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "dns.example.com.", Qtype: dns.TypeNS, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeNS, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -29,8 +29,8 @@ type Externaler interface {
 	External(request.Request) ([]msg.Service, int)
 	// ExternalAddress should return a string slice of addresses for the nameserving endpoint.
 	ExternalAddress(state request.Request) []dns.RR
-	// ExternalServices returns all services in a slice of msg.Service.
-	ExternalServices(string) []msg.Service
+	// ExternalServices returns all services in the given zone as a slice of msg.Service.
+	ExternalServices(zone string) []msg.Service
 	// ExternalSerial gets the current serial.
 	ExternalSerial(string) uint32
 }

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -29,9 +29,13 @@ type Externaler interface {
 	External(request.Request) ([]msg.Service, int)
 	// ExternalAddress should return a string slice of addresses for the nameserving endpoint.
 	ExternalAddress(state request.Request) []dns.RR
+	// ExternalServices returns all services in a slice of msg.Service.
+	ExternalServices(string) []msg.Service
+	// ExternalSerial gets the current serial.
+	ExternalSerial(string) uint32
 }
 
-// External resolves Ingress and Loadbalance IPs from kubernetes clusters.
+// External serves records for External IPs and Loadbalance IPs of Services in Kubernetes clusters.
 type External struct {
 	Next  plugin.Handler
 	Zones []string
@@ -42,8 +46,10 @@ type External struct {
 
 	upstream *upstream.Upstream
 
-	externalFunc     func(request.Request) ([]msg.Service, int)
-	externalAddrFunc func(request.Request) []dns.RR
+	externalFunc         func(request.Request) ([]msg.Service, int)
+	externalAddrFunc     func(request.Request) []dns.RR
+	externalSerialFunc   func(string) uint32
+	externalServicesFunc func(string) []msg.Service
 }
 
 // New returns a new and initialized *External.

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -23,7 +23,8 @@ func TestExternal(t *testing.T) {
 	e.Zones = []string{"example.com."}
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External
-	e.externalAddrFunc = externalAddress // internal test function
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
 
 	ctx := context.TODO()
 	for i, tc := range tests {
@@ -147,10 +148,36 @@ var tests = []test.Case{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	// svc11
 	{
 		Qname: "svc11.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "_http._tcp.svc11.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "svc11.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	// svc12
+	{
+		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
 		},
 	},
 	{
@@ -160,9 +187,9 @@ var tests = []test.Case{
 		},
 	},
 	{
-		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Qname: "svc12.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
+			test.SRV("svc12.testns.example.com.	5	IN	SRV	0 100 80 dummy.hostname."),
 		},
 	},
 }
@@ -175,6 +202,7 @@ func (external) Stop() error                                                    
 func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
 func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
 func (external) Modified() int64                                                   { return 0 }
+func (external) ExtModified() int64                                                { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
 func (external) EndpointsList() []*object.Endpoints                                { return nil }
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
@@ -239,4 +267,8 @@ func (external) ServiceList() []*object.Service {
 func externalAddress(state request.Request) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
+}
+
+func externalSerial(string) uint32 {
+	return 1499347823
 }

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -200,9 +200,8 @@ func (external) HasSynced() bool                                                
 func (external) Run()                                                              {}
 func (external) Stop() error                                                       { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
-func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
-func (external) Modified() int64                                                   { return 0 }
-func (external) ExtModified() int64                                                { return 0 }
+func (external) SvcIndexReverse(string) []*object.Service { return nil }
+func (external) Modified(bool) int64                      { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
 func (external) EndpointsList() []*object.Endpoints                                { return nil }
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/coredns/caddy"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
@@ -26,6 +27,8 @@ func setup(c *caddy.Controller) error {
 		if x, ok := m.(Externaler); ok {
 			e.externalFunc = x.External
 			e.externalAddrFunc = x.ExternalAddress
+			e.externalServicesFunc = x.ExternalServices
+			e.externalSerialFunc = x.ExternalSerial
 		}
 		return nil
 	})

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/coredns/caddy"
-
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/upstream"

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -1,12 +1,12 @@
 package external
 
 import (
+	"context"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/coredns/coredns/request"
-
-	"context"
 
 	"github.com/miekg/dns"
 )

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -1,0 +1,81 @@
+package external
+
+import (
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/transfer"
+	"github.com/coredns/coredns/request"
+
+	"context"
+
+	"github.com/miekg/dns"
+)
+
+// Transfer implements transfer.Transferer
+func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	z := plugin.Zones(e.Zones).Matches(zone)
+	if z != zone {
+		return nil, transfer.ErrNotAuthoritative
+	}
+
+	ctx := context.Background()
+	ch := make(chan []dns.RR, 2)
+	if zone == "." {
+		zone = ""
+	}
+	state := request.Request{Zone: zone}
+
+	// SOA
+	soa := e.soa(state)
+	ch <- []dns.RR{soa}
+	if serial != 0 && serial >= soa.Serial {
+		close(ch)
+		return ch, nil
+	}
+
+	go func() {
+		// Add NS
+		nsName := "ns1." + e.apex + "." + zone
+		nsHdr := dns.RR_Header{Name: zone, Rrtype: dns.TypeNS, Ttl: e.ttl, Class: dns.ClassINET}
+		ch <- []dns.RR{&dns.NS{Hdr: nsHdr, Ns: nsName}}
+
+		// Add Nameserver A/AAAA records
+		nsRecords := e.externalAddrFunc(state)
+		for i := range nsRecords {
+			// externalAddrFunc returns incomplete header names, correct here
+			nsRecords[i].Header().Name = nsName
+			nsRecords[i].Header().Ttl = e.ttl
+			ch <- []dns.RR{nsRecords[i]}
+		}
+
+		// Add Service A/AAAA records
+		svcs := e.externalServicesFunc(zone)
+		for i := range svcs {
+			name := msg.Domain(svcs[i].Key)
+			if svcs[i].TargetStrip == 0 {
+				s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
+				as := e.a(ctx, []msg.Service{svcs[i]}, s)
+				if len(as) > 0 {
+					ch <- as
+				}
+				aaaas := e.aaaa(ctx, []msg.Service{svcs[i]}, s)
+				if len(aaaas) > 0 {
+					ch <- aaaas
+				}
+				recs, _ := e.srv(ctx, []msg.Service{svcs[i]}, s)
+				if len(recs) > 0 {
+					ch <- recs
+				}
+				continue
+			}
+			s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
+			recs, _ := e.srv(ctx, []msg.Service{svcs[i]}, s)
+			if len(recs) > 0 {
+				ch <- recs
+			}
+		}
+		close(ch)
+	}()
+
+	return ch, nil
+}

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -48,11 +48,12 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 			ch <- []dns.RR{nsRecords[i]}
 		}
 
-		// Add Service A/AAAA records
 		svcs := e.externalServicesFunc(zone)
+		srvSeen := make(map[string]struct{})
 		for i := range svcs {
 			name := msg.Domain(svcs[i].Key)
 			if svcs[i].TargetStrip == 0 {
+				// Add Service A/AAAA records
 				s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
 				as := e.a(ctx, []msg.Service{svcs[i]}, s)
 				if len(as) > 0 {
@@ -62,20 +63,35 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 				if len(aaaas) > 0 {
 					ch <- aaaas
 				}
+				// Add bare SRV record, ensuring uniqueness
 				recs, _ := e.srv(ctx, []msg.Service{svcs[i]}, s)
-				if len(recs) > 0 {
-					ch <- recs
+				for _, srv := range recs {
+					if !nameSeen(srvSeen, srv) {
+						ch <- []dns.RR{srv}
+					}
 				}
 				continue
 			}
+			// Add full SRV record, ensuring uniqueness
 			s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
 			recs, _ := e.srv(ctx, []msg.Service{svcs[i]}, s)
-			if len(recs) > 0 {
-				ch <- recs
+			for _, srv := range recs {
+				if !nameSeen(srvSeen, srv) {
+					ch <- []dns.RR{srv}
+				}
 			}
 		}
+		ch <- []dns.RR{soa}
 		close(ch)
 	}()
 
 	return ch, nil
+}
+
+func nameSeen(namesSeen map[string]struct{}, rr dns.RR) bool {
+	if _, duplicate := namesSeen[rr.Header().Name]; duplicate {
+		return true
+	}
+	namesSeen[rr.Header().Name] = struct{}{}
+	return false
 }

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -50,7 +50,7 @@ func TestTransferAXFR(t *testing.T) {
 		}
 
 		for _, ans := range tc.Answer {
-			// Exclude wildcard searches
+			// Exclude wildcard test cases
 			if strings.Contains(ans.Header().Name, "*") {
 				continue
 			}

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -1,0 +1,142 @@
+package external
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/plugin/transfer"
+
+	"github.com/miekg/dns"
+)
+
+func TestImplementsTransferer(t *testing.T) {
+	var e plugin.Handler
+	e = &External{}
+	_, ok := e.(transfer.Transferer)
+	if !ok {
+		t.Error("Transferer not implemented")
+	}
+}
+
+func TestTransferAXFR(t *testing.T) {
+	k := kubernetes.New([]string{"cluster.local."})
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	k.APIConn = &external{}
+
+	e := New()
+	e.Zones = []string{"example.com."}
+	e.externalFunc = k.External
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
+	e.externalServicesFunc = k.ExternalServices
+
+	ch, err := e.Transfer("example.com.", 0)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var records []dns.RR
+	for rrs := range ch {
+		records = append(records, rrs...)
+	}
+
+	expect := []dns.RR{}
+	for _, tc := range append(tests, testsApex...) {
+		if tc.Rcode != dns.RcodeSuccess {
+			continue
+		}
+
+		for _, ans := range tc.Answer {
+			// Exclude wildcard searches
+			if strings.Contains(ans.Header().Name, "*") {
+				continue
+			}
+
+			// Exclude TXT records
+			if ans.Header().Rrtype == dns.TypeTXT {
+				continue
+			}
+			expect = append(expect, ans)
+		}
+	}
+
+	diff := difference(expect, records)
+	if len(diff) != 0 {
+		t.Errorf("Got back %d records that do not exist in test cases, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+	diff = difference(records, expect)
+	if len(diff) != 0 {
+		t.Errorf("Result is missing %d records, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+}
+
+func TestTransferIXFR(t *testing.T) {
+	k := kubernetes.New([]string{"cluster.local."})
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	k.APIConn = &external{}
+
+	e := New()
+	e.Zones = []string{"example.com."}
+	e.externalFunc = k.External
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
+	e.externalServicesFunc = k.ExternalServices
+
+	ch, err := e.Transfer("example.com.", externalSerial("example.com."))
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var records []dns.RR
+	for rrs := range ch {
+		records = append(records, rrs...)
+	}
+
+	expect := []dns.RR{
+		test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
+	}
+
+	diff := difference(expect, records)
+	if len(diff) != 0 {
+		t.Errorf("Got back %d records that do not exist in test cases, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+	diff = difference(records, expect)
+	if len(diff) != 0 {
+		t.Errorf("Result is missing %d records, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+}
+
+// difference shows what we're missing when comparing two RR slices
+func difference(testRRs []dns.RR, gotRRs []dns.RR) []dns.RR {
+	expectedRRs := map[string]struct{}{}
+	for _, rr := range testRRs {
+		expectedRRs[rr.String()] = struct{}{}
+	}
+
+	foundRRs := []dns.RR{}
+	for _, rr := range gotRRs {
+		if _, ok := expectedRRs[rr.String()]; !ok {
+			foundRRs = append(foundRRs, rr)
+		}
+	}
+	return foundRRs
+}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -47,13 +47,20 @@ type dnsController interface {
 
 	// Modified returns the timestamp of the most recent changes
 	Modified() int64
+
+	// ExtModified returns the timestamp of the most recent changes to
+	// services with external facing IP addresses
+	ExtModified() int64
 }
 
 type dnsControl struct {
-	// Modified tracks timestamp of the most recent changes
+	// modified tracks timestamp of the most recent changes
 	// It needs to be first because it is guaranteed to be 8-byte
 	// aligned ( we use sync.LoadAtomic with this )
 	modified int64
+	// extModified tracks timestamp of the most recent changes to
+	// services with external facing IP addresses
+	extModified int64
 
 	client kubernetes.Interface
 
@@ -572,7 +579,13 @@ func (dns *dnsControl) detectChanges(oldObj, newObj interface{}) {
 	}
 	switch ob := obj.(type) {
 	case *object.Service:
-		dns.updateModified()
+		imod, emod := serviceModified(oldObj, newObj)
+		if imod {
+			dns.updateModified()
+		}
+		if emod {
+			dns.updateExtModifed()
+		}
 	case *object.Pod:
 		dns.updateModified()
 	case *object.Endpoints:
@@ -646,8 +659,68 @@ func endpointsEquivalent(a, b *object.Endpoints) bool {
 	return true
 }
 
+// serviceModified checks the services passed for changes that result in changes
+// to internal and or external records.  It returns two booleans, one for internal
+// record changes, and a second for external record changes
+func serviceModified(oldObj, newObj interface{}) (intSvc, extSvc bool) {
+	if oldObj != nil && newObj == nil {
+		// deleted service only modifies external zone records if it had external ips
+		return true, len(oldObj.(*object.Service).ExternalIPs) > 0
+	}
+
+	if oldObj == nil && newObj != nil {
+		// added service only modifies external zone records if it has external ips
+		return true, len(newObj.(*object.Service).ExternalIPs) > 0
+	}
+
+	newSvc := newObj.(*object.Service)
+	oldSvc := oldObj.(*object.Service)
+
+	// External IPs are mutable, affecting external zone records
+	if len(oldSvc.ExternalIPs) != len(newSvc.ExternalIPs) {
+		extSvc = true
+	} else {
+		for i := range oldSvc.ExternalIPs {
+			if oldSvc.ExternalIPs[i] != newSvc.ExternalIPs[i] {
+				extSvc = true
+				break
+			}
+		}
+	}
+
+	// ExternalName is mutable, affecting internal zone records
+	intSvc = oldSvc.ExternalName != newSvc.ExternalName
+
+	if intSvc && extSvc {
+		return intSvc, extSvc
+	}
+
+	// All Port fields are mutable, affecting both internal/external zone records
+	if len(oldSvc.Ports) != len(newSvc.Ports) {
+		return true, true
+	}
+	for i := range oldSvc.Ports {
+		if oldSvc.Ports[i].Name != newSvc.Ports[i].Name {
+			return true, true
+		}
+		if oldSvc.Ports[i].Port != newSvc.Ports[i].Port {
+			return true, true
+		}
+		if oldSvc.Ports[i].Protocol != newSvc.Ports[i].Protocol {
+			return true, true
+		}
+	}
+
+	return intSvc, extSvc
+}
+
 func (dns *dnsControl) Modified() int64 {
 	unix := atomic.LoadInt64(&dns.modified)
+	return unix
+}
+
+func (dns *dnsControl) ExtModified() int64 {
+	unix := atomic.LoadInt64(&dns.extModified)
 	return unix
 }
 
@@ -655,6 +728,12 @@ func (dns *dnsControl) Modified() int64 {
 func (dns *dnsControl) updateModified() {
 	unix := time.Now().Unix()
 	atomic.StoreInt64(&dns.modified, unix)
+}
+
+// updateExtModified set dns.extModified to the current time.
+func (dns *dnsControl) updateExtModifed() {
+	unix := time.Now().Unix()
+	atomic.StoreInt64(&dns.extModified, unix)
 }
 
 var errObj = errors.New("obj was not of the correct type")

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -45,12 +45,9 @@ type dnsController interface {
 	HasSynced() bool
 	Stop() error
 
-	// Modified returns the timestamp of the most recent changes
-	Modified() int64
-
-	// ExtModified returns the timestamp of the most recent changes to
-	// services with external facing IP addresses
-	ExtModified() int64
+	// Modified returns the timestamp of the most recent changes to services.  If the passed bool is true, it should
+	// return the timestamp of the most recent changes to services with external facing IP addresses
+	Modified(bool) int64
 }
 
 type dnsControl struct {
@@ -714,14 +711,11 @@ func serviceModified(oldObj, newObj interface{}) (intSvc, extSvc bool) {
 	return intSvc, extSvc
 }
 
-func (dns *dnsControl) Modified() int64 {
-	unix := atomic.LoadInt64(&dns.modified)
-	return unix
-}
-
-func (dns *dnsControl) ExtModified() int64 {
-	unix := atomic.LoadInt64(&dns.extModified)
-	return unix
+func (dns *dnsControl) Modified(external bool) int64 {
+	if external {
+		return atomic.LoadInt64(&dns.extModified)
+	}
+	return atomic.LoadInt64(&dns.modified)
 }
 
 // updateModified set dns.modified to the current time.

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -92,3 +92,26 @@ func (k *Kubernetes) ExternalAddress(state request.Request) []dns.RR {
 	// plugin to bind to a different IP address.
 	return k.nsAddrs(true, state.Zone)
 }
+
+// ExternalServices returns all services with external IPs
+func (k *Kubernetes) ExternalServices(zone string) (services []msg.Service) {
+	zonePath := msg.Path(zone, coredns)
+	for _, svc := range k.APIConn.ServiceList() {
+		for _, ip := range svc.ExternalIPs {
+			for _, p := range svc.Ports {
+				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+				services = append(services, s)
+				s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+				s.TargetStrip = 2
+				services = append(services, s)
+			}
+		}
+	}
+	return services
+}
+
+//ExternalSerial returns the serial of the external zone
+func (k *Kubernetes) ExternalSerial(string) uint32 {
+	return uint32(k.APIConn.ExtModified())
+}

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -113,5 +113,5 @@ func (k *Kubernetes) ExternalServices(zone string) (services []msg.Service) {
 
 //ExternalSerial returns the serial of the external zone
 func (k *Kubernetes) ExternalSerial(string) uint32 {
-	return uint32(k.APIConn.ExtModified())
+	return uint32(k.APIConn.Modified(true))
 }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -84,6 +84,7 @@ func (external) Stop() error                                                    
 func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
 func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
 func (external) Modified() int64                                                   { return 0 }
+func (external) ExtModified() int64                                                { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
 func (external) EndpointsList() []*object.Endpoints                                { return nil }
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -83,8 +83,7 @@ func (external) Run()                                                           
 func (external) Stop() error                                                       { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
 func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
-func (external) Modified() int64                                                   { return 0 }
-func (external) ExtModified() int64                                                { return 0 }
+func (external) Modified(bool) int64                                               { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
 func (external) EndpointsList() []*object.Endpoints                                { return nil }
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -555,8 +555,7 @@ func (APIConnServeTest) Run()                                      {}
 func (APIConnServeTest) Stop() error                               { return nil }
 func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }
-func (APIConnServeTest) Modified() int64                           { return int64(3) }
-func (APIConnServeTest) ExtModified() int64                        { return int64(3) }
+func (APIConnServeTest) Modified(bool) int64                       { return int64(3) }
 
 func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 	if ip != "10.240.0.1" {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -556,6 +556,7 @@ func (APIConnServeTest) Stop() error                               { return nil 
 func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }
 func (APIConnServeTest) Modified() int64                           { return int64(3) }
+func (APIConnServeTest) ExtModified() int64                        { return int64(3) }
 
 func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 	if ip != "10.240.0.1" {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -592,7 +592,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 }
 
 // Serial return the SOA serial.
-func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIConn.Modified()) }
+func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIConn.Modified(false)) }
 
 // MinTTL returns the minimal TTL.
 func (k *Kubernetes) MinTTL(state request.Request) uint32 { return k.ttl }

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -67,6 +67,7 @@ func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return ni
 func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }
 func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServiceTest) Modified() int64                           { return 0 }
+func (APIConnServiceTest) ExtModified() int64                        { return 0 }
 
 func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -66,8 +66,7 @@ func (APIConnServiceTest) Stop() error                               { return ni
 func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return nil }
 func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }
 func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints { return nil }
-func (APIConnServiceTest) Modified() int64                           { return 0 }
-func (APIConnServiceTest) ExtModified() int64                        { return 0 }
+func (APIConnServiceTest) Modified(bool) int64                       { return 0 }
 
 func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -22,6 +22,7 @@ func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
 func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
 func (APIConnTest) Modified() int64                          { return 0 }
+func (APIConnTest) ExtModified() int64                       { return 0 }
 
 func (a APIConnTest) SvcIndex(s string) []*object.Service {
 	switch s {

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -21,8 +21,7 @@ func (APIConnTest) PodIndex(string) []*object.Pod            { return nil }
 func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
 func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
-func (APIConnTest) Modified() int64                          { return 0 }
-func (APIConnTest) ExtModified() int64                       { return 0 }
+func (APIConnTest) Modified(bool) int64                      { return 0 }
 
 func (a APIConnTest) SvcIndex(s string) []*object.Service {
 	switch s {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -22,8 +22,7 @@ func (APIConnReverseTest) PodIndex(string) []*object.Pod      { return nil }
 func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }
 func (APIConnReverseTest) EndpointsList() []*object.Endpoints { return nil }
 func (APIConnReverseTest) ServiceList() []*object.Service     { return nil }
-func (APIConnReverseTest) Modified() int64                    { return 0 }
-func (APIConnReverseTest) ExtModified() int64                 { return 0 }
+func (APIConnReverseTest) Modified(bool) int64                { return 0 }
 
 func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
 	if svc != "svc1.testns" {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -23,6 +23,7 @@ func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }
 func (APIConnReverseTest) EndpointsList() []*object.Endpoints { return nil }
 func (APIConnReverseTest) ServiceList() []*object.Service     { return nil }
 func (APIConnReverseTest) Modified() int64                    { return 0 }
+func (APIConnReverseTest) ExtModified() int64                 { return 0 }
 
 func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
 	if svc != "svc1.testns" {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Implements zone transfers for the k8s_external plugin. This PR does not implement Notifies.

### 2. Which issues (if any) are related?

#4803

### 3. Which documentation changes (if any) need to be made?

This PR adds a usage example to the k8s_external README

### 4. Does this introduce a backward incompatible change or deprecation?
