### PR TITLE
fix: convert key to domain

### DIFF
--- a/plugin/etcd/msg/path.go
+++ b/plugin/etcd/msg/path.go
@@ -22,6 +22,9 @@ func Path(s, prefix string) string {
 // Domain is the opposite of Path.
 func Domain(s string) string {
 	l := strings.Split(s, "/")
+	if l[len(l)-1] == "" {
+		l = l[:len(l)-1]
+	}
 	// start with 1, to strip /skydns
 	for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
 		l[i], l[j] = l[j], l[i]

--- a/plugin/etcd/msg/path_test.go
+++ b/plugin/etcd/msg/path_test.go
@@ -11,7 +11,7 @@ func TestPath(t *testing.T) {
 	}
 }
 
-func TestPath(t *testing.T) {
+func TestDomain(t *testing.T) {
 	result1 := Domain("/skydns/local/cluster/staging/service/")
 	if result1 != "service.staging.cluster.local." {
 		t.Errorf("==>%s", result1)

--- a/plugin/etcd/msg/path_test.go
+++ b/plugin/etcd/msg/path_test.go
@@ -14,11 +14,11 @@ func TestPath(t *testing.T) {
 func TestDomain(t *testing.T) {
 	result1 := Domain("/skydns/local/cluster/staging/service/")
 	if result1 != "service.staging.cluster.local." {
-		t.Errorf("==>%s", result1)
+		t.Errorf("Failure to get domain from etcd key (with a trailing '/'), expect: 'service.staging.cluster.local.', actually get: '%s'", result1)
 	}
 
 	result2 := Domain("/skydns/local/cluster/staging/service")
 	if result2 != "service.staging.cluster.local." {
-		t.Errorf("==>%s", result2)
+		t.Errorf("Failure to get domain from etcd key (without trailing '/'), expect: 'service.staging.cluster.local.' actually get: '%s'", result2)
 	}
 }

--- a/plugin/etcd/msg/path_test.go
+++ b/plugin/etcd/msg/path_test.go
@@ -10,3 +10,15 @@ func TestPath(t *testing.T) {
 		}
 	}
 }
+
+func TestPath(t *testing.T) {
+	result1 := Domain("/skydns/local/cluster/staging/service/")
+	if result1 != "service.staging.cluster.local." {
+		t.Errorf("==>%s", result1)
+	}
+
+	result2 := Domain("/skydns/local/cluster/staging/service")
+	if result2 != "service.staging.cluster.local." {
+		t.Errorf("==>%s", result2)
+	}
+}


### PR DESCRIPTION
If the Key ends with '/', there'll be an extra character '.' at the beginning of the Domain.
