### PR TITLE
Workaround for incorrect architecture on Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ buildCoreDNSImage: &buildCoreDNSImage
       command: |
         cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
         make coredns SYSTEM="GOOS=linux" && \
-        docker build -t coredns . && \
+        DOCKER_BUILDKIT=1 docker build -t coredns . && \
         kind load docker-image coredns
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:stable-slim
+FROM --platform=$BUILDPLATFORM debian:stable-slim
 
 RUN apt-get update && apt-get -uy upgrade
 RUN apt-get -y install ca-certificates && update-ca-certificates
 
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 ADD coredns /coredns

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -83,7 +83,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
+	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
 	done
 endif
 
@@ -102,10 +102,6 @@ else
 	done
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_VERSIONED)
-	for arch in $(LINUX_ARCH); do \
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
-	done
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
 	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"$(DOCKER_LOGIN)\",\"password\":\"$(DOCKER_PASSWORD)\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

`Makefile.docker` generates correct manifest file, however, when it is pushed to Docker Hub, OS/Arch is incorrect. The problem seems to be on Docker Hub's side, as the exact same manifest would result in correct OS/Arch on ghcr.io.

### 2. Which issues (if any) are related?

#5363

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Modified Dockerfile requires [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).