### PR TITLE
plugin/dnstap: support FQDN TCP endpoint 

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -41,6 +41,12 @@ Log to a remote endpoint.
 dnstap tcp://127.0.0.1:6000 full
 ~~~
 
+Log to a remote endpoint by FQDN.
+
+~~~ txt
+dnstap tcp://example.com:6000 full
+~~~
+
 ## Command Line Tool
 
 Dnstap has a command line tool that can be used to inspect the logging. The tool can be found

--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -25,7 +25,6 @@ type tapper interface {
 type dio struct {
 	endpoint     string
 	proto        string
-	conn         net.Conn
 	enc          *encoder
 	queue        chan tap.Dnstap
 	dropped      uint32

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -1,13 +1,13 @@
 package dnstap
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
-	"github.com/coredns/coredns/plugin/pkg/parse"
 )
 
 var log = clog.NewWithPlugin("dnstap")
@@ -24,12 +24,12 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 	}
 
 	if strings.HasPrefix(endpoint, "tcp://") {
-		// remote IP endpoint
-		servers, err := parse.HostPortOrFile(endpoint[6:])
+		// remote network endpoint
+		endpointURL, err := url.Parse(endpoint)
 		if err != nil {
 			return d, c.ArgErr()
 		}
-		dio := newIO("tcp", servers[0])
+		dio := newIO("tcp", endpointURL.Host)
 		d = Dnstap{io: dio}
 	} else {
 		endpoint = strings.TrimPrefix(endpoint, "unix://")

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -17,6 +17,8 @@ func TestConfig(t *testing.T) {
 		{"dnstap dnstap.sock full", "dnstap.sock", true, "unix", false},
 		{"dnstap unix://dnstap.sock", "dnstap.sock", false, "unix", false},
 		{"dnstap tcp://127.0.0.1:6000", "127.0.0.1:6000", false, "tcp", false},
+		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false},
+		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false},
 		{"dnstap", "fail", false, "tcp", true},
 	}
 	for i, tc := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Previously used parsing function only allows IP address as TCP endpoint.
This PR resolves TCP endpoint using `url.Parse` instead to support FQDN.

### 2. Which issues (if any) are related?
Relates to #5355.

### 3. Which documentation changes (if any) need to be made?
Included

### 4. Does this introduce a backward incompatible change or deprecation?
No