### PR TITLE
plugin/k8s_external: Set authoritative bit in responses

### DIFF
--- a/plugin/k8s_external/apex.go
+++ b/plugin/k8s_external/apex.go
@@ -11,6 +11,7 @@ import (
 func (e *External) serveApex(state request.Request) (int, error) {
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
+	m.Authoritative = true
 	switch state.QType() {
 	case dns.TypeSOA:
 		m.Answer = []dns.RR{e.soa(state)}
@@ -37,6 +38,7 @@ func (e *External) serveSubApex(state request.Request) (int, error) {
 
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
+	m.Authoritative = true
 
 	// base is either dns. of ns1.dns (or another name), if it's longer return nxdomain
 	switch labels := dns.CountLabel(base); labels {

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -41,6 +41,9 @@ func TestApex(t *testing.T) {
 		if resp == nil {
 			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
 		}
+		if !resp.Authoritative {
+			t.Error("Expected authoritative answer")
+		}
 		if err := test.SortAndCheck(resp, tc); err != nil {
 			t.Error(err)
 		}

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -89,6 +89,7 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
+	m.Authoritative = true
 
 	if len(svc) == 0 {
 		m.Rcode = rcode

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -65,7 +65,7 @@ var tests = []test.Case{
 	{
 		Qname: "svc1.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
-		Extra:  []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
 	},
 	// SRV Service Not udp/tcp
 	{

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -45,6 +45,9 @@ func TestExternal(t *testing.T) {
 		if resp == nil {
 			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
 		}
+		if !resp.Authoritative {
+			t.Error("Expected authoritative answer")
+		}
 		if err = test.SortAndCheck(resp, tc); err != nil {
 			t.Error(err)
 		}
@@ -62,7 +65,7 @@ var tests = []test.Case{
 	{
 		Qname: "svc1.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
-		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+		Extra:  []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
 	},
 	// SRV Service Not udp/tcp
 	{


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This sets the authoritative bit in responses produced by _k8s_external_, since it is authoritative for the zone it serves.

### 2. Which issues (if any) are related?

closes: #5282

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
