### PR TITLE
plugin/cache: Reword serve_stale docs for clarity

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -56,7 +56,7 @@ cache [TTL] [ZONES...] {
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
 * `serve_stale`, when serve\_stale is set, cache will always serve an expired entry to a client if there is one
   available as long as it has not been expired for longer than **DURATION** (default 1 hour). By default, the _cache_ plugin will
-  attempt to refresh the cache entry after sending the expired cache entry to the client. The 
+  attempt to refresh the cache entry after sending the expired cache entry to the client. The
   responses have a TTL of 0. **REFRESH_MODE** controls the timing of the expired cache entry refresh.
   `verified` will first verify that an entry is still unavailable from the source before sending the expired entry to the client.
   `immediate` will immediately send the expired response to the client before

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -59,7 +59,7 @@ cache [TTL] [ZONES...] {
   attempt to refresh the cache entry after sending the expired cache entry to the client. The
   responses have a TTL of 0. **REFRESH_MODE** controls the timing of the expired cache entry refresh.
   `verified` will first verify that an entry is still unavailable from the source before sending the expired entry to the client.
-  `immediate` will immediately send the expired response to the client before
+  `immediate` will immediately send the expired entry to the client before
   checking to see if the entry is available from the source. **REFRESH_MODE** defaults to `immediate`. Setting this
   value to `verified` can lead to increased latency when serving stale responses, but will prevent stale entries
   from ever being served if an updated response can be retrieved from the source.

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -54,12 +54,12 @@ cache [TTL] [ZONES...] {
   **DURATION** defaults to 1m. Prefetching will happen when the TTL drops below **PERCENTAGE**,
   which defaults to `10%`, or latest 1 second before TTL expiration. Values should be in the range `[10%, 90%]`.
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
-* `serve_stale`, when serve\_stale is set, cache always will serve an expired entry to a client if there is one
-  available.  When this happens, cache will attempt to refresh the cache entry after sending the expired cache
-  entry to the client. The responses have a TTL of 0. **DURATION** is how far back to consider
-  stale responses as fresh. The default duration is 1h. **REFRESH_MODE** controls when the attempt to refresh
-  the cache happens. `verified` will first verify that an entry is still unavailable from the source before sending
-  the stale response to the client. `immediate` will immediately send the expired response to the client before
+* `serve_stale`, when serve\_stale is set, cache will always serve an expired entry to a client if there is one
+  available as long as it has not been expired for longer than **DURATION** (default 1 hour). By default, the _cache_ plugin will
+  attempt to refresh the cache entry after sending the expired cache entry to the client. The 
+  responses have a TTL of 0. **REFRESH_MODE** controls the timing of the expired cache entry refresh.
+  `verified` will first verify that an entry is still unavailable from the source before sending the expired entry to the client.
+  `immediate` will immediately send the expired response to the client before
   checking to see if the entry is available from the source. **REFRESH_MODE** defaults to `immediate`. Setting this
   value to `verified` can lead to increased latency when serving stale responses, but will prevent stale entries
   from ever being served if an updated response can be retrieved from the source.


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Reword for `serve_stale` docs to be more clear.

### 2. Which issues (if any) are related?

#5393

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
