### PR TITLE
remove unused coredns_forward_sockets_open metric

### DIFF
--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -40,12 +40,6 @@ var (
 		Name:      "healthcheck_broken_total",
 		Help:      "Counter of the number of complete failures of the healthchecks.",
 	})
-	SocketGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: plugin.Namespace,
-		Subsystem: "forward",
-		Name:      "sockets_open",
-		Help:      "Gauge of open sockets per upstream.",
-	}, []string{"to"})
 	MaxConcurrentRejectCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
removes a metric declaration, this metric is obsolete and is not used anywhere, all usage was removed as part of https://github.com/coredns/coredns/commit/2d98d520b5c75d31e37dfe72a67b39707a56dc69#diff-2f8a7b4f46ff73fbc67bb790ed42d9d2923ef137d36e12b884cc71928ba67dab

### 2. Which issues (if any) are related?
no issue, trivial refactoring

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
