### PR TITLE
plugin/template: fix rcode option documentation

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -28,7 +28,7 @@ template CLASS TYPE [ZONE...] {
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
-  per the `RcodeToString` map defined by the `miekg/dns` in `msg.go`.
+  per the `RcodeToString` map defined by the `miekg/dns` package in `msg.go`.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
   If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for
   those zones will be subject to fallthrough.

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -27,7 +27,8 @@ template CLASS TYPE [ZONE...] {
 * **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
-* `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
+* `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
+  per the `RcodeToString` map defined by the `miekg/dns` in `msg.go`.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
   If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for
   those zones will be subject to fallthrough.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

For the `rcode` option, correct the default value and reference the source of all valid values (in miekg/dns package).

### 2. Which issues (if any) are related?

closes #5327

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
