### PR TITLE
plugin/file:multiple file plugin have same reload time

### DIFF
--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -126,11 +126,11 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				return Zones{}, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
-	}
 
-	for origin := range z {
-		z[origin].ReloadInterval = reload
-		z[origin].Upstream = upstream.New()
+		for i := range origins {
+			z[origins[i]].ReloadInterval = reload
+			z[origins[i]].Upstream = upstream.New()
+		}
 	}
 
 	if openErr != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
when corefile like this
```
.:1053 {
    reload
    log
    errors
    file db.123.com 123.com {
        reload 100s
    }
    file db.456.com 456.com {
        reload 3s
    }
    prometheus
    health
    forward . 8.8.8.8
}
```
then zone 123.com reload interval 100s would be override by zone 456.com reload interval 3s

this PR would fix this.

### 2. Which issues (if any) are related?
No.

### 3. Which documentation changes (if any) need to be made?
No.

### 4. Does this introduce a backward incompatible change or deprecation?
Should Not.
