### PR TITLE
plugin/kubernetes: Don't panic on empty SRV segments

### DIFF
--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -82,6 +82,9 @@ func parseRequest(name, zone string) (r recordRequest, err error) {
 
 // stripUnderscore removes a prefixed underscore from s.
 func stripUnderscore(s string) string {
+	if len(s) == 0 {
+		return s
+	}
 	if s[0] != '_' {
 		return s
 	}

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -23,6 +23,8 @@ func TestParseRequest(t *testing.T) {
 		{"svc.inter.webs.tests.", "....."},
 		// bare pod type
 		{"pod.inter.webs.tests.", "....."},
+		// SRV request with empty segments
+		{"..webs.mynamespace.svc.inter.webs.tests.", "...webs.mynamespace.svc"},
 	}
 	for i, tc := range tests {
 		m := new(dns.Msg)


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Add a length check so we don't panic if a request is received with an empty port/protocol segment of a request.
Instead, act as if the empty segments are not present.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-9 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
