### PR TITLE
Fix response should keep option when request with it

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -196,6 +196,15 @@ func (r *Request) SizeAndDo(m *dns.Msg) bool {
 		if o.Do() {
 			mo.SetDo()
 		}
+
+		if len(mo.Option) > 0 {
+			return true
+		}
+
+		if len(o.Option) > 0 {
+			mo.Option = supportedOptions(o.Option)
+		}
+
 		return true
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

As we know that the cache plugin will cache items by removing OPT RR. Then the response from cached will reuse the request's OPT RR. 

When the response msg with edns0 and without Option is not from the cache plugin, the client received MSG size is different.

### 2. Which issues (if any) are related?

#5182

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
