### PR TITLE
plugin/k8s_external: Add support for PTR requests

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -10,7 +10,7 @@ This plugin allows an additional zone to resolve the external IP address(es) of 
 service. This plugin is only useful if the *kubernetes* plugin is also loaded.
 
 The plugin uses an external zone to resolve in-cluster IP addresses. It only handles queries for A,
-AAAA and SRV records; all others result in NODATA responses. To make it a proper DNS zone, it handles
+AAAA, SRV, and PTR records; all others result in NODATA responses. To make it a proper DNS zone, it handles
 SOA and NS queries for the apex of the zone.
 
 By default the apex of the zone will look like the following (assuming the zone used is `example.org`):
@@ -101,6 +101,3 @@ zone transfers.  Notifies are not supported.
 For some background see [resolve external IP address](https://github.com/kubernetes/dns/issues/242).
 And [A records for services with Load Balancer IP](https://github.com/coredns/coredns/issues/1851).
 
-# Bugs
-
-PTR queries for the reverse zone is not supported.

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -71,6 +71,20 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return plugin.NextOrFailure(e.Name(), e.Next, ctx, w, r)
 	}
 
+	if state.QType() == dns.TypePTR {
+
+		m := new(dns.Msg)
+		m.SetReply(state.Req)
+		m.Authoritative = true
+
+		m.Answer = e.ptr(ctx, state)
+
+		m.Ns = []dns.RR{e.soa(state)}
+
+		w.WriteMsg(m)
+		return 0, nil
+	}
+
 	state.Zone = zone
 	for _, z := range e.Zones {
 		// TODO(miek): save this in the External struct.

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -71,20 +71,6 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return plugin.NextOrFailure(e.Name(), e.Next, ctx, w, r)
 	}
 
-	if state.QType() == dns.TypePTR {
-
-		m := new(dns.Msg)
-		m.SetReply(state.Req)
-		m.Authoritative = true
-
-		m.Answer = e.ptr(ctx, state)
-
-		m.Ns = []dns.RR{e.soa(state)}
-
-		w.WriteMsg(m)
-		return 0, nil
-	}
-
 	state.Zone = zone
 	for _, z := range e.Zones {
 		// TODO(miek): save this in the External struct.
@@ -119,6 +105,8 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		m.Answer, m.Truncated = e.aaaa(ctx, svc, state)
 	case dns.TypeSRV:
 		m.Answer, m.Extra = e.srv(ctx, svc, state)
+	case dns.TypePTR:
+		m.Answer = e.ptr(svc, state)
 	default:
 		m.Ns = []dns.RR{e.soa(state)}
 	}

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -49,7 +49,7 @@ func TestExternal(t *testing.T) {
 			t.Error("Expected authoritative answer")
 		}
 		if err = test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
+			t.Errorf("Test %d: %v", i, err)
 		}
 	}
 }
@@ -60,6 +60,20 @@ var tests = []test.Case{
 		Qname: "4.3.2.1.in-addr.arpa.", Qtype: dns.TypePTR, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.PTR("4.3.2.1.in-addr.arpa. 5 IN PTR svc1.testns.example.com."),
+		},
+	},
+	// Bad PTR reverse lookup using existing service name
+	{
+		Qname: "svc1.testns.example.com.", Qtype: dns.TypePTR, Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// Bad PTR reverse lookup using non-existing service name
+	{
+		Qname: "not-existing.testns.example.com.", Qtype: dns.TypePTR, Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	// A Service

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -176,7 +176,7 @@ var tests = []test.Case{
 	{
 		Qname: "svc11.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("svc11.testns.example.com.	5	IN	A	2.3.4.5"),
 		},
 	},
 	{
@@ -185,7 +185,7 @@ var tests = []test.Case{
 			test.SRV("_http._tcp.svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
 		},
 		Extra: []dns.RR{
-			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("svc11.testns.example.com.	5	IN	A	2.3.4.5"),
 		},
 	},
 	{
@@ -194,7 +194,7 @@ var tests = []test.Case{
 			test.SRV("svc11.testns.example.com.	5	IN	SRV	0 100 80 svc11.testns.example.com."),
 		},
 		Extra: []dns.RR{
-			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("svc11.testns.example.com.	5	IN	A	2.3.4.5"),
 		},
 	},
 	// svc12
@@ -278,7 +278,7 @@ var svcIndexExternal = map[string][]*object.Service{
 			Name:        "svc11",
 			Namespace:   "testns",
 			Type:        api.ServiceTypeLoadBalancer,
-			ExternalIPs: []string{"1.2.3.4"},
+			ExternalIPs: []string{"2.3.4.5"},
 			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
 		},
 	},

--- a/plugin/k8s_external/msg_to_dns.go
+++ b/plugin/k8s_external/msg_to_dns.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -74,6 +75,19 @@ func (e *External) aaaa(ctx context.Context, services []msg.Service, state reque
 		}
 	}
 	return records, truncated
+}
+
+func (e *External) ptr(services []msg.Service, state request.Request) (records []dns.RR) {
+	dup := make(map[string]struct{})
+	for _, s := range services {
+		if _, ok := dup[s.Host]; !ok {
+			dup[s.Host] = struct{}{}
+			rr := s.NewPTR(state.QName(), dnsutil.Join(s.Host, e.Zones[0]))
+			rr.Hdr.Ttl = e.ttl
+			records = append(records, rr)
+		}
+	}
+	return records
 }
 
 func (e *External) srv(ctx context.Context, services []msg.Service, state request.Request) (records, extra []dns.RR) {
@@ -150,39 +164,6 @@ func (e *External) srv(ctx context.Context, services []msg.Service, state reques
 		}
 	}
 	return records, extra
-}
-
-func (e *External) ptr(ctx context.Context, state request.Request) (records []dns.RR) {
-	dup := make(map[string]struct{})
-
-	for _, s := range services {
-
-		what, ip := s.HostType()
-
-		switch what {
-		case dns.TypeCNAME:
-			rr := s.NewCNAME(state.QName(), s.Host)
-			records = append(records, rr)
-			if resp, err := e.upstream.Lookup(ctx, state, dns.Fqdn(s.Host), dns.TypeA); err == nil {
-				records = append(records, resp.Answer...)
-				if resp.Truncated {
-					truncated = true
-				}
-			}
-
-		case dns.TypeA:
-			if _, ok := dup[s.Host]; !ok {
-				dup[s.Host] = struct{}{}
-				rr := s.NewA(state.QName(), ip)
-				rr.Hdr.Ttl = e.ttl
-				records = append(records, rr)
-			}
-
-		case dns.TypeAAAA:
-			// nada
-		}
-	}
-	return records, truncated
 }
 
 // not sure if this is even needed.

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -59,6 +59,11 @@ func TestTransferAXFR(t *testing.T) {
 			if ans.Header().Rrtype == dns.TypeTXT {
 				continue
 			}
+
+			// Exclude PTR records
+			if ans.Header().Rrtype == dns.TypePTR {
+				continue
+			}
 			expect = append(expect, ans)
 		}
 	}

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -138,13 +138,13 @@ func (k *Kubernetes) ExternalReverse(ip string) ([]msg.Service, error) {
 }
 
 func (k *Kubernetes) serviceRecordForExternalIP(ip string) []msg.Service {
+	var svcs []msg.Service
 	for _, service := range k.APIConn.SvcExtIndexReverse(ip) {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
 			continue
 		}
 		domain := strings.Join([]string{service.Name, service.Namespace}, ".")
-		return []msg.Service{{Host: domain, TTL: k.ttl}}
+		svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
 	}
-	// none found
-	return nil
+	return svcs
 }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -80,6 +80,7 @@ func (external) Run()                                                           
 func (external) Stop() error                                                       { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
 func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
+func (external) SvcExtIndexReverse(string) []*object.Service                       { return nil }
 func (external) Modified(bool) int64                                               { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
 func (external) EndpointsList() []*object.Endpoints                                { return nil }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -536,12 +536,13 @@ type APIConnServeTest struct {
 	notSynced bool
 }
 
-func (a APIConnServeTest) HasSynced() bool                         { return !a.notSynced }
-func (APIConnServeTest) Run()                                      {}
-func (APIConnServeTest) Stop() error                               { return nil }
-func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
-func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }
-func (APIConnServeTest) Modified(bool) int64                       { return int64(3) }
+func (a APIConnServeTest) HasSynced() bool                           { return !a.notSynced }
+func (APIConnServeTest) Run()                                        {}
+func (APIConnServeTest) Stop() error                                 { return nil }
+func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints   { return nil }
+func (APIConnServeTest) SvcIndexReverse(string) []*object.Service    { return nil }
+func (APIConnServeTest) SvcExtIndexReverse(string) []*object.Service { return nil }
+func (APIConnServeTest) Modified(bool) int64                         { return int64(3) }
 
 func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 	if ip != "10.240.0.1" {

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -39,13 +39,14 @@ func TestEndpointHostname(t *testing.T) {
 
 type APIConnServiceTest struct{}
 
-func (APIConnServiceTest) HasSynced() bool                           { return true }
-func (APIConnServiceTest) Run()                                      {}
-func (APIConnServiceTest) Stop() error                               { return nil }
-func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return nil }
-func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }
-func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints { return nil }
-func (APIConnServiceTest) Modified(bool) int64                       { return 0 }
+func (APIConnServiceTest) HasSynced() bool                             { return true }
+func (APIConnServiceTest) Run()                                        {}
+func (APIConnServiceTest) Stop() error                                 { return nil }
+func (APIConnServiceTest) PodIndex(string) []*object.Pod               { return nil }
+func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service    { return nil }
+func (APIConnServiceTest) SvcExtIndexReverse(string) []*object.Service { return nil }
+func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints   { return nil }
+func (APIConnServiceTest) Modified(bool) int64                         { return 0 }
 
 func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -14,14 +14,15 @@ import (
 
 type APIConnTest struct{}
 
-func (APIConnTest) HasSynced() bool                          { return true }
-func (APIConnTest) Run()                                     {}
-func (APIConnTest) Stop() error                              { return nil }
-func (APIConnTest) PodIndex(string) []*object.Pod            { return nil }
-func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
-func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
-func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
-func (APIConnTest) Modified(bool) int64                      { return 0 }
+func (APIConnTest) HasSynced() bool                             { return true }
+func (APIConnTest) Run()                                        {}
+func (APIConnTest) Stop() error                                 { return nil }
+func (APIConnTest) PodIndex(string) []*object.Pod               { return nil }
+func (APIConnTest) SvcIndexReverse(string) []*object.Service    { return nil }
+func (APIConnTest) SvcExtIndexReverse(string) []*object.Service { return nil }
+func (APIConnTest) EpIndex(string) []*object.Endpoints          { return nil }
+func (APIConnTest) EndpointsList() []*object.Endpoints          { return nil }
+func (APIConnTest) Modified(bool) int64                         { return 0 }
 
 func (a APIConnTest) SvcIndex(s string) []*object.Service {
 	switch s {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -15,14 +15,15 @@ import (
 
 type APIConnReverseTest struct{}
 
-func (APIConnReverseTest) HasSynced() bool                    { return true }
-func (APIConnReverseTest) Run()                               {}
-func (APIConnReverseTest) Stop() error                        { return nil }
-func (APIConnReverseTest) PodIndex(string) []*object.Pod      { return nil }
-func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }
-func (APIConnReverseTest) EndpointsList() []*object.Endpoints { return nil }
-func (APIConnReverseTest) ServiceList() []*object.Service     { return nil }
-func (APIConnReverseTest) Modified(bool) int64                { return 0 }
+func (APIConnReverseTest) HasSynced() bool                             { return true }
+func (APIConnReverseTest) Run()                                        {}
+func (APIConnReverseTest) Stop() error                                 { return nil }
+func (APIConnReverseTest) PodIndex(string) []*object.Pod               { return nil }
+func (APIConnReverseTest) EpIndex(string) []*object.Endpoints          { return nil }
+func (APIConnReverseTest) EndpointsList() []*object.Endpoints          { return nil }
+func (APIConnReverseTest) ServiceList() []*object.Service              { return nil }
+func (APIConnReverseTest) SvcExtIndexReverse(string) []*object.Service { return nil }
+func (APIConnReverseTest) Modified(bool) int64                         { return 0 }
 
 func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
 	if svc != "svc1.testns" {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fixes issue #5422 by:
* Excluding External IP addresses from being added to the existing _kubernetes'_ plugin IP->Service index
* Adding support for PTR requests on External IPs of Services to the _k8s_external_ plugin

### 2. Which issues (if any) are related?

Closes #5422

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
