### PR TITLE
plugin/grpc: Fix healthy proxy error case

### DIFF
--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -37,10 +37,10 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	var (
-		span, child      ot.Span
-		ret              *dns.Msg
-		upstreamErr, err error
-		i                int
+		span, child ot.Span
+		ret         *dns.Msg
+		err         error
+		i           int
 	)
 	span = ot.SpanFromContext(ctx)
 	list := g.list()
@@ -74,8 +74,6 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 			child.Finish()
 		}
 
-		upstreamErr = err
-
 		// Check if the reply is correct; if not return FormErr.
 		if !state.Match(ret) {
 			debug.Hexdumpf(ret, "Wrong reply for id: %d, %s %d", ret.Id, state.QName(), state.QType())
@@ -90,8 +88,10 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		return 0, nil
 	}
 
-	if upstreamErr != nil {
-		return dns.RcodeServerFailure, upstreamErr
+	// SERVFAIL if all healthy proxys returned errors.
+	if err != nil {
+		// just return the last error received
+		return dns.RcodeServerFailure, err
 	}
 
 	return dns.RcodeServerFailure, ErrNoHealthy


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?
 
This fixes what I believe was the original intent: To return a SERVFAIL if querying all healthy proxys results in an error.
Currently, upstreamErr is always nil, so this does not happen.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-2 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
