### PR TITLE
Replace io.LimitReader with http.MaxBytesReader

### DIFF
--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -92,7 +92,7 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 }
 
 func toMsg(r io.ReadCloser) (*dns.Msg, error) {
-	buf, err := io.ReadAll(io.LimitReader(r, 65536))
+	buf, err := io.ReadAll(http.MaxBytesReader(nil, r, 65536))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously we use io.LimitReader to limit the number of bytes
from http request. However, there is a subtle difference between
io.LimitReader and io.ReadAll as io.LimitReader will return
a Reader, not a ReadCloser. As such the behavior will actually
be different in case of error handling (and when to close).
This may cause an issue if request body is not immediately available.

This PR changes io.LimitReader to http.MaxBytesReader
so that the behavior can be preserved (except the number of bytes).
See https://stackoverflow.com/a/52699702

Also see https://stackoverflow.com/questions/62430594/io-limitreader-eof-when-reading-http-body

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
