### PR TITLE
support plain HTTP for DoH

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,15 @@ https://example.org {
     tls mycert mykey
 }
 ~~~
+in this setup, the CoreDNS will be responsible for TLS termination
 
-Note that you must have the *tls* plugin configured as DoH requires that to be setup.
+you can also start DNS server serving DoH without TLS termination (plain HTTP), but beware that in such scenario there has to be some kind
+of TLS termination proxy before CoreDNS instance, which forwards DNS requests otherwise clients will not be able to communicate via DoH with the server
+~~~ corefile
+https://example.org {
+    whoami
+}
+~~~
 
 Specifying ports works in the same way:
 

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -39,12 +39,12 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 		// Should we error if some configs *don't* have TLS?
 		tlsConfig = conf.TLSConfig
 	}
-	if tlsConfig == nil {
-		return nil, fmt.Errorf("DoH requires TLS to be configured, see the tls plugin")
-	}
+
 	// http/2 is recommended when using DoH. We need to specify it in next protos
 	// or the upgrade won't happen.
-	tlsConfig.NextProtos = []string{"h2", "http/1.1"}
+	if tlsConfig != nil {
+		tlsConfig.NextProtos = []string{"h2", "http/1.1"}
+	}
 
 	// Use a custom request validation func or use the standard DoH path check.
 	var validator func(*http.Request) bool

--- a/plugin/tls/README.md
+++ b/plugin/tls/README.md
@@ -2,7 +2,7 @@
 
 ## Name
 
-*tls* - allows you to configure the server certificates for the TLS and gRPC servers.
+*tls* - allows you to configure the server certificates for the TLS, gRPC, DoH servers.
 
 ## Description
 
@@ -52,6 +52,14 @@ incoming queries.
 
 ~~~
 grpc://. {
+	tls cert.pem key.pem ca.pem
+	forward . /etc/resolv.conf
+}
+~~~
+
+Start a DoH server on port 443 that is similar to the previous example, but using DoH for incoming queries.
+~~~
+https://. {
 	tls cert.pem key.pem ca.pem
 	forward . /etc/resolv.conf
 }


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
basically reverts https://github.com/coredns/coredns/commit/5235b35e3f321fc1e273c39e19eae71bd0df7fcc and by doing this also enables CoreDNS serving DoH over plain HTTP (and TLS termination can be delegated to the forwarding proxy)
### 2. Which issues (if any) are related?
#4994
### 3. Which documentation changes (if any) need to be made?
I have updated main README and tls plugin README
### 4. Does this introduce a backward incompatible change or deprecation?
no
