### PR TITLE
plugin/rewrite: Write failures with ResponseReverter

### DIFF
--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -7,6 +7,35 @@ import (
 	"github.com/miekg/dns"
 )
 
+func TestRewriteFailure(t *testing.T) {
+	t.Parallel()
+	i, udp, _, err := CoreDNSServerAndPorts(`.:0 {
+        rewrite name regex (.*)\.test\.$ {1}. answer auto
+        # no next plugin to induce SERVFAIL
+    }`)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.test.", dns.TypeMX)
+
+	r, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// expect answer section with A record in it
+	if len(r.Question) == 0 {
+		t.Error("Invalid empty question section")
+	}
+	if r.Question[0].Name != "example.test." {
+		t.Errorf("Question section mismatch. expected \"example.test.\" got %q", r.Question[0].Name)
+	}
+}
+
 func TestRewrite(t *testing.T) {
 	t.Parallel()
 	corefile := `.:0 {

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -27,7 +27,6 @@ func TestRewriteFailure(t *testing.T) {
 		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 
-	// expect answer section with A record in it
 	if len(r.Question) == 0 {
 		t.Error("Invalid empty question section")
 	}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

When the next plugins do not write a response to the client, write one with the ResponseReverter.
If `server.ServeDNS` is left to write a response it will result in an answer mismatch.

### 2. Which issues (if any) are related?

Fixes #4407

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no
