### PR TITLE
plugin/kubernetes: Accept IPv4s with leading zeros

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -73,7 +73,7 @@ func ToEndpoints(obj meta.Object) (meta.Object, error) {
 		}
 
 		for j, a := range eps.Addresses {
-			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname}
+			ea := EndpointAddress{IP: stripLeadingZerosIPv4(a.IP), Hostname: a.Hostname}
 			if a.NodeName != nil {
 				ea.NodeName = *a.NodeName
 			}
@@ -93,7 +93,7 @@ func ToEndpoints(obj meta.Object) (meta.Object, error) {
 
 	for _, eps := range end.Subsets {
 		for _, a := range eps.Addresses {
-			e.IndexIP = append(e.IndexIP, a.IP)
+			e.IndexIP = append(e.IndexIP, stripLeadingZerosIPv4(a.IP))
 		}
 	}
 
@@ -132,6 +132,7 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 			continue
 		}
 		for _, a := range end.Addresses {
+			a = stripLeadingZerosIPv4(a)
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname
@@ -183,6 +184,7 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 			continue
 		}
 		for _, a := range end.Addresses {
+			a = stripLeadingZerosIPv4(a)
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname

--- a/plugin/kubernetes/object/endpoint_test.go
+++ b/plugin/kubernetes/object/endpoint_test.go
@@ -1,0 +1,67 @@
+package object
+
+import (
+	"fmt"
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEndpointsIPStripLeadingZeros(t *testing.T) {
+	obj := &api.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "endpoint1", Namespace: "test1"},
+		Subsets: []api.EndpointSubset{{
+			Addresses: []api.EndpointAddress{{IP: "01.02.03.04"}},
+			Ports:     []api.EndpointPort{{Port: 80}}},
+		},
+	}
+	expectedIP := "1.2.3.4"
+
+	got, err := ToEndpoints(obj)
+	if err != nil {
+		t.Fatalf("get added object failed: %v", err)
+	}
+
+	o, ok := got.(*Endpoints)
+	if !ok {
+		t.Fatal("object in index was incorrect type")
+	}
+	if fmt.Sprintf("%v", o.Subsets[0].Addresses[0].IP) != fmt.Sprintf("%v", expectedIP) {
+		t.Fatalf("expected '%v', got '%v'", expectedIP, o.Subsets[0].Addresses[0].IP)
+	}
+	if fmt.Sprintf("%v", o.IndexIP) != fmt.Sprintf("%v", []string{expectedIP}) {
+		t.Fatalf("expected '%v', got '%v'", []string{expectedIP}, o.IndexIP)
+	}
+}
+
+func TestEndpointSliceIPStripLeadingZeros(t *testing.T) {
+	var port int32 = 80
+	var portName string = "http"
+	var portProt api.Protocol = "tcp"
+	obj := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "endpoint1", Namespace: "test1"},
+		Endpoints: []discovery.Endpoint{{
+			Addresses: []string{"01.02.03.04"},
+		}},
+		Ports: []discovery.EndpointPort{{Port: &port, Protocol: &portProt, Name: &portName}},
+	}
+	expectedIP := "1.2.3.4"
+
+	got, err := EndpointSliceToEndpoints(obj)
+	if err != nil {
+		t.Fatalf("get added object failed: %v", err)
+	}
+
+	o, ok := got.(*Endpoints)
+	if !ok {
+		t.Fatal("object in index was incorrect type")
+	}
+	if fmt.Sprintf("%v", o.Subsets[0].Addresses[0].IP) != fmt.Sprintf("%v", expectedIP) {
+		t.Fatalf("expected '%v', got '%v'", expectedIP, o.Subsets[0].Addresses[0].IP)
+	}
+	if fmt.Sprintf("%v", o.IndexIP) != fmt.Sprintf("%v", []string{expectedIP}) {
+		t.Fatalf("expected '%v', got '%v'", []string{expectedIP}, o.IndexIP)
+	}
+}

--- a/plugin/kubernetes/object/object_test.go
+++ b/plugin/kubernetes/object/object_test.go
@@ -1,0 +1,36 @@
+package object
+
+import (
+	"testing"
+)
+
+func TestCopyAndStripLeadingZerosIPv4(t *testing.T) {
+	in := []string{
+		"010.00.0.01",
+		"010.00.0.0000001",
+		"10.0.0.2",
+		"1.2.3.4",
+		"1:2:3::04",
+	}
+	expect := []string{
+		"10.0.0.1",
+		"10.0.0.1",
+		"10.0.0.2",
+		"1.2.3.4",
+		"1:2:3::04",
+	}
+	out := make([]string, len(in))
+
+	n := copyAndStripLeadingZerosIPv4(out, in)
+
+	if n != len(in) {
+		t.Errorf("Expected return value %v, got %v", len(in), n)
+	}
+
+	for i := range expect {
+		if out[i] == expect[i] {
+			continue
+		}
+		t.Errorf("For entry %v expected %v, got %v", i, expect[i], out[i])
+	}
+}

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -30,7 +30,7 @@ func ToPod(obj meta.Object) (meta.Object, error) {
 	}
 	pod := &Pod{
 		Version:   apiPod.GetResourceVersion(),
-		PodIP:     apiPod.Status.PodIP,
+		PodIP:     stripLeadingZerosIPv4(apiPod.Status.PodIP),
 		Namespace: apiPod.GetNamespace(),
 		Name:      apiPod.GetName(),
 	}

--- a/plugin/kubernetes/object/pod_test.go
+++ b/plugin/kubernetes/object/pod_test.go
@@ -1,0 +1,35 @@
+package object
+
+import (
+	"fmt"
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodIPStripLeadingZeros(t *testing.T) {
+	obj := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test1"},
+		Status: api.PodStatus{
+			PodIP: "01.02.03.04",
+		},
+	}
+	expectedIP := "1.2.3.4"
+
+	got, err := ToPod(obj)
+	if err != nil {
+		t.Fatalf("get added object failed: %v", err)
+	}
+
+	o, ok := got.(*Pod)
+	if !ok {
+		t.Fatal("object in index was incorrect type")
+	}
+	if fmt.Sprintf("%v", o.PodIP) != fmt.Sprintf("%v", expectedIP) {
+		t.Fatalf("expected '%v', got '%v'", expectedIP, o.PodIP)
+	}
+	if fmt.Sprintf("%v", o.PodIP) != fmt.Sprintf("%v", expectedIP) {
+		t.Fatalf("expected '%v', got '%v'", expectedIP, o.PodIP)
+	}
+}

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -48,9 +48,9 @@ func ToService(obj meta.Object) (meta.Object, error) {
 
 	if len(svc.Spec.ClusterIPs) > 0 {
 		s.ClusterIPs = make([]string, len(svc.Spec.ClusterIPs))
-		copy(s.ClusterIPs, svc.Spec.ClusterIPs)
+		copyAndStripLeadingZerosIPv4(s.ClusterIPs, svc.Spec.ClusterIPs)
 	} else {
-		s.ClusterIPs = []string{svc.Spec.ClusterIP}
+		s.ClusterIPs = []string{stripLeadingZerosIPv4(svc.Spec.ClusterIP)}
 	}
 
 	if len(svc.Spec.Ports) == 0 {
@@ -61,10 +61,10 @@ func ToService(obj meta.Object) (meta.Object, error) {
 		copy(s.Ports, svc.Spec.Ports)
 	}
 
-	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
+	li := copyAndStripLeadingZerosIPv4(s.ExternalIPs, svc.Spec.ExternalIPs)
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			s.ExternalIPs[li+i] = lb.IP
+			s.ExternalIPs[li+i] = stripLeadingZerosIPv4(lb.IP)
 			continue
 		}
 		s.ExternalIPs[li+i] = lb.Hostname

--- a/plugin/kubernetes/object/service_test.go
+++ b/plugin/kubernetes/object/service_test.go
@@ -1,0 +1,39 @@
+package object
+
+import (
+	"fmt"
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServiceIPStripLeadingZeros(t *testing.T) {
+	obj := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "service1", Namespace: "test1"},
+		Spec: api.ServiceSpec{
+			ClusterIP:   "01.02.03.04",
+			ClusterIPs:  []string{"01.02.03.04"},
+			ExternalIPs: []string{"05.06.07.08"},
+			Ports:       []api.ServicePort{{Port: 80}},
+		},
+	}
+	expectedClusterIPs := []string{"1.2.3.4"}
+	expectedExternalIPs := []string{"5.6.7.8"}
+
+	got, err := ToService(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc, ok := got.(*Service)
+	if !ok {
+		t.Fatal("object was incorrect type")
+	}
+	if fmt.Sprintf("%v", svc.ClusterIPs) != fmt.Sprintf("%v", expectedClusterIPs) {
+		t.Fatalf("expected '%v', got '%v'", expectedClusterIPs, svc.ClusterIPs)
+	}
+	if fmt.Sprintf("%v", svc.ExternalIPs) != fmt.Sprintf("%v", expectedExternalIPs) {
+		t.Fatalf("expected '%v', got '%v'", expectedExternalIPs, svc.ClusterIPs)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Kubernetes 1.23 allows IPv4s with leading zeros, and always interprets them as decimal.  Since Go 1.17, if we encounter such an IP, we may no longer treat it as a valid IP due to changes in net.ParseIP/net.ParseCIDR.

This PR strips leading zeros as we receive them from the K8s informers, essentially treating them as decimal, so that they are not rejected later by net.ParseIP/net.ParseCIDR operations.

From the Kubertnetes 1.23 release notes:

> Since golang 1.17 both net.ParseIP and net.ParseCIDR rejects leading zeros in the dot-decimal notation of IPv4
> addresses, Kubernetes will keep allowing leading zeros on IPv4 address to not break the compatibility.
> IMPORTANT: **Kubernetes interprets leading zeros on IPv4 addresses as decimal**, users must not rely on parser alignment
> to not being impacted by the associated security advisory: CVE-2021-29923 golang standard library "net" - Improper
> Input Validation of octal literals in golang 1.16.2 and below standard library "net" results in indeterminate SSRF
> & RFI vulnerabilities.

My understanding is that this a temporary measure by Kubernetes to maintain backward compatibility, and eventually leading zeros will be rejected - at which point we can remove this code.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
