### PR TITLE
fix goroutine leaks in TestRoute53

### DIFF
--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -77,7 +77,8 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 }
 
 func TestRoute53(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Minute)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

I find there is a goroutine leaking in `TestRoute53` and fix it:

```
[Goroutine 28 in state select, with github.com/coredns/coredns/plugin/route53.(*Route53).Run.func1 on top of the stack:
goroutine 28 [select]:
github.com/coredns/coredns/plugin/route53.(*Route53).Run.func1()
	/root/actions-runner/_work/synctrapper/synctrapper/coredns/plugin/route53/route53.go:87 +0x129
created by github.com/coredns/coredns/plugin/route53.(*Route53).Run
	/root/actions-runner/_work/synctrapper/synctrapper/coredns/plugin/route53/route53.go:85 +0xf9
]
```

I suspect `TestSetupRoute53` is also leak goroutines since it doesn't call any functions in `c.OnShutdown` but I don't know how to fix it.

### 2. Which issues (if any) are related?

No

### 3. Which documentation changes (if any) need to be made?

Not needed

### 4. Does this introduce a backward incompatible change or deprecation?

No