### PR TITLE
Update to avoid pseudo-random number

### DIFF
--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -3,6 +3,7 @@ package forward
 import (
 	"math/rand"
 	"sync/atomic"
+	"time"
 )
 
 // Policy defines a policy we use for selecting upstreams.
@@ -21,13 +22,13 @@ func (r *random) List(p []*Proxy) []*Proxy {
 	case 1:
 		return p
 	case 2:
-		if rand.Int()%2 == 0 {
+		if rn.Int()%2 == 0 {
 			return []*Proxy{p[1], p[0]} // swap
 		}
 		return p
 	}
 
-	perms := rand.Perm(len(p))
+	perms := rn.Perm(len(p))
 	rnd := make([]*Proxy, len(p))
 
 	for i, p1 := range perms {
@@ -62,3 +63,5 @@ func (r *sequential) String() string { return "sequential" }
 func (r *sequential) List(p []*Proxy) []*Proxy {
 	return p
 }
+
+var rn = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -1,9 +1,10 @@
 package forward
 
 import (
-	"math/rand"
 	"sync/atomic"
 	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/rand"
 )
 
 // Policy defines a policy we use for selecting upstreams.
@@ -64,4 +65,4 @@ func (r *sequential) List(p []*Proxy) []*Proxy {
 	return p
 }
 
-var rn = rand.New(rand.NewSource(time.Now().UnixNano()))
+var rn = rand.New(time.Now().UnixNano())

--- a/plugin/grpc/policy.go
+++ b/plugin/grpc/policy.go
@@ -1,9 +1,10 @@
 package grpc
 
 import (
-	"math/rand"
 	"sync/atomic"
 	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/rand"
 )
 
 // Policy defines a policy we use for selecting upstreams.
@@ -64,4 +65,4 @@ func (r *sequential) List(p []*Proxy) []*Proxy {
 	return p
 }
 
-var rn = rand.New(rand.NewSource(time.Now().UnixNano()))
+var rn = rand.New(time.Now().UnixNano())

--- a/plugin/grpc/policy.go
+++ b/plugin/grpc/policy.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"math/rand"
 	"sync/atomic"
+	"time"
 )
 
 // Policy defines a policy we use for selecting upstreams.
@@ -21,13 +22,13 @@ func (r *random) List(p []*Proxy) []*Proxy {
 	case 1:
 		return p
 	case 2:
-		if rand.Int()%2 == 0 {
+		if rn.Int()%2 == 0 {
 			return []*Proxy{p[1], p[0]} // swap
 		}
 		return p
 	}
 
-	perms := rand.Perm(len(p))
+	perms := rn.Perm(len(p))
 	rnd := make([]*Proxy, len(p))
 
 	for i, p1 := range perms {
@@ -62,3 +63,5 @@ func (r *sequential) String() string { return "sequential" }
 func (r *sequential) List(p []*Proxy) []*Proxy {
 	return p
 }
+
+var rn = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -1,7 +1,6 @@
 package loop
 
 import (
-	"math/rand"
 	"net"
 	"strconv"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/plugin/pkg/rand"
 )
 
 func init() { plugin.Register("loop", setup) }
@@ -84,4 +84,4 @@ func qname(zone string) string {
 	return dnsutil.Join(l1, l2, zone)
 }
 
-var r = rand.New(rand.NewSource(time.Now().UnixNano()))
+var r = rand.New(time.Now().UnixNano())

--- a/plugin/pkg/rand/rand.go
+++ b/plugin/pkg/rand/rand.go
@@ -1,0 +1,36 @@
+// Package rand is used for concurrency safe random number generator.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// Rand is used for concurrency safe random number generator.
+type Rand struct {
+	m sync.Mutex
+	r *rand.Rand
+}
+
+// New returns a new Rand from seed.
+func New(seed int64) *Rand {
+	return &Rand{r: rand.New(rand.NewSource(seed))}
+}
+
+// Int returns a non-negative pseudo-random int from the Source in Rand.r.
+func (r *Rand) Int() int {
+	r.m.Lock()
+	v := r.r.Int()
+	r.m.Unlock()
+	return v
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the
+// integers in the half-open interval [0,n) from the Source in Rand.r.
+func (r *Rand) Perm(n int) []int {
+	r.m.Lock()
+	v := r.r.Perm(n)
+	r.m.Unlock()
+	return v
+
+}


### PR DESCRIPTION
This PR update the usage of rand so that non-global seed is used.

Addresses issue TOB-CDNS-7 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
