### PR TITLE
Changes to cover noerror/nosoa condition

### DIFF
--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -20,11 +20,11 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 		return MinimalDefaultTTL
 	}
 
-	if mt == response.NoData &&  len(m.Ns) == 0{
+	if mt == response.NoData && len(m.Ns) == 0 {
 		// Nodata and no NS, SOA
 		return MinimalDefaultTTL
 	}
-	
+
 	minTTL := MaximumDefaulTTL
 	for _, r := range m.Answer {
 		if r.Header().Ttl < uint32(minTTL.Seconds()) {

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -22,7 +22,7 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 
 	if mt == response.NoData &&  len(m.Ns) == 0{
 		// Nodata and no NS, SOA
-		return MinimumDefaultTTL
+		return MinimalDefaultTTL
 	}
 	
 	minTTL := MaximumDefaulTTL

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -20,6 +20,11 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 		return MinimalDefaultTTL
 	}
 
+	if mt == response.NoData &&  len(m.Ns) == 0{
+		// Nodata and no NS, SOA
+		return MinimumDefaultTTL
+	}
+	
 	minTTL := MaximumDefaulTTL
 	for _, r := range m.Answer {
 		if r.Header().Ttl < uint32(minTTL.Seconds()) {

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -76,7 +76,7 @@ func TestMinimalTTLNoDataNoSOA(t *testing.T) {
 	if mt != response.NoData {
 		t.Fatalf("Expected type to be response.NoData, got %s", mt)
 	}
-	dur := MinimalTTL(m, mt) 
+	dur := MinimalTTL(m, mt)
 	if dur != MinimalDefaultTTL {
 		t.Fatalf("Expected minttl duration to be %d, got %d", MinimalDefaultTTL, dur)
 	}

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -39,12 +39,12 @@ func TestMinimalTTL(t *testing.T) {
 	if dur != time.Duration(1800*time.Second) {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
-	
+
 }
 func TestMinimalTTLNoDataNoSOA(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeNoError // No Error
+	m.Rcode = dns.RcodeNoError                                                        // No Error
 	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
 
 	utc := time.Now().UTC()
@@ -57,12 +57,8 @@ func TestMinimalTTLNoDataNoSOA(t *testing.T) {
 	if dur != MinimalDefaultTTL {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
-	
+
 }
-
-
-
-
 
 func BenchmarkMinimalTTL(b *testing.B) {
 	m := new(dns.Msg)

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -44,7 +44,7 @@ func TestMinimalTTL(t *testing.T) {
 func TestMinimalTTLNoDataNoSOA(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeNoError                                                        // No Error
+	m.Rcode = dns.RcodeSuccess
 	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
 
 	utc := time.Now().UTC()

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -39,7 +39,30 @@ func TestMinimalTTL(t *testing.T) {
 	if dur != time.Duration(1800*time.Second) {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
+	
 }
+func TestMinimalTTLNoDataNoSOA(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion("bar.www.example.org.", dns.TypeA)
+	m.Rcode = dns.RcodeNoError // No Error
+	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
+
+	utc := time.Now().UTC()
+
+	mt, _ := response.Typify(m, utc)
+	if mt != response.NoData {
+		t.Fatalf("Expected type to be response.NoData, got %s", mt)
+	}
+	dur := MinimalTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
+	if dur != MinimalDefaultTTL {
+		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
+	}
+	
+}
+
+
+
+
 
 func BenchmarkMinimalTTL(b *testing.B) {
 	m := new(dns.Msg)

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -115,7 +115,7 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 		return NoData, opt
 	}
 
-	if len(m.Answer)>0 && !answerMatch && m.Rcode == dns.RcodeSucess && !soa {
+	if len(m.Answer)>0 && !answerMatch && m.Rcode == dns.RcodeSuccess && !soa {
 		return NoData, opt
 	}
 	

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -86,21 +86,20 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 		}
 	}
 
-	answerMatch:= false
-	for _, r :=  range m.Answer{
-		if(m.Question[0].Qtype==r.Header().Rrtype){
-			answerMatch=true
+	answerMatch := false
+	for _, r := range m.Answer {
+		if m.Question[0].Qtype == r.Header().Rrtype {
+			answerMatch = true
 		}
 	}
-	
-	
+
 	if len(m.Answer) > 0 && m.Rcode == dns.RcodeSuccess && answerMatch {
 		return NoError, opt
 	}
 
 	soa := false
 	ns := 0
-	
+
 	for _, r := range m.Ns {
 		if r.Header().Rrtype == dns.TypeSOA {
 			soa = true
@@ -110,15 +109,15 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 			ns++
 		}
 	}
-	
+
 	if soa && m.Rcode == dns.RcodeSuccess {
 		return NoData, opt
 	}
 
-	if len(m.Answer)>0 && !answerMatch && m.Rcode == dns.RcodeSuccess && !soa {
+	if len(m.Answer) > 0 && !answerMatch && m.Rcode == dns.RcodeSuccess && !soa {
 		return NoData, opt
 	}
-	
+
 	if soa && m.Rcode == dns.RcodeNameError {
 		return NameError, opt
 	}

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -87,12 +87,13 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 	}
 
 	answerMatch := false
-	for _, r := range m.Answer {
-		if m.Question[0].Qtype == r.Header().Rrtype {
-			answerMatch = true
+	if len(m.Question) > 0 {
+		for _, r := range m.Answer {
+			if m.Question[0].Qtype == r.Header().Rrtype {
+				answerMatch = true
+			}
 		}
 	}
-
 	if len(m.Answer) > 0 && m.Rcode == dns.RcodeSuccess && answerMatch {
 		return NoError, opt
 	}

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -60,6 +60,34 @@ func TestTypifyImpossible(t *testing.T) {
 	}
 }
 
+
+func TestTypifyNoDataType1(t *testing.T) {
+	// NoError and  just CNAME -  Typical of recursive query from F5
+	m := new(dns.Msg)
+	m.SetQuestion("bar.www.example.org.", dns.TypeA)
+	m.Rcode = dns.RcodeNoError // No Error
+	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != NoData {
+		t.Errorf("Impossible message not typified as NoData, got %s", mt)
+	}
+}
+
+func TestTypifyNoDataType2(t *testing.T) {
+	// NoError and  just CNAME -  Typical of recursive query from F5
+	m := new(dns.Msg)
+	m.SetQuestion("bar.www.example.org.", dns.TypeA)
+	m.Rcode = dns.RcodeNoError // No Error
+	m.Answer = []dns.RR{
+		test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")
+		test.SOA("example.org. 900 IN SOA ns.example.org. hostmaster.example.org 63121 3600 900 1209600 900")
+	} 
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != NoData {
+		t.Errorf("Impossible message not typified as NoData, got %s", mt)
+	}
+}
+
 func TestTypifyRefused(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("foo.example.org.", dns.TypeA)

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -64,7 +64,7 @@ func TestTypifyNoDataType1(t *testing.T) {
 	// NoError and  just CNAME -  Typical of recursive query from F5
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeNoError                                                        // No Error
+	m.Rcode = dns.RcodeSuccess                                                        // No Error
 	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
 	mt, _ := Typify(m, time.Now().UTC())
 	if mt != NoData {
@@ -76,7 +76,7 @@ func TestTypifyNoDataType2(t *testing.T) {
 	// NoError and  just CNAME -  Typical of recursive query from F5
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeNoError // No Error
+	m.Rcode = dns. // No Error
 	m.Answer = []dns.RR{
 
 		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."),

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -76,7 +76,7 @@ func TestTypifyNoDataType2(t *testing.T) {
 	// NoError and  just CNAME -  Typical of recursive query from F5
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeSuccess  // No Error
+	m.Rcode = dns.RcodeSuccess // No Error
 	m.Answer = []dns.RR{
 
 		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."),

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -79,7 +79,8 @@ func TestTypifyNoDataType2(t *testing.T) {
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
 	m.Rcode = dns.RcodeNoError // No Error
 	m.Answer = []dns.RR{
-		test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")
+		
+		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."), 
 		test.SOA("example.org. 900 IN SOA ns.example.org. hostmaster.example.org 63121 3600 900 1209600 900")
 	} 
 	mt, _ := Typify(m, time.Now().UTC())

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -60,12 +60,11 @@ func TestTypifyImpossible(t *testing.T) {
 	}
 }
 
-
 func TestTypifyNoDataType1(t *testing.T) {
 	// NoError and  just CNAME -  Typical of recursive query from F5
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns.RcodeNoError // No Error
+	m.Rcode = dns.RcodeNoError                                                        // No Error
 	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
 	mt, _ := Typify(m, time.Now().UTC())
 	if mt != NoData {
@@ -79,10 +78,10 @@ func TestTypifyNoDataType2(t *testing.T) {
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
 	m.Rcode = dns.RcodeNoError // No Error
 	m.Answer = []dns.RR{
-		
-		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."), 
-		test.SOA("example.org. 900 IN SOA ns.example.org. hostmaster.example.org 63121 3600 900 1209600 900")
-	} 
+
+		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."),
+		test.SOA("example.org. 900 IN SOA ns.example.org. hostmaster.example.org 63121 3600 900 1209600 900"),
+	}
 	mt, _ := Typify(m, time.Now().UTC())
 	if mt != NoData {
 		t.Errorf("Impossible message not typified as NoData, got %s", mt)

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -76,7 +76,7 @@ func TestTypifyNoDataType2(t *testing.T) {
 	// NoError and  just CNAME -  Typical of recursive query from F5
 	m := new(dns.Msg)
 	m.SetQuestion("bar.www.example.org.", dns.TypeA)
-	m.Rcode = dns. // No Error
+	m.Rcode = dns.RcodeSuccess  // No Error
 	m.Answer = []dns.RR{
 
 		test.CNAME("bar.www.example.org. IN CNAME foo.example.org."),


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When upstream responses doesn't include SOA to indicate NODATA  but with NOERROR code - CoreDNS treats this as NOERROR and picks least TTL from any record included in the response.

This is typical behavior in case of F5 Global Loadbalancer dns responses:

1. When all service members fail GLB returns no records and NOERROR
2. Combined with recursion by an upstream server - responses may contain CNAME section
3. CoreDNS uses TTL on CNAME for caching an NODATA condition

This set of patches treats this condition as NODATA 

### 2. Which issues (if any) are related?
See Above

### 3. Which documentation changes (if any) need to be made?
Not Applicable

### 4. Does this introduce a backward incompatible change or deprecation?
Not Applicable
