### PR TITLE
plugin/health : try to shutdown overloaded goroutine first to prevent warnings

### DIFF
--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	h := &health{Addr: ":0", stop: make(chan bool)}
+	h := &health{Addr: ":0"}
 
 	if err := h.OnStartup(); err != nil {
 		t.Fatalf("Unable to startup the health server: %v", err)
@@ -37,7 +37,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestHealthLameduck(t *testing.T) {
-	h := &health{Addr: ":0", stop: make(chan bool), lameduck: 250 * time.Millisecond}
+	h := &health{Addr: ":0", lameduck: 250 * time.Millisecond}
 
 	if err := h.OnStartup(); err != nil {
 		t.Fatalf("Unable to startup the health server: %v", err)

--- a/plugin/health/overloaded_test.go
+++ b/plugin/health/overloaded_test.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_health_overloaded_cancellation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	h := &health{
+		Addr: ts.URL,
+		stop: cancel,
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		h.overloaded(ctx)
+		stopped <- struct{}{}
+	}()
+
+	// wait for overloaded function to start atleast once
+	time.Sleep(1 * time.Second)
+
+	cancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("overloaded function should have been cancelled")
+	}
+}

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -17,7 +17,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("health", err)
 	}
 
-	h := &health{Addr: addr, stop: make(chan bool), lameduck: lame}
+	h := &health{Addr: addr, lameduck: lame}
 
 	c.OnStartup(h.OnStartup)
 	c.OnRestart(h.OnFinalShutdown)


### PR DESCRIPTION
There are two goroutines in the `health` plugin, one is running a health HTTP server and the second is pinging the health HTTP server = function [overloaded](https://github.com/coredns/coredns/blob/master/plugin/health/overloaded.go#L14). When CoreDNS is shutting down, the health HTTP server is shutdown first, and then the `overloaded` goroutine second, therefore there is a possibility for the second goroutine to call the already closed health HTTP server.

example of logs
```
.:53
CoreDNS-1.9.0
darwin/amd64, go1.17.6, 
[INFO] SIGTERM: Shutting down servers then terminating
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": dial tcp :8080: connect: connection refused
```

### 1. Why is this pull request needed and what does it do?
This PR is changing the `overloaded` function to support graceful shutdown, by accepting context which is cancelled by parent goroutine upon CoreDNS shutdown, this way we can gracefully cancel the `overloaded` function even in the middle of HTTP request

### 2. Which issues (if any) are related?
#5249

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
