### PR TITLE
Log panic cause for better debugging

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -213,7 +213,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			// In case the user doesn't enable error plugin, we still
 			// need to make sure that we stay alive up here
 			if rec := recover(); rec != nil {
-				log.Errorf("Recovered from panic in server: %q", s.Addr)
+				log.Errorf("Recovered from panic in server: %q %v", s.Addr, rec)
 				vars.Panic.Inc()
 				errorAndMetricsFunc(s.Addr, w, r, dns.RcodeServerFailure)
 			}


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

Hello, we are using CoreDNS in our product and we recently noticed this behavior of CoreDNS with our custom plugins

### 1. Why is this pull request needed and what does it do?
Currently, when a panic occurs in CoreDNS it is logged like this:
```
[ERROR] Recovered from panic in server: "dns://:53"
```
which is not very helpful for debugging the issue related to the panic cause. 

As part of this PR, I propose to add the cause of panic as part of the log to improve these logs, so it will for example look like this (note the last part saying that the cause was `index out of range`)
```
[ERROR] Recovered from panic in server "dns://:53" runtime error: index out of range [1] with length 0
```

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
I don't think so
