### PR TITLE
Change deprecated CircleCI image to supported ubuntu-2004:202201-02

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ initWorkingDir: &initWorkingDir
 
 integrationDefaults: &integrationDefaults
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202201-02
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
     - K8S_VERSION: v1.22.0


### PR DESCRIPTION
This PR changes deprecated CircleCI image of ubuntu-1604:201903-01
to supported ubuntu-2004:202201-02.

Received deprecation email, also see:
See https://circleci.com/blog/ubuntu-14-16-image-deprecation/

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
