### PR TITLE
plugin/log: Add option to log slow dns responses

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -30,11 +30,12 @@ log [NAMES...] [FORMAT]
   for the Common Log Format. You can also use `{combined}` for a format that adds the query opcode
   `{>opcode}` to the Common Log Format.
 
-You can further specify the classes of responses that get logged:
+You can further specify the classes of responses that get logged and log slow responses:
 
 ~~~ txt
 log [NAMES...] [FORMAT] {
     class CLASSES...
+    minDuration [DURATION]
 }
 ~~~
 
@@ -51,6 +52,10 @@ The classes of responses have the following meaning:
   logged whatever we mix together with "all".
 
 If no class is specified, it defaults to `all`.
+
+* `DURATION` is a string representing a time duration, e.g. 1s or 100ms. Responses that are not
+already logged due to their class may be logged in case their duration exceeds the specified
+duration.
 
 ## Log Format
 
@@ -139,6 +144,17 @@ Log all queries on which we did not get errors
 . {
     log . {
         class denial success
+    }
+}
+~~~
+
+Log all queries on which we got errors or which took longer than 1 second.
+
+~~~ corefile
+. {
+    log . {
+        class error
+        minDuration 1s
     }
 }
 ~~~

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin/pkg/response"
@@ -121,10 +122,30 @@ func TestLogParse(t *testing.T) {
 			Class:     map[response.Class]struct{}{response.Denial: {}, response.Error: {}},
 		}}},
 		{`log {
+			minDuration
+		}`, false, []Rule{{
+			NameScope:   ".",
+			Format:      CommonLogFormat,
+			Class:       map[response.Class]struct{}{response.All: {}},
+			MinDuration: 100 * time.Millisecond,
+		}}},
+		{`log {
+			class error
+			minDuration 1s
+		}`, false, []Rule{{
+			NameScope:   ".",
+			Format:      CommonLogFormat,
+			Class:       map[response.Class]struct{}{response.Error: {}},
+			MinDuration: 1 * time.Second,
+		}}},
+		{`log {
 			class abracadabra
 		}`, true, []Rule{}},
 		{`log {
 			class
+		}`, true, []Rule{}},
+		{`log {
+			minDuration 123abc
 		}`, true, []Rule{}},
 		{`log {
 			unknown


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This change adds a flag to the log plugin to log slow dns responses.
The duration of what is defined as slow is configurable, default is
100ms.
Slow dns responses are important to keep track of as dns clients
may have a low timeout and a late response may therefore be considered
as no response whatsoever.

### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
The log plugin documentation is updated as part of the pull request.
### 4. Does this introduce a backward incompatible change or deprecation?
No, the change should be completely compatible.