### PR TITLE
Fix the unwanted command line options

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -1,7 +1,6 @@
 package dnsserver
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/caddy/caddyfile"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/flag"
 	"github.com/coredns/coredns/plugin/pkg/parse"
 	"github.com/coredns/coredns/plugin/pkg/transport"
 
@@ -20,8 +20,10 @@ const serverType = "dns"
 // Any flags defined here, need to be namespaced to the serverType other
 // wise they potentially clash with other server types.
 func init() {
-	flag.StringVar(&Port, serverType+".port", DefaultPort, "Default port")
-	flag.StringVar(&Port, "p", DefaultPort, "Default port")
+	f := flag.FlagSet()
+
+	f.StringVar(&Port, serverType+".port", DefaultPort, "Default port")
+	f.StringVar(&Port, "p", DefaultPort, "Default port")
 
 	caddy.RegisterServerType(serverType, caddy.ServerType{
 		Directives: func() []string { return Directives },

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -2,7 +2,6 @@
 package coremain
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin/pkg/flag"
 )
 
 func init() {
@@ -19,11 +19,13 @@ func init() {
 	caddy.Quiet = true // don't show init stuff from caddy
 	setVersion()
 
-	flag.StringVar(&conf, "conf", "", "Corefile to load (default \""+caddy.DefaultConfigFile+"\")")
-	flag.BoolVar(&plugins, "plugins", false, "List installed plugins")
-	flag.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
-	flag.BoolVar(&version, "version", false, "Show version")
-	flag.BoolVar(&dnsserver.Quiet, "quiet", false, "Quiet mode (no initialization output)")
+	f := flag.FlagSet()
+
+	f.StringVar(&conf, "conf", "", "Corefile to load (default \""+caddy.DefaultConfigFile+"\")")
+	f.BoolVar(&plugins, "plugins", false, "List installed plugins")
+	f.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
+	f.BoolVar(&version, "version", false, "Show version")
+	f.BoolVar(&dnsserver.Quiet, "quiet", false, "Quiet mode (no initialization output)")
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
@@ -35,10 +37,13 @@ func init() {
 // Run is CoreDNS's main() function.
 func Run() {
 	caddy.TrapSignals()
-	flag.Parse()
 
-	if len(flag.Args()) > 0 {
-		mustLogFatal(fmt.Errorf("extra command line arguments: %s", flag.Args()))
+	f := flag.FlagSet()
+
+	f.Parse(os.Args[1:])
+
+	if len(f.Args()) > 0 {
+		mustLogFatal(fmt.Errorf("extra command line arguments: %s", f.Args()))
 	}
 
 	log.SetOutput(os.Stdout)

--- a/plugin/pkg/flag/flag.go
+++ b/plugin/pkg/flag/flag.go
@@ -1,0 +1,22 @@
+// Package flag is used to return a FlagSet that can be used across
+// the application.
+package flag
+
+import (
+	"flag"
+	"os"
+	"sync"
+)
+
+var (
+	o sync.Once
+	f *flag.FlagSet
+)
+
+// FlagSet returns a FlagSet that is shared across the application.
+func FlagSet() *flag.FlagSet {
+	o.Do(func() {
+		f = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	})
+	return f
+}


### PR DESCRIPTION
This PR is related to #5223 where coredns incorrectly print out
command line options (such as log_dir) where those options was
never processed.
The reason was that coredns uses global "flag" for process
flags, yet some dependency libraries will also use the global
"flag" and injects the flags implicitly.
This PR uses flag.NewFlatSet to explicitly use a dedicated
FlagSet to process flags.
Before:
```
./coredns --help
Usage of ./coredns:
  -alsologtostderr
    	log to standard error as well as files
  -conf string
    	Corefile to load (default "Corefile")
  -dns.port string
    	Default port (default "53")
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -p string
    	Default port (default "53")
  -pidfile string
    	Path to write pid file
  -plugins
    	List installed plugins
  -quiet
    	Quiet mode (no initialization output)
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -v value
    	log level for V logs
  -version
    	Show version
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```
After:
```
./coredns --help
Usage of ./coredns:
  -conf string
    	Corefile to load (default "Corefile")
  -dns.port string
    	Default port (default "53")
  -p string
    	Default port (default "53")
  -pidfile string
    	Path to write pid file
  -plugins
    	List installed plugins
  -quiet
    	Quiet mode (no initialization output)
  -version
    	Show version

```
Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
