### PR TITLE
Encourage the use of tls_servername in forward plugin

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -79,7 +79,9 @@ forward FROM TO... {
 * `tls_servername` **NAME** allows you to set a server name in the TLS configuration; for instance 9.9.9.9
   needs this to be set to `dns.quad9.net`. Multiple upstreams are still allowed in this scenario,
   but they have to use the same `tls_servername`. E.g. mixing 9.9.9.9 (QuadDNS) with 1.1.1.1
-  (Cloudflare) will not work.
+  (Cloudflare) will not work. Using TLS forwarding but not setting `tls_servername` results in anyone
+  being able to man-in-the-middle your connection to the DNS server you are forwarding to. Because of this,
+  it is strongly recommended to set this value when using TLS forwarding.
 * `policy` specifies the policy to use for selecting upstream servers. The default is `random`.
   * `random` is a policy that implements random upstream selection.
   * `round_robin` is a policy that selects hosts based on round robin ordering.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Updates the docs to warn users to specify `tls_servername` when using the forward plugin to forward over TLS.

If `tls_servername` isn't specified then any TLS certificate that has been signed by a trusted CA will be accepted, which means anyone with a cert issued to another domain could man-in-the-middle you.

While there are some valid use cases for this, for most, it probably is something undesirable.

Considering that no errors or warnings are thrown when you don't specify a `tls_servername` in the config while using TLS forwarding, users might not realize that the TLS connection they are establishing is highly insecure.
### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A