### PR TITLE
plugin/template: Return SERVFAIL for zone-match regex-no-match case

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -17,23 +17,24 @@ template CLASS TYPE [ZONE...] {
     additional RR
     authority RR
     rcode CODE
-    fallthrough [ZONE...]
+    fallthrough [FALLTHROUGH-ZONE...]
 }
 ~~~
 
 * **CLASS** the query class (usually IN or ANY).
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
 * **ZONE** the zone scope(s) for this template. Defaults to the server zones.
-* **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
+* `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. 
+  Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
-  built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
+  built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply. Specifying no answer will result
+  in a response with an empty answer section.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
   per the `RcodeToString` map defined by the `miekg/dns` package in `msg.go`.
-* `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
-  If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for
-  those zones will be subject to fallthrough.
-
-At least one `answer` or `rcode` directive is needed (e.g. `rcode NXDOMAIN`).
+* `fallthrough` Continue with the next _template_ instance if the _template_'s **ZONE** matches a query name but no regex match.
+  If there is no next _template_, continue resolution with the next plugin. If **[FALLTHROUGH-ZONE...]** are listed (for example
+  `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough. Without
+  `fallthrough`, when the _template_'s **ZONE** matches a query but no regex match then a `SERVFAIL` response is returned.
 
 [Also see](#also-see) contains an additional reading list.
 

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -81,7 +81,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		data, match, fthrough := template.match(ctx, state)
 		if !match {
 			if !fthrough {
-				return dns.RcodeNameError, nil
+				return dns.RcodeServerFailure, nil
 			}
 			continue
 		}

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -587,8 +587,8 @@ func TestMultiSection(t *testing.T) {
 	if code == rcodeFallthrough {
 		t.Fatalf("TestMultiSection expected no fall through resolving something.example. IN MX")
 	}
-	if code != dns.RcodeNameError {
-		t.Fatalf("TestMultiSection expected NXDOMAIN resolving something.example. IN MX, got %v, %v", code, dns.RcodeToString[code])
+	if code != dns.RcodeServerFailure {
+		t.Fatalf("TestMultiSection expected SERVFAIL resolving something.example. IN MX, got %v, %v", code, dns.RcodeToString[code])
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This fixes the condition when a template's zone matches, but its match statements no not match the query, and there is no `fallthrough` specified.

The intent of the original code was to return `NXDOMAIN`, but it just returned to the plugin chain without actually writing a response to client, resulting in no response to the client.  However, `NXDOMAIN` is not always the correct response anyways (see discussion in #3034).

So, this PR makes this condition a `SERVFAIL`. So instead of hanging the client, a `SERVFAIL` is returned.

A correct `NXDOMAIN` / `NODATA` response can be implemented using multiple _template_ definitions using the `fallthrough` option.

The PR also cleans up some minor README formatting issues, readability and doc/behavior drift.

### 2. Which issues (if any) are related?

closes #3034

### 3. Which documentation changes (if any) need to be made?

Included

### 4. Does this introduce a backward incompatible change or deprecation?

No. Although I suppose some people could intentionally be abusing this bug as a black hole mechanism.