### PR TITLE
plugin/metrics: Acknowledge other stats exported in README

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -40,6 +40,9 @@ Extra labels used are:
 If monitoring is enabled, queries that do not enter the plugin chain are exported under the fake
 name "dropped" (without a closing dot - this is never a valid domain name).
 
+Other plugins may export additional stats when the _prometheus_ plugin is enabled.  Those stats are documented in each
+plugin's README.
+
 This plugin can only be used once per Server Block.
 
 ## Syntax

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -8,7 +8,9 @@
 
 With *prometheus* you export metrics from CoreDNS and any plugin that has them.
 The default location for the metrics is `localhost:9153`. The metrics path is fixed to `/metrics`.
-The following metrics are exported:
+
+In addition to the default Go metrics exported by the [Prometheus Go client](https://prometheus.io/docs/guides/go-application/),
+the following metrics are exported:
 
 * `coredns_build_info{version, revision, goversion}` - info about CoreDNS itself.
 * `coredns_panics_total{}` - total number of panics.


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Document the existence of the Prometheus client default Go stats, and that other plugins may export additional stats in the README.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-11 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
