### PR TITLE
[plugin/log] Expand `{combined}` and `{common}` in log format

### DIFF
--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -53,15 +53,9 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			format := DefaultLogFormat
 
 			if strings.Contains(args[len(args)-1], "{") {
-				switch args[len(args)-1] {
-				case "{common}":
-					format = CommonLogFormat
-				case "{combined}":
-					format = CombinedLogFormat
-				default:
-					format = args[len(args)-1]
-				}
-
+				format = args[len(args)-1]
+				format = strings.Replace(format, "{common}", CommonLogFormat, -1)
+				format = strings.Replace(format, "{combined}", CombinedLogFormat, -1)
 				args = args[:len(args)-1]
 			}
 

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -129,6 +129,26 @@ func TestLogParse(t *testing.T) {
 		{`log {
 			unknown
 		}`, true, []Rule{}},
+		{`log example.org "{combined} {/forward/upstream}"`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    CombinedLogFormat + " {/forward/upstream}",
+			Class:     map[response.Class]struct{}{response.All: {}},
+		}}},
+		{`log example.org "{common} {/forward/upstream}"`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    CommonLogFormat + " {/forward/upstream}",
+			Class:     map[response.Class]struct{}{response.All: {}},
+		}}},
+		{`log example.org "{when} {combined} {/forward/upstream}"`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    "{when} " + CombinedLogFormat + " {/forward/upstream}",
+			Class:     map[response.Class]struct{}{response.All: {}},
+		}}},
+		{`log example.org "{when} {common} {/forward/upstream}"`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    "{when} " + CommonLogFormat + " {/forward/upstream}",
+			Class:     map[response.Class]struct{}{response.All: {}},
+		}}},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputLogRules)
@@ -141,7 +161,7 @@ func TestLogParse(t *testing.T) {
 				i, test.inputLogRules, err)
 		}
 		if len(actualLogRules) != len(test.expectedLogRules) {
-			t.Fatalf("Test %d expected %d no of Log rules, but got %d ",
+			t.Fatalf("Test %d expected %d no of Log rules, but got %d",
 				i, len(test.expectedLogRules), len(actualLogRules))
 		}
 		for j, actualLogRule := range actualLogRules {


### PR DESCRIPTION
This PR tries to address the issue raised in #5223 where `{combined}`
or `{common}` in log format will not expand when `{combined}` or `{common}`
is not the only token in the format.

This PR fixes #5223.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
