### PR TITLE
plugin/tls: `tls.PreferServerCipherSuites` is ignored as of go 1.17

### DIFF
--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -33,7 +33,6 @@ func setTLSDefaults(tls *ctls.Config) {
 		ctls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		ctls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	}
-	tls.PreferServerCipherSuites = true
 }
 
 func parseTLS(c *caddy.Controller) error {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

`tls.PreferServerCipherSuites` is ignored as of go 1.17.

```
	// PreferServerCipherSuites is a legacy field and has no effect.
	//
	// It used to control whether the server would follow the client's or the
	// server's preference. Servers now select the best mutually supported
	// cipher suite based on logic that takes into account inferred client
	// hardware, server hardware, and security.
	//
	// Deprected: PreferServerCipherSuites is ignored.
```

Since the project now requires go 1.17 to build, probably should remove this so it not misleading.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-5 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
