### PR TITLE
Fix a couple of code scanning alerts

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -163,12 +163,9 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		if !c.NextArg() {
 			return c.ArgErr()
 		}
-		n, err := strconv.Atoi(c.Val())
+		n, err := strconv.ParseUint(c.Val(), 10, 32)
 		if err != nil {
 			return err
-		}
-		if n < 0 {
-			return fmt.Errorf("max_fails can't be negative: %d", n)
 		}
 		f.maxfails = uint32(n)
 	case "health_check":

--- a/plugin/whoami/whoami.go
+++ b/plugin/whoami/whoami.go
@@ -45,7 +45,7 @@ func (wh Whoami) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	if state.QName() == "." {
 		srv.Hdr.Name = "_" + state.Proto() + state.QName()
 	}
-	port, _ := strconv.Atoi(state.Port())
+	port, _ := strconv.ParseUint(state.Port(), 10, 16)
 	srv.Port = uint16(port)
 	srv.Target = "."
 


### PR DESCRIPTION
This PR fixed a couple of code scanning alerts:

https://github.com/coredns/coredns/security/code-scanning?query=branch%3Amaster+is%3Aclosed

The findings have been there for some time, though it only alert once and I don't see any alert since then. I only noticed the alert when a scan was done on a different repo: https://github.com/yongtang/coredns/pull/2

(See `Code scanning results / CodeQL Failing after 4s — 2 new alerts including 2 high severity security `)

The CodeQL configuration may need to be adjusted to make it truly useful. Something to follow up later.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
