### PR TITLE
Fix CircleCI build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ initWorkingDir: &initWorkingDir
     GOROOT=$(go env GOROOT)
     sudo rm -r $(go env GOROOT)
     sudo mkdir $GOROOT
-    LATEST=$(curl -s https://golang.org/VERSION?m=text)
+    LATEST=$(curl -s https://go.dev/VERSION?m=text)
     curl https://dl.google.com/go/${LATEST}.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 integrationDefaults: &integrationDefaults


### PR DESCRIPTION
This PR tries to fix CircleCI build failure as version
string of the Golang not goes to go.dev (previously golang.org)
and our Kubernetes tests are failing.

See https://github.com/coredns/coredns/pull/5001 for an example of failed test.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
