### PR TITLE
[plugin/azure] Deprecate the usage of plaintext secret in azure plugin

### DIFF
--- a/plugin/azure/README.md
+++ b/plugin/azure/README.md
@@ -14,11 +14,11 @@ record types. NS record type is not supported by azure private DNS.
 
 ~~~ txt
 azure RESOURCE_GROUP:ZONE... {
-    tenant TENANT_ID
-    client CLIENT_ID
-    secret CLIENT_SECRET
-    subscription SUBSCRIPTION_ID
-    environment ENVIRONMENT
+    tenant AZURE_TENANT_ID
+    client AZURE_CLIENT_ID
+    secret AZURE_CLIENT_SECRET
+    subscription AZURE_SUBSCRIPTION_ID
+    environment AZURE_ENVIRONMENT
     fallthrough [ZONES...]
     access private
 }
@@ -27,17 +27,30 @@ azure RESOURCE_GROUP:ZONE... {
 *   **RESOURCE_GROUP:ZONE** is the resource group to which the hosted zones belongs on Azure,
     and **ZONE** the zone that contains data.
 
-*   **CLIENT_ID** and **CLIENT_SECRET** are the credentials for Azure, and `tenant` specifies the
-    **TENANT_ID** to be used. **SUBSCRIPTION_ID** is the subscription ID. All of these are needed
-    to access the data in Azure.
+*   **AZURE_CLIENT_ID** and **AZURE_CLIENT_SECRET** are the credentials for Azure, and `tenant` specifies the
+    **AZURE_TENANT_ID** to be used. **AZURE_SUBSCRIPTION_ID** is the subscription ID. All of these are needed
+    to access the data in Azure. If `tenant`, `client`, `secret`, or `subscription` are not specified
+    in Corefile, then values will be obtained through environmental variables `AZURE_TENENT_ID`,
+    `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_SUBSCRIPTION_ID` respectively.
+    Note `secret` field in Corefile has been deprecated and may be removed in future releases. Environmental
+    variable **AZURE_CLIENT_SECRET** should be used instead.
 
-*  `environment` specifies the Azure **ENVIRONMENT**.
+*   **AZURE_ENVIRONMENT** specifies the Azure **Environment**. This value is optional, and can be specified
+    through `environment` field in Corefile, or through environmental variable `AZURE_ENVIRONMENT`.
 
 *   `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
     If **ZONES** is omitted, then fallthrough happens for all zones for which the plugin is
     authoritative.
 
 *   `access`  specifies if the zone is `public` or `private`. Default is `public`.
+
+## Authentication
+
+Azure plugin uses [environment-based authentication](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization#use-environment-based-authentication),
+where there is a list of accepted environmental variables. Note in additional to passing those environmental variables,
+it is also possible to use `tenant`, `client`, `subscription`, and `environment` to override corresponding environmental variables.
+Note `secret` field in Corefile has been deprecated and may be removed in future releases. Users should pass secret through
+environmental variable **AZURE_CLIENT_SECRET** instead.
 
 ## Examples
 
@@ -49,7 +62,7 @@ example.org {
       tenant 123abc-123abc-123abc-123abc
       client 123abc-123abc-123abc-234xyz
       subscription 123abc-123abc-123abc-563abc
-      secret mysecret
+      secret mysecret # Deprecated, uses environmental variable `AZURE_CLIENT_SECRET` instead.
       access private
     }
 }

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -310,7 +310,6 @@ func (h *Azure) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	if zone == "" {
 		return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 	}
-
 	zones, ok := h.zones[zone] // ok true if we are authoritative for the zone.
 	if !ok || zones == nil {
 		return dns.RcodeServerFailure, nil

--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/coredns/caddy"
@@ -12,7 +13,6 @@ import (
 
 	publicAzureDNS "github.com/Azure/azure-sdk-for-go/profiles/latest/dns/mgmt/dns"
 	privateAzureDNS "github.com/Azure/azure-sdk-for-go/profiles/latest/privatedns/mgmt/privatedns"
-	azurerest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
@@ -21,21 +21,22 @@ var log = clog.NewWithPlugin("azure")
 func init() { plugin.Register("azure", setup) }
 
 func setup(c *caddy.Controller) error {
-	env, keys, accessMap, fall, err := parse(c)
+	keys, accessMap, fall, err := parse(c)
 	if err != nil {
 		return plugin.Error("azure", err)
 	}
+
 	ctx, cancel := context.WithCancel(context.Background())
-
-	publicDNSClient := publicAzureDNS.NewRecordSetsClient(env.Values[auth.SubscriptionID])
-	if publicDNSClient.Authorizer, err = env.GetAuthorizer(); err != nil {
+	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	if err != nil {
 		return plugin.Error("azure", err)
 	}
 
-	privateDNSClient := privateAzureDNS.NewRecordSetsClient(env.Values[auth.SubscriptionID])
-	if privateDNSClient.Authorizer, err = env.GetAuthorizer(); err != nil {
-		return plugin.Error("azure", err)
-	}
+	publicDNSClient := publicAzureDNS.NewRecordSetsClient(os.Getenv(auth.SubscriptionID))
+	publicDNSClient.Authorizer = authorizer
+
+	privateDNSClient := privateAzureDNS.NewRecordSetsClient(os.Getenv(auth.SubscriptionID))
+	privateDNSClient.Authorizer = authorizer
 
 	h, err := New(ctx, publicDNSClient, privateDNSClient, keys, accessMap)
 	if err != nil {
@@ -54,12 +55,10 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, map[string]string, fall.F, error) {
+func parse(c *caddy.Controller) (map[string][]string, map[string]string, fall.F, error) {
 	resourceGroupMapping := map[string][]string{}
 	accessMap := map[string]string{}
 	resourceGroupSet := map[string]struct{}{}
-	azureEnv := azurerest.PublicCloud
-	env := auth.EnvironmentSettings{Values: map[string]string{}}
 
 	var fall fall.F
 	var access string
@@ -72,14 +71,14 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 		for i := 0; i < len(args); i++ {
 			parts := strings.SplitN(args[i], ":", 2)
 			if len(parts) != 2 {
-				return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
+				return resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
 			}
 			resourceGroup, zoneName = parts[0], parts[1]
 			if resourceGroup == "" || zoneName == "" {
-				return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
+				return resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
 			}
 			if _, ok := resourceGroupSet[resourceGroup+zoneName]; ok {
-				return env, resourceGroupMapping, accessMap, fall, c.Errf("conflicting zone: %q", args[i])
+				return resourceGroupMapping, accessMap, fall, c.Errf("conflicting zone: %q", args[i])
 			}
 
 			resourceGroupSet[resourceGroup+zoneName] = struct{}{}
@@ -91,50 +90,46 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 			switch c.Val() {
 			case "subscription":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				env.Values[auth.SubscriptionID] = c.Val()
+				os.Setenv(auth.SubscriptionID, c.Val())
 			case "tenant":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				env.Values[auth.TenantID] = c.Val()
+				os.Setenv(auth.TenantID, c.Val())
 			case "client":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				env.Values[auth.ClientID] = c.Val()
+				os.Setenv(auth.ClientID, c.Val())
 			case "secret":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				env.Values[auth.ClientSecret] = c.Val()
+				os.Setenv(auth.ClientSecret, c.Val())
+				log.Warningf("Save secret in Corefile has been deprecated, please use environmental variable 'AZURE_CLIENT_SECRET' instead")
 			case "environment":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				var err error
-				if azureEnv, err = azurerest.EnvironmentFromName(c.Val()); err != nil {
-					return env, resourceGroupMapping, accessMap, fall, c.Errf("cannot set azure environment: %q", err.Error())
-				}
+				os.Setenv(auth.EnvironmentName, c.Val())
 			case "fallthrough":
 				fall.SetZonesFromArgs(c.RemainingArgs())
 			case "access":
 				if !c.NextArg() {
-					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
+					return resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
 				access = c.Val()
 				if access != "public" && access != "private" {
-					return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid access value: can be public/private, found: %s", access)
+					return resourceGroupMapping, accessMap, fall, c.Errf("invalid access value: can be public/private, found: %s", access)
 				}
 				accessMap[resourceGroup+zoneName] = access
 			default:
-				return env, resourceGroupMapping, accessMap, fall, c.Errf("unknown property: %q", c.Val())
+				return resourceGroupMapping, accessMap, fall, c.Errf("unknown property: %q", c.Val())
 			}
 		}
 	}
 
-	env.Values[auth.Resource] = azureEnv.ResourceManagerEndpoint
-	env.Environment = azureEnv
-	return env, resourceGroupMapping, accessMap, fall, nil
+	return resourceGroupMapping, accessMap, fall, nil
 }

--- a/plugin/azure/setup_test.go
+++ b/plugin/azure/setup_test.go
@@ -64,7 +64,7 @@ func TestSetup(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.body)
-		if _, _, _, _, err := parse(c); (err == nil) == test.expectedError {
+		if _, _, _, err := parse(c); (err == nil) == test.expectedError {
 			t.Fatalf("Unexpected errors: %v in test: %d\n\t%s", err, i, test.body)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR deprecates the usage of plaintext secret in azure plugin.
Instead, this PR utilizes the environment-based authentication
that is recommended by azure:
https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization#use-environment-based-authentication

Note in order to maintain partial backward-compatibility, when `tenant`,
`client`, `secret`, `subscription` are specified, the values are saved
to environmental variables of `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
`AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID` respectively.

Note also only `secret` has been deprecated now, all other options can still
be used (will replace the environment variable when appropriate).

The purpose of this PR is to remove the plaintext secret in Corefile for security
reasons.


### 2. Which issues (if any) are related?

Addresses issue TOB-CDNS-12 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf

### 3. Which documentation changes (if any) need to be made?

plugin/azure

### 4. Does this introduce a backward incompatible change or deprecation?

plugin/azure

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>