### PR TITLE
Pin docker image by SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:stable-slim@sha256:a04e8ec615db03154299695a65f7a85b8800a4e7878d241871419d3878e3662d
 
 RUN apt-get update && apt-get -uy upgrade
 RUN apt-get -y install ca-certificates && update-ca-certificates


### PR DESCRIPTION

Signed-off-by: neil <42328488+neilnaveen@users.noreply.github.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
- pinned docker image by SHA using crane digest https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_digest.md
- https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
