### PR TITLE
plugin/cache: Add refresh mode setting to serve_stale

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -37,7 +37,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
-    serve_stale [DURATION]
+    serve_stale [DURATION] [REFRESH_MODE]
 }
 ~~~
 
@@ -57,7 +57,12 @@ cache [TTL] [ZONES...] {
 * `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
   available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
   entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default duration is 1h.
+  stale responses as fresh. The default duration is 1h. **REFRESH_MODE** controls when the attempt to refresh
+  the cache happens. `verified` will first verify that an entry is still unavailable from the source before sending
+  the stale response to the client. `immediate` will immediately send the expired response to the client before
+  checking to see if the entry is available from the source. **REFRESH_MODE** defaults to `immediate`. Setting this
+  value to `verified` can lead to increased latency when serving stale responses, but will prevent stale entries
+  from ever being served if an updated response can be retrieved from the source.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -266,7 +266,7 @@ func TestServeFromStaleCache(t *testing.T) {
 	req.SetQuestion("cached.org.", dns.TypeA)
 	ctx := context.TODO()
 
-	// Cache example.org.
+	// Cache cached.org. with 60s TTL
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 	c.staleUpTo = 1 * time.Hour
 	c.ServeDNS(ctx, rec, req)
@@ -300,6 +300,80 @@ func TestServeFromStaleCache(t *testing.T) {
 		r.SetQuestion(tt.name, dns.TypeA)
 		if ret, _ := c.ServeDNS(ctx, rec, r); ret != tt.expectedResult {
 			t.Errorf("Test %d: expecting %v; got %v", i, tt.expectedResult, ret)
+		}
+	}
+}
+
+func TestServeFromStaleCacheFetchVerify(t *testing.T) {
+	c := New()
+	c.Next = ttlBackend(120)
+
+	req := new(dns.Msg)
+	req.SetQuestion("cached.org.", dns.TypeA)
+	ctx := context.TODO()
+
+	// Cache cached.org. with 120s TTL
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	c.staleUpTo = 1 * time.Hour
+	c.verifyStale = true
+	c.ServeDNS(ctx, rec, req)
+	if c.pcache.Len() != 1 {
+		t.Fatalf("Msg with > 0 TTL should have been cached")
+	}
+
+	tests := []struct {
+		name          string
+		upstreamRCode int
+		upstreamTtl   int
+		futureMinutes int
+		expectedRCode int
+		expectedTtl   int
+	}{
+		// After 1 minutes of initial TTL, we should see a cached response
+		{"cached.org.", dns.RcodeSuccess, 200, 1, dns.RcodeSuccess, 60}, // ttl = 120 - 60 -- not refreshed
+
+		// After the 2 more minutes, we should see upstream responses because upstream is available
+		{"cached.org.", dns.RcodeSuccess, 200, 3, dns.RcodeSuccess, 200},
+
+		// After the TTL expired, if the server fails we should get the cached entry
+		{"cached.org.", dns.RcodeServerFailure, 200, 7, dns.RcodeSuccess, 0},
+
+		// After 1 more minutes, if the server serves nxdomain we should see them (despite being within the serve stale period)
+		{"cached.org.", dns.RcodeNameError, 150, 8, dns.RcodeNameError, 150},
+	}
+
+	for i, tt := range tests {
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		c.now = func() time.Time { return time.Now().Add(time.Duration(tt.futureMinutes) * time.Minute) }
+
+		if tt.upstreamRCode == dns.RcodeSuccess {
+			c.Next = ttlBackend(tt.upstreamTtl)
+		} else if tt.upstreamRCode == dns.RcodeServerFailure {
+			// Make upstream fail, should now rely on cache during the c.staleUpTo period
+			c.Next = servFailBackend(tt.upstreamTtl)
+		} else if tt.upstreamRCode == dns.RcodeNameError {
+			c.Next = nxDomainBackend(tt.upstreamTtl)
+		} else {
+			t.Fatal("upstream code not implemented")
+		}
+
+		r := req.Copy()
+		r.SetQuestion(tt.name, dns.TypeA)
+		ret, _ := c.ServeDNS(ctx, rec, r)
+		if ret != tt.expectedRCode {
+			t.Errorf("Test %d: expected rcode=%v, got rcode=%v", i, tt.expectedRCode, ret)
+			continue
+		}
+		if ret == dns.RcodeSuccess {
+			recTtl := rec.Msg.Answer[0].Header().Ttl
+			if tt.expectedTtl != int(recTtl) {
+				t.Errorf("Test %d: expected TTL=%d, got TTL=%d", i, tt.expectedTtl, recTtl)
+			}
+		} else if ret == dns.RcodeNameError {
+			soaTtl := rec.Msg.Ns[0].Header().Ttl
+			if tt.expectedTtl != int(soaTtl) {
+				t.Errorf("Test %d: expected TTL=%d, got TTL=%d", i, tt.expectedTtl, soaTtl)
+			}
 		}
 	}
 }
@@ -451,6 +525,20 @@ func ttlBackend(ttl int) plugin.Handler {
 		m.Answer = []dns.RR{test.A(fmt.Sprintf("example.org. %d IN A 127.0.0.53", ttl))}
 		w.WriteMsg(m)
 		return dns.RcodeSuccess, nil
+	})
+}
+
+func servFailBackend(ttl int) plugin.Handler {
+	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Response, m.RecursionAvailable = true, true
+
+		m.Ns = []dns.RR{test.SOA(fmt.Sprintf("example.org. %d IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600", ttl))}
+
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return dns.RcodeServerFailure, nil
 	})
 }
 

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -166,11 +166,11 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 
 			case "serve_stale":
 				args := c.RemainingArgs()
-				if len(args) > 1 {
+				if len(args) > 2 {
 					return nil, c.ArgErr()
 				}
 				ca.staleUpTo = 1 * time.Hour
-				if len(args) == 1 {
+				if len(args) > 0 {
 					d, err := time.ParseDuration(args[0])
 					if err != nil {
 						return nil, err
@@ -179,6 +179,14 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, errors.New("invalid negative duration for serve_stale")
 					}
 					ca.staleUpTo = d
+				}
+				ca.verifyStale = false
+				if len(args) > 1 {
+					mode := strings.ToLower(args[1])
+					if mode != "immediate" && mode != "verify" {
+						return nil, fmt.Errorf("invalid value for serve_stale refresh mode: %s", mode)
+					}
+					ca.verifyStale = mode == "verify"
 				}
 			default:
 				return nil, c.ArgErr()

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -117,20 +117,25 @@ func TestSetup(t *testing.T) {
 
 func TestServeStale(t *testing.T) {
 	tests := []struct {
-		input     string
-		shouldErr bool
-		staleUpTo time.Duration
+		input       string
+		shouldErr   bool
+		staleUpTo   time.Duration
+		verifyStale bool
 	}{
-		{"serve_stale", false, 1 * time.Hour},
-		{"serve_stale 20m", false, 20 * time.Minute},
-		{"serve_stale 1h20m", false, 80 * time.Minute},
-		{"serve_stale 0m", false, 0},
-		{"serve_stale 0", false, 0},
+		{"serve_stale", false, 1 * time.Hour, false},
+		{"serve_stale 20m", false, 20 * time.Minute, false},
+		{"serve_stale 1h20m", false, 80 * time.Minute, false},
+		{"serve_stale 0m", false, 0, false},
+		{"serve_stale 0", false, 0, false},
+		{"serve_stale 0 verify", false, 0, true},
+		{"serve_stale 0 immediate", false, 0, false},
+		{"serve_stale 0 VERIFY", false, 0, true},
 		// fails
-		{"serve_stale 20", true, 0},
-		{"serve_stale -20m", true, 0},
-		{"serve_stale aa", true, 0},
-		{"serve_stale 1m nono", true, 0},
+		{"serve_stale 20", true, 0, false},
+		{"serve_stale -20m", true, 0, false},
+		{"serve_stale aa", true, 0, false},
+		{"serve_stale 1m nono", true, 0, false},
+		{"serve_stale 0 after nono", true, 0, false},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", fmt.Sprintf("cache {\n%s\n}", test.input))


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR adds an optional REFRESH_MODE parameter on the serve_stale configuration directive of the cache plugin. For context, please see #4309

### 2. Which issues (if any) are related?

Reasoning and RFC discussed at #4309
Other similar issues are #4097 and #4199.

### 3. Which documentation changes (if any) need to be made?

I updated the cache plugin README.md to document the new parameter on the PR.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
