### PR TITLE
plugin/file: add a lookup test case for wildcard RRs do not apply

### DIFF
--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -103,6 +103,13 @@ var dnsTestCases = []test.Case{
 		Ns: miekAuth,
 	},
 	{
+		Qname: "a.b.x.miek.nl.", Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+	{
 		Qname: "asterisk.y.miek.nl.", Qtype: dns.TypeA,
 		Answer: []dns.RR{
 			test.A("asterisk.y.miek.nl.     1800    IN      A       139.162.196.78"),
@@ -222,6 +229,7 @@ a               IN      A       139.162.196.78
 www             IN      CNAME   a
 archive         IN      CNAME   a
 *.x             IN      CNAME   www
+b.x             IN      CNAME   a
 *.y             IN      A       139.162.196.78
 dname           IN      DNAME   x
 


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add a lookup test case for wildcard RRs do not apply.   #5076 
From RFC 1034 ...

```
Wildcard RRs do not apply:
[...]

When the query name or a name between the wildcard domain and
the query name is know to exist. For example, if a wildcard
RR has an owner name of "*.X", and the zone also contains RRs
attached to B.X, the wildcards would apply to queries for name
Z.X (presuming there is no explicit information for Z.X), but
not to B.X, A.B.X, or X.
```

### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
None.
### 4. Does this introduce a backward incompatible change or deprecation?
No.