### PR TITLE
Don't add OPT RR to non-EDNS0 queries

### DIFF
--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -5,6 +5,7 @@
 ## Description
 *bufsize* limits a requester's UDP payload size.
 It prevents IP fragmentation, mitigating certain DNS vulnerabilities.
+This will only affect query replies to EDNS0-capable clients; i.e. queries that have an OPT RR.
 
 ## Syntax
 ```txt
@@ -36,4 +37,3 @@ Enable limiting the buffer size as an authoritative nameserver:
 
 ## Considerations
 - Setting 1232 bytes to bufsize may avoid fragmentation on the majority of networks in use today, but it depends on the MTU of the physical network links.
-- For now, if a client does not use EDNS, this plugin adds OPT RR.

--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -5,7 +5,7 @@
 ## Description
 *bufsize* limits a requester's UDP payload size.
 It prevents IP fragmentation, mitigating certain DNS vulnerabilities.
-This will only affect query replies to EDNS0-capable clients; i.e. queries that have an OPT RR.
+This will only affect queries that have an OPT RR.
 
 ## Syntax
 ```txt

--- a/plugin/bufsize/bufsize.go
+++ b/plugin/bufsize/bufsize.go
@@ -19,9 +19,6 @@ type Bufsize struct {
 func (buf Bufsize) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if option := r.IsEdns0(); option != nil {
 		option.SetUDPSize(uint16(buf.Size))
-	} else {
-		// If a client does not use EDNS, add it
-		r.SetEdns0(uint16(buf.Size), false)
 	}
 
 	return plugin.NextOrFailure(buf.Name(), buf.Next, ctx, w, r)

--- a/plugin/bufsize/bufsize_test.go
+++ b/plugin/bufsize/bufsize_test.go
@@ -31,7 +31,7 @@ func TestBufsize(t *testing.T) {
 			outgoingBufsize: 512,
 			expectedErr:     nil,
 		},
-		// If EDNS is not enabled, this plugin adds it
+		// If EDNS is not enabled, this plugin should not add it
 		{
 			next:            whoami.Whoami{},
 			qname:           ".",
@@ -65,6 +65,14 @@ func TestBufsize(t *testing.T) {
 					}
 				} else {
 					t.Errorf("Test %d: Not found OPT RR.", i)
+				}
+			}
+		}
+
+		if tc.inputBufsize == 0 {
+			for _, extra := range req.Extra {
+				if _, ok := extra.(*dns.OPT); ok {
+					t.Errorf("Test %d: Found OPT RR on reply to query with no OPT RR.", i)
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Patrick W. Healy <phealy@phealy.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It stops the bufsize plugin from adding an OPT RR to replies where the query didn't contain an OPT RR, making the bufsize plugin compliant with [RFC 6891 section 7](https://www.rfc-editor.org/rfc/rfc6891#section-7): ["Lack of presence of an OPT record in a request MUST be taken as an indication that the requestor does not implement any part of this specification and that the responder MUST NOT include an OPT record in its response."](https://www.rfc-editor.org/rfc/rfc6891#:~:text=Lack%20of%20presence%20of%20an%20OPT%20record%20in%20a%20request%20MUST%20be%20taken%20as%20an%0A%20%20%20indication%20that%20the%20requestor%20does%20not%20implement%20any%20part%20of%20this%0A%20%20%20specification%20and%20that%20the%20responder%20MUST%20NOT%20include%20an%20OPT%20record%0A%20%20%20in%20its%20response.)

Additionally, this behavior would cause the server to send responses that could be larger than the client could handle; non-EDNS0 clients only expect 512 bytes in a UDP reply, but if the plugin was enabled the server would send UDP packets of up to <bufsize>, causing resolution failures for any reply that was less than 512 bytes but less or equal than the configured value for bufsize.

### 2. Which issues (if any) are related?
#5366 - Bufsize plugin causes non-RFC-compliant and sometimes too-large responses to non-EDNS0 clients

### 3. Which documentation changes (if any) need to be made?
Only README.md, which is already updated.

### 4. Does this introduce a backward incompatible change or deprecation?
No