### PR TITLE
Fixing issue #5376 by adding a check to parse out Zone info

### DIFF
--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
-	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
 	"github.com/infobloxopen/go-trees/iptree"
 	"github.com/miekg/dns"
+
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 )
 
 // ACL enforces access control policies on DNS queries.
@@ -51,6 +52,8 @@ const (
 	// actionFilter returns empty sets for queries towards protected DNS zones.
 	actionFilter
 )
+
+var log = clog.NewWithPlugin("acl")
 
 // ServeDNS implements the plugin.Handler interface.
 func (a ACL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
@@ -109,7 +112,7 @@ func matchWithPolicies(policies []policy, w dns.ResponseWriter, r *dns.Msg) acti
 	// if the parsing did not return a proper response then we simply return 'actionBlock' to
 	// block the query
 	if ip == nil {
-		log.Errorf("ParseIP failed for ip address: %v", state.IP())
+		log.Errorf("Blocking request. Unable to parse source address: %v", state.IP())
 		return actionBlock
 	}
 	qtype := state.QType()

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -3,17 +3,15 @@ package acl
 import (
 	"context"
 	"net"
-
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
 	"github.com/infobloxopen/go-trees/iptree"
 	"github.com/miekg/dns"
-
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 )
 
 // ACL enforces access control policies on DNS queries.

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -102,7 +102,7 @@ RulesCheckLoop:
 func matchWithPolicies(policies []policy, w dns.ResponseWriter, r *dns.Msg) action {
 	state := request.Request{W: w, Req: r}
 
-	ip := []byte(nil)
+	var ip net.IP
 	if idx := strings.IndexByte(state.IP(), '%'); idx >= 0 {
 		ip = net.ParseIP(state.IP()[:idx])
 	} else {

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -12,6 +12,7 @@ import (
 type ResponseWriter struct {
 	TCP      bool // if TCP is true we return an TCP connection instead of an UDP one.
 	RemoteIP string
+	Zone     string
 }
 
 // LocalAddr returns the local address, 127.0.0.1:53 (UDP, TCP if t.TCP is true).
@@ -33,9 +34,9 @@ func (t *ResponseWriter) RemoteAddr() net.Addr {
 	ip := net.ParseIP(remoteIP)
 	port := 40212
 	if t.TCP {
-		return &net.TCPAddr{IP: ip, Port: port, Zone: ""}
+		return &net.TCPAddr{IP: ip, Port: port, Zone: t.Zone}
 	}
-	return &net.UDPAddr{IP: ip, Port: port, Zone: ""}
+	return &net.UDPAddr{IP: ip, Port: port, Zone: t.Zone}
 }
 
 // WriteMsg implements dns.ResponseWriter interface.


### PR DESCRIPTION

This fixes issue #5376 by simply removing any Zone info in the IP address before net.ParseIP(). This also adds a test in the acl-test  file to test the new changes.

It also blocks any queries which fail in the parsing step.