### PR TITLE
plugin/autopath: Don't panic on empty token

### DIFF
--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -2,6 +2,7 @@ package autopath
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -50,7 +51,7 @@ func autoPathParse(c *caddy.Controller) (*AutoPath, string, error) {
 			return ap, "", fmt.Errorf("no resolv-conf specified")
 		}
 		resolv := zoneAndresolv[len(zoneAndresolv)-1]
-		if resolv[0] == '@' {
+		if strings.HasPrefix(resolv, "@") {
 			mw = resolv[1:]
 		} else {
 			// assume file on disk

--- a/plugin/autopath/setup_test.go
+++ b/plugin/autopath/setup_test.go
@@ -33,6 +33,7 @@ func TestSetupAutoPath(t *testing.T) {
 		// negative
 		{`autopath kubernetes`, true, "", "", nil, "open kubernetes: no such file or directory"},
 		{`autopath`, true, "", "", nil, "no resolv-conf"},
+		{`autopath ""`, true, "", "", nil, "no such file"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Prevents a panic if autopath is configured with an empty filename.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-3 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
