### PR TITLE
plugin/health: fix the default http endpoint address

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -15,7 +15,7 @@ status code. The health is exported, by default, on port 8080/health.
 health [ADDRESS]
 ~~~
 
-Optionally takes an address; the default is `:8080`. The health path is fixed to `/health`. The
+Optionally takes an address; the default is `localhost:8080`. The health path is fixed to `/health`. The
 health endpoint returns a 200 response code and the word "OK" when this server is healthy.
 
 An extra option can be set with this extended syntax:

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -27,7 +27,7 @@ type health struct {
 
 func (h *health) OnStartup() error {
 	if h.Addr == "" {
-		h.Addr = ":8080"
+		h.Addr = "localhost:8080"
 	}
 	h.stop = make(chan bool)
 	ln, err := reuseport.Listen("tcp", h.Addr)


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
As described in the readme of health plugin,  syntax:

~~~
health [ADDRESS] {
    lameduck DURATION
}
~~~
But when we use health plugin by it default config：
```
.:1053 {
    health
    log
}
```
log print a lot of WARNING：
```
CoreDNS-1.8.7
darwin/amd64, go1.17, 
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": read tcp 127.0.0.1:63671->127.0.0.1:4440: read: connection reset by peer
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": read tcp 127.0.0.1:63670->127.0.0.1:4440: read: connection reset by peer
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": read tcp 127.0.0.1:63669->127.0.0.1:4440: read: connection reset by peer
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": read tcp 127.0.0.1:63668->127.0.0.1:4440: read: connection reset by peer
```
### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
Changed health plugin readme
### 4. Does this introduce a backward incompatible change or deprecation?
None.