### PR TITLE
plugin/secondary: Fix startup transfer failure wrong zone logged

### DIFF
--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/coredns/caddy"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/file"
@@ -23,8 +24,10 @@ func setup(c *caddy.Controller) error {
 	}
 
 	// Add startup functions to retrieve the zone and keep it up to date.
-	for _, n := range zones.Names {
+	for i := range zones.Names {
+		n := zones.Names[i]
 		z := zones.Z[n]
+
 		if len(z.TransferFrom) > 0 {
 			c.OnStartup(func() error {
 				z.StartupOnce.Do(func() {

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/coredns/caddy"
-
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/file"

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -26,7 +26,6 @@ func setup(c *caddy.Controller) error {
 	for i := range zones.Names {
 		n := zones.Names[i]
 		z := zones.Z[n]
-
 		if len(z.TransferFrom) > 0 {
 			c.OnStartup(func() error {
 				z.StartupOnce.Do(func() {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

The transfer failure log warning during startup references a loop iterator, which is a single variable in Go and assigned a new value each iteration.  Since the warning logged from within a go routine, this can result the wrong zone name printed to the log when a zone fails to transfer at startup.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-1 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
