### PR TITLE
plugin/file: add NoData test case 

### DIFF
--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -42,6 +42,20 @@ var dnsTestCases = []test.Case{
 		},
 		Ns: miekAuth,
 	},
+	// the NoData test case for found entire name when lookup
+	{
+		Qname: "a.miek.nl.", Qtype: dns.TypeMX,
+		Ns: []dns.RR{
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+	// the NoData test case for found wildcard when lookup
+	{
+		Qname: "wildcard.nodata.miek.nl.", Qtype: dns.TypeMX,
+		Ns: []dns.RR{
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
 	{
 		Qname: "mIeK.NL.", Qtype: dns.TypeAAAA,
 		Answer: []dns.RR{
@@ -236,4 +250,5 @@ dname           IN      DNAME   x
 srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.
 
-ext-cname   IN   CNAME  example.com.`
+ext-cname   IN   CNAME  example.com.
+*.nodata        IN      A       139.162.196.79`


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add NoData test case for lookup hit `len(rrs) == 0` that mock by query another type of none rr.
Background see https://github.com/coredns/coredns/issues/5086#issuecomment-1010219772_ .
### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
None.
### 4. Does this introduce a backward incompatible change or deprecation?
No.