### PR TITLE
Update version and release note to 1.9.3

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.9.2"
+	CoreVersion = "1.9.3"
 	coreName    = "CoreDNS"
 	serverType  = "dns"
 )

--- a/notes/coredns-1.9.3.md
+++ b/notes/coredns-1.9.3.md
@@ -1,0 +1,31 @@
++++
+title = "CoreDNS-1.9.3 Release"
+description = "CoreDNS-1.9.3 Release Notes."
+tags = ["Release", "1.9.3", "Notes"]
+release = "1.9.3"
+date = "2022-05-27T00:00:00+00:00"
+author = "coredns"
++++
+
+This is a release with a focus on security (CVE-2022-27191 and CVE-2022-28948) fixes. Additional,
+several feature enhancements and bug fixes have also been added.
+
+## Brought to You By
+
+Chris O'Haver,
+lobshunter,
+Naveen,
+Radim Hatlapatka,
+RetoHaslerMGB,
+Tintin,
+Yong Tang
+
+
+## Noteworthy Changes
+
+* core: update gopkg.in/yaml.v3 to fix CVE-2022-28948 (https://github.com/coredns/coredns/pull/5408)
+* core: update golang.org/x/crypto to fix CVE-2022-27191 (https://github.com/coredns/coredns/pull/5407)
+* plugin/acl: adding a check to parse out zone info (https://github.com/coredns/coredns/pull/5387)
+* plugin/dnstap: support FQDN TCP endpoint (https://github.com/coredns/coredns/pull/5377)
+* plugin/errors: add `stacktrace` option to log a stacktrace during panic recovery (https://github.com/coredns/coredns/pull/5392)
+* plugin/template: return SERVFAIL for zone-match regex-no-match case (https://github.com/coredns/coredns/pull/5180)

--- a/notes/coredns-1.9.3.md
+++ b/notes/coredns-1.9.3.md
@@ -7,7 +7,7 @@ date = "2022-05-27T00:00:00+00:00"
 author = "coredns"
 +++
 
-This is a release with a focus on security (CVE-2022-27191 and CVE-2022-28948) fixes. Additional,
+This is a release with a focus on security (CVE-2022-27191 and CVE-2022-28948) fixes. Additionally,
 several feature enhancements and bug fixes have also been added.
 
 ## Brought to You By

--- a/notes/coredns-1.9.3.md
+++ b/notes/coredns-1.9.3.md
@@ -8,7 +8,7 @@ author = "coredns"
 +++
 
 This is a release with a focus on security (CVE-2022-27191 and CVE-2022-28948) fixes. Additionally,
-several feature enhancements and bug fixes have also been added.
+several feature enhancements and bug fixes have been added.
 
 ## Brought to You By
 


### PR DESCRIPTION

This PR update version and release note to prepare for 1.9.3.
Main reason is to address s (CVE-2022-27191 and CVE-2022-28948) 

This PR is part of #5410

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>