### PR TITLE
Revert "plugin/kubernetes: add wildcard warnings"

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -2,8 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"strings"
-	"sync/atomic"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -28,10 +26,6 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		extra   []dns.RR
 		err     error
 	)
-
-	if wildQuestion(state.Name()) {
-		atomic.AddUint64(&wildCount, 1)
-	}
 
 	switch state.QType() {
 	case dns.TypeA:
@@ -91,12 +85,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	m.Answer = append(m.Answer, records...)
 	m.Extra = append(m.Extra, extra...)
 	w.WriteMsg(m)
-
 	return dns.RcodeSuccess, nil
-}
-
-func wildQuestion(name string) bool {
-	return strings.HasPrefix(name, "*.") || strings.HasPrefix(name, "any.") || strings.Contains(name, ".*.") || strings.Contains(name, ".any.")
 }
 
 // Name implements the Handler interface.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -86,7 +86,6 @@ var (
 	errNoItems        = errors.New("no items found")
 	errNsNotExposed   = errors.New("namespace is not exposed")
 	errInvalidRequest = errors.New("invalid query name")
-	wildCount         uint64
 )
 
 // Services implements the ServiceBackend interface.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync/atomic"
-	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -60,25 +58,6 @@ func setup(c *caddy.Controller) error {
 	// get locally bound addresses
 	c.OnStartup(func() error {
 		k.localIPs = boundIPs(c)
-		return nil
-	})
-
-	wildWarner := time.NewTicker(10 * time.Second)
-	c.OnStartup(func() error {
-		go func() {
-			for {
-				select {
-				case <-wildWarner.C:
-					if wc := atomic.SwapUint64(&wildCount, 0); wc > 0 {
-						log.Warningf("%d deprecated wildcard queries received. Wildcard queries will no longer be supported in the next minor release.", wc)
-					}
-				}
-			}
-		}()
-		return nil
-	})
-	c.OnShutdown(func() error {
-		wildWarner.Stop()
 		return nil
 	})
 


### PR DESCRIPTION
Wildcard query support is removed in 1.9.0, so we can revert the deprecation warning now.

Reverts coredns/coredns#5030