### PR TITLE
plugin/forward: dont panic when from-zone cannot be normalized

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -94,6 +94,9 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	}
 	origFrom := f.from
 	zones := plugin.Host(f.from).NormalizeExact()
+	if len(zones) == 0 {
+		return f, fmt.Errorf("unable to normalize '%s'", f.from)
+	}
 	f.from = zones[0] // there can only be one here, won't work with non-octet reverse
 
 	if len(zones) > 1 {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -38,6 +38,7 @@ func TestSetup(t *testing.T) {
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
 		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
+		{"forward xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true}, "unable to normalize 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Don't panic when the `from` zone cannot be normalized.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-4 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
