### PR TITLE
[plugin/route53] Eliminate the unnecessary passing of provider chain

### DIFF
--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/coredns/caddy"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 )
 
 func TestSetupRoute53(t *testing.T) {
-	f = func(credential *credentials.Credentials, endpoint *string) route53iface.Route53API {
+	f = func(endpoint *string) route53iface.Route53API {
 		return fakeRoute53{}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
- Passed static credential is used as `opts` overriding all preceding config sources during the mergeConfigSrcs 
https://github.com/aws/aws-sdk-go/blob/92b5621bf8338d68f64c79cd094969d289428723/aws/session/session.go#L499

- The override prevents creating sessions using `envCfg` as we see in https://github.com/coredns/coredns/issues/5153

- Passed in aws_access_key pair and shared credential configs will be set as ENV variables and picked up as `envCfg`

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/5153

### 3. Which documentation changes (if any) need to be made?
plugin/route53

### 4. Does this introduce a backward incompatible change or deprecation?
nope
