### PR TITLE
Replace deprecated NewDeltaFIFO with NewDeltaFIFOWithOptions

### DIFF
--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -13,7 +13,7 @@ func NewIndexerInformer(lw cache.ListerWatcher, objType runtime.Object, h cache.
 	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
 
 	cfg := &cache.Config{
-		Queue:            cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, clientState),
+		Queue:            cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{KeyFunction: cache.MetaNamespaceKeyFunc, KnownObjects: clientState}),
 		ListerWatcher:    lw,
 		ObjectType:       objType,
 		FullResyncPeriod: defaultResyncPeriod,


### PR DESCRIPTION
Fixes  `cache.NewDeltaFIFO is deprecated:` issue

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
