### PR TITLE
Add Reviewdog to suggestion gofmt and whitespace changes in pull request

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,23 @@
+name: Reviewdog
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  gofmt:
+    name: Go Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: find . -not -path '*/\.git/*' -type f -name '*.go' -exec gofmt -s -w {} \+
+      - uses: reviewdog/action-suggester@v1
+
+  whitespace:
+    name: Whitespace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: find . -not -path '*/\.git/*' -type f -not -name '*.go' -exec sed -i 's/[[:space:]]\{1,\}$//' {} \+
+      - uses: reviewdog/action-suggester@v1


### PR DESCRIPTION
While we already automatically reformat gofmt and whitepsace changes,
they are invoked only regularly after the fact with only weekly runs.

This PR use reviewdog to automatically suggest the commit on the PR
itself so that code will be clean before committing into master branch.

See https://github.com/yongtang/coredns/pull/2 for example.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
