### PR TITLE
Fix yaml lint warning introduced by cifuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -9,18 +9,18 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master # cifuzz can't be pinned https://github.com/google/oss-fuzz/issues/6836
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master  # cifuzz can't be pinned https://github.com/google/oss-fuzz/issues/6836
         with:
           oss-fuzz-project-name: "go-coredns"
           dry-run: false
       - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master # cifuzz can't be pinned
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master  # cifuzz can't be pinned
         with:
           oss-fuzz-project-name: "go-coredns"
           fuzz-seconds: 600
           dry-run: false
       - name: Upload Crash
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 #v2.3.1
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts


### PR DESCRIPTION
This PR fixes yamllint warning introduced by cifuzz.

/cc @nathannaveen, please see warnings in following actions run:

https://github.com/coredns/coredns/actions/runs/1981347318


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
