### PR TITLE
[plugin/rewrite] Refactor to satisfy security scan

### DIFF
--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -298,18 +298,19 @@ func newNameRule(nextAction string, args ...string) (Rule, error) {
 		return nil, fmt.Errorf("too few arguments for a name rule")
 	}
 	if len(args) == 2 {
-		matchType = "exact"
+		matchType = ExactMatch
 		rewriteQuestionFrom = plugin.Name(args[0]).Normalize()
 		rewriteQuestionTo = plugin.Name(args[1]).Normalize()
 	}
 	if len(args) >= 3 {
 		matchType = strings.ToLower(args[0])
-		rewriteQuestionFrom = plugin.Name(args[1]).Normalize()
-		rewriteQuestionTo = plugin.Name(args[2]).Normalize()
-	}
-	if len(args) >= 3 && matchType == RegexMatch {
-		rewriteQuestionFrom = args[1]
-		rewriteQuestionTo = args[2]
+		if matchType == RegexMatch {
+			rewriteQuestionFrom = args[1]
+			rewriteQuestionTo = args[2]
+		} else {
+			rewriteQuestionFrom = plugin.Name(args[1]).Normalize()
+			rewriteQuestionTo = plugin.Name(args[2]).Normalize()
+		}
 	}
 	if matchType == ExactMatch || matchType == SuffixMatch {
 		if !hasClosingDot(rewriteQuestionFrom) {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -307,7 +307,7 @@ func newNameRule(nextAction string, args ...string) (Rule, error) {
 		rewriteQuestionFrom = plugin.Name(args[1]).Normalize()
 		rewriteQuestionTo = plugin.Name(args[2]).Normalize()
 	}
-	if matchType == RegexMatch {
+	if len(args) >= 3 && matchType == RegexMatch {
 		rewriteQuestionFrom = args[1]
 		rewriteQuestionTo = args[2]
 	}


### PR DESCRIPTION
Re-arrange the logic so that it will not hit the false positive of DAST scan result from LTGM.com:
https://lgtm.com/projects/g/coredns/coredns/?mode=list

The re-arrange also avoid an extra assign (not a big diff, though).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>