### PR TITLE
[plugin/reload]: Change hash from md5 to sha512

### DIFF
--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -10,7 +10,7 @@ This plugin allows automatic reload of a changed _Corefile_.
 To enable automatic reloading of _zone file_ changes, use the `auto` plugin.
 
 This plugin periodically checks if the Corefile has changed by reading
-it and calculating its MD5 checksum. If the file has changed, it reloads
+it and calculating its SHA512 checksum. If the file has changed, it reloads
 CoreDNS with the new Corefile. This eliminates the need to send a SIGHUP
 or SIGUSR1 after changing the Corefile.
 
@@ -101,7 +101,7 @@ CoreDNS v1.7.0 and later does parse the Corefile and supports detecting changes 
 * `coredns_reload_failed_total{}` - counts the number of failed reload attempts.
 * `coredns_reload_version_info{hash, value}` - record the hash value during reload.
 
-Currently the type of `hash` is "md5", the `value` is the returned hash value.
+Currently the type of `hash` is "sha512", the `value` is the returned hash value.
 
 ## See Also
 

--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -3,7 +3,7 @@ package reload
 
 import (
 	"bytes"
-	"crypto/md5"
+	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"sync"
@@ -78,8 +78,8 @@ func hook(event caddy.EventName, info interface{}) error {
 		return err
 	}
 
-	md5sum := md5.Sum(parsedCorefile)
-	log.Infof("Running configuration MD5 = %x\n", md5sum)
+	sha512sum := sha512.Sum512(parsedCorefile)
+	log.Infof("Running configuration SHA512 = %x\n", sha512sum)
 
 	go func() {
 		tick := time.NewTicker(r.interval())
@@ -96,16 +96,16 @@ func hook(event caddy.EventName, info interface{}) error {
 					log.Warningf("Corefile parse failed: %s", err)
 					continue
 				}
-				s := md5.Sum(parsedCorefile)
-				if s != md5sum {
-					reloadInfo.Delete(prometheus.Labels{"hash": "md5", "value": hex.EncodeToString(md5sum[:])})
+				s := sha512.Sum512(parsedCorefile)
+				if s != sha512sum {
+					reloadInfo.Delete(prometheus.Labels{"hash": "sha512", "value": hex.EncodeToString(sha512sum[:])})
 					// Let not try to restart with the same file, even though it is wrong.
-					md5sum = s
+					sha512sum = s
 					// now lets consider that plugin will not be reload, unless appear in next config file
 					// change status of usage will be reset in setup if the plugin appears in config file
 					r.setUsage(maybeUsed)
 					_, err := instance.Restart(corefile)
-					reloadInfo.WithLabelValues("md5", hex.EncodeToString(md5sum[:])).Set(1)
+					reloadInfo.WithLabelValues("sha512", hex.EncodeToString(sha512sum[:])).Set(1)
 					if err != nil {
 						log.Errorf("Corefile changed but reload failed: %s", err)
 						failedCount.Add(1)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR changes the reload plugin's hash from md5 to sha512,
for the purpose of avoid using md5. MD5 is a weak hash algorithm
and for security reasons we will avoid using it.

### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-6 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

reload plugin.

### 4. Does this introduce a backward incompatible change or deprecation?

This is a potential backward incompatible change, so likely will have to wait until 1.10 release.