### PR TITLE
plugin/grpc: dont panic when from-zone cannot be normalized

### DIFF
--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -56,7 +56,11 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 	if !c.Args(&g.from) {
 		return g, c.ArgErr()
 	}
-	g.from = plugin.Host(g.from).NormalizeExact()[0] // only the first is used.
+	normalized := plugin.Host(g.from).NormalizeExact()
+	if len(normalized) == 0 {
+		return g, fmt.Errorf("unable to normalize '%s'", g.from)
+	}
+	g.from = normalized[0] // only the first is used.
 
 	to := c.RemainingArgs()
 	if len(to) == 0 {

--- a/plugin/grpc/setup_test.go
+++ b/plugin/grpc/setup_test.go
@@ -30,6 +30,7 @@ func TestSetup(t *testing.T) {
 		{"grpc . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, "unknown property"},
 		{`grpc . ::1
 		grpc com ::2`, true, "", nil, "plugin"},
+		{"grpc xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 127.0.0.1", true, "", nil, "unable to normalize 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Don't panic when from-zone cannot be normalized.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-15 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
