### PR TITLE
Harden tls on all places

### DIFF
--- a/plugin/pkg/tls/tls.go
+++ b/plugin/pkg/tls/tls.go
@@ -10,6 +10,22 @@ import (
 	"time"
 )
 
+func setTLSDefaults(ctls *tls.Config) {
+	ctls.MinVersion = tls.VersionTLS12
+	ctls.MaxVersion = tls.VersionTLS13
+	ctls.CipherSuites = []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+}
+
 // NewTLSConfigFromArgs returns a TLS config based upon the passed
 // in list of arguments. Typically these come straight from the
 // Corefile.
@@ -75,7 +91,10 @@ func NewTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
 		return nil, err
 	}
 
-	return &tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: roots}, nil
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: roots}
+	setTLSDefaults(tlsConfig)
+
+	return tlsConfig, nil
 }
 
 // NewTLSClientConfig returns a TLS config for a client connection
@@ -86,7 +105,10 @@ func NewTLSClientConfig(caPath string) (*tls.Config, error) {
 		return nil, err
 	}
 
-	return &tls.Config{RootCAs: roots}, nil
+	tlsConfig := &tls.Config{RootCAs: roots}
+	setTLSDefaults(tlsConfig)
+
+	return tlsConfig, nil
 }
 
 func loadRoots(caPath string) (*x509.CertPool, error) {

--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -19,22 +19,6 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func setTLSDefaults(tls *ctls.Config) {
-	tls.MinVersion = ctls.VersionTLS12
-	tls.MaxVersion = ctls.VersionTLS13
-	tls.CipherSuites = []uint16{
-		ctls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		ctls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		ctls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		ctls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		ctls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		ctls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		ctls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		ctls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		ctls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	}
-}
-
 func parseTLS(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
 
@@ -80,8 +64,6 @@ func parseTLS(c *caddy.Controller) error {
 		tls.ClientAuth = clientAuth
 		// NewTLSConfigFromArgs only sets RootCAs, so we need to let ClientCAs refer to it.
 		tls.ClientCAs = tls.RootCAs
-
-		setTLSDefaults(tls)
 
 		config.TLSConfig = tls
 	}


### PR DESCRIPTION
PR #2938 hardens tls though there are other places that uses TLS
as well and setTLSDefaults are not invoked in other paths.

This PR hardens tls on all places.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>