### PR TITLE
plugin/file: Fix NXDomain status case

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -39,7 +39,12 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	// TODO(miek): match the qname better in the map
 	zone := plugin.Zones(f.Zones.Names).Matches(qname)
 	if zone == "" {
-		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		m.Rcode = dns.RcodeNameError
+		w.WriteMsg(m)
+		return dns.RcodeNameError, nil
 	}
 
 	z, ok := f.Zones.Z[zone]


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When using the file plugin, lookup a domain that does not exist in zone file, it does not return the expected status NXDOMAIN but SERVFAIL instead.
In addition, it will print a error log :
`[ERROR] plugin/errors: 2 server1.example222.org. A: plugin/file: no next plugin found`
The reason for the error log is that no plugin behind the file that can be executed.

My test case corefile：
```
.:1053 {
    file db.example.org example.org
    log
    debug
}
```

the zone file db.example.org :
```
$ORIGIN example.org.
@  3600 IN    SOA sns.dns.icann.org. noc.dns.icann.org. (
            2017042745 ; serial
            7200       ; refresh (2 hours)
            3600       ; retry (1 hour)
            1209600    ; expire (2 weeks)
            3600       ; minimum (1 hour)
            )

   3600 IN NS a.iana-servers.net.
   3600 IN NS b.iana-servers.net.

server1  IN  A  10.0.1.3
         IN  A  10.0.1.5

```
Test dig a not exist domain  :
```
$ dig @127.0.0.1 -p 1053 server1.example222.org

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p 1053 server1.example222.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 14435        // <- notes the status
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;server1.example222.org.		IN	A

;; Query time: 0 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1)
;; WHEN: Thu Dec 02 21:44:53 CST 2021
;; MSG SIZE  rcvd: 51
```

After fixed when dig a not exist domain:
```
dig @127.0.0.1 -p 1053 server1.example222.org

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p 1053 server1.example222.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 12467      // <- notes the status
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;server1.example222.org.		IN	A

;; Query time: 0 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1)
;; WHEN: Thu Dec 02 21:43:39 CST 2021
;; MSG SIZE  rcvd: 51
```

### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
None.
### 4. Does this introduce a backward incompatible change or deprecation?
None.