### PR TITLE
Clean up dependency on github.com/golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/coredns/caddy v1.1.1
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/farsightsec/golang-framestream v0.3.0
-	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/infobloxopen/go-trees v0.0.0-20200715205103-96a057b8dfb9
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
@@ -66,6 +65,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/plugin/dnstap/encoder.go
+++ b/plugin/dnstap/encoder.go
@@ -6,7 +6,7 @@ import (
 
 	tap "github.com/dnstap/golang-dnstap"
 	fs "github.com/farsightsec/golang-framestream"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // encoder wraps a golang-framestream.Encoder.


### PR DESCRIPTION
This PR cldean up remaining left over of github.com/golang/protobuf in coredns,
as github.com/golang/protobuf has been deprecated.

Note the github.com/golang/protobuf is now only indirectly
used by external libraries. Manually updating coredns' dependency to futher clean up has been tried.
However, it was not possible as external library usages of github.com/golang/protobuf are too interleaved.

This PR fixes #4939.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
