### PR TITLE
New RoundRobin plugin added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Currently CoreDNS is able to:
 * Serve zone data from a file; both DNSSEC (NSEC only) and DNS are supported (*file* and *auto*).
 * Retrieve zone data from primaries, i.e., act as a secondary server (AXFR only) (*secondary*).
 * Sign zone data on-the-fly (*dnssec*).
+* Advanced round-robin load balancing (*roundrobin*).
 * Load balancing of responses (*loadbalance*).
 * Allow for zone transfers, i.e., act as a primary server (*file* + *transfer*).
 * Automatically load zone files from disk (*auto*).

--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -33,6 +33,7 @@ var Directives = []string{
 	"acl",
 	"any",
 	"chaos",
+	"roundrobin",
 	"loadbalance",
 	"cache",
 	"rewrite",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"
+	_ "github.com/coredns/coredns/plugin/roundrobin"
 	_ "github.com/coredns/coredns/plugin/route53"
 	_ "github.com/coredns/coredns/plugin/secondary"
 	_ "github.com/coredns/coredns/plugin/sign"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -42,6 +42,7 @@ dns64:dns64
 acl:acl
 any:any
 chaos:chaos
+roundrobin:roundrobin
 loadbalance:loadbalance
 cache:cache
 rewrite:rewrite

--- a/plugin/roundrobin/README.md
+++ b/plugin/roundrobin/README.md
@@ -1,0 +1,142 @@
+# RoundRobin
+
+## Name
+*roundrobin* - plugin provides several round-robin strategies that shuffle A and AAAA 
+records in a DNS response.
+
+## Description
+The roundrobin plugin implements [round-robin](https://en.wikipedia.org/wiki/Round-robin_scheduling)
+strategies on returned A and AAAA records. 
+```
+roundrobin [STRATEGY]
+```
+`[STRATEGY]` defines how A and AAAA will be shuffled. If there are records other than A or AAAA in the
+answer, they are moved to the end of the answer section in the exact order as they were in the answer 
+section before the roundrobin applied. 
+- [stateful](#stateful)
+- [stateless](#stateless)
+- [random](#random)
+
+## Syntax
+~~~
+roundrobin [STRATEGY]
+~~~
+For each zone that you want to shake for; the default strategy is stateful.
+
+## Examples
+### stateful
+Stateful will probably be the strategy you expect from a round-robin. Each query rotates the A or AAAA records 
+by one position. The RoundRobin plugin remembers the positions of the last query for ten minutes and manages changes 
+to the answers: clears non-existing records, adds new ones, shuffling (rotation by one position) and garbage collection.
+
+_NOTE: key to the request state is the pair `EDNS0_SUBNET` and request `domain name`, [see more](https://en.wikipedia.org/wiki/EDNS_Client_Subnet)._
+
+#### Example
+~~~ corefile
+.:5053 {
+    log
+    roundrobin stateful
+}
+~~~
+After you run the `dig` command repeatedly, the records for the `myhosts.com` domain rotate. The roundrobin plugin can 
+handle the number of records or individual records changing. In addition, garbage collector clears the records every ten 
+minutes of inactivity.
+
+```shell
+# runnig against a local hosts plugin `hosts etchosts` 
+
+dig @localhost -p 5053 myhost.com                                 dig @localhost -p 5053 myhost.com                        
+myhost.com.             3600    IN      A       200.0.0.2         myhost.com.             3600    IN      A       200.0.0.3
+myhost.com.             3600    IN      A       200.0.0.3         myhost.com.             3600    IN      A       200.0.0.4
+myhost.com.             3600    IN      A       200.0.0.4         myhost.com.             3600    IN      A       200.0.0.1
+myhost.com.             3600    IN      A       200.0.0.1         myhost.com.             3600    IN      A       200.0.0.2
+
+dig @localhost -p 5053 myhost.com                                 dig @localhost -p 5053 myhost.com                        
+myhost.com.             3600    IN      A       200.0.0.4         myhost.com.             3600    IN      A       200.0.0.1
+myhost.com.             3600    IN      A       200.0.0.1         myhost.com.             3600    IN      A       200.0.0.2
+myhost.com.             3600    IN      A       200.0.0.2         myhost.com.             3600    IN      A       200.0.0.3
+myhost.com.             3600    IN      A       200.0.0.3         myhost.com.             3600    IN      A       200.0.0.4
+```
+
+### stateless
+Stateless is useful where you require extremely high scalability, customization, or you cannot use stateful. The state 
+is stored on the client and like in HTTP, you send the records back to CoreDNS in the DNS query having the section Extra 
+records filled. ( `EDNS0_LOCAL`, see GO example below). The `stateless` plugin takes care of shuffling, 
+clears non-existing records and adds new ones. As in HTTP, the client must store the response in its memory for the next 
+request. Sending client data must be in form of text encoded as a byte-array where `_rr_state=` is a constant 
+identifying the state followed by the json containing the client state, see: `_rr_state={"ip":["10.0.0.1","10.2.2.1","10.1.1.2"]}` 
+
+#### Example
+~~~ corefile
+.:5053 {
+    log
+    roundrobin stateless
+}
+~~~
+The state must be managed on the client side. The following example creates a simple DNS query that can be consumed by 
+the stateless plugin.
+```go
+type State struct {
+    IPs    []string `json:"ip"`
+}
+
+func statelessExchange(state State) (r *dns.Msg, err error){
+    json, _ := json.Marshal(state)
+    opt := new(dns.EDNS0_LOCAL)
+    opt.Data = append([]byte("_rr_state="),json...)
+    ext := new(dns.OPT)
+    ext.Hdr.Name = "."
+    ext.Hdr.Rrtype = dns.TypeOPT
+    ext.Option = append(ext.Option, opt)
+    msg := new(dns.Msg)
+    msg.SetQuestion("myhost.com.", dns.TypeA)
+    msg.Extra = append(msg.Extra, ext)
+    return dns.Exchange(msg, fmt.Sprintf("%s:%v", dnsServer, port))
+}
+```
+
+```
+# runnig against a local hosts plugin `hosts etchosts` 
+
+_rr_state={"ip":[]}                                                 _rr_state={"ip":["200.0.0.2","200.0.0.3","200.0.0.4","200.0.0.1"]}
+myhost.com.   3600    IN      A       200.0.0.2                       myhost.com.   3600    IN      A       200.0.0.3          
+myhost.com.   3600    IN      A       200.0.0.3                       myhost.com.   3600    IN      A       200.0.0.4          
+myhost.com.   3600    IN      A       200.0.0.4                       myhost.com.   3600    IN      A       200.0.0.1          
+myhost.com.   3600    IN      A       200.0.0.1                       myhost.com.   3600    IN      A       200.0.0.2          
+
+_rr_state={"ip":["200.0.0.3","200.0.0.4","200.0.0.1","200.0.0.2"]}    _rr_state={"ip":["200.0.0.4","200.0.0.1","200.0.0.2","200.0.0.3"]}
+myhost.com.   3600    IN      A       200.0.0.4                       myhost.com.   3600    IN      A       200.0.0.1          
+myhost.com.   3600    IN      A       200.0.0.1                       myhost.com.   3600    IN      A       200.0.0.2          
+myhost.com.   3600    IN      A       200.0.0.2                       myhost.com.   3600    IN      A       200.0.0.3          
+myhost.com.   3600    IN      A       200.0.0.3                       myhost.com.   3600    IN      A       200.0.0.4          
+```
+
+### random
+~~~ corefile
+.:5053 {
+    log
+    roundrobin random
+}
+~~~
+Random is the simplest strategy available. It is simple, fast, and does not work with any state. On the other hand, 
+it does not offer consistent results. Responses may be repeated, and you have no guarantee that the returned IP 
+addresses will be provided equally. 
+
+#### Example
+It is clear from the following example that if you work with the first address in the list, for example, you can easily 
+select the same address (200.0.0.1) three times before something else comes up.
+```shell
+# runnig against a local hosts plugin `hosts etchosts` 
+
+dig @localhost -p 5053 myhost.com                                 dig @localhost -p 5053 myhost.com                        
+myhost.com.             3600    IN      A       200.0.0.1         myhost.com.             3600    IN      A       200.0.0.1
+myhost.com.             3600    IN      A       200.0.0.2         myhost.com.             3600    IN      A       200.0.0.2
+myhost.com.             3600    IN      A       200.0.0.3         myhost.com.             3600    IN      A       200.0.0.4
+myhost.com.             3600    IN      A       200.0.0.4         myhost.com.             3600    IN      A       200.0.0.3
+
+dig @localhost -p 5053 myhost.com                                 dig @localhost -p 5053 myhost.com                        
+myhost.com.             3600    IN      A       200.0.0.1         myhost.com.             3600    IN      A       200.0.0.3
+myhost.com.             3600    IN      A       200.0.0.3         myhost.com.             3600    IN      A       200.0.0.1
+myhost.com.             3600    IN      A       200.0.0.2         myhost.com.             3600    IN      A       200.0.0.4
+myhost.com.             3600    IN      A       200.0.0.4         myhost.com.             3600    IN      A       200.0.0.2
+```

--- a/plugin/roundrobin/handler.go
+++ b/plugin/roundrobin/handler.go
@@ -1,0 +1,45 @@
+package roundrobin
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/roundrobin/internal/strategy"
+
+	"github.com/miekg/dns"
+)
+
+// RoundRobin provider
+type RoundRobin struct {
+	Next     plugin.Handler
+	strategy strategy.Shuffler
+}
+
+const (
+	strategyWeight    = "weight"
+	strategyStateless = "stateless"
+	strategyRandom    = "random"
+	strategyStateful  = "stateful"
+)
+
+// New create new RoundRobin instance
+func New(next plugin.Handler, strategy strategy.Shuffler) *RoundRobin {
+	return &RoundRobin{
+		Next:     next,
+		strategy: strategy,
+	}
+}
+
+// ServeDNS makes the middleware accessible by implementing Handler interface
+func (rr *RoundRobin) ServeDNS(ctx context.Context, w dns.ResponseWriter, msg *dns.Msg) (int, error) {
+	wrr, err := NewMessageWriter(w, msg, rr.strategy)
+	if err != nil {
+		return dns.RcodeServerFailure, err
+	}
+	return plugin.NextOrFailure(rr.Name(), rr.Next, ctx, wrr, msg)
+}
+
+// Name retrieves plugin name, implements Handler interface
+func (rr *RoundRobin) Name() string {
+	return pluginName
+}

--- a/plugin/roundrobin/internal/strategy/common.go
+++ b/plugin/roundrobin/internal/strategy/common.go
@@ -1,0 +1,42 @@
+package strategy
+
+import "github.com/miekg/dns"
+
+// parseAnswerSection converts []dns.RR into map of A or AAAA records and slice containing all except A or AAAA
+func parseAnswerSection(arr []dns.RR) (ipmap map[string]dns.RR, ip []string, noip []dns.RR) {
+	ipmap = make(map[string]dns.RR)
+	ip = make([]string, 0)
+	noip = make([]dns.RR, 0)
+	for _, r := range arr {
+		switch r.Header().Rrtype {
+		case dns.TypeA:
+			a := r.(*dns.A).A.String()
+			ipmap[a] = r
+			ip = append(ip, a)
+		case dns.TypeAAAA:
+			aaaa := r.(*dns.AAAA).AAAA.String()
+			ipmap[aaaa] = r
+			ip = append(ip, aaaa)
+		default:
+			noip = append(noip, r)
+		}
+	}
+	return
+}
+
+// ipsToSet converts list of IPs into set of IP's
+func ipsToSet(ips []string) (m map[string]bool) {
+	m = make(map[string]bool)
+	for _, ip := range ips {
+		m[ip] = true
+	}
+	return
+}
+
+// rotate items from one slice to another
+func rotate(slice []string) (r []string) {
+	for i := range slice {
+		r = append(r, slice[(i+1)%len(slice)])
+	}
+	return
+}

--- a/plugin/roundrobin/internal/strategy/random.go
+++ b/plugin/roundrobin/internal/strategy/random.go
@@ -1,0 +1,36 @@
+package strategy
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Random strategy, retrieves randomly shuffled A or AAAA records.
+type Random struct {
+}
+
+// NewRandom returns new instance of Random strategy
+func NewRandom() *Random {
+	return &Random{}
+}
+
+// Shuffle implements Shuffler interface, retrieves randomly shuffled A or AAAA records
+func (r *Random) Shuffle(_ request.Request, msg *dns.Msg) ([]dns.RR, error) {
+	var shuffled []dns.RR
+	var skipped []dns.RR
+	for _, a := range msg.Answer {
+		switch a.Header().Rrtype {
+		case dns.TypeA, dns.TypeAAAA:
+			shuffled = append(shuffled, a)
+		default:
+			skipped = append(skipped, a)
+		}
+	}
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	return append(shuffled, skipped...), nil
+}

--- a/plugin/roundrobin/internal/strategy/random_test.go
+++ b/plugin/roundrobin/internal/strategy/random_test.go
@@ -1,0 +1,110 @@
+package strategy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestRoundRobinIsSwitchingCorrectly(t *testing.T) {
+	const maxAttemptsToReachVariation = 100
+	var avariations = []string{"[10.240.0.1 10.240.0.2 10.240.0.3]", "[10.240.0.1 10.240.0.3 10.240.0.2]",
+		"[10.240.0.3 10.240.0.2 10.240.0.1]", "[10.240.0.3 10.240.0.1 10.240.0.2]",
+		"[10.240.0.2 10.240.0.1 10.240.0.3]", "[10.240.0.2 10.240.0.3 10.240.0.1]"}
+
+	var aaaavariations = []string{"[4001:a1:1014::89 4001:a1:1014::8a 4001:a1:1014::8b]", "[4001:a1:1014::89 4001:a1:1014::8b 4001:a1:1014::8a]",
+		"[4001:a1:1014::8b 4001:a1:1014::8a 4001:a1:1014::89]", "[4001:a1:1014::8b 4001:a1:1014::89 4001:a1:1014::8a]",
+		"[4001:a1:1014::8a 4001:a1:1014::89 4001:a1:1014::8b]", "[4001:a1:1014::8a 4001:a1:1014::8b 4001:a1:1014::89]"}
+
+	tests := []struct {
+		name             string
+		rr               []dns.RR
+		expectedResponse []string
+	}{
+		{"A and non A records",
+			[]dns.RR{
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com.")},
+			avariations,
+		},
+		{
+			"A records only",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3")},
+			avariations,
+		},
+		{
+			"AAAA records only",
+			[]dns.RR{
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::89"),
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+			},
+			aaaavariations,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := newMid()
+			m.res.Answer = test.rr
+			for _, v := range test.expectedResponse {
+				var x int
+				for x = 0; x < maxAttemptsToReachVariation; x++ {
+					result, _ := NewRandom().Shuffle(m.req, m.res)
+					if fmt.Sprintf("%v", getIPs(result)) == v {
+						break
+					}
+				}
+				if x == maxAttemptsToReachVariation {
+					t.Errorf("The Random shuffle is not working as expected. %v didn't occure during %v attempts", v, x)
+				}
+			}
+		})
+	}
+}
+
+func TestRoundRobinRandomEmptyAnswer(t *testing.T) {
+	m := newMid()
+	result, _ := NewRandom().Shuffle(m.req, m.res)
+	if len(result) != 0 {
+		t.Errorf("Expecting empty result but got %v", result)
+	}
+}
+
+func TestRoundRobinRandomOrderForAandNonA(t *testing.T) {
+	m := newMid()
+	m.AddResponseAnswer(test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."))
+	m.AddResponseAnswer(test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"))
+	result, _ := NewRandom().Shuffle(m.req, m.res)
+	if result[0].String() != m.res.Answer[1].String() {
+		t.Errorf("Expecting %s result but got %s", result[0].String(), m.res.Answer[1].String())
+	}
+	if result[1].String() != m.res.Answer[0].String() {
+		t.Errorf("Expecting %s result but got %s", result[1].String(), m.res.Answer[0].String())
+	}
+}
+
+func TestRoundRobinRandomStableOrderForNonA(t *testing.T) {
+	m := newMid()
+	m.AddResponseAnswer(test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."))
+	m.AddResponseAnswer(test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."))
+	m.AddResponseAnswer(test.MX("alpha.cloud.example.com.			300	IN	MX		1	mx-beta.cloud.example.com."))
+	result, _ := NewRandom().Shuffle(m.req, m.res)
+	if len(result) != 3 {
+		t.Errorf("Expecting %v result but got %v", len(m.res.Answer), len(result))
+	}
+	for i, v := range result {
+		if v.String() != m.res.Answer[i].String() {
+			t.Errorf("Expecting %s result but got %s", v.String(), m.res.Answer[i].String())
+		}
+	}
+}

--- a/plugin/roundrobin/internal/strategy/shuffler.go
+++ b/plugin/roundrobin/internal/strategy/shuffler.go
@@ -1,0 +1,14 @@
+package strategy
+
+import (
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Shuffler implementation returns mixed (or rotated) A or AAAA result.
+type Shuffler interface {
+	// Shuffle runs round-robin algorithm. Each call to Shuffle causes
+	// the A or AAAA record positions in the response to change.
+	Shuffle(req request.Request, msg *dns.Msg) ([]dns.RR, error)
+}

--- a/plugin/roundrobin/internal/strategy/stateful.go
+++ b/plugin/roundrobin/internal/strategy/stateful.go
@@ -1,0 +1,28 @@
+package strategy
+
+import (
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Stateful strategy, retrieves rotated A or AAAA records.
+// It remembers the previous state, so it is able to rotate
+// A or AAAA consistently by one position depending on the
+// subnet+question+dnsType call
+type Stateful struct {
+	state *stateful
+}
+
+// NewStateful creates new instance of Stateful
+func NewStateful() *Stateful {
+	return &Stateful{
+		state: newStateful(),
+	}
+}
+
+// Shuffle implements Shuffler interface. Rotates A or AAAA
+// consistently by one position
+func (s *Stateful) Shuffle(req request.Request, res *dns.Msg) ([]dns.RR, error) {
+	return s.state.update(&req, res)
+}

--- a/plugin/roundrobin/internal/strategy/stateful_gc.go
+++ b/plugin/roundrobin/internal/strategy/stateful_gc.go
@@ -1,0 +1,40 @@
+package strategy
+
+import "time"
+
+const (
+	// garbageCollectionDefaultTTLSeconds defines the period after which the resource is removed
+	garbageCollectionDefaultTTLSeconds = 600
+	// garbageCollectionPeriodSeconds defines the period when garbage collection is triggered
+	garbageCollectionPeriodSeconds = 10
+)
+
+// garbageCollector clear the state of dead records
+type garbageCollector struct {
+	state mstate
+	ttl   time.Duration
+}
+
+func newGarbageCollector(state mstate, ttlSeconds int) *garbageCollector {
+	return &garbageCollector{
+		state: state,
+		ttl:   time.Duration(ttlSeconds),
+	}
+}
+
+func (gc *garbageCollector) collect() {
+	for k, qm := range gc.state {
+		for q, a := range qm {
+			for _, s := range a {
+				// remove death states for death questions
+				if s.timestamp.Before(time.Now().Add(-gc.ttl * time.Second)) {
+					delete(qm, q)
+				}
+			}
+		}
+		// remove key, if contains 0 items
+		if len(qm) == 0 {
+			delete(gc.state, k)
+		}
+	}
+}

--- a/plugin/roundrobin/internal/strategy/stateful_gc_test.go
+++ b/plugin/roundrobin/internal/strategy/stateful_gc_test.go
@@ -1,0 +1,112 @@
+package strategy
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestStatefulGCCleaning(t *testing.T) {
+	flattenTests := []stateFlatten{
+		{"10.20.30.40", "test.example.com.", dnsTypes.A, time.Now().Add(time.Hour * -5), []string{"10.10.10.10"}},
+		{"10.20.30.40", "alpha.example.com.", dnsTypes.A, time.Now().Add(time.Minute * -5), []string{"10.10.10.10", "20.20.20.20"}},
+	}
+	tests := []struct {
+		name       string
+		ttlSeconds int
+		state      mstate
+	}{
+		{"clean on empty", 5, mstate{}},
+		{"clean all records", 5, buildState(flattenTests)},
+		{"nil state", 5, nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newGarbageCollector(test.state, test.ttlSeconds).collect()
+			if len(test.state) != 0 {
+				t.Fatalf("Expected empty state but have %v records", len(test.state))
+			}
+		})
+	}
+}
+
+func TestStatefulGCCleaningLive(t *testing.T) {
+	flattenTests := []stateFlatten{
+		{"10.20.30.40", "alpha.example.com.", dnsTypes.A, time.Now().Add(time.Hour * -5), []string{"10.10.10.10", "20.20.20.20"}},
+	}
+	tests := []struct {
+		name     string
+		question string
+		dnstype  dnsType
+		from     string
+		answer   []dns.RR
+	}{
+		{"Retrieving records with old timestamp", "alpha.example.com.", dnsTypes.A, "10.20.30.40",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.10.10.10"),
+				test.A("alpha.cloud.example.com.		300	IN	A			20.20.20.20")}},
+		{"Call once again", "alpha.example.com.", dnsTypes.A, "10.20.30.40",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.10.10.10"),
+				test.A("alpha.cloud.example.com.		300	IN	A			20.20.20.20")}},
+	}
+	s := NewStateful()
+	s.state.state = buildState(flattenTests)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := newMid()
+			m.SetQuestion(test.question, dns.TypeA)
+			m.SetSubnet(test.from)
+			m.res.Answer = test.answer
+			ts := s.state.state[key(test.from)][question(test.question)][test.dnstype].timestamp
+			_, _ = s.Shuffle(m.req, m.res)
+
+			if !s.state.state[key(test.from)][question(test.question)][test.dnstype].timestamp.After(ts) {
+				t.Fatalf("timestamp has not been properly set")
+			}
+		})
+	}
+}
+
+func TestStatefulGCRemoveItem(t *testing.T) {
+	flattenTests := []stateFlatten{
+		{"10.20.30.40", "test.example.com.", dnsTypes.A, time.Now().Add(time.Hour * -5), []string{"10.10.10.10"}},
+		{"10.20.30.40", "alpha.example.com.", dnsTypes.A, time.Now().Add(time.Minute * -5), []string{"10.10.10.10", "20.20.20.20"}},
+		{"10.20.30.40", "beta.example.com.", dnsTypes.A, time.Now().Add(time.Second * -5), []string{}},
+		{"10.20.30.40", "beta.example.com.", dnsTypes.A, time.Now().Add(time.Second * -1), []string{"11.111.111.111", "222.222.222.333"}},
+		{"11.11.11.11", "gc.test.com.", dnsTypes.A, time.Now(), []string{"10.10.10.10"}},
+	}
+
+	tests := []struct {
+		state              []stateFlatten
+		ttlSeconds         int
+		survivalRowIndexes map[int]bool
+	}{
+		{flattenTests, 3600*5 + 1, map[int]bool{0: true, 1: true, 2: true, 3: true, 4: true}},
+		{flattenTests, 60 * 5, map[int]bool{0: false, 1: false, 2: true, 3: true, 4: true}},
+		{flattenTests, 60*5 + 1, map[int]bool{0: false, 1: true, 2: true, 3: true, 4: true}},
+		{flattenTests, 2, map[int]bool{0: false, 1: false, 2: true, 3: true, 4: true}},
+		{flattenTests, 1, map[int]bool{0: false, 1: false, 2: false, 3: false, 4: true}},
+		{flattenTests, 0, map[int]bool{0: false, 1: false, 2: false, 3: false, 4: false}},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Delete records older than %v seconds", test.ttlSeconds), func(t *testing.T) {
+			s := buildState(test.state)
+			newGarbageCollector(s, test.ttlSeconds).collect()
+
+			for i, v := range flattenTests {
+				// check if state for key x question exists
+				exists := s.exists(key(v.key), question(v.question), v.t)
+
+				if test.survivalRowIndexes[i] != exists {
+					t.Fatalf("Inconsistent state. Check if %v should be there or not ", v)
+				}
+			}
+		})
+	}
+}

--- a/plugin/roundrobin/internal/strategy/stateful_impl.go
+++ b/plugin/roundrobin/internal/strategy/stateful_impl.go
@@ -1,0 +1,118 @@
+package strategy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	missingSubnet = "missing-subnet"
+	emptySubnet   = "empty-subnet"
+)
+
+type stateful struct {
+	state mstate
+}
+
+func newStateful() *stateful {
+	this := new(stateful)
+	this.state = make(mstate)
+	gc := newGarbageCollector(this.state, garbageCollectionDefaultTTLSeconds)
+	go func() {
+		for range time.Tick(time.Second * garbageCollectionPeriodSeconds) {
+			gc.collect()
+		}
+	}()
+	return this
+}
+
+func (s *stateful) update(req *request.Request, res *dns.Msg) (rr []dns.RR, err error) {
+	if req == nil {
+		err = fmt.Errorf("nil request")
+		return
+	}
+	if res == nil {
+		err = fmt.Errorf("nil response")
+		return
+	}
+	if len(req.Req.Question) == 0 {
+		err = fmt.Errorf("empty request question")
+		return
+	}
+	return s.updateState(req, res)
+}
+
+func (s *stateful) updateState(req *request.Request, res *dns.Msg) (answer []dns.RR, err error) {
+	q := question(req.Req.Question[0].Name)
+	k := s.key(req)
+	t := toDNSType(req.Req.Question[0].Qtype)
+	responseIPsTable, responseIPs, responseNoIPs := parseAnswerSection(res.Answer)
+	s.refresh(k, q, t, responseIPsTable, responseIPs)
+	for _, ip := range s.state[k][q][t].ip {
+		answer = append(answer, responseIPsTable[ip])
+	}
+	return append(answer, responseNoIPs...), nil
+}
+
+func (s *stateful) key(req *request.Request) key {
+	subnet := s.readSubnet(req.Req)
+	return key(subnet)
+}
+
+// readSubnet reads the option EDNS0_SUBNET which is usually filled by resolvers.
+func (s *stateful) readSubnet(req *dns.Msg) string {
+	for _, e := range req.Extra {
+		opt := e.(*dns.OPT)
+		if opt == nil {
+			continue
+		}
+		for _, o := range opt.Option {
+			x := o.(*dns.EDNS0_SUBNET)
+			if x == nil {
+				continue
+			}
+			if o.(*dns.EDNS0_SUBNET).Address.String() == "<nil>" {
+				return emptySubnet
+			}
+			return o.(*dns.EDNS0_SUBNET).Address.String()
+		}
+	}
+	return missingSubnet
+}
+
+func (s *stateful) refresh(k key, q question, t dnsType, responseA map[string]dns.RR, responseIPs []string) {
+	if !s.state.exists(k, q, t) {
+		s.state.upsert(k, q, t, state{ip: []string{}, timestamp: time.Now()})
+	}
+	s.state[k][q][t].updateState(responseA, responseIPs)
+	s.state[k][q][t].rotateIPs()
+}
+
+func (s *state) updateState(responseA map[string]dns.RR, responseIPs []string) {
+	var newIPs []string
+	currentA := ipsToSet(s.ip)
+
+	// append only such IP which exist in response
+	for _, ip := range s.ip {
+		if _, found := responseA[ip]; found {
+			newIPs = append(newIPs, ip)
+		}
+	}
+
+	// to the end of the IP list append new records which doesn't exist in request but exist in response.
+	for _, ip := range responseIPs {
+		if !currentA[ip] {
+			newIPs = append(newIPs, ip)
+		}
+	}
+	s.ip = newIPs
+	s.timestamp = time.Now()
+}
+
+func (s *state) rotateIPs() {
+	s.ip = rotate(s.ip)
+}

--- a/plugin/roundrobin/internal/strategy/stateful_mstate.go
+++ b/plugin/roundrobin/internal/strategy/stateful_mstate.go
@@ -1,0 +1,78 @@
+package strategy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// clientSubnet
+type key string
+
+// one client could hit many domains
+type question string
+
+type dnsType uint16
+
+var dnsTypes = struct {
+	A    dnsType
+	AAAA dnsType
+}{
+	A:    dnsType(dns.TypeA),
+	AAAA: dnsType(dns.TypeAAAA),
+}
+
+type state struct {
+	timestamp time.Time
+	ip        []string
+}
+
+type mstate map[key]map[question]map[dnsType]*state
+
+// exists returns false if
+func (m mstate) exists(k key, q question, t dnsType) (exists bool) {
+	if _, ok := m[k]; ok {
+		if _, ob := m[k][q]; ob {
+			_, exists = m[k][q][t]
+		}
+	}
+	return
+}
+
+// upsert add or insert new item to mstate
+func (m mstate) upsert(k key, q question, t dnsType, s state) {
+	if _, ok := m[k]; !ok {
+		m[k] = make(map[question]map[dnsType]*state)
+	}
+	if _, ok := m[k][q]; !ok {
+		m[k][q] = make(map[dnsType]*state)
+	}
+	m[k][q][t] = &s
+}
+
+func (m mstate) String() (out string) {
+	for k, v := range m {
+		for q, a := range v {
+			for t, s := range a {
+				out += fmt.Sprintf("[%v][%v][%s]{ips: %v} \n", k, q, t, s.ip)
+			}
+		}
+	}
+	return
+}
+
+func (t dnsType) String() string {
+	if t == dnsTypes.AAAA {
+		return "AAAA"
+	}
+	return "A"
+}
+
+// converts miekg.dnsType (uint16) to dnsType
+func toDNSType(t uint16) dnsType {
+	if t == dns.TypeAAAA {
+		return dnsTypes.AAAA
+	}
+	return dnsTypes.A
+}

--- a/plugin/roundrobin/internal/strategy/stateful_test.go
+++ b/plugin/roundrobin/internal/strategy/stateful_test.go
@@ -1,0 +1,462 @@
+package strategy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestRoundRobinStatefulShuffle(t *testing.T) {
+	tests := []struct {
+		name                         string
+		question                     string
+		dnsType                      uint16
+		expectedResults              []string
+		answer                       []dns.RR
+		expectedNonAPositionsMapping map[int]int
+	}{
+		{
+			name:     "A and non A records",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults: []string{"[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]", "[10.240.0.3 10.240.0.4 10.240.0.1 10.240.0.2]",
+				"[10.240.0.4 10.240.0.1 10.240.0.2 10.240.0.3]", "[10.240.0.1 10.240.0.2 10.240.0.3 10.240.0.4]"},
+			answer: []dns.RR{
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			expectedNonAPositionsMapping: map[int]int{0: 4, 4: 5},
+		},
+		{
+			name:     "A records only",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults: []string{"[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]", "[10.240.0.3 10.240.0.4 10.240.0.1 10.240.0.2]",
+				"[10.240.0.4 10.240.0.1 10.240.0.2 10.240.0.3]", "[10.240.0.1 10.240.0.2 10.240.0.3 10.240.0.4]"},
+			answer: []dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			expectedNonAPositionsMapping: map[int]int{},
+		},
+		{
+			name:     "AAAA and non AAAA records",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults: []string{"[4001:a1:1014::8a 4001:a1:1014::8b 4001:a1:1014::89]", "[4001:a1:1014::8b 4001:a1:1014::89 4001:a1:1014::8a]",
+				"[4001:a1:1014::89 4001:a1:1014::8a 4001:a1:1014::8b]"},
+			answer: []dns.RR{
+				test.AAAA("alpha.cloud.example.com.		300	IN	AAAA			4001:a1:1014::89"),
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."),
+				test.AAAA("alpha.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("alpha.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+			},
+			expectedNonAPositionsMapping: map[int]int{1: 3, 2: 4},
+		},
+		{
+			name:     "Empty answers",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults:              []string{},
+			answer:                       []dns.RR{},
+			expectedNonAPositionsMapping: map[int]int{},
+		},
+		{
+			name:     "Nil answers",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults:              []string{},
+			answer:                       []dns.RR{},
+			expectedNonAPositionsMapping: map[int]int{},
+		},
+		{
+			name:     "One A record",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults: []string{"[10.240.0.1]"},
+			answer: []dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+			},
+			expectedNonAPositionsMapping: map[int]int{},
+		},
+		{
+			name:     "One A record and several non A records",
+			question: "alpha.cloud.example.com.", dnsType: dns.TypeA,
+			expectedResults: []string{"[10.240.0.1]"},
+			answer: []dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."),
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+			},
+			expectedNonAPositionsMapping: map[int]int{1: 1, 2: 2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var s = NewStateful()
+			// requesting several times and check if rotation works
+			for i := 0; i < 10; i++ {
+				m := newMid()
+				m.SetQuestion(test.question, test.dnsType)
+				m.res.Answer = test.answer
+				clientState, e := s.Shuffle(m.req, m.res)
+
+				if e != nil {
+					t.Errorf("unexpepcted error %s", e)
+				}
+
+				if len(test.expectedResults) > 0 && fmt.Sprintf("%v", getIPs(clientState)) !=
+					fmt.Sprintf("%v", test.expectedResults[i%len(test.expectedResults)]) {
+					t.Errorf("%v: The stateful rotation is not working. Expecting %v but got %v.",
+						i, test.expectedResults[i%len(test.expectedResults)], getIPs(clientState))
+				}
+
+				if len(clientState) != len(m.res.Answer) {
+					t.Errorf("The stateful retrieved different number of records. Expected %v got %v",
+						len(m.res.Answer), len(clientState))
+				}
+
+				// If clientState contains non A, we check it exists on specified positions
+				for originalPosition, newPosition := range test.expectedNonAPositionsMapping {
+					if clientState[newPosition].String() != test.answer[originalPosition].String() {
+						t.Errorf("Expecting %s result but got %s", test.answer[originalPosition], clientState[newPosition])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRoundRobinStatefulNoQuestion(t *testing.T) {
+	m := newMid()
+	clientState, e := NewStateful().Shuffle(m.req, m.res)
+	if e == nil {
+		t.Errorf("expecting error")
+	}
+	if len(clientState) != 0 {
+		t.Errorf("The stateful retrieved different number of records. Expected %v got %v", len(m.res.Answer), 0)
+	}
+}
+
+func TestRoundRobinStatefulState(t *testing.T) {
+	s := NewStateful()
+	tests := []struct {
+		question    string
+		from        string
+		expectedKey string
+		setSubnet   bool
+		rr          []dns.RR
+	}{
+		{"alpha.cloud.example.com.", "200.10.0.0", "200.10.0.0", true,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2")}},
+		{"alpha.cloud.example.com.", "101.203.0.0", "101.203.0.0", true,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2")}},
+		{"beta.cloud.example.com.", "101.203.0.0", "101.203.0.0", true,
+			[]dns.RR{
+				test.A("beta.cloud.example.com.		300	IN	A			20.100.0.1")}},
+		{"beta.cloud.example.com.", "102.203.0.0", "102.203.0.0", true,
+			[]dns.RR{
+				test.A("beta.cloud.example.com.		300	IN	A			20.100.0.1")}},
+		{"ipv6-subnet.cloud.example.com.", "4001:a1:1014::8a", "4001:a1:1014::8a", true,
+			[]dns.RR{
+				test.A("ipv6.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("ipv6.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("ipv6.cloud.example.com.		300	IN	A			10.240.0.3")}},
+		{"no-records.cloud.example.com.", "200.10.0.0", "200.10.0.0", true, []dns.RR{}},
+		{"empty-subnet-and-empty-response.cloud.com.", "", emptySubnet, true, []dns.RR{}},
+		{"empty-subnet-with-a-records.cloud.com.", "", emptySubnet, true, []dns.RR{
+			test.A("empty-subnet-with-a-records.cloud.com.		300	IN	A			10.240.0.1"),
+			test.A("empty-subnet-with-a-records.cloud.com.		300	IN	A			10.240.0.2"),
+		}},
+		{"missing-subnet-and-empty-response.cloud.com.", "", missingSubnet, false, []dns.RR{}},
+		{"missing-subnet-with-a-records.cloud.com.", "", missingSubnet, false, []dns.RR{
+			test.A("missing-subnet-with-a-records.cloud.com.		300	IN	A			10.240.0.1"),
+			test.A("missing-subnet-with-a-records.cloud.com.		300	IN	A			10.240.0.2"),
+		}},
+		{"only-cname.cloud.example.com.", "200.10.0.0", "200.10.0.0", true, []dns.RR{
+			test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Request %s from %s", test.question, test.from), func(t *testing.T) {
+			// arrange
+			m := newMid()
+			m.SetQuestion(test.question, dns.TypeA)
+			if test.setSubnet {
+				m.SetSubnet(test.from)
+			}
+			for _, a := range test.rr {
+				m.AddResponseAnswer(a)
+			}
+
+			// act
+			_, _ = s.Shuffle(m.req, m.res)
+
+			// assert
+			ipMap := ipsToSet(getIPs(test.rr))
+			if len(s.state.state[key(test.expectedKey)][question(test.question)][dnsTypes.A].ip) != len(getIPs(test.rr)) {
+				t.Errorf("the number of records in the test (%v) and the state (%v) do not match.",
+					len(test.rr), len(s.state.state[key(test.from)][question(test.question)][dnsTypes.A].ip))
+			}
+			for _, ip := range s.state.state[key(test.expectedKey)][question(test.question)][dnsTypes.A].ip {
+				if !ipMap[ip] {
+					t.Errorf("Can't find %s for state[%s][%s] ", ip, test.from, test.question)
+				}
+			}
+		})
+	}
+}
+
+func TestRoundRobinStatefulDNSRecordsChange(t *testing.T) {
+	tests := []struct {
+		name           string
+		question       string
+		from           string
+		rr             []dns.RR
+		expectedResult []string
+	}{
+		{"Create records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.2", "10.240.0.3", "10.240.0.1"},
+		},
+		{"Alter record for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.3", "10.240.0.1", "10.240.0.4", "10.240.0.2"},
+		},
+		{"Remove records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.4", "10.240.0.1"},
+		},
+		{"Add non A records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."),
+			},
+			[]string{"10.240.0.1", "10.240.0.4"},
+		},
+		{"Remove non A records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.4", "10.240.0.1"},
+		},
+		{"Exchange records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.100"),
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.200"),
+			},
+			[]string{"100.0.0.200", "100.0.0.100"},
+		},
+		{"No change.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.100"),
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.200"),
+			},
+			[]string{"100.0.0.100", "100.0.0.200"},
+		},
+		{"Remove records",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{},
+			[]string{},
+		},
+	}
+	s := NewStateful()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// arrange
+			m := newMid()
+			m.SetQuestion(test.question, dns.TypeA)
+			m.SetSubnet(test.from)
+			for _, a := range test.rr {
+				m.AddResponseAnswer(a)
+			}
+
+			// act
+			clientState, e := s.Shuffle(m.req, m.res)
+
+			// assert
+			if e != nil {
+				t.Errorf("unexpepcted error %s", e)
+			}
+
+			if len(test.rr) != len(clientState) {
+				t.Errorf("The stateful retrieved different number of records. Expected %v got %v", len(test.rr), len(clientState))
+			}
+
+			if fmt.Sprintf("%v", getIPs(clientState)) != fmt.Sprintf("%v", test.expectedResult) {
+				t.Errorf("The stateful rotation is not working. Expecting %v but got %v.", test.expectedResult, getIPs(clientState))
+			}
+		})
+	}
+}
+
+func TestResolverBehaviorIPv4asFallbackOfIPv6(t *testing.T) {
+	tests := []struct {
+		name           string
+		question       string
+		from           string
+		dnsType        uint16
+		rr             []dns.RR
+		expectedResult []string
+	}{
+		{"Resolver makes automatically AAAA request first but has no records",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeAAAA,
+			[]dns.RR{},
+			[]string{},
+		},
+		{"Empty result fallbacks to A request and retrieves records in right order",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.2", "10.240.0.3", "10.240.0.1"},
+		},
+		{"Resolver makes again AAAA request again and has no records",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeAAAA,
+			[]dns.RR{},
+			[]string{},
+		},
+		{"Empty result fallbacks to A request and retrieves records in right order",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.3", "10.240.0.1", "10.240.0.2"},
+		},
+		{"Resolver makes again AAAA request again and has no records",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeAAAA,
+			[]dns.RR{},
+			[]string{},
+		},
+		{"Someone makes  AAAA request and has no records",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeAAAA,
+			[]dns.RR{},
+			[]string{},
+		},
+		{"Empty result fallbacks to A request and retrieves records in right order",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.1", "10.240.0.2", "10.240.0.3"},
+		},
+		{"Doing A request only and retrieves records in right order",
+			"alpha.cloud.example.com.", "200.10.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.2", "10.240.0.3", "10.240.0.1"},
+		},
+		{"Resolver makes AAAA request and records successfully retrieved",
+			"beta.cloud.example.com.", "200.11.0.0", dns.TypeAAAA,
+			[]dns.RR{
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8c"),
+			},
+			[]string{"4001:a1:1014::8b", "4001:a1:1014::8c", "4001:a1:1014::8a"},
+		},
+		{"Resolver makes AAAA request and records successfully retrieved",
+			"beta.cloud.example.com.", "200.11.0.0", dns.TypeAAAA,
+			[]dns.RR{
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8c"),
+			},
+			[]string{"4001:a1:1014::8c", "4001:a1:1014::8a", "4001:a1:1014::8b"},
+		},
+		{"Someone makes A request and records successfully retrieved",
+			"beta.cloud.example.com.", "200.11.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("beta.cloud.example.com.		300	IN	A			1.1.1.1"),
+				test.A("beta.cloud.example.com.		300	IN	A			1.1.1.2"),
+			},
+			[]string{"1.1.1.2", "1.1.1.1"},
+		},
+		{"Resolver makes AAAA request and records successfully retrieved",
+			"beta.cloud.example.com.", "200.11.0.0", dns.TypeAAAA,
+			[]dns.RR{
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+				test.AAAA("beta.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8c"),
+			},
+			[]string{"4001:a1:1014::8a", "4001:a1:1014::8b", "4001:a1:1014::8c"},
+		},
+		{"Someone makes A request and records successfully retrieved",
+			"beta.cloud.example.com.", "200.11.0.0", dns.TypeA,
+			[]dns.RR{
+				test.A("beta.cloud.example.com.		300	IN	A			1.1.1.1"),
+				test.A("beta.cloud.example.com.		300	IN	A			1.1.1.2"),
+			},
+			[]string{"1.1.1.1", "1.1.1.2"},
+		},
+	}
+	s := NewStateful()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// arrange
+			m := newMid()
+			m.SetQuestion(test.question, test.dnsType)
+			m.SetSubnet(test.from)
+			for _, a := range test.rr {
+				m.AddResponseAnswer(a)
+			}
+
+			// act
+			clientState, e := s.Shuffle(m.req, m.res)
+
+			// assert
+			if e != nil {
+				t.Errorf("unexpepcted error %s", e)
+			}
+
+			if len(test.rr) != len(clientState) {
+				t.Errorf("The stateful retrieved different number of records. Expected %v got %v", len(test.rr), len(clientState))
+			}
+
+			if fmt.Sprintf("%v", getIPs(clientState)) != fmt.Sprintf("%v", test.expectedResult) {
+				t.Errorf("The stateful rotation is not working. Expecting %v but got %v.", test.expectedResult, getIPs(clientState))
+			}
+		})
+	}
+}

--- a/plugin/roundrobin/internal/strategy/stateless.go
+++ b/plugin/roundrobin/internal/strategy/stateless.go
@@ -1,0 +1,26 @@
+package strategy
+
+import (
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Stateless strategy, retrieves rotated A or AAAA records.
+// It doesn't remember the previous state, so the previous state
+// must be provided by client request in Extra section.
+// Read README.md for more details.
+type Stateless struct {
+}
+
+// NewStateless provides new Stateless instance
+func NewStateless() *Stateless {
+	return &Stateless{}
+}
+
+// Shuffle implements Shuffler interface. Rotates A or AAAA consistently by one position.
+// The records from previous state must be provided by client otherwise it copy
+// response from *dns.Msg response and rotates it by one position.
+func (r *Stateless) Shuffle(req request.Request, msg *dns.Msg) ([]dns.RR, error) {
+	return newStateless(req.Req, msg).updateState().rotate().getAnswers()
+}

--- a/plugin/roundrobin/internal/strategy/stateless_impl.go
+++ b/plugin/roundrobin/internal/strategy/stateless_impl.go
@@ -1,0 +1,102 @@
+package strategy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+type stateless struct {
+	IPs []string `json:"ip"`
+	// IPs converted into map
+	requestIPs map[string]bool
+	// response.Answers[] converted into map which are A or AAAA. IP is a key
+	responseA map[string]dns.RR
+	// contains all response IPs which are A or AAAA
+	responseIPs []string
+	// contains all response records which are not A nor AAAA
+	responseNoA []dns.RR
+	err         error
+}
+
+func newStateless(request *dns.Msg, response *dns.Msg) (s *stateless) {
+	const identifierPrefix = "_rr_state="
+	var empty = func() *stateless {
+		return &stateless{
+			requestIPs:  map[string]bool{},
+			responseA:   map[string]dns.RR{},
+			responseIPs: []string{},
+			responseNoA: []dns.RR{},
+		}
+	}
+	if request == nil || response == nil {
+		s.err = fmt.Errorf("nil response or request")
+		return
+	}
+	s = empty()
+	// extracting records from client request
+	for _, e := range request.Extra {
+		opt := e.(*dns.OPT)
+		if opt == nil {
+			continue
+		}
+		for _, o := range opt.Option {
+			e := o.(*dns.EDNS0_LOCAL)
+			if e == nil {
+				continue
+			}
+			data := string(o.(*dns.EDNS0_LOCAL).Data)
+			if strings.HasPrefix(data, identifierPrefix) {
+				str := strings.ReplaceAll(data, identifierPrefix, "")
+				_ = json.Unmarshal([]byte(str), &s)
+				if s == nil {
+					s = empty()
+				}
+			}
+		}
+	}
+	s.responseA, s.responseIPs, s.responseNoA = parseAnswerSection(response.Answer)
+	s.requestIPs = ipsToSet(s.IPs)
+	return s
+}
+
+// updateState compare stateless records with response message records
+// and cuts removed records or append new records to stateless
+// updateState keeps records in the same order as they ar defined in the IPs field.
+func (s *stateless) updateState() *stateless {
+	var newIPs []string
+
+	// append only such IP which exist in response
+	for _, ip := range s.IPs {
+		if _, found := s.responseA[ip]; found {
+			newIPs = append(newIPs, ip)
+		}
+	}
+
+	// to the end of the IP list append new records which doesn't exist in OPT but exist in response.
+	for _, ip := range s.responseIPs {
+		if !s.requestIPs[ip] {
+			newIPs = append(newIPs, ip)
+		}
+	}
+
+	s.IPs = newIPs
+	return s
+}
+
+// rotate performs a cyclic rotation of the IPs records
+func (s *stateless) rotate() *stateless {
+	s.IPs = rotate(s.IPs)
+	return s
+}
+
+// getAnswers recreates Answer slice from original answers
+func (s *stateless) getAnswers() ([]dns.RR, error) {
+	var shuffled []dns.RR
+	for _, ip := range s.IPs {
+		shuffled = append(shuffled, s.responseA[ip])
+	}
+	return append(shuffled, s.responseNoA...), s.err
+}

--- a/plugin/roundrobin/internal/strategy/stateless_test.go
+++ b/plugin/roundrobin/internal/strategy/stateless_test.go
@@ -1,0 +1,285 @@
+package strategy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+// In stateless, the client sends back previous state to the CoreDNS per DNS query,
+// the server doesn't know anything about client's data.
+// This test examines the response, different situations when we send different
+// types of data to the server (uninitialized data or valid or invalid) and tests that we get the expected response.
+func TestRoundRobinStatelessInitialize(t *testing.T) {
+	expected := "[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]"
+	cname := test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com.")
+	mx := test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com.")
+	testValues := []struct {
+		value    string
+		expected string
+	}{
+		{"_rr_state=invalid", expected},
+		{`_rr_state=`, expected},
+		{``, expected},
+		{`_rr_state=nil`, expected},
+		{`_rr_state={}`, expected},
+		{`_rr_state={"ip":[]}`, expected},
+		{`_rr_state={"ip":["10.240.0.1"]}`, expected},
+		{`_rr_state={"ip":[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]}`, expected},
+		{`_rr_state={"ip":[10.240.0.10 10.240.0.20 10.240.0.40 10.240.0.111]}`, expected},
+		{`_rr_state={"ip":["10.0.0.1","10.2.2.1","10.1.1.2","10.1.1.3","10.2.2.2","10.2.2.3","10.0.0.2","10.0.0.3","10.1.1.1"]}`, expected},
+		{`blah=`, expected},
+	}
+	for _, raw := range testValues {
+		t.Run(fmt.Sprintf("with%s", raw.value), func(t *testing.T) {
+			m := newMid()
+
+			m.AddResponseAnswer(cname)
+			m.AddResponseAnswer(test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"))
+			m.AddResponseAnswer(test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"))
+			m.AddResponseAnswer(test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"))
+			m.AddResponseAnswer(test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"))
+			m.AddResponseAnswer(mx)
+			m.AddRequestOptRaw(raw.value)
+
+			var clientState, err = NewStateless().Shuffle(m.req, m.res)
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if len(clientState) != len(m.res.Answer) {
+				t.Errorf("The stateless retrieved different number of records. Expected %v got %v", len(m.res.Answer), len(clientState))
+			}
+
+			if fmt.Sprintf("%v", getIPs(clientState)) != raw.expected {
+				t.Errorf("The stateless shuffle is not working as expected. For %s Expecting %v but got %v.", raw.value, expected, getIPs(clientState))
+			}
+
+			// end of the list contains additional records in the order of they are defined in the response
+			if clientState[4].String() != cname.String() {
+				t.Errorf("Expecting %s result but got %s", cname, clientState[4].String())
+			}
+			if clientState[5].String() != mx.String() {
+				t.Errorf("Expecting %s result but got %s", mx, clientState[5].String())
+			}
+		})
+	}
+}
+
+func TestRoundRobinStatelessShuffle(t *testing.T) {
+	tests := []struct {
+		name                         string
+		answer                       []dns.RR
+		expectedResponse             []string
+		expectedNonAPositionsMapping map[int]int
+		requestOpt                   []dns.RR
+	}{
+		{"A records",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			}, []string{"[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]", "[10.240.0.3 10.240.0.4 10.240.0.1 10.240.0.2]",
+				"[10.240.0.4 10.240.0.1 10.240.0.2 10.240.0.3]", "[10.240.0.1 10.240.0.2 10.240.0.3 10.240.0.4]"},
+			map[int]int{},
+			[]dns.RR{},
+		},
+		{
+			"AAAA and Non AAAA records",
+			[]dns.RR{
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::89"),
+				test.CNAME("ipv6.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8a"),
+				test.AAAA("ipv6.cloud.example.com.		300	IN	AAAA			4001:a1:1014::8b"),
+				test.MX("ipv6.cloud.example.com.			300	IN	MX		1	mxa-ipv6.cloud.example.com."),
+			},
+			[]string{"[4001:a1:1014::8a 4001:a1:1014::8b 4001:a1:1014::89]", "[4001:a1:1014::8b 4001:a1:1014::89 4001:a1:1014::8a]",
+				"[4001:a1:1014::89 4001:a1:1014::8a 4001:a1:1014::8b]"},
+			map[int]int{1: 3, 4: 4},
+			[]dns.RR{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for i := 0; i < 10; i++ {
+				m := newMid()
+				m.res.Answer = test.answer
+				// state, from the previous loop that arrived in the DNS query
+				m.AddRequestOpt(test.requestOpt...)
+				var clientState, err = NewStateless().Shuffle(m.req, m.res)
+
+				// save the new state for the next query
+				test.requestOpt = filterAandAAAA(clientState)
+
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if fmt.Sprintf("%v", getIPs(clientState)) != fmt.Sprintf("%v", test.expectedResponse[i%len(test.expectedResponse)]) {
+					t.Errorf("%v: The stateless rotation is not working. Expecting %v but got %v.",
+						i, test.expectedResponse[i%len(test.expectedResponse)], getIPs(clientState))
+				}
+
+				if len(clientState) != len(m.res.Answer) {
+					t.Errorf("The stateless retrieved different number of records. Expected %v got %v", len(m.res.Answer), len(clientState))
+				}
+
+				for originalPosition, newPosition := range test.expectedNonAPositionsMapping {
+					if clientState[newPosition].String() != test.answer[originalPosition].String() {
+						t.Errorf("Expecting %s result but got %s", test.answer[originalPosition], clientState[newPosition])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRoundRobinStatelessNoShuffle(t *testing.T) {
+	tests := []struct {
+		name             string
+		request          string
+		answer           []dns.RR
+		expectedResponse []dns.RR
+	}{
+		{"answer is empty for any state",
+			`_rr_state={"ip":[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]}`, []dns.RR{}, []dns.RR{}},
+		{"answer is empty for empty state", ``, []dns.RR{}, []dns.RR{}},
+		{"one record for any state", `_rr_state={"ip":[10.240.0.2 10.240.0.3 10.240.0.4 10.240.0.1]}`,
+			[]dns.RR{test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1")},
+			[]dns.RR{test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1")}},
+		{"one record for empty state", "",
+			[]dns.RR{test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1")},
+			[]dns.RR{test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1")}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// arrange
+			m := newMid()
+			if len(test.request) != 0 {
+				m.AddRequestOptRaw(test.request)
+			}
+			for _, a := range test.answer {
+				m.AddResponseAnswer(a)
+			}
+			// act
+			clientState, err := NewStateless().Shuffle(m.req, m.res)
+
+			// assert
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if fmt.Sprintf("%v", getIPs(clientState)) != fmt.Sprintf("%v", getIPs(test.answer)) {
+				t.Errorf("The stateless retrieved different number of records. Expected %v got %v", getIPs(test.answer), getIPs(clientState))
+			}
+		})
+	}
+}
+
+func TestRoundRobinStatelessDNSRecordsChange(t *testing.T) {
+	tests := []struct {
+		name           string
+		question       string
+		request        string
+		rr             []dns.RR
+		expectedResult []string
+	}{
+		{"Create records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+			},
+			[]string{"10.240.0.2", "10.240.0.3", "10.240.0.1"},
+		},
+		{"Alter record for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.2"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.3"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.3", "10.240.0.1", "10.240.0.4", "10.240.0.2"},
+		},
+		{"Remove records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.4", "10.240.0.1"},
+		},
+		{"Add non A records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+				test.CNAME("alpha.cloud.example.com.	300	IN	CNAME		beta.cloud.example.com."),
+				test.MX("alpha.cloud.example.com.			300	IN	MX		1	mxa-alpha.cloud.example.com."),
+			},
+			[]string{"10.240.0.1", "10.240.0.4"},
+		},
+		{"Remove non A records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+				test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.4"),
+			},
+			[]string{"10.240.0.4", "10.240.0.1"},
+		},
+		{"Exchange records for alpha.cloud.example.com.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.100"),
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.200"),
+			},
+			[]string{"100.0.0.200", "100.0.0.100"},
+		},
+		{"No change.",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.100"),
+				test.A("alpha.cloud.example.com.		300	IN	A			100.0.0.200"),
+			},
+			[]string{"100.0.0.100", "100.0.0.200"},
+		},
+		{"Remove records",
+			"alpha.cloud.example.com.", "200.10.0.0",
+			[]dns.RR{},
+			[]string{},
+		},
+	}
+	clientState := []dns.RR{}
+	var err error
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// arrange
+			m := newMid()
+			m.SetQuestion(test.question, dns.TypeA)
+			m.AddRequestOpt(clientState...)
+			for _, a := range test.rr {
+				m.AddResponseAnswer(a)
+			}
+
+			// act
+			clientState, err = NewStateless().Shuffle(m.req, m.res)
+
+			// assert
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if len(test.rr) != len(clientState) {
+				t.Errorf("The stateful retrieved different number of records. Expected %v got %v", len(test.rr), len(clientState))
+			}
+
+			if fmt.Sprintf("%v", getIPs(clientState)) != fmt.Sprintf("%v", test.expectedResult) {
+				t.Errorf("The stateful rotation is not working. Expecting %v but got %v.", test.expectedResult, getIPs(clientState))
+			}
+		})
+	}
+}

--- a/plugin/roundrobin/internal/strategy/test_helper.go
+++ b/plugin/roundrobin/internal/strategy/test_helper.go
@@ -1,0 +1,116 @@
+package strategy
+
+import (
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+type mid struct {
+	req request.Request
+	res *dns.Msg
+}
+
+func newMid() mid {
+	return mid{
+		req: request.Request{
+			Req: &dns.Msg{},
+		},
+		res: &dns.Msg{},
+	}
+}
+
+func (p mid) SetQuestion(q string, t uint16) {
+	p.req.Req.SetQuestion(q, t)
+}
+
+func (p mid) SetSubnet(ip string) {
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	e := new(dns.EDNS0_SUBNET)
+	e.Address = net.ParseIP(ip)
+	opt.Option = append(opt.Option, e)
+	p.req.Req.Extra = append(p.req.Req.Extra, opt)
+}
+
+func (p mid) AddResponseAnswer(rr dns.RR) {
+	p.res.Answer = append(p.res.Answer, rr)
+}
+
+func (p mid) AddResponseExtra(rr dns.RR) {
+	p.res.Extra = append(p.res.Answer, rr)
+}
+
+func (p mid) AddRequestAnswer(rr dns.RR) {
+	p.req.Req.Answer = append(p.req.Req.Answer, rr)
+}
+
+// adds raw value from slice of dns.RR
+func (p mid) AddRequestOpt(rr ...dns.RR) {
+	type state struct {
+		IPs []string `json:"ip"`
+	}
+	json, _ := json.Marshal(state{IPs: getIPs(rr)})
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	e := new(dns.EDNS0_LOCAL)
+	e.Code = dns.EDNS0LOCALSTART
+	e.Data = append([]byte("_rr_state="), json...)
+	opt.Option = append(opt.Option, e)
+	p.req.Req.Extra = append(p.req.Req.Extra, opt)
+}
+
+// adds raw value to OPT of the DNS query
+func (p mid) AddRequestOptRaw(data string) {
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	e := new(dns.EDNS0_LOCAL)
+	e.Code = dns.EDNS0LOCALSTART
+	e.Data = []byte(data)
+	opt.Option = append(opt.Option, e)
+	p.req.Req.Extra = append(p.req.Req.Extra, opt)
+}
+
+func getIPs(arr []dns.RR) (ips []string) {
+	ips = []string{}
+	for _, rr := range arr {
+		switch rr.Header().Rrtype {
+		case dns.TypeA:
+			ips = append(ips, rr.(*dns.A).A.String())
+		case dns.TypeAAAA:
+			ips = append(ips, rr.(*dns.AAAA).AAAA.String())
+		}
+	}
+	return
+}
+
+var filterAandAAAA = func(answers []dns.RR) (rr []dns.RR) {
+	rrMap, ipSlice, _ := parseAnswerSection(answers)
+	for _, ip := range ipSlice {
+		rr = append(rr, rrMap[ip])
+	}
+	return
+}
+
+type stateFlatten struct {
+	key       string
+	question  string
+	t         dnsType
+	timestamp time.Time
+	ips       []string
+}
+
+func buildState(tests []stateFlatten) mstate {
+	m := make(mstate)
+	for _, test := range tests {
+		m.upsert(key(test.key), question(test.question), test.t, state{test.timestamp, test.ips})
+	}
+	return m
+}

--- a/plugin/roundrobin/setup.go
+++ b/plugin/roundrobin/setup.go
@@ -1,0 +1,50 @@
+package roundrobin
+
+import (
+	"fmt"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/roundrobin/internal/strategy"
+)
+
+const (
+	pluginName = "roundrobin"
+)
+
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
+
+func setup(c *caddy.Controller) error {
+	strategy, err := parse(c)
+	if err != nil {
+		return plugin.Error(pluginName, err)
+	}
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return New(next, strategy)
+	})
+	return nil
+}
+
+func parse(c *caddy.Controller) (strategy.Shuffler, error) {
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) == 0 {
+			return strategy.NewStateful(), nil
+		}
+		switch args[0] {
+		case strategyStateless:
+			return strategy.NewStateless(), nil
+		case strategyWeight:
+			return nil, fmt.Errorf("not implemented %s", args[0])
+		case strategyRandom:
+			return strategy.NewRandom(), nil
+		case strategyStateful:
+			return strategy.NewStateful(), nil
+		}
+	}
+	return nil, fmt.Errorf("unknown roundrobin type")
+}

--- a/plugin/roundrobin/setup_test.go
+++ b/plugin/roundrobin/setup_test.go
@@ -1,0 +1,96 @@
+package roundrobin
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/plugin/roundrobin/internal/strategy"
+)
+
+func TestSetup(t *testing.T) {
+	tests := []struct {
+		input              string
+		shouldErr          bool
+		expectedErrContent string // substring from the expected error. Empty for positive cases.
+	}{
+		{"round_robin ", false, ""},
+		{"round_robin stateful", false, ""},
+		{"round_robin stateless", false, ""},
+		{"round_robin random", false, ""},
+		{"round_robin random stateless", false, ""},
+		{"round_robin invalid", true, "unknown roundrobin type"},
+	}
+	for i, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			c := caddy.NewTestController("dns", test.input)
+			err := setup(c)
+
+			if test.shouldErr && err == nil {
+				t.Errorf("Test %d: Expected error but found %s for input %s", i, err, test.input)
+			}
+
+			if err != nil {
+				if !test.shouldErr {
+					t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				}
+
+				if !strings.Contains(err.Error(), test.expectedErrContent) {
+					t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+				}
+			}
+		})
+	}
+}
+
+func TestParseArguments(t *testing.T) {
+	var getType = func(v strategy.Shuffler) string {
+		if v == nil {
+			return ""
+		}
+		t := reflect.TypeOf(v)
+		if t.Kind() == reflect.Ptr {
+			return "*" + t.Elem().Name()
+		}
+		return t.Name()
+	}
+
+	tests := []struct {
+		input              string
+		shouldErr          bool
+		expectedStrategy   string
+		expectedErrContent string // substring from the expected error. Empty for positive cases.
+	}{
+		{"round_robin ", false, "*Stateful", ""},
+		{"round_robin stateful", false, "*Stateful", ""},
+		{"round_robin stateless", false, "*Stateless", ""},
+		{"round_robin random", false, "*Random", ""},
+		{"round_robin random stateless", false, "*Random", ""},
+		{"round_robin invalid", true, "", "unknown roundrobin type"},
+	}
+	for i, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			c := caddy.NewTestController("dns", test.input)
+			strategy, err := parse(c)
+
+			if test.expectedStrategy != getType(strategy) {
+				t.Errorf("Test %d: Expected strategy %s but found %s for input %s", i, test.expectedStrategy, getType(strategy), test.input)
+			}
+
+			if test.shouldErr && err == nil {
+				t.Errorf("Test %d: Expected error but found %s for input %s", i, err, test.input)
+			}
+
+			if err != nil {
+				if !test.shouldErr {
+					t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				}
+
+				if !strings.Contains(err.Error(), test.expectedErrContent) {
+					t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+				}
+			}
+		})
+	}
+}

--- a/plugin/roundrobin/writer.go
+++ b/plugin/roundrobin/writer.go
@@ -1,0 +1,57 @@
+package roundrobin
+
+import (
+	"fmt"
+
+	"github.com/coredns/coredns/plugin/roundrobin/internal/strategy"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// MessageWriter is a response writer that shuffles A or AAAA records
+type MessageWriter struct {
+	dns.ResponseWriter
+	strategy strategy.Shuffler
+	state    request.Request
+}
+
+// NewMessageWriter provides new MessageWriter instance
+func NewMessageWriter(w dns.ResponseWriter, msg *dns.Msg, strategy strategy.Shuffler) (*MessageWriter, error) {
+	return &MessageWriter{
+		state:          request.Request{W: w, Req: msg},
+		ResponseWriter: w,
+		strategy:       strategy,
+	}, nil
+}
+
+// WriteMsg implements the dns.ResponseWriter interface.
+func (r *MessageWriter) WriteMsg(msg *dns.Msg) error {
+	if msg == nil || len(msg.Question) == 0 {
+		return fmt.Errorf("writing mesage (nil)")
+	}
+	if msg.Rcode != dns.RcodeSuccess {
+		return r.ResponseWriter.WriteMsg(msg)
+	}
+	q := msg.Question[0]
+
+	if q.Qtype == dns.TypeAXFR || q.Qtype == dns.TypeIXFR {
+		return r.ResponseWriter.WriteMsg(msg)
+	}
+
+	if answer, err := r.strategy.Shuffle(r.state, msg); err == nil {
+		msg.Answer = answer
+	} else {
+		log.Errorf("RoundRobin plugin failed %s.", err)
+	}
+
+	return r.ResponseWriter.WriteMsg(msg)
+}
+
+// Write implements the dns.ResponseWriter interface.
+func (r *MessageWriter) Write(buf []byte) (int, error) {
+	// Should we pack and unpack here to fiddle with the packet... Not likely.
+	log.Warning("RoundRobin called with Write: not shuffling records")
+	n, err := r.ResponseWriter.Write(buf)
+	return n, err
+}

--- a/plugin/roundrobin/writer_test.go
+++ b/plugin/roundrobin/writer_test.go
@@ -1,0 +1,74 @@
+package roundrobin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/roundrobin/internal/strategy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestWriteMessage(t *testing.T) {
+	var tests = []struct {
+		name          string
+		expectedError bool
+		setQuestion   bool
+		msg           *dns.Msg
+		shuffler      strategy.Shuffler
+	}{
+		{"nil dns.Msg", true, true, nil, strategy.NewStateful()},
+		{"nil dns.Msg.Question", true, false, &dns.Msg{}, strategy.NewStateful()},
+		{"empty answers", false, true, &dns.Msg{Answer: []dns.RR{}}, strategy.NewStateful()},
+		{"skip shuffling", false, true, &dns.Msg{Answer: []dns.RR{
+			test.A("alpha.cloud.example.com.		300	IN	A			10.240.0.1"),
+		}}, &shufflerStub{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// arrange
+
+			w, err := NewMessageWriter(&wStub{}, test.msg, test.shuffler)
+			if err != nil {
+				t.Errorf("unexpepcted error %s", err)
+			}
+
+			// act
+			if test.setQuestion && test.msg != nil {
+				test.msg.SetQuestion("alpha.cloud.example.com.", dns.TypeA)
+			}
+			err = w.WriteMsg(test.msg)
+
+			// assert
+			if (err == nil) == test.expectedError {
+				t.Errorf("unexpepcted error %s", err)
+			}
+
+			if !test.expectedError {
+				if len(test.msg.Answer) != w.ResponseWriter.(*wStub).AnswersCount {
+					t.Errorf("unexpected answer count")
+				}
+			}
+		})
+	}
+}
+
+type wStub struct {
+	dns.ResponseWriter
+	AnswersCount int
+}
+
+func (s *wStub) WriteMsg(msg *dns.Msg) error {
+	s.AnswersCount = len(msg.Answer)
+	return nil
+}
+
+type shufflerStub struct {
+	strategy.Shuffler
+}
+
+func (s *shufflerStub) Shuffle(req request.Request, msg *dns.Msg) ([]dns.RR, error) {
+	return []dns.RR{}, fmt.Errorf("skip shuffling")
+}


### PR DESCRIPTION
I am adding a new roundrobin plugin that implements several load balancing strategies. Please read the README.md for details.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
PR implements new plugin `roundrobin`; provides several loadbalancing strategies (consistent stateful, consistent stateless, random) that shuffle A and AAAA records in a DNS response.

### 2. Which issues (if any) are related?
No issues

### 3. Which documentation changes (if any) need to be made?
Adding plugin to main `README.md`

### 4. Does this introduce a backward incompatible change or deprecation?
The `loadbalance` plugin is now deprecated, because it only implements a simple random strategy (also implemented in the `roundrobin` plugin).
Both loadbalance and roundrobin are completely independent and can coexist.

Signed-off-by: kuritka <kuritka@gmail.com>