### PR TITLE
Add limit to ioutil.ReadAll for request body

### DIFF
--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -92,7 +92,7 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 }
 
 func toMsg(r io.ReadCloser) (*dns.Msg, error) {
-	buf, err := io.ReadAll(r)
+	buf, err := io.ReadAll(io.LimitReader(r, 65536))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds limit to ioutil.ReadAll for DoH request body
so that it will not be subject to large requests.

Addresses issue TOB-CDNS-14 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
