### PR TITLE
plugin/bind: Don't immediately abort when getting the interface list fails

### DIFF
--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/log"
 )
 
 func setup(c *caddy.Controller) error {
@@ -17,7 +18,7 @@ func setup(c *caddy.Controller) error {
 	all := []string{}
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return plugin.Error("bind", fmt.Errorf("failed to get interfaces list: %s", err))
+		log.Warning(plugin.Error("bind", fmt.Errorf("failed to get interfaces list, cannot bind by interface name: %s", err)))
 	}
 
 	for c.Next() {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

If getting the interface list fails, don't abort immediately.  Abort later only if the configuration attempts to bind to an interface name.  In this way, problems with `net.Interfaces()` will not impact configurations that only bind on IP addresses.

### 2. Which issues (if any) are related?

closes #5133

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
