### PR TITLE
Health-checks should respect force_tcp

### DIFF
--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -16,6 +16,7 @@ type HealthChecker interface {
 	SetTLSConfig(*tls.Config)
 	SetRecursionDesired(bool)
 	GetRecursionDesired() bool
+	SetTCPTransport()
 }
 
 // dnsHc is a health checker for a DNS endpoint (DNS, and DoT).
@@ -55,6 +56,10 @@ func (h *dnsHc) SetRecursionDesired(recursionDesired bool) {
 }
 func (h *dnsHc) GetRecursionDesired() bool {
 	return h.recursionDesired
+}
+
+func (h *dnsHc) SetTCPTransport() {
+	h.c.Net = "tcp"
 }
 
 // For HC we send to . IN NS +[no]rec message to the upstream. Dial timeouts and empty

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -52,6 +52,46 @@ func TestHealth(t *testing.T) {
 	}
 }
 
+func TestHealthTCP(t *testing.T) {
+	hcReadTimeout = 10 * time.Millisecond
+	hcWriteTimeout = 10 * time.Millisecond
+	readTimeout = 10 * time.Millisecond
+	defaultTimeout = 10 * time.Millisecond
+
+	i := uint32(0)
+	q := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		if atomic.LoadUint32(&q) == 0 { //drop the first query to trigger health-checking
+			atomic.AddUint32(&q, 1)
+			return
+		}
+		if r.Question[0].Name == "." && r.RecursionDesired == true {
+			atomic.AddUint32(&i, 1)
+		}
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	p := NewProxy(s.Addr, transport.DNS)
+	p.health.SetTCPTransport()
+	f := New()
+	f.SetProxy(p)
+	defer f.OnShutdown()
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	f.ServeDNS(context.TODO(), &test.ResponseWriter{TCP: true}, req)
+
+	time.Sleep(20 * time.Millisecond)
+	i1 := atomic.LoadUint32(&i)
+	if i1 != 1 {
+		t.Errorf("Expected number of health checks with RecursionDesired==true to be %d, got %d", 1, i1)
+	}
+}
+
 func TestHealthNoRecursion(t *testing.T) {
 	hcReadTimeout = 10 * time.Millisecond
 	readTimeout = 10 * time.Millisecond

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -144,7 +144,8 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 		f.proxies[i].SetExpire(f.expire)
 		f.proxies[i].health.SetRecursionDesired(f.opts.hcRecursionDesired)
-		if f.opts.forceTCP {
+		// when TLS is used, checks are set to tcp-tls
+		if f.opts.forceTCP && transports[i] != transport.TLS {
 			f.proxies[i].health.SetTCPTransport()
 		}
 	}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -144,6 +144,9 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 		f.proxies[i].SetExpire(f.expire)
 		f.proxies[i].health.SetRecursionDesired(f.opts.hcRecursionDesired)
+		if f.opts.forceTCP {
+			f.proxies[i].health.SetTCPTransport()
+		}
 	}
 
 	return f, nil


### PR DESCRIPTION
Signed-off-by: tombokombo <tombo@sysart.tech>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Forwarding with force_tcp is using UDP proto for health-checks. I would expect that setting force_tcp for communication with upstream will use tcp for health-checks as well, but this PR is needed to do so.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
