### PR TITLE
plugin/file: unified NoData result

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -230,7 +230,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 				nsec := typeFromElem(wildElem, dns.TypeNSEC, do)
 				ret = append(ret, nsec...)
 			}
-			return nil, ret, nil, Success
+			return nil, ret, nil, NoData
 		}
 
 		if do {


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When `len(rrs) == 0` in case of found entire name, it `return nil, ret, nil, NoData`, but in case of found wildcard, it `return nil, ret, nil, Success`.
This PR try to unified the result when `len(rrs) == 0`.
https://github.com/coredns/coredns/blob/6b537effda2c612b2bdbbd4a91bae231e9267e4c/plugin/file/lookup.go#L189-L197

https://github.com/coredns/coredns/blob/6b537effda2c612b2bdbbd4a91bae231e9267e4c/plugin/file/lookup.go#L226-L234
### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
None.
### 4. Does this introduce a backward incompatible change or deprecation?
No.