### PR TITLE
Add stale github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close Stale Issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+          stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+          days-before-stale: 30
+          days-before-close: 7


### PR DESCRIPTION
This PR adds stale github action, so that stale issues or PRs will be merged when there is no activity for 30+7 days.

We can polish on fine control after some experiments.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>