### PR TITLE
plugin/cache: Fix cache poisoning exploit

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -191,7 +191,7 @@ func TestCache(t *testing.T) {
 
 	c, crr := newTestCache(maxTTL)
 
-	for _, tc := range cacheTestCases {
+	for n, tc := range cacheTestCases {
 		m := tc.in.Msg()
 		m = cacheMsg(m, tc)
 
@@ -204,11 +204,15 @@ func TestCache(t *testing.T) {
 			crr.set(m, k, mt, c.pttl)
 		}
 
-		i, _ := c.get(time.Now().UTC(), state, "dns://:53")
+		i := c.getIgnoreTTL(time.Now().UTC(), state, "dns://:53")
 		ok := i != nil
 
-		if ok != tc.shouldCache {
-			t.Errorf("Cached message that should not have been cached: %s", state.Name())
+		if !tc.shouldCache && ok {
+			t.Errorf("Test %d: Cached message that should not have been cached: %s", n, state.Name())
+			continue
+		}
+		if tc.shouldCache && !ok {
+			t.Errorf("Test %d: Did not cache message that should have been cached: %s", n, state.Name())
 			continue
 		}
 

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -1,14 +1,18 @@
 package cache
 
 import (
+	"strings"
 	"time"
 
 	"github.com/coredns/coredns/plugin/cache/freq"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
 
 type item struct {
+	Name               string
+	QType              uint16
 	Rcode              int
 	AuthenticatedData  bool
 	RecursionAvailable bool
@@ -24,6 +28,10 @@ type item struct {
 
 func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i := new(item)
+	if len(m.Question) != 0 {
+		i.Name = strings.ToLower(m.Question[0].Name)
+		i.QType = m.Question[0].Qtype
+	}
 	i.Rcode = m.Rcode
 	i.AuthenticatedData = m.AuthenticatedData
 	i.RecursionAvailable = m.RecursionAvailable
@@ -86,4 +94,11 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool) *dns.Msg {
 func (i *item) ttl(now time.Time) int {
 	ttl := int(i.origTTL) - int(now.UTC().Sub(i.stored).Seconds())
 	return ttl
+}
+
+func (i *item) matches(state request.Request) bool {
+	if state.QType() == i.QType && state.Name() == i.Name {
+		return true
+	}
+	return false
 }

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -29,7 +29,7 @@ type item struct {
 func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i := new(item)
 	if len(m.Question) != 0 {
-		i.Name = strings.ToLower(m.Question[0].Name)
+		i.Name = m.Question[0].Name
 		i.QType = m.Question[0].Qtype
 	}
 	i.Rcode = m.Rcode
@@ -97,7 +97,7 @@ func (i *item) ttl(now time.Time) int {
 }
 
 func (i *item) matches(state request.Request) bool {
-	if state.QType() == i.QType && state.Name() == i.Name {
+	if state.QType() == i.QType && strings.EqualFold(state.QName(), i.Name) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

To protect against the possibility that two different valid DNS requests might produce the same hash key, verify that name and type match the request when retrieving an item from cache.

This also fixes a unit test coverage problem: where a defunct unused `get()` function was being tested instead of the get function actually used: `getIgnoreTTL()`.

### 2. Which issues (if any) are related?

* #3698
* #2072
* TOB-CDNS-8 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
