### PR TITLE
Add github actions for docker release.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,22 @@
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          echo "Docker release ${{ github.event.release.tag_name }}:"
+          release=${{ github.event.release.tag_name }}
+          version=${release:1}
+          export DOCKER_LOGIN=${{ secrets.DOCKERHUB_USERNAME }}
+          export DOCKER_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }}
+          make VERSION=${version} DOCKER=coredns -f Makefile.docker release
+          docker images
+          make VERSION=${version} DOCKER=coredns -f Makefile.docker docker-push
+          echo "Docker release ${{ github.event.release.tag_name }} successful"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker Images
-        run: |
-          set -x -e
-          make VERSION=${RELEASE:1} DOCKER=yongtang -f Makefile.docker release
-          docker images
+        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker release
+      - name: Show Docker Images
+        run: docker images
       - name: Publish Docker Images
-        run: |
-          set -x -e
-          make VERSION=${RELEASE:1} DOCKER=yongtang -f Makefile.docker docker-push
+        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker docker-push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,20 +3,27 @@ name: Docker Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Release (e.g., v1.9.0)"
+        required: true
 
 jobs:
   docker-release:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_LOGIN: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      RELEASE: ${{ github.event.inputs.release || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v2
-      - run: |
+      - name: Build Docker Images
+        run: |
           set -x -e
-          echo "Docker release ${{ github.event.release.tag_name }}:"
-          release=${{ github.event.release.tag_name }}
-          version=${release:1}
-          export DOCKER_LOGIN=${{ secrets.DOCKERHUB_USERNAME }}
-          export DOCKER_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }}
-          make VERSION=${version} DOCKER=coredns -f Makefile.docker release
+          make VERSION=${RELEASE:1} DOCKER=yongtang -f Makefile.docker release
           docker images
-          make VERSION=${version} DOCKER=coredns -f Makefile.docker docker-push
-          echo "Docker release ${{ github.event.release.tag_name }} successful"
+      - name: Publish Docker Images
+        run: |
+          set -x -e
+          make VERSION=${RELEASE:1} DOCKER=yongtang -f Makefile.docker docker-push


### PR DESCRIPTION
Once a release/tag shown up in GitHub, an GitHub Action will be automatically triggered for docker release.

This will help avoid additional steps when releasing.

See comment https://github.com/coredns/coredns/issues/5144#issuecomment-1026257712

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>