### PR TITLE
should reuse the request's OPT record and avoid OPT's Option removed

### DIFF
--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -149,7 +149,11 @@ func setDo(m *dns.Msg) {
 		return
 	}
 
-	o = &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+	o.Hdr.Name = "."
+	o.Hdr.Rrtype = dns.TypeOPT
+	o.SetVersion(0)
+	o.Hdr.Ttl &= 0xff00 // clear flags
+
 	o.SetDo()
 	o.SetUDPSize(defaultUDPBufSize)
 	m.Extra = append(m.Extra, o)


### PR DESCRIPTION
Signed-off-by: vanceli <vanceli@tencent.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

the cache plugin does DNSSEC lookups on cache misses after the `setDo` function is executed
```
// setDo sets the DO bit and UDP buffer size in the message m.
func setDo(m *dns.Msg) {
	o := m.IsEdns0()
	if o != nil {
		o.SetDo()
		o.SetUDPSize(defaultUDPBufSize)
		return
	}

	o = &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
	o.SetDo()
	o.SetUDPSize(defaultUDPBufSize)
	m.Extra = append(m.Extra, o)
}
This is a new OPT record without `Option` 

```
Then we will reuse the request's modified OPT record when the reply MSG `SetAndDo`. This will reduce the reply MSG's length because OPT's Option was removed before it was added to reply MSG. 

### 2. Which issues (if any) are related?

if a client does an edns request with a cookie, and the response DNS msg length is larger than 1468 bytes and is lower than 1480 bytes. the cache plugin will respond to compressed DNS msg, when cache missed, will response to uncompressed DNS msg 

### 3. Which documentation changes (if any) need to be made?
if we don't accept this PR, we can make notice with `the cache plugin don't keep EDNS's Option`

### 4. Does this introduce a backward incompatible change or deprecation?
