### PR TITLE
plugin/file: fix lost extra section when delegated subdomain to another

### DIFF
--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -132,6 +132,16 @@ var dnsTestCases = []test.Case{
 		Rcode: dns.RcodeServerFailure,
 		Ns:    miekAuth,
 	},
+	{
+		Qname: "sub.miek.nl.", Qtype: dns.TypeNS,
+		Ns: []dns.RR{
+			test.NS("sub.miek.nl.	1800	IN	NS	a.miek.nl."),
+		},
+		Extra: []dns.RR{
+			test.A("a.miek.nl.	1800	IN	A       139.162.196.78"),
+			test.AAAA("a.miek.nl.	1800	IN	AAAA	2a01:7e00::f03c:91ff:fef1:6735"),
+		},
+	},
 }
 
 const (
@@ -236,4 +246,5 @@ dname           IN      DNAME   x
 srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.
 
-ext-cname   IN   CNAME  example.com.`
+ext-cname   IN   CNAME  example.com.
+sub         IN   NS     a.miek.nl.`

--- a/plugin/file/tree/glue.go
+++ b/plugin/file/tree/glue.go
@@ -10,7 +10,7 @@ import (
 func (t *Tree) Glue(nsrrs []dns.RR, do bool) []dns.RR {
 	glue := []dns.RR{}
 	for _, rr := range nsrrs {
-		if ns, ok := rr.(*dns.NS); ok && dns.IsSubDomain(ns.Header().Name, ns.Ns) {
+		if ns, ok := rr.(*dns.NS); ok {
 			glue = append(glue, t.searchGlue(ns.Ns, do)...)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix lost extra section when delegated subdomain to another. For example:
test case:
```
	{
		Qname: "sub.miek.nl.", Qtype: dns.TypeNS,
		Ns: []dns.RR{
			test.NS("sub.miek.nl.	1800	IN	NS	a.miek.nl."),
		},
		Extra: []dns.RR{
			test.A("a.miek.nl.	1800	IN	A       139.162.196.78"),
			test.AAAA("a.miek.nl.	1800	IN	AAAA	2a01:7e00::f03c:91ff:fef1:6735"),
		},
	}
```
zone file:
```
sub          IN   NS     a.miek.nl.
a              IN      A       139.162.196.78
                IN      AAAA    2a01:7e00::f03c:91ff:fef1:6735
```
### 2. Which issues (if any) are related?
None.
### 3. Which documentation changes (if any) need to be made?
None.
### 4. Does this introduce a backward incompatible change or deprecation?
No.