### PR TITLE
plugin/health: Bypass proxy in self health check

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -50,7 +50,7 @@ Doing this is supported but both endpoints ":8080" and ":8081" will export the e
 
 If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
 
- * `coredns_health_request_duration_seconds{}` - The *health* plugin performs a self health check 
+ * `coredns_health_request_duration_seconds{}` - The *health* plugin performs a self health check
     once per second on the `/health` endpoint. This metric is the duration to process that request.
     As this is a local operation it should be fast. A (large) increase in this
     duration indicates the CoreDNS process is having trouble keeping up with its query load.

--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -48,13 +48,13 @@ Doing this is supported but both endpoints ":8080" and ":8081" will export the e
 
 ## Metrics
 
-If monitoring is enabled (via the *prometheus* plugin) then the following metric is exported:
+If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
 
- * `coredns_health_request_duration_seconds{}` - duration to process a HTTP query to the local
-    `/health` endpoint. As this a local operation it should be fast. A (large) increase in this
+ * `coredns_health_request_duration_seconds{}` - The *health* plugin performs a self health check 
+    once per second on the `/health` endpoint. This metric is the duration to process that request.
+    As this is a local operation it should be fast. A (large) increase in this
     duration indicates the CoreDNS process is having trouble keeping up with its query load.
- * `coredns_health_request_failures_total{}` - The number of times the internal health check loop
-    failed to query `/health`.
+ * `coredns_health_request_failures_total{}` - The number of times the self health check failed.
 
 Note that these metrics *do not* have a `server` label, because being overloaded is a symptom of
 the running process, *not* a specific server.

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -13,9 +13,12 @@ import (
 
 // overloaded queries the health end point and updates a metrics showing how long it took.
 func (h *health) overloaded(ctx context.Context) {
+	bypassProxy := http.DefaultTransport
+	bypassProxy.(*http.Transport).Proxy = nil
 	timeout := 3 * time.Second
 	client := http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: bypassProxy,
 	}
 
 	url := "http://" + h.Addr + "/health"

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -13,8 +14,18 @@ import (
 
 // overloaded queries the health end point and updates a metrics showing how long it took.
 func (h *health) overloaded(ctx context.Context) {
-	bypassProxy := http.DefaultTransport
-	bypassProxy.(*http.Transport).Proxy = nil
+	bypassProxy := &http.Transport{
+		Proxy: nil,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	timeout := 3 * time.Second
 	client := http.Client{
 		Timeout:   timeout,


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Raised in #5390, self health checks go through the proxy if present.  Since the check is always destined locally, it doesn't make sense for the query to go though a proxy.

PR also adds some detail to the self health check docs in the README.

### 2. Which issues (if any) are related?

closes #5390

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
