### PR TITLE
Convert HostPortOrFile error to var

### DIFF
--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/miekg/dns"
 )
+
+// ErrNoNameservers is returned by HostPortOrFile if no servers can be parsed.
+var ErrNoNameservers = errors.New("no nameservers found")
 
 // Strips the zone, but preserves any port that comes after the zone
 func stripZone(host string) string {
@@ -70,7 +74,7 @@ func HostPortOrFile(s ...string) ([]string, error) {
 		servers = append(servers, h)
 	}
 	if len(servers) == 0 {
-		return servers, fmt.Errorf("no nameservers found")
+		return servers, ErrNoNameservers
 	}
 	return servers, nil
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Convert "no nameservers found" error on parse.HostPortOrFile() to an
exported var for use with `errors.Is()`.

### 2. Which issues (if any) are related?

Alternative solution to https://github.com/coredns/coredns/pull/5057

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
