### PR TITLE
plugin/etcd: Comment reason for non-exact match in direct cname loop checks

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -30,6 +30,7 @@ func A(ctx context.Context, b ServiceBackend, zone string, state request.Request
 		case dns.TypeCNAME:
 			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
+				// in etcd/skydns w.x CNAME x is also direct loop due to the "recursive" nature of search results
 				continue
 			}
 
@@ -104,6 +105,7 @@ func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Requ
 			// Try to resolve as CNAME if it's not an IP, but only if we don't create loops.
 			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
+				// in etcd/skydns w.x CNAME x is also direct loop due to the "recursive" nature of search results
 				continue
 			}
 
@@ -358,6 +360,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 		case dns.TypeCNAME:
 			if Name(state.Name()).Matches(dns.Fqdn(serv.Host)) {
 				// x CNAME x is a direct loop, don't add those
+				// in etcd/skydns w.x CNAME x is also direct loop due to the "recursive" nature of search results
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>


### 1. Why is this pull request needed and what does it do?

**This only adds some code  comments** that clarify the counterintuitive way we check for direct CNAME loops. When checking for direct CNAME loops (where a name points too itself) we don't do an exact comparison of name and target. Instead we do a subdomain check, to see if the CNAME is a subdomain or equal to the CNAME's target. This is because in etcd/skydns `w.x CNAME x` is also a direct loop due to the "recursive" nature of how skydns processes lookups.

I found this confusing enough to warrant a comment. 

### 2. Which issues (if any) are related?

replaces #5291

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
