### PR TITLE
plugin/file/cache: Add metadata for wildcard record responses

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -107,14 +107,16 @@ func computeTTL(msgTTL, minTTL, maxTTL time.Duration) time.Duration {
 type ResponseWriter struct {
 	dns.ResponseWriter
 	*Cache
-	state    request.Request
-	server   string // Server handling the request.
-	wildcard string // Wildcard record name that synthesized the result.
+	state  request.Request
+	server string // Server handling the request.
 
 	do         bool // When true the original request had the DO bit set.
 	ad         bool // When true the original request had the AD bit set.
 	prefetch   bool // When true write nothing back to the client.
 	remoteAddr net.Addr
+
+	wildcardFunc func() string // function to retrieve wildcard name that synthesized the result.
+
 }
 
 // newPrefetchResponseWriter returns a Cache ResponseWriter to be used in
@@ -203,7 +205,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 	switch mt {
 	case response.NoError, response.Delegation:
 		i := newItem(m, w.now(), duration)
-		i.wildcard = w.wildcard
+		i.wildcard = w.wildcardFunc()
 		if w.pcache.Add(key, i) {
 			evictions.WithLabelValues(w.server, Success, w.zonesMetricLabel).Inc()
 		}
@@ -214,7 +216,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 
 	case response.NameError, response.NoData, response.ServerError:
 		i := newItem(m, w.now(), duration)
-		i.wildcard = w.wildcard
+		i.wildcard = w.wildcardFunc()
 		if w.ncache.Add(key, i) {
 			evictions.WithLabelValues(w.server, Denial, w.zonesMetricLabel).Inc()
 		}

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -205,7 +205,9 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 	switch mt {
 	case response.NoError, response.Delegation:
 		i := newItem(m, w.now(), duration)
-		i.wildcard = w.wildcardFunc()
+		if w.wildcardFunc != nil {
+			i.wildcard = w.wildcardFunc()
+		}
 		if w.pcache.Add(key, i) {
 			evictions.WithLabelValues(w.server, Success, w.zonesMetricLabel).Inc()
 		}
@@ -216,7 +218,9 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 
 	case response.NameError, response.NoData, response.ServerError:
 		i := newItem(m, w.now(), duration)
-		i.wildcard = w.wildcardFunc()
+		if w.wildcardFunc != nil {
+			i.wildcard = w.wildcardFunc()
+		}
 		if w.ncache.Add(key, i) {
 			evictions.WithLabelValues(w.server, Denial, w.zonesMetricLabel).Inc()
 		}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
-
 	"github.com/miekg/dns"
 )
 
@@ -577,4 +577,60 @@ func TestComputeTTL(t *testing.T) {
 			t.Errorf("Test %v: Expected ttl %v but found: %v", i, test.expectedTTL, ttl)
 		}
 	}
+}
+
+func TestCacheWildcardMetadata(t *testing.T) {
+	c := New()
+	qname := "foo.bar.example.org."
+	wildcard := "*.bar.example.org."
+	c.Next = wildcardMetadataBackend(qname, wildcard)
+
+	req := new(dns.Msg)
+	req.SetQuestion(qname, dns.TypeA)
+
+	// 1. Test writing wildcard metadata retrieved from backend to the cache
+
+	ctx := metadata.ContextWithMetadata(context.TODO())
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	c.ServeDNS(ctx, w, req)
+	if c.pcache.Len() != 1 {
+		t.Errorf("Msg should have been cached")
+	}
+	_, k := key(qname, w.Msg, response.NoError)
+	i, _ := c.pcache.Get(k)
+	if i.(*item).wildcard != wildcard {
+		t.Errorf("expected wildcard reponse to enter cache with cache item's wildcard = %q, got %q", wildcard, i.(*item).wildcard)
+	}
+
+	// 2. Test retrieving the cached item from cache and writing its wildcard value to metadata
+
+	// reset context and response writer
+	ctx = metadata.ContextWithMetadata(context.TODO())
+	w = dnstest.NewRecorder(&test.ResponseWriter{})
+
+	c.ServeDNS(ctx, &test.ResponseWriter{}, req)
+	f := metadata.ValueFunc(ctx, "zone/wildcard")
+	if f == nil {
+		t.Fatal("expected metadata func for wildcard response retrieved from cache, got nil")
+	}
+	if f() != wildcard {
+		t.Errorf("after retrieving wildcard item from cache, expected \"zone/wildcard\" metadata value to be %q, got %q", wildcard, i.(*item).wildcard)
+	}
+}
+
+// wildcardMetadataBackend mocks a backend that reponds with a response for qname synthesized by wildcard
+// and sets the zone/wildcard metadata value
+func wildcardMetadataBackend(qname, wildcard string) plugin.Handler {
+	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Response, m.RecursionAvailable = true, true
+		m.Answer = []dns.RR{test.A(qname + " 300 IN A 127.0.0.1")}
+		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
+			return wildcard
+		})
+		w.WriteMsg(m)
+
+		return dns.RcodeSuccess, nil
+	})
 }

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/request"
 
@@ -38,6 +39,9 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	i := c.getIgnoreTTL(now, state, server)
 	if i == nil {
 		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad}
+		if f := metadata.ValueFunc(ctx, "file/wildcard"); f != nil {
+			crr.wildcard = f()
+		}
 		return c.doRefresh(ctx, state, crr)
 	}
 	ttl = i.ttl(now)

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -38,10 +38,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	ttl := 0
 	i := c.getIgnoreTTL(now, state, server)
 	if i == nil {
-		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad}
-		if f := metadata.ValueFunc(ctx, "file/wildcard"); f != nil {
-			crr.wildcard = f()
-		}
+		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do,  ad: ad, wildcardFunc: wildcardFunc(ctx)}
 		return c.doRefresh(ctx, state, crr)
 	}
 	ttl = i.ttl(now)
@@ -67,10 +64,27 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		cw := newPrefetchResponseWriter(server, state, c)
 		go c.doPrefetch(ctx, state, cw, i, now)
 	}
+
+	if i.wildcard != "" {
+		// Set wildcard source record name to metadata
+		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
+			return i.wildcard
+		})
+	}
+
 	resp := i.toMsg(r, now, do, ad)
 	w.WriteMsg(resp)
-
 	return dns.RcodeSuccess, nil
+}
+
+func wildcardFunc(ctx context.Context) func() string {
+	return func() string {
+		// Get wildcard source record name from metadata
+		if f := metadata.ValueFunc(ctx, "zone/wildcard"); f != nil {
+			return f()
+		}
+		return ""
+	}
 }
 
 func (c *Cache) doPrefetch(ctx context.Context, state request.Request, cw *ResponseWriter, i *item, now time.Time) {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -19,6 +19,7 @@ type item struct {
 	Answer             []dns.RR
 	Ns                 []dns.RR
 	Extra              []dns.RR
+	wildcard           string
 
 	origTTL uint32
 	stored  time.Time

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin/file/rrutil"
 	"github.com/coredns/coredns/plugin/file/tree"
+	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -214,7 +215,10 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 	// Found wildcard.
 	if wildElem != nil {
-		auth := ap.ns(do)
+		// set metadata value for the wildcard record that synthesized the result
+		metadata.SetValueFunc(ctx, "file/wildcard", func() string {
+			return wildElem.Name()
+		})
 
 		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 && qtype != dns.TypeCNAME {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
@@ -233,6 +237,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			return nil, ret, nil, NoData
 		}
 
+		auth := ap.ns(do)
 		if do {
 			// An NSEC is needed to say no longer name exists under this wildcard.
 			if deny, found := tr.Prev(qname); found {

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -216,7 +216,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	// Found wildcard.
 	if wildElem != nil {
 		// set metadata value for the wildcard record that synthesized the result
-		metadata.SetValueFunc(ctx, "file/wildcard", func() string {
+		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
 			return wildElem.Name()
 		})
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR adds metadata for responses that are synthesized by known wildcard records. It will be used by the _rrl_ plugin to limit wildcard flooding reflection attacks.

Employing Response Rate Limiting was recently recommended in a [CoreDNS security review by Trail of Bits](https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf), issue TOB-CDNS-13.  This can be done with  the external plugin _rrl_.  That implementation however has a [documented wildcard flooding vulnerability](https://github.com/coredns/rrl#bugs--known-issues--limitations). 

With this PR, if a zone served by _file_ contains the wildcard `*.bar.example.com` then a query for `foo.bar.example.com` will produce metadata named `zone/wildcard` = `*.bar.example.com`, since this is the wildcard record that synthesized the result.

This is implemented for _file_ plugin, and any plugins that use file's `zone.Lookup` (e.g. _azure_, _route53_, _cloudns_).
Also implemented for writing/retrieving those responses to/from cache.

The metadata value [will be used by the _rrl_ plugin](https://github.com/coredns/rrl/pull/34) to prevent attackers from evading response rate limits with wildcard flooding.

Please see the issue in coredns/rrl for more background.  https://github.com/coredns/rrl/issues/33


### 2. Which issues (if any) are related?

* TOB-CDNS-13 in Trail of Bits' Review: https://github.com/trailofbits/publications/blob/master/reviews/CoreDNS.pdf
* Issue in coredns/rrl: https://github.com/coredns/rrl/issues/33
* The PR in coredns/rrl (which is dependent on changes in this PR): https://github.com/coredns/rrl/pull/34

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
