### PR TITLE
plugin/kubernetes: Add wildcards option

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -42,6 +42,7 @@ kubernetes [ZONES...] {
     noendpoints
     fallthrough [ZONES...]
     ignore empty_service
+    wildcards enabled|disabled
 }
 ```
 
@@ -101,7 +102,9 @@ kubernetes [ZONES...] {
 * `ignore empty_service` returns NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
-
+* `wildcards enabled|disabled` enables or disables the wildcard query feature (see Wildcards section below).
+  Default is enabled.
+  
 Enabling zone transfer is done by using the *transfer* plugin.
 
 ## Startup

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -69,7 +69,7 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 
 		for _, ip := range svc.ExternalIPs {
 			for _, p := range svc.Ports {
-				if !(match(port, p.Name) && match(protocol, string(p.Protocol))) {
+				if !(k.match(port, p.Name) && k.match(protocol, string(p.Protocol))) {
 					continue
 				}
 				rcode = dns.RcodeSuccess

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -34,6 +34,14 @@ func TestWildcard(t *testing.T) {
 			t.Errorf("Expected Wildcard result '%v' for example '%v', got '%v'.", te.expected, te.s, got)
 		}
 	}
+
+	k = Kubernetes{wildcardsDisabled: true}
+	for _, te := range tests {
+		got := k.wildcard(te.s)
+		if got != false {
+			t.Errorf("Expected Wildcard result '%v' for example '%v', got '%v'.", false, te.s, got)
+		}
+	}
 }
 
 func TestEndpointHostname(t *testing.T) {

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -27,8 +27,9 @@ func TestWildcard(t *testing.T) {
 		{"myname*", false},
 	}
 
+	k := Kubernetes{wildcardsDisabled: false}
 	for _, te := range tests {
-		got := wildcard(te.s)
+		got := k.wildcard(te.s)
 		if got != te.expected {
 			t.Errorf("Expected Wildcard result '%v' for example '%v', got '%v'.", te.expected, te.s, got)
 		}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/coredns/caddy"
-
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/coredns/caddy"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
@@ -232,6 +233,20 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				overrides,
 			)
 			k8s.ClientConfig = config
+		case "wildcards":
+			args := c.RemainingArgs()
+			if len(args) == 1 {
+				switch args[0] {
+				case "enabled":
+					k8s.wildcardsDisabled = false
+				case "disabled":
+					k8s.wildcardsDisabled = true
+				default:
+					return nil, fmt.Errorf("wrong value for wildcards: %s,  must be one of: enabled, disabled", args[0])
+				}
+				continue
+			}
+			return nil, c.ArgErr()
 		default:
 			return nil, c.Errf("unknown property '%s'", c.Val())
 		}

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/coredns/caddy"
-
 	"github.com/coredns/coredns/plugin/pkg/fall"
 
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add option to enable/disable wildcard queries. Default for now is `enabled`.

### 2. Which issues (if any) are related?

#4984

### 3. Which documentation changes (if any) need to be made?

included

### 4. Does this introduce a backward incompatible change or deprecation?

No.  But if we default to `disabled`, it would be.