### PR TITLE
plugin/auto: Fix panic caused by config invalid reload value

### DIFF
--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -126,3 +126,52 @@ func TestAutoParse(t *testing.T) {
 		}
 	}
 }
+
+func TestSetupReload(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr bool
+	}{
+		{
+			name: "reload valid",
+			config: `auto {
+				directory .
+				reload 5s
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "reload disable",
+			config: `auto {
+				directory .
+				reload 0
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "reload invalid",
+			config: `auto {
+				directory .
+				reload -1s
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "reload invalid",
+			config: `auto {
+				directory .
+				reload
+			}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctr := caddy.NewTestController("dns", tt.config)
+			if err := setup(ctr); (err != nil) != tt.wantErr {
+				t.Errorf("Error: setup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -108,7 +109,11 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 		for c.NextBlock() {
 			switch c.Val() {
 			case "reload":
-				d, err := time.ParseDuration(c.RemainingArgs()[0])
+				t := c.RemainingArgs()
+				if len(t) < 1 {
+					return Zones{}, errors.New("reload duration value is expected")
+				}
+				d, err := time.ParseDuration(t[0])
 				if err != nil {
 					return Zones{}, plugin.Error("file", err)
 				}


### PR DESCRIPTION
Signed-off-by: hack <reiachvowfllz@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
As stated in the readme of the auto plugin:
_reload interval default is one minute. Value of 0 means to not scan for changes and reload._ 
Configured in corefile like this：

```
  auto miek.nl {
        directory .
        reload 0s
    }
```
This reload parameter is involved in the *setup.go* of the auto plugin：

```
ticker := time.NewTicker(a.loader.ReloadInterval)
```
However, time.NewTicker cannot receive a value of 0, it will cause panic：

```
func NewTicker(d Duration) *Ticker {
	if d <= 0 {
		panic(errors.New("non-positive interval for NewTicker"))
	}
```
Follow the rules in auto plugin readme: _value of 0 means to not scan for changes and reload_, we fixed it.
### 2. Which issues (if any) are related?
No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.