### PR TITLE
plugin/bind: add support for bind IPv4 subnet ip

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -82,6 +82,16 @@ You can exclude some addresses by their IP or interface name (The following will
 }
 ~~~
 
+If you want to bind one subnet hosts, you can use the following server block:
+
+```
+. {
+    bind 10.0.0.0/16
+}
+```
+
+Please make sure that these ip have been configured in advance on the network card.
+
 ## Bugs
 
 When defining more than one server block, take care not to bind more than one server to the same

--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -21,6 +21,7 @@ func TestSetup(t *testing.T) {
 		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, true},
 		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, false},
 		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, false},
+		{`bind 10.0.0.0/30`, []string{"10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3"}, false},
 	} {
 		c := caddy.NewTestController("dns", test.config)
 		err := setup(c)


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
 Add support for bind IPv4 subnet ip.
```
. {
    bind 10.0.0.0/16
}
```
### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
plugin/bind/README.md
### 4. Does this introduce a backward incompatible change or deprecation?
No.