### PR TITLE
plugin/backend: Fix direct CNAME loop check

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"strings"
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
@@ -28,7 +29,7 @@ func A(ctx context.Context, b ServiceBackend, zone string, state request.Request
 
 		switch what {
 		case dns.TypeCNAME:
-			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
+			if strings.EqualFold(state.Name(), dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
 				continue
 			}
@@ -102,7 +103,7 @@ func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Requ
 		switch what {
 		case dns.TypeCNAME:
 			// Try to resolve as CNAME if it's not an IP, but only if we don't create loops.
-			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
+			if strings.EqualFold(state.Name(), dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
 				continue
 			}
@@ -356,7 +357,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 
 		switch what {
 		case dns.TypeCNAME:
-			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
+			if strings.EqualFold(state.Name(), dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
 				continue
 			}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Fixes the direct CNAME loop check done in a few places in `backend_lookup.go`.  The intent of the check is to detect a CNAME that directly targets itself (e.g. per comments `// x CNAME x is a direct loop, don't add those`).

However the check was using`Name(X).Matches(Y)` which despite its name returns true if X is a _subdomain_ of Y.  Therefore for example, the CNAME `an.example.com. CNAME example.com.` would be be detected as a direct loop, and dropped from responses. 

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
