### PR TITLE
plugin/cache: Correct responses to Authenticated Data requests

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -107,6 +107,7 @@ type ResponseWriter struct {
 	server string // Server handling the request.
 
 	do         bool // When true the original request had the DO bit set.
+	ad         bool // When true the original request had the AD bit set.
 	prefetch   bool // When true write nothing back to the client.
 	remoteAddr net.Addr
 }
@@ -183,8 +184,10 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	res.Ns = filterRRSlice(res.Ns, ttl, w.do, false)
 	res.Extra = filterRRSlice(res.Extra, ttl, w.do, false)
 
-	if !w.do {
-		res.AuthenticatedData = false // unset AD bit if client is not OK with DNSSEC
+	if !w.do && !w.ad {
+		// unset AD bit if requester is not OK with DNSSEC
+		// But retain AD bit if requester set the AD bit in the request, per RFC6840 5.7-5.8
+		res.AuthenticatedData = false
 	}
 
 	return w.ResponseWriter.WriteMsg(res)

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -213,7 +213,7 @@ func TestCache(t *testing.T) {
 		}
 
 		if ok {
-			resp := i.toMsg(m, time.Now().UTC(), state.Do())
+			resp := i.toMsg(m, time.Now().UTC(), state.Do(), m.AuthenticatedData)
 
 			if err := test.Header(tc.Case, resp); err != nil {
 				t.Logf("Cache %v", resp)

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -17,6 +17,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	rc := r.Copy() // We potentially modify r, to prevent other plugins from seeing this (r is a pointer), copy r into rc.
 	state := request.Request{W: w, Req: rc}
 	do := state.Do()
+	ad := r.AuthenticatedData
 
 	zone := plugin.Zones(c.Zones).Matches(state.Name())
 	if zone == "" {
@@ -39,7 +40,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		ttl = i.ttl(now)
 	}
 	if i == nil {
-		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do}
+		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad}
 		return c.doRefresh(ctx, state, crr)
 	}
 	if ttl < 0 {
@@ -52,7 +53,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		cw := newPrefetchResponseWriter(server, state, c)
 		go c.doPrefetch(ctx, state, cw, i, now)
 	}
-	resp := i.toMsg(r, now, do)
+	resp := i.toMsg(r, now, do, ad)
 	w.WriteMsg(resp)
 
 	return dns.RcodeSuccess, nil

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -56,7 +56,7 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 // So we're forced to always set this to 1; regardless if the answer came from the cache or not.
 // On newer systems(e.g. ubuntu 16.04 with glib version 2.23), this issue is resolved.
 // So we may set this bit back to 0 in the future ?
-func (i *item) toMsg(m *dns.Msg, now time.Time, do bool) *dns.Msg {
+func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool) *dns.Msg {
 	m1 := new(dns.Msg)
 	m1.SetReply(m)
 
@@ -65,8 +65,10 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool) *dns.Msg {
 	// just set it to true.
 	m1.Authoritative = true
 	m1.AuthenticatedData = i.AuthenticatedData
-	if !do {
-		m1.AuthenticatedData = false // when DNSSEC was not wanted, it can't be authenticated data.
+	if !do && !ad {
+		// When DNSSEC was not wanted, it can't be authenticated data.
+		// However, retain the AD bit if the requester set the AD bit, per RFC6840 5.7-5.8
+		m1.AuthenticatedData = false
 	}
 	m1.RecursionAvailable = i.RecursionAvailable
 	m1.Rcode = i.Rcode


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Cache interferes with AD bit as part of un-DNSSEC-ifying responses to non-DNSSEC requests. As part of that process, we strip DNSSEC records and unset the AD bit. However, Per https://datatracker.ietf.org/doc/html/rfc6840#section-5.7 and https://datatracker.ietf.org/doc/html/rfc6840#section-5.8,
A requester may specify the AD bit without setting the DO bit, to indicate that it cares about the AD it in the response, but does not care to receive DNSSEC records.  **Therefore, we should retain the AD bit of the cached response whenever the requester sets the AD bit.**

~One thing I'm unsure of here is how the addition of the DO bit to the upstream query will affect the AD bit in the response.  That is, will the AD bit in a response differ between a query with AD and DO set vs AD set and DO unset?  If so, then this fix would not work and we may need to reassess #4085, since the AD bit in the response will always be as if the DO bit was set in the original request.  This depends on what the legacy usage of the AD bit is that rfc6840 is aiming to accommodate.~ 
I'm going to assume that the only reason a resolver will validly set the AD bit and not the DO bit is for the reason mentioned in rfc6840 - that a resolver wants to know if the data has been authenticated by a trusted source, and does not care to verify itself.

### 2. Which issues (if any) are related?

closes #5189

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
