### PR TITLE
plugin/kubernetes: Fix API connection timeout

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -284,8 +284,6 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 		checkSyncTicker := time.NewTicker(100 * time.Millisecond)
 		defer checkSyncTicker.Stop()
 		for {
-			timeoutTicker.Reset(timeout)
-			logTicker.Reset(logDelay)
 			select {
 			case <-checkSyncTicker.C:
 				if k.APIConn.HasSynced() {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Fixes API connection timeout. Prior to fix the connection would never timeout, resulting in CoreDNS not starting until API successfully connects.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
