### PR TITLE
Use tickers instead of time.After to avoid memory leak

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -84,12 +84,16 @@ func (h *Azure) Run(ctx context.Context) error {
 		return err
 	}
 	go func() {
+		delay := 1 * time.Minute
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
 		for {
+			timer.Reset(delay)
 			select {
 			case <-ctx.Done():
 				log.Debugf("Breaking out of Azure update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
-			case <-time.After(1 * time.Minute):
+			case <-timer.C:
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil {
 					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -82,12 +82,16 @@ func (h *CloudDNS) Run(ctx context.Context) error {
 		return err
 	}
 	go func() {
+		delay := 1 * time.Minute
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
 		for {
+			timer.Reset(delay)
 			select {
 			case <-ctx.Done():
 				log.Debugf("Breaking out of CloudDNS update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
-			case <-time.After(1 * time.Minute):
+			case <-timer.C:
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil /* Don't log error if ctx expired. */ {
 					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -84,12 +84,15 @@ func (h *Route53) Run(ctx context.Context) error {
 		return err
 	}
 	go func() {
+		timer := time.NewTimer(h.refresh)
+		defer timer.Stop()
 		for {
+			timer.Reset(h.refresh)
 			select {
 			case <-ctx.Done():
 				log.Debugf("Breaking out of Route53 update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
-			case <-time.After(h.refresh):
+			case <-timer.C:
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil /* Don't log error if ctx expired. */ {
 					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

`time.After` is not garbage collected after it fires  (See https://pkg.go.dev/time#After) 

This converts most uses of time.After to use tickers instead.

I don't think the remaining usages of time.After pose a potential leak problem, but can convert those too if we think it's better to just avoid using time.After all together .

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-10 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
