### PR TITLE
plugin/forward: configurable domain support for healthcheck

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,7 +50,7 @@ forward FROM TO... {
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
-    health_check DURATION [no_rec]
+    health_check DURATION [no_rec] [domain DOMAIN]
     max_concurrent MAX
 }
 ~~~
@@ -90,6 +90,8 @@ forward FROM TO... {
   * `<duration>` - use a different duration for health checking, the default duration is 0.5s.
   * `no_rec` - optional argument that sets the RecursionDesired-flag of the dns-query used in health checking to `false`.
     The flag is default `true`.
+  * `domain DOMAIN` - optional arguments that sets the domain of the dns-query used in health checking.
+    If not configured, the requested domain name is `.`. `DOMAIN` is used to configure the domain name.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
@@ -177,6 +179,18 @@ service with health checks.
     forward . tls://9.9.9.9 {
        tls_servername dns.quad9.net
        health_check 5s
+    }
+    cache 30
+}
+~~~
+
+Or configure other domain name for health check requests
+
+~~~ corefile
+. {
+    forward . tls://9.9.9.9 {
+       tls_servername dns.quad9.net
+       health_check 5s domain example.org
     }
     cache 30
 }

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -56,7 +56,7 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true}}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true, hcDomain: "."}}
 	return f
 }
 
@@ -234,6 +234,7 @@ type options struct {
 	forceTCP           bool
 	preferUDP          bool
 	hcRecursionDesired bool
+	hcDomain           string
 }
 
 var defaultTimeout = 5 * time.Second

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -242,3 +242,42 @@ func TestHealthNoMaxFails(t *testing.T) {
 		t.Errorf("Expected number of health checks to be %d, got %d", 0, i1)
 	}
 }
+
+func TestHealthDomain(t *testing.T) {
+	hcReadTimeout = 10 * time.Millisecond
+	readTimeout = 10 * time.Millisecond
+	defaultTimeout = 10 * time.Millisecond
+	hcWriteTimeout = 10 * time.Millisecond
+	hcDomain := "example.org."
+	i := uint32(0)
+	q := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		if atomic.LoadUint32(&q) == 0 { //drop the first query to trigger health-checking
+			atomic.AddUint32(&q, 1)
+			return
+		}
+		if r.Question[0].Name == hcDomain && r.RecursionDesired == true {
+			atomic.AddUint32(&i, 1)
+		}
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+	p := NewProxy(s.Addr, transport.DNS)
+	p.health.SetDomain(hcDomain)
+	f := New()
+	f.SetProxy(p)
+	defer f.OnShutdown()
+
+	req := new(dns.Msg)
+	req.SetQuestion(".", dns.TypeNS)
+
+	f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+
+	time.Sleep(20 * time.Millisecond)
+	i1 := atomic.LoadUint32(&i)
+	if i1 != 1 {
+		t.Errorf("Expected number of health checks with RecursionDesired==false to be %d, got %d", 1, i1)
+	}
+}

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -278,6 +278,6 @@ func TestHealthDomain(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	i1 := atomic.LoadUint32(&i)
 	if i1 != 1 {
-		t.Errorf("Expected number of health checks with RecursionDesired==false to be %d, got %d", 1, i1)
+		t.Errorf("Expected number of health checks with Domain==%s to be %d, got %d", hcDomain, 1, i1)
 	}
 }

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -29,7 +29,7 @@ func NewProxy(addr, trans string) *Proxy {
 		probe:     up.New(),
 		transport: newTransport(addr),
 	}
-	p.health = NewHealthChecker(trans, true)
+	p.health = NewHealthChecker(trans, true, ".")
 	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
 }

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -151,6 +151,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		if f.opts.forceTCP && transports[i] != transport.TLS {
 			f.proxies[i].health.SetTCPTransport()
 		}
+		f.proxies[i].health.SetDomain(f.opts.hcDomain)
 	}
 
 	return f, nil
@@ -187,11 +188,17 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return fmt.Errorf("health_check can't be negative: %d", dur)
 		}
 		f.hcInterval = dur
+		f.opts.hcDomain = "."
 
 		for c.NextArg() {
 			switch hcOpts := c.Val(); hcOpts {
 			case "no_rec":
 				f.opts.hcRecursionDesired = false
+			case "domain":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				f.opts.hcDomain = c.Val()
 			default:
 				return fmt.Errorf("health_check: unknown option %s", hcOpts)
 			}


### PR DESCRIPTION
Signed-off-by: hansedong <admin@yinxiaoluo.com>

### 1. Why is this pull request needed and what does it do?

Add support for configurable domains for the health_check configuration item in the forward plugin.

In some cases, CoreDNS is deployed in a company's internal network and cannot resolve `. NS` records. If health check is enabled, CoreDNS will use the `. NS` record as the request method for health check.

At this time, if the upstream DNS Server does not have the ability to resolve `. NS` records, or the response to resolve `. NS` records is very slow (for example, the DNS Server is not in the United States), but it is very fast to resolve other domestic domain names. In this case, using `. NS` records as a fixed detection method will cause the health check to fail all the time.

### 2. Which issues (if any) are related?

#5121 

### 3. Which documentation changes (if any) need to be made?

https://coredns.io/plugins/forward/

### 4. Does this introduce a backward incompatible change or deprecation?

No