### PR TITLE
plugin/file: External lookup errors should not result in SERVFAIL

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -381,12 +381,7 @@ Redo:
 }
 
 func (z *Zone) doLookup(ctx context.Context, state request.Request, target string, qtype uint16) ([]dns.RR, Result) {
-	m, e := z.Upstream.Lookup(ctx, state, target, qtype)
-	if e != nil {
-		// An error here usually indicates that we have no means or don't know how to do the lookup.
-		// Return a success here so a recursive resolver can accept the lone CNAME, and do the lookup itself.
-		return nil, Success
-	}
+	m, _ := z.Upstream.Lookup(ctx, state, target, qtype)
 	if m == nil {
 		return nil, Success
 	}

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -331,17 +331,13 @@ func (z *Zone) externalLookup(ctx context.Context, state request.Request, elem *
 	}
 
 	targetName := rrs[0].(*dns.CNAME).Target
-	// if the target name is not in the zone, do an "external" lookup, otherwise just search the zone's tree
-	if !dns.IsSubDomain(z.SOA.Header().Name, targetName) {
+	elem, _ = z.Tree.Search(targetName)
+	if elem == nil {
 		lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
 		rrs = append(rrs, lookupRRs...)
 		return rrs, z.Apex.ns(do), nil, result
 	}
 
-	elem, _ = z.Tree.Search(targetName)
-	if elem == nil {
-		return rrs, z.Apex.ns(do), nil, NameError
-	}
 	i := 0
 
 Redo:

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -132,14 +132,6 @@ var dnsTestCases = []test.Case{
 		Rcode: dns.RcodeSuccess,
 		Ns:    miekAuth,
 	},
-	{
-		Qname: "dangling-cname.miek.nl.", Qtype: dns.TypeA,
-		Answer: []dns.RR{
-			test.CNAME("dangling-cname.miek.nl.	1800	IN	CNAME	no-record.miek.nl."),
-		},
-		Rcode: dns.RcodeNameError,
-		Ns:    miekAuth,
-	},
 }
 
 const (
@@ -245,4 +237,4 @@ srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.
 
 ext-cname   IN   CNAME  example.com.
-dangling-cname IN CNAME no-record`
+`

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -129,7 +129,15 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{
 			test.CNAME("ext-cname.miek.nl.	1800	IN	CNAME	example.com."),
 		},
-		Rcode: dns.RcodeServerFailure,
+		Rcode: dns.RcodeSuccess,
+		Ns:    miekAuth,
+	},
+	{
+		Qname: "dangling-cname.miek.nl.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.CNAME("dangling-cname.miek.nl.	1800	IN	CNAME	no-record.miek.nl."),
+		},
+		Rcode: dns.RcodeNameError,
 		Ns:    miekAuth,
 	},
 }
@@ -236,4 +244,5 @@ dname           IN      DNAME   x
 srv		IN	SRV     10 10 8080 a.miek.nl.
 mx		IN	MX      10 a.miek.nl.
 
-ext-cname   IN   CNAME  example.com.`
+ext-cname   IN   CNAME  example.com.
+dangling-cname IN CNAME no-record`


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

When doing a CNAME target lookup for a target, if the _external_ lookup fails with an error, return NOERROR.  Returning a SERVFAIL could prevent a recursive resolver from looking up the CNAME target itself. Also added a comment in the code describing this, since it is counter intuitive to return NOERROR where there is an error.

### 2. Which issues (if any) are related?

#5104 - observations suggest that for Cloudflare, the SERVFAIL response prevents the recursive resolver from looking up the CNAME target itself.

#4863 - I had changed the failure case from NOERROR to SERVFAIL fairly recently (last September).

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
