### PR TITLE
Inactive PRs awaiting info from author for > 30 days should go stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,4 @@ jobs:
           exempt-all-milestones: true
           labels-to-remove-when-unstale: 'answered,needs info,needs update'
           any-of-issue-labels: 'answered,needs info'
-          any-of-pr-labels: 'needs update'
+          any-of-pr-labels: 'needs update,needs info'


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

PRs can be marked with `needs info` to indicate that more information is needed from the author to complete a review.
If such a PR is inactive for > 30 days, it should be marked stale.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
