### PR TITLE
plugin/etcd: Fix multi record TXT lookups 

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -343,7 +343,7 @@ func CNAME(ctx context.Context, b ServiceBackend, zone string, state request.Req
 // TXT returns TXT records from Backend or an error.
 func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, truncated bool, err error) {
 
-	services, err := b.Services(ctx, state, true, opt)
+	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, false, err
 	}
@@ -398,9 +398,9 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			continue
 
 		case dns.TypeTXT:
-			if _, ok := dup[serv.Host]; !ok {
-				dup[serv.Host] = struct{}{}
-				return append(records, serv.NewTXT(state.QName())), truncated, nil
+			if _, ok := dup[serv.Text]; !ok {
+				dup[serv.Text] = struct{}{}
+				records = append(records, serv.NewTXT(state.QName()))
 			}
 
 		}

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -221,12 +221,14 @@ If you query the zone name for `SRV` now, you will get the following response:
 If you would like to use `TXT` records, you can set the following:
 ~~~
 % etcdctl put /skydns/local/skydns/x6 '{"ttl":60,"text":"this is a random text message."}'
+% etcdctl put /skydns/local/skydns/x7 '{"ttl":60,"text":"this is a another random text message."}'
 ~~~
 
 If you query the zone name for `TXT` now, you will get the following response:
 ~~~ sh
 % dig +short skydns.local TXT @localhost
 "this is a random text message."
+"this is a another random text message."
 ~~~
 
 ## See Also

--- a/plugin/etcd/group_test.go
+++ b/plugin/etcd/group_test.go
@@ -46,12 +46,15 @@ var servicesGroup = []*msg.Service{
 
 	{Host: "127.0.0.1", Key: "a.dom1.skydns.test.", Group: "g1"},
 	{Host: "127.0.0.2", Key: "b.sub.dom1.skydns.test.", Group: "g2"},
+
+	{Text: "foo", Key: "a.dom3.skydns.test.", Group: "g1"},
+	{Text: "bar", Key: "b.sub.dom3.skydns.test.", Group: "g1"},
 }
 
 var dnsTestCasesGroup = []test.Case{
 	// Groups
 	{
-		// hits the group 'g1' and only includes those records
+		// hits the group 'g1' and only includes those A records
 		Qname: "dom.skydns.test.", Qtype: dns.TypeA,
 		Answer: []dns.RR{
 			test.A("dom.skydns.test. 300 IN A 127.0.0.1"),
@@ -71,6 +74,14 @@ var dnsTestCasesGroup = []test.Case{
 		Qname: "dom1.skydns.test.", Qtype: dns.TypeA,
 		Answer: []dns.RR{
 			test.A("dom1.skydns.test. 300 IN A 127.0.0.1"),
+		},
+	},
+	{
+		// hits the group 'g1' and only includes those TXT records
+		Qname: "dom3.skydns.test.", Qtype: dns.TypeTXT,
+		Answer: []dns.RR{
+			test.TXT("dom3.skydns.test. 300 IN TXT bar"),
+			test.TXT("dom3.skydns.test. 300 IN TXT foo"),
 		},
 	},
 }

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -28,7 +28,8 @@ var services = []*msg.Service{
 	{Host: "10.0.0.2", Port: 8080, Key: "b.server1.prod.region1.skydns.test."},
 	{Host: "::1", Port: 8080, Key: "b.server6.prod.region1.skydns.test."},
 	// TXT record in server1.
-	{Host: "", Port: 8080, Text: "sometext", Key: "txt.server1.prod.region1.skydns.test."},
+	{Text: "sometext", Key: "a.txt.server1.prod.region1.skydns.test."},
+	{Text: "moretext", Key: "b.txt.server1.prod.region1.skydns.test."},
 	// Unresolvable internal name.
 	{Host: "unresolvable.skydns.test", Key: "cname.prod.region1.skydns.test."},
 	// Priority.
@@ -145,6 +146,7 @@ var dnsTestCases = []test.Case{
 	{
 		Qname: "txt.server1.prod.region1.skydns.test.", Qtype: dns.TypeTXT,
 		Answer: []dns.RR{
+			test.TXT("txt.server1.prod.region1.skydns.test. 303 IN TXT moretext"),
 			test.TXT("txt.server1.prod.region1.skydns.test. 303 IN TXT sometext"),
 		},
 	},
@@ -337,7 +339,7 @@ func TestLookup(t *testing.T) {
 		defer delete(t, etc, serv.Key)
 	}
 
-	for _, tc := range dnsTestCases {
+	for i, tc := range dnsTestCases {
 		m := tc.Msg()
 
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
@@ -345,7 +347,7 @@ func TestLookup(t *testing.T) {
 
 		resp := rec.Msg
 		if err := test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
+			t.Errorf("Test %d: %v", i, err)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

backend_lookup ignores TXT sub records in etcd.

* enable recursive get for TXT records
* fix duplicate check
* don't return after finding first record
* Add/adjust tests

### 2. Which issues (if any) are related?

fixes #5283

### 3. Which documentation changes (if any) need to be made?

included

### 4. Does this introduce a backward incompatible change or deprecation?
