### PR TITLE
Stale-bot: Do not mark issues stale when pending maintainer action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,3 +15,6 @@ jobs:
           days-before-close: 7
           exempt-issue-labels: 'enhancement'
           exempt-all-milestones: true
+          labels-to-remove-when-unstale: 'answered,needs info,needs update'
+          any-of-issue-labels: 'answered,needs info'
+          any-of-pr-labels: 'needs update'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
-          stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
-          days-before-stale: 30
-          days-before-close: 7
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+          stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+          days-before-stale: 90
+          days-before-close: 15
           exempt-issue-labels: 'enhancement'
           exempt-all-milestones: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
-          stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
-          days-before-stale: 90
-          days-before-close: 15
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+          stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+          days-before-issue-stale: 60
+          days-before-issue-close: 15
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
           exempt-issue-labels: 'enhancement'
           exempt-all-milestones: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,11 +9,9 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
           stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
-          days-before-issue-stale: 60
-          days-before-issue-close: 15
-          days-before-pr-stale: 30
-          days-before-pr-close: 7
+          days-before-stale: 30
+          days-before-close: 7
           exempt-issue-labels: 'enhancement'
           exempt-all-milestones: true


### PR DESCRIPTION
If an issue has been labeled as 'answered' or 'needs info', or a PR has been labeled with 'needs update' by maintainers,
then it will be marked with stale after 30 days and +7 days to close.

Any activity in between will unstale, and 'answered,needs info' in issues and 'needs update' in PRs will be removed.

So authors can exempt the issue or PR from stale as long as there is some activity.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
