### PR TITLE
plugin/forward: Enable multiple forward declarations

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -139,8 +139,8 @@ example.org {
 }
 ~~~
 
-Send all requests within `lab.example.local.` `10.20.0.1`, all requests within `example.local.` (and not in
-`lab.example.local.`) to `10.0.0.1`, and all others requests to the servers defined in `/etc/resolv.conf`, and
+Send all requests within `lab.example.local.` to `10.20.0.1`, all requests within `example.local.` (and not in
+`lab.example.local.`) to `10.0.0.1`, all others requests to the servers defined in `/etc/resolv.conf`, and
 caches results.
 
 ~~~ corefile

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -139,6 +139,37 @@ example.org {
 }
 ~~~
 
+Send all requests within `lab.example.local.` `10.20.0.1`, all requests within `example.local.` (and not in
+`lab.example.local.`) to `10.0.0.1`, and all others requests to the servers defined in `/etc/resolv.conf`, and
+caches results.
+
+~~~ corefile
+. {
+    cache
+    forward lab.example.local 10.20.0.1
+    forward example.local 10.0.0.1
+    forward . /etc/resolv.conf
+}
+~~~
+
+The example above is almost equivalent to the following example, except that example below defines three separate plugin
+chains (and thus 3 separate instances of _cache_).
+
+~~~ corefile
+lab.example.local {
+    cache
+    forward . 10.20.0.1
+}
+example.local {
+    cache
+    forward . 10.0.0.1
+}
+. {
+    cache
+    forward . /etc/resolv.conf
+}
+~~~
+
 Load balance all requests between three resolvers, one of which has a IPv6 address.
 
 ~~~ corefile

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -141,7 +141,10 @@ example.org {
 
 Send all requests within `lab.example.local.` to `10.20.0.1`, all requests within `example.local.` (and not in
 `lab.example.local.`) to `10.0.0.1`, all others requests to the servers defined in `/etc/resolv.conf`, and
-caches results.
+caches results. Note that a CoreDNS server configured with multiple _forward_ plugins in a server block will evaluate those
+forward plugins in the order they are listed when serving a request.  Therefore, subdomains should be
+placed before parent domains otherwise subdomain requests will be forwarded to the parent domain's upstream.
+Accordingly, in this example `lab.example.local` is before `example.local`, and `example.local` is before `.`.
 
 ~~~ corefile
 . {

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -19,8 +19,6 @@ is taken as a healthy upstream. The health check uses the same protocol as speci
 When *all* upstreams are down it assumes health checking as a mechanism has failed and will try to
 connect to a random upstream (which may or may not work).
 
-This plugin can only be used once per Server Block.
-
 ## Syntax
 
 In its most basic form, a simple forwarder uses this syntax:

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -23,7 +23,8 @@ func TestProxy(t *testing.T) {
 	defer s.Close()
 
 	c := caddy.NewTestController("dns", "forward . "+s.Addr)
-	f, err := parseForward(c)
+	fs, err := parseForward(c)
+	f := fs[0]
 	if err != nil {
 		t.Errorf("Failed to create forwarder: %s", err)
 	}
@@ -53,7 +54,8 @@ func TestProxyTLSFail(t *testing.T) {
 	defer s.Close()
 
 	c := caddy.NewTestController("dns", "forward . tls://"+s.Addr)
-	f, err := parseForward(c)
+	fs, err := parseForward(c)
+	f := fs[0]
 	if err != nil {
 		t.Errorf("Failed to create forwarder: %s", err)
 	}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -19,7 +19,7 @@ import (
 func init() { plugin.Register("forward", setup) }
 
 func setup(c *caddy.Controller) error {
-	fs, err := parseMultiForward(c)
+	fs, err := parseForward(c)
 	if err != nil {
 		return plugin.Error("forward", err)
 	}
@@ -80,26 +80,7 @@ func (f *Forward) OnShutdown() error {
 	return nil
 }
 
-func parseForward(c *caddy.Controller) (*Forward, error) {
-	var (
-		f   *Forward
-		err error
-		i   int
-	)
-	for c.Next() {
-		if i > 0 {
-			return nil, plugin.ErrOnce
-		}
-		i++
-		f, err = parseStanza(c)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return f, nil
-}
-
-func parseMultiForward(c *caddy.Controller) ([]*Forward, error) {
+func parseForward(c *caddy.Controller) ([]*Forward, error) {
 	var fs = []*Forward{}
 	for c.Next() {
 		f, err := parseStanza(c)

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -19,34 +19,47 @@ import (
 func init() { plugin.Register("forward", setup) }
 
 func setup(c *caddy.Controller) error {
-	f, err := parseForward(c)
+	fs, err := parseMultiForward(c)
 	if err != nil {
 		return plugin.Error("forward", err)
 	}
-	if f.Len() > max {
-		return plugin.Error("forward", fmt.Errorf("more than %d TOs configured: %d", max, f.Len()))
-	}
-
-	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		f.Next = next
-		return f
-	})
-
-	c.OnStartup(func() error {
-		return f.OnStartup()
-	})
-	c.OnStartup(func() error {
-		if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
-			if tapPlugin, ok := taph.(dnstap.Dnstap); ok {
-				f.tapPlugin = &tapPlugin
-			}
+	for i := range fs {
+		f := fs[i]
+		if f.Len() > max {
+			return plugin.Error("forward", fmt.Errorf("more than %d TOs configured: %d", max, f.Len()))
 		}
-		return nil
-	})
 
-	c.OnShutdown(func() error {
-		return f.OnShutdown()
-	})
+		if i == len(fs)-1 {
+			// last forward: point next to next plugin
+			dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+				f.Next = next
+				return f
+			})
+		} else {
+			// middle forward: point next to next forward
+			nextForward := fs[i+1]
+			dnsserver.GetConfig(c).AddPlugin(func(plugin.Handler) plugin.Handler {
+				f.Next = nextForward
+				return f
+			})
+		}
+
+		c.OnStartup(func() error {
+			return f.OnStartup()
+		})
+		c.OnStartup(func() error {
+			if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
+				if tapPlugin, ok := taph.(dnstap.Dnstap); ok {
+					f.tapPlugin = &tapPlugin
+				}
+			}
+			return nil
+		})
+
+		c.OnShutdown(func() error {
+			return f.OnShutdown()
+		})
+	}
 
 	return nil
 }
@@ -84,6 +97,18 @@ func parseForward(c *caddy.Controller) (*Forward, error) {
 		}
 	}
 	return f, nil
+}
+
+func parseMultiForward(c *caddy.Controller) ([]*Forward, error) {
+	var fs = []*Forward{}
+	for c.Next() {
+		f, err := parseStanza(c)
+		if err != nil {
+			return nil, err
+		}
+		fs = append(fs, f)
+	}
+	return fs, nil
 }
 
 func parseStanza(c *caddy.Controller) (*Forward, error) {

--- a/plugin/forward/setup_policy_test.go
+++ b/plugin/forward/setup_policy_test.go
@@ -24,7 +24,7 @@ func TestSetupPolicy(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -40,8 +40,8 @@ func TestSetupPolicy(t *testing.T) {
 			}
 		}
 
-		if !test.shouldErr && f.p.String() != test.expectedPolicy {
-			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedPolicy, f.p.String())
+		if !test.shouldErr && (len(fs) == 0 || fs[0].p.String() != test.expectedPolicy) {
+			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedPolicy, fs[0].p.String())
 		}
 	}
 }

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -34,19 +34,19 @@ func TestSetup(t *testing.T) {
 		{"forward . [2003::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, ""},
 		{"forward . 127.0.0.1 \n", false, ".", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, ""},
 		{"forward 10.9.3.0/18 127.0.0.1", false, "0.9.10.in-addr.arpa.", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, ""},
+		{`forward . ::1
+		forward com ::2`, false, ".", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, "plugin"},
 		// negative
 		{"forward . a27.0.0.1", true, "", nil, 0, options{hcRecursionDesired: true, hcDomain: "."}, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true, hcDomain: "."}, "unknown property"},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain\n}\n", true, "", nil, 0, options{hcRecursionDesired: true, hcDomain: "."}, "Wrong argument count or unexpected line ending after 'domain'"},
-		{`forward . ::1
-		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true, hcDomain: "."}, "plugin"},
 		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
 		{"forward xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true, hcDomain: "."}, "unable to normalize 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
 	}
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -62,19 +62,22 @@ func TestSetup(t *testing.T) {
 			}
 		}
 
-		if !test.shouldErr && f.from != test.expectedFrom {
-			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedFrom, f.from)
-		}
-		if !test.shouldErr && test.expectedIgnored != nil {
-			if !reflect.DeepEqual(f.ignored, test.expectedIgnored) {
-				t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedIgnored, f.ignored)
+		if !test.shouldErr {
+			f := fs[0]
+			if f.from != test.expectedFrom {
+				t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedFrom, f.from)
 			}
-		}
-		if !test.shouldErr && f.maxfails != test.expectedFails {
-			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedFails, f.maxfails)
-		}
-		if !test.shouldErr && f.opts != test.expectedOpts {
-			t.Errorf("Test %d: expected: %v, got: %v", i, test.expectedOpts, f.opts)
+			if test.expectedIgnored != nil {
+				if !reflect.DeepEqual(f.ignored, test.expectedIgnored) {
+					t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedIgnored, f.ignored)
+				}
+			}
+			if f.maxfails != test.expectedFails {
+				t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedFails, f.maxfails)
+			}
+			if f.opts != test.expectedOpts {
+				t.Errorf("Test %d: expected: %v, got: %v", i, test.expectedOpts, f.opts)
+			}
 		}
 	}
 }
@@ -101,7 +104,8 @@ func TestSetupTLS(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
+		f := fs[0]
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -150,7 +154,7 @@ nameserver 10.10.255.253`), 0666); err != nil {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -167,17 +171,18 @@ nameserver 10.10.255.253`), 0666); err != nil {
 			}
 		}
 
-		if !test.shouldErr {
-			for j, n := range test.expectedNames {
-				addr := f.proxies[j].addr
-				if n != addr {
-					t.Errorf("Test %d, expected %q, got %q", j, n, addr)
-				}
-			}
-		}
 		if test.shouldErr {
 			continue
 		}
+
+		f := fs[0]
+		for j, n := range test.expectedNames {
+			addr := f.proxies[j].addr
+			if n != addr {
+				t.Errorf("Test %d, expected %q, got %q", j, n, addr)
+			}
+		}
+
 		for _, p := range f.proxies {
 			p.health.Check(p) // this should almost always err, we don't care it shouldn't crash
 		}
@@ -200,7 +205,7 @@ func TestSetupMaxConcurrent(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -216,7 +221,11 @@ func TestSetupMaxConcurrent(t *testing.T) {
 			}
 		}
 
-		if !test.shouldErr && f.maxConcurrent != test.expectedVal {
+		if test.shouldErr {
+			continue
+		}
+		f := fs[0]
+		if f.maxConcurrent != test.expectedVal {
 			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedVal, f.maxConcurrent)
 		}
 	}
@@ -245,7 +254,7 @@ func TestSetupHealthCheck(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		f, err := parseForward(c)
+		fs, err := parseForward(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -259,8 +268,14 @@ func TestSetupHealthCheck(t *testing.T) {
 				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
 			}
 		}
-		if !test.shouldErr && (f.opts.hcRecursionDesired != test.expectedRecVal || f.proxies[0].health.GetRecursionDesired() != test.expectedRecVal ||
-			f.opts.hcDomain != test.expectedDomain || f.proxies[0].health.GetDomain() != test.expectedDomain) {
+
+		if test.shouldErr {
+			continue
+		}
+
+		f := fs[0]
+		if f.opts.hcRecursionDesired != test.expectedRecVal || f.proxies[0].health.GetRecursionDesired() != test.expectedRecVal ||
+			f.opts.hcDomain != test.expectedDomain || f.proxies[0].health.GetDomain() != test.expectedDomain {
 			t.Errorf("Test %d: expectedRec: %v, got: %v. expectedDomain: %s, got: %s. ", i, test.expectedRecVal, f.opts.hcRecursionDesired, test.expectedDomain, f.opts.hcDomain)
 		}
 	}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coredns/coredns/core/dnsserver"
-
 	"github.com/coredns/caddy"
+
+	"github.com/coredns/coredns/core/dnsserver"
 )
 
 func TestSetup(t *testing.T) {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/coredns/caddy"
-
 	"github.com/coredns/coredns/core/dnsserver"
 )
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This PR enables multiple forward plugin definitions in a server block.  
When processing a query, each forward instance is evaluated in their order in the Corefile.

This implementation chains the multiple forward plugin instances to each other via the existing `forward.Next`.  This keeps the amount of code change to a minimum.

An alternate solution is to create a slice of `Forward` structs, and loop through each one, essentially acting as a single plugin that checks multiple `Forward` instances.

### 2. Which issues (if any) are related?

This limitation comes up now and then in Q&A.  

### 3. Which documentation changes (if any) need to be made

### 4. Does this introduce a backward incompatible change or deprecation?

no