### PR TITLE
[plugin/clouddns] Add additional doc in explaining credentials file field is optional

### DIFF
--- a/plugin/clouddns/README.md
+++ b/plugin/clouddns/README.md
@@ -34,6 +34,9 @@ clouddns [ZONE:PROJECT_ID:HOSTED_ZONE_NAME...] {
     accessed.
 
 *   `credentials` is used for reading the credential file from **FILENAME** (normally a .json file).
+    This field is optional. If this field is not provided then authentication will be done automatically,
+    e.g., through environmental variable `GOOGLE_APPLICATION_CREDENTIALS`. Please see
+    Google Cloud's [authentication method](https://cloud.google.com/docs/authentication) for more details.
 
 *   `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
     If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin is


### PR DESCRIPTION
This PR adds additional doc in explaining credentials file field is optional,
in case user might be concerned to save a dedicated filename location in Corefile
(hacker may trace the filename and obtained the secret even without access to
live system if the filename is accessible, e.g., on a NFS share).

Technically since Corefile does not save plaintext secret for clouddns
(unlikely route53/azure), this is not too big of a concern (as far as I can see).
Still it is worth to pointing out in documentation.

Addresses issue TOB-CDNS-12 in https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>