### PR TITLE
plugin/kubernetes: add wildcard warnings

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -2,6 +2,8 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
+	"sync/atomic"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -26,6 +28,10 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		extra   []dns.RR
 		err     error
 	)
+
+	if wildQuestion(state.Name()) {
+		atomic.AddUint64(&wildCount, 1)
+	}
 
 	switch state.QType() {
 	case dns.TypeA:
@@ -85,7 +91,12 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	m.Answer = append(m.Answer, records...)
 	m.Extra = append(m.Extra, extra...)
 	w.WriteMsg(m)
+
 	return dns.RcodeSuccess, nil
+}
+
+func wildQuestion(name string) bool {
+	return strings.HasPrefix(name, "*.") || strings.HasPrefix(name, "any.") || strings.Contains(name, ".*.") || strings.Contains(name, ".any.")
 }
 
 // Name implements the Handler interface.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -86,6 +86,7 @@ var (
 	errNoItems        = errors.New("no items found")
 	errNsNotExposed   = errors.New("namespace is not exposed")
 	errInvalidRequest = errors.New("invalid query name")
+	wildCount         uint64
 )
 
 // Services implements the ServiceBackend interface.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -58,6 +60,25 @@ func setup(c *caddy.Controller) error {
 	// get locally bound addresses
 	c.OnStartup(func() error {
 		k.localIPs = boundIPs(c)
+		return nil
+	})
+
+	wildWarner := time.NewTicker(10 * time.Second)
+	c.OnStartup(func() error {
+		go func() {
+			for {
+				select {
+				case <-wildWarner.C:
+					if wc := atomic.SwapUint64(&wildCount, 0); wc > 0 {
+						log.Warningf("%d deprecated wildcard queries received. Wildcard queries will no longer be supported in the next minor release.", wc)
+					}
+				}
+			}
+		}()
+		return nil
+	})
+	c.OnShutdown(func() error {
+		wildWarner.Stop()
 		return nil
 	})
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Log deprecation warnings when wildcard queries are received by _kubernetes_.
Warning is logged at most once every 10 seconds.

### 2. Which issues (if any) are related?

#5019 - removal of wildcards. queued for 1.9.0
#4984

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
