### PR TITLE
Log the literal value, not a format string

### DIFF
--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -46,7 +46,7 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		}
 		if ok || ok1 {
 			logstr := l.repl.Replace(ctx, state, rrw, rule.Format)
-			clog.Infof(logstr)
+			clog.Info(logstr)
 		}
 
 		return rc, err

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -202,6 +202,19 @@ func TestLogged(t *testing.T) {
 			ShouldLog:    true,
 			ShouldString: "\"0\"",
 		},
+		{
+			Rules: []Rule{
+				{
+					NameScope: ".",
+					Format:    CombinedLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:          "foo.%s.example.org.",
+			ShouldLog:       true,
+			ShouldString:    "foo.%s.example.org.",
+			ShouldNOTString: "%!s(MISSING)",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `log` plugin currently passes the replaced log string to `Infof` which expects a format string.

The query question or an IPv6 link local address could contain a `%` which the Go formatter would interpret as a verb, resulting in a log message such as:

```
Jun 05 16:41:03 router coredns[10786]: [INFO] [fe80::abcd:abcd:abcd:abcd%!l(MISSING)an0]:54939 - 57566 "A IN foo.%!s(MISSING).example. udp 43 false 4096" NXDOMAIN qr,aa,rd,ra 107 0.010446858s
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No