### PR TITLE
plugin/kubernetes: Add wildcard query deprecation notice to kubernetes readme

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -198,6 +198,8 @@ packet received by CoreDNS must be the IP address of the Pod that sent the reque
 
 ## Wildcards
 
+**NOTE: Wildcard queries are deprecated** and will no longer be supported in the next minor release.
+
 Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (\*,
 or the word "any"), then that label will match all values.  The labels that accept wildcards are:
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Adds a deprecation notice to the Wildcards section of the _kubernetes_ plugin README.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
