### PR TITLE
Avoid expose arch-specific docker image tags

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -21,6 +21,9 @@
 ifeq (, $(shell which curl))
     $(error "No curl in $$PATH, please install")
 endif
+ifeq (, $(shell which jq))
+    $(error "No jq in $$PATH, please install")
+endif
 
 # VERSION is the version we should download and use.
 VERSION:=
@@ -31,8 +34,7 @@ GITHUB:=https://github.com/coredns/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
 LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:$(VERSION)~g")
-DOCKER_IMAGE_LIST_LATEST:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME)\-&:latest~g")
+DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
 
 all:
 	@echo Use the 'release' target to download released binaries and build containers per arch, 'docker-push' to build and push a multi arch manifest.
@@ -81,8 +83,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) build/docker/$${arch}  && \
-	    docker tag $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+	    docker build -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
 	done
 endif
 
@@ -97,15 +98,18 @@ else
 	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
 	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
 	for arch in $(LINUX_ARCH); do \
-		docker push $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
-		docker push $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+		docker push $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
 	done
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_LATEST)
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_VERSIONED)
 	for arch in $(LINUX_ARCH); do \
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME)-$${arch}:$(VERSION) ;\
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME)-$${arch}:latest ;\
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
+		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
 	done
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
+	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"$(DOCKER_LOGIN)\",\"password\":\"$(DOCKER_PASSWORD)\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \
+	for arch in $(LINUX_ARCH); do \
+		curl -X DELETE -H "Authorization: JWT $${TOKEN}" "https://hub.docker.com/v2/repositories/$(DOCKER_IMAGE_NAME)/tags/$${arch}-$(VERSION)/" ;\
+	done
 endif


### PR DESCRIPTION
This PR tries to address the issue in #5199
where there were confusion on which image tag to use.
Because the image-specific `coredns/coredns-{arch}:version` is not usable
for all arch other than arm64, confusion happens.

This PR fixes #5199.

This PR, for all arch-specific docker images:
1. Use `coredns/coredns:{arch}-version` (not `coredns/coredns-{arch}:version`)
   so that all images remain within the same docker repo (not multiple repos).
2. Push the arch-specific image `coredns/coredns:{arch}-version` to dockerhub.
3. Create manifest-specific `coredns/coredns:version` and `coredns/coredns:latest` from arch-specific images.
4. Push `coredns/coredns:version` and `coredns/coredns:latest` to dockerhub
5. Delete arch-specific image tags `coredns/coredns:{arch}-version` from dockerhub.

This will make arch-specific image tags invisible, but the  `coredns/coredns:version` and `coredns/coredns:latest`
will work as expected.

Note: https://hub.docker.com/repository/docker/yongtang/coredns is the example docker image build after this PR.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
