### PR TITLE
recover from panic log including stacktrace to help finding the origin

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// Debug controls the panic/recover mechanism that is enabled by default.
 	Debug bool
 
+	// Stacktrace controls including stacktrace as part of log from recover mechanism, it is disabled by default.
+	Stacktrace bool
+
 	// The transport we implement, normally just "dns" over TCP/UDP, but could be
 	// DNS-over-TLS or DNS-over-gRPC.
 	Transport string

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -154,6 +154,7 @@ func (h *dnsContext) MakeServers() ([]caddy.Server, error) {
 		c.Plugin = c.firstConfigInBlock.Plugin
 		c.ListenHosts = c.firstConfigInBlock.ListenHosts
 		c.Debug = c.firstConfigInBlock.Debug
+		c.Stacktrace = c.firstConfigInBlock.Stacktrace
 		c.TLSConfig = c.firstConfigInBlock.TLSConfig
 	}
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -213,7 +214,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			// In case the user doesn't enable error plugin, we still
 			// need to make sure that we stay alive up here
 			if rec := recover(); rec != nil {
-				log.Errorf("Recovered from panic in server: %q %v", s.Addr, rec)
+				log.Errorf("Recovered from panic in server: %q %v\n%s", s.Addr, rec, string(debug.Stack()))
 				vars.Panic.Inc()
 				errorAndMetricsFunc(s.Addr, w, r, dns.RcodeServerFailure)
 			}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -42,6 +42,7 @@ type Server struct {
 	graceTimeout time.Duration      // the maximum duration of a graceful shutdown
 	trace        trace.Trace        // the trace plugin for the server
 	debug        bool               // disable recover()
+	stacktrace   bool               // enable stacktrace in recover error log
 	classChaos   bool               // allow non-INET class queries
 }
 
@@ -68,6 +69,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 			s.debug = true
 			log.D.Set()
 		}
+		s.stacktrace = site.Stacktrace
 		// set the config per zone
 		s.zones[site.Zone] = site
 
@@ -214,7 +216,11 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			// In case the user doesn't enable error plugin, we still
 			// need to make sure that we stay alive up here
 			if rec := recover(); rec != nil {
-				log.Errorf("Recovered from panic in server: %q %v\n%s", s.Addr, rec, string(debug.Stack()))
+				if s.stacktrace {
+					log.Errorf("Recovered from panic in server: %q %v\n%s", s.Addr, rec, string(debug.Stack()))
+				} else {
+					log.Errorf("Recovered from panic in server: %q %v", s.Addr, rec)
+				}
 				vars.Panic.Inc()
 				errorAndMetricsFunc(s.Addr, w, r, dns.RcodeServerFailure)
 			}

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -26,6 +26,7 @@ func testConfig(transport string, p plugin.Handler) *Config {
 		ListenHosts: []string{"127.0.0.1"},
 		Port:        "53",
 		Debug:       false,
+		Stacktrace:  false,
 	}
 
 	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
@@ -73,6 +74,27 @@ func TestDebug(t *testing.T) {
 	}
 	if log.D.Value() {
 		t.Errorf("Expected debug logging disabled")
+	}
+}
+
+func TestStacktrace(t *testing.T) {
+	configNoStacktrace, configStacktrace := testConfig("dns", testPlugin{}), testConfig("dns", testPlugin{})
+	configStacktrace.Stacktrace = true
+
+	s1, err := NewServer("127.0.0.1:53", []*Config{configStacktrace, configStacktrace})
+	if err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	if !s1.stacktrace {
+		t.Errorf("Expected stacktrace mode enabled for server s1")
+	}
+
+	s2, err := NewServer("127.0.0.1:53", []*Config{configNoStacktrace})
+	if err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	if s2.stacktrace {
+		t.Errorf("Expected stacktrace disabled for server s2")
 	}
 }
 

--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -22,12 +22,12 @@ Extra knobs are available with an expanded syntax:
 
 ~~~
 errors {
-	panicRecoveryStacktrace
+	stacktrace
 	consolidate DURATION REGEXP [LEVEL]
 }
 ~~~
 
-Option `panicRecoveryStacktrace` enables logging of stacktrace in case of panic recovery.
+Option `stacktrace` will log a stacktrace during panic recovery.
 
 Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
 log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.

--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -22,9 +22,12 @@ Extra knobs are available with an expanded syntax:
 
 ~~~
 errors {
+	panicRecoveryStacktrace
 	consolidate DURATION REGEXP [LEVEL]
 }
 ~~~
+
+Option `panicRecoveryStacktrace` enables logging of stacktrace in case of panic recovery.
 
 Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
 log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -52,38 +52,41 @@ func errorsParse(c *caddy.Controller) (*errorHandler, error) {
 		}
 
 		for c.NextBlock() {
-			if err := parseBlock(c, handler); err != nil {
-				return nil, err
+			switch c.Val() {
+			case "panicRecoveryStacktrace":
+				dnsserver.GetConfig(c).Stacktrace = true
+			case "consolidate":
+				pattern, err := parseConsolidate(c)
+				if err != nil {
+					return nil, err
+				}
+				handler.patterns = append(handler.patterns, pattern)
+			default:
+				return handler, c.SyntaxErr("Unknown field " + c.Val())
 			}
 		}
 	}
 	return handler, nil
 }
 
-func parseBlock(c *caddy.Controller, h *errorHandler) error {
-	if c.Val() != "consolidate" {
-		return c.SyntaxErr("consolidate")
-	}
-
+func parseConsolidate(c *caddy.Controller) (*pattern, error) {
 	args := c.RemainingArgs()
 	if len(args) < 2 || len(args) > 3 {
-		return c.ArgErr()
+		return nil, c.ArgErr()
 	}
 	p, err := time.ParseDuration(args[0])
 	if err != nil {
-		return c.Err(err.Error())
+		return nil, c.Err(err.Error())
 	}
 	re, err := regexp.Compile(args[1])
 	if err != nil {
-		return c.Err(err.Error())
+		return nil, c.Err(err.Error())
 	}
 	lc, err := parseLogLevel(c, args)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	h.patterns = append(h.patterns, &pattern{period: p, pattern: re, logCallback: lc})
-
-	return nil
+	return &pattern{period: p, pattern: re, logCallback: lc}, nil
 }
 
 func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...interface{}), error) {

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -53,7 +53,7 @@ func errorsParse(c *caddy.Controller) (*errorHandler, error) {
 
 		for c.NextBlock() {
 			switch c.Val() {
-			case "panicRecoveryStacktrace":
+			case "stacktrace":
 				dnsserver.GetConfig(c).Stacktrace = true
 			case "consolidate":
 				pattern, err := parseConsolidate(c)

--- a/plugin/errors/setup_test.go
+++ b/plugin/errors/setup_test.go
@@ -7,55 +7,64 @@ import (
 	"testing"
 
 	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 )
 
 func TestErrorsParse(t *testing.T) {
 	tests := []struct {
-		inputErrorsRules string
-		shouldErr        bool
-		optCount         int
+		inputErrorsRules        string
+		shouldErr               bool
+		optCount                int
+		panicRecoveryStacktrace bool
 	}{
-		{`errors`, false, 0},
-		{`errors stdout`, false, 0},
-		{`errors errors.txt`, true, 0},
-		{`errors visible`, true, 0},
-		{`errors { log visible }`, true, 0},
+		{`errors`, false, 0, false},
+		{`errors stdout`, false, 0, false},
+		{`errors errors.txt`, true, 0, false},
+		{`errors visible`, true, 0, false},
+		{`errors { log visible }`, true, 0, false},
 		{`errors
-		  errors `, true, 0},
-		{`errors a b`, true, 0},
+		  errors `, true, 0, false},
+		{`errors a b`, true, 0, false},
 
 		{`errors {
 		    consolidate
-		  }`, true, 0},
+		  }`, true, 0, false},
 		{`errors {
 		    consolidate 1m
-		  }`, true, 0},
+		  }`, true, 0, false},
 		{`errors {
 		    consolidate 1m .* extra
-		  }`, true, 0},
+		  }`, true, 0, false},
 		{`errors {
 		    consolidate abc .*
-		  }`, true, 0},
+		  }`, true, 0, false},
 		{`errors {
 		    consolidate 1 .*
-		  }`, true, 0},
+		  }`, true, 0, false},
 		{`errors {
 		    consolidate 1m ())
-		  }`, true, 0},
+		  }`, true, 0, false},
+		{`errors {
+            panicRecoveryStacktrace
+		  }`, false, 0, true},
+		{`errors {
+            panicRecoveryStacktrace
+		    consolidate 1m ^exact$
+		  }`, false, 1, true},
 		{`errors {
 		    consolidate 1m ^exact$
-		  }`, false, 1},
+		  }`, false, 1, false},
 		{`errors {
 		    consolidate 1m error
-		  }`, false, 1},
+		  }`, false, 1, false},
 		{`errors {
 		    consolidate 1m "format error"
-		  }`, false, 1},
+		  }`, false, 1, false},
 		{`errors {
 		    consolidate 1m error1
 		    consolidate 5s error2
-		  }`, false, 2},
+		  }`, false, 2, false},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputErrorsRules)
@@ -68,6 +77,10 @@ func TestErrorsParse(t *testing.T) {
 		} else if h != nil && len(h.patterns) != test.optCount {
 			t.Errorf("Test %d: pattern count mismatch, expected %d, got %d",
 				i, test.optCount, len(h.patterns))
+		}
+		if dnsserver.GetConfig(c).Stacktrace != test.panicRecoveryStacktrace {
+			t.Errorf("Test %d: panicRecoveryStacktrace, expected %t, got %t",
+				i, test.panicRecoveryStacktrace, dnsserver.GetConfig(c).Stacktrace)
 		}
 	}
 }

--- a/plugin/errors/setup_test.go
+++ b/plugin/errors/setup_test.go
@@ -16,7 +16,7 @@ func TestErrorsParse(t *testing.T) {
 		inputErrorsRules        string
 		shouldErr               bool
 		optCount                int
-		panicRecoveryStacktrace bool
+		stacktrace bool
 	}{
 		{`errors`, false, 0, false},
 		{`errors stdout`, false, 0, false},
@@ -46,10 +46,10 @@ func TestErrorsParse(t *testing.T) {
 		    consolidate 1m ())
 		  }`, true, 0, false},
 		{`errors {
-            panicRecoveryStacktrace
+            stacktrace
 		  }`, false, 0, true},
 		{`errors {
-            panicRecoveryStacktrace
+            stacktrace
 		    consolidate 1m ^exact$
 		  }`, false, 1, true},
 		{`errors {
@@ -78,9 +78,9 @@ func TestErrorsParse(t *testing.T) {
 			t.Errorf("Test %d: pattern count mismatch, expected %d, got %d",
 				i, test.optCount, len(h.patterns))
 		}
-		if dnsserver.GetConfig(c).Stacktrace != test.panicRecoveryStacktrace {
-			t.Errorf("Test %d: panicRecoveryStacktrace, expected %t, got %t",
-				i, test.panicRecoveryStacktrace, dnsserver.GetConfig(c).Stacktrace)
+		if dnsserver.GetConfig(c).Stacktrace != test.stacktrace {
+			t.Errorf("Test %d: stacktrace, expected %t, got %t",
+				i, test.stacktrace, dnsserver.GetConfig(c).Stacktrace)
 		}
 	}
 }


### PR DESCRIPTION
Currently CoreDNS doesn't log stactrace when recovering from panic which makes it hard to find the source from where the panic originates. This change proposes including the stacktrace as part of the logged message.

### 1. Why is this pull request needed and what does it do?
Currently when CoreDNS recovers from a panic, it just logs the error message without the stacktrace.

See difference output log from artificially added panic to whoami plugin

```
[ERROR] Recovered from panic in server: "dns://:53" index out of range [0] with length 0
```

After the proposed update you will get it including stacktrace which will help to find the origin:
```
[ERROR] Recovered from panic in server: "dns://:53" index out of range [0] with length 0
goroutine 55 [running]:
runtime/debug.Stack()
	/Users/radim.hatlapatka/sdk/go1.17.8/src/runtime/debug/stack.go:24 +0x88
github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS.func1(0x14000682180, 0x140004c1e20, 0x1400060a000)
	/Users/radim.hatlapatka/projects/upstream/coredns/core/dnsserver/server.go:217 +0x48
panic({0x1047fd300, 0x104ba7638})
	/Users/radim.hatlapatka/sdk/go1.17.8/src/runtime/panic.go:1038 +0x21c
github.com/coredns/coredns/plugin/whoami.Whoami.ServeDNS({}, {0x104bf4498, 0x140002873e0}, {0x104c24de8, 0x1400012c340}, 0x1400060a000)
	/Users/radim.hatlapatka/projects/upstream/coredns/plugin/whoami/whoami.go:28 +0x94
github.com/coredns/coredns/plugin.NextOrFailure({0x1042c8b15, 0x3}, {0x104bdd048, 0x105c71b08}, {0x104bf4498, 0x140002873e0}, {0x104c24de8, 0x1400012c340}, 0x1400060a000)
	/Users/radim.hatlapatka/projects/upstream/coredns/plugin/plugin.go:80 +0x1ec
github.com/coredns/coredns/plugin/log.Logger.ServeDNS({{0x104bdd048, 0x105c71b08}, {0x1400011fd70, 0x1, 0x1}, {}}, {0x104bf4498, 0x140002873e0}, {0x104c24ef0, 0x14000316198}, ...)
	/Users/radim.hatlapatka/projects/upstream/coredns/plugin/log/log.go:36 +0x2ac
github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS(0x14000682180, {0x104bf4498, 0x140002873e0}, {0x104c24ef0, 0x14000316198}, 0x1400060a000)
	/Users/radim.hatlapatka/projects/upstream/coredns/core/dnsserver/server.go:281 +0x620
github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1({0x104c269c0, 0x140002c2300}, 0x1400060a000)
	/Users/radim.hatlapatka/projects/upstream/coredns/core/dnsserver/server.go:129 +0xe4
github.com/miekg/dns.HandlerFunc.ServeDNS(0x1400020a040, {0x104c269c0, 0x140002c2300}, 0x1400060a000)
	/Users/radim.hatlapatka/go/pkg/mod/github.com/miekg/dns@v1.1.49/server.go:37 +0x40
github.com/miekg/dns.(*Server).serveDNS(0x14000606000, {0x14000578800, 0x2c, 0x200}, 0x140002c2300)
	/Users/radim.hatlapatka/go/pkg/mod/github.com/miekg/dns@v1.1.49/server.go:659 +0x3cc
github.com/miekg/dns.(*Server).serveUDPPacket(0x14000606000, 0x140002a80b0, {0x14000578800, 0x2c, 0x200}, {0x104c185b0, 0x1400000f4c0}, 0x14000344020, {0x0, 0x0})
	/Users/radim.hatlapatka/go/pkg/mod/github.com/miekg/dns@v1.1.49/server.go:603 +0x1bc
created by github.com/miekg/dns.(*Server).serveUDP
	/Users/radim.hatlapatka/go/pkg/mod/github.com/miekg/dns@v1.1.49/server.go:533 +0x3a8
```

### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
no