### PR TITLE
Correct timeout description

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -103,7 +103,7 @@ Also note the TLS config is "global" for the whole forwarding proxy if you need 
 
 On each endpoint, the timeouts for communication are set as follows:
 
-* The dial timeout by default is 30s, and can decrease automatically down to 100ms based on early results.
+* The dial timeout by default is 30s, and can decrease automatically down to 1s based on early results.
 * The read timeout is static at 2s.
 
 ## Metadata


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

It corrects the timeout values in the documentation (currently the documentation says 100ms dial timeout, but actually its 1000ms=1s)

```
// plugin/forward/persistent.go starting at line 151
const (
	defaultExpire  = 10 * time.Second
	minDialTimeout = 1 * time.Second  // <<<<< DEFINITION IN THE CODE
	maxDialTimeout = 30 * time.Second
)
```

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

No futher documentation adjustment needed. This already fixes the documentation.

### 4. Does this introduce a backward incompatible change or deprecation?

Since this only changes the documentation I would not excpect an incompatible change or deprecation. 
