### PR TITLE
plugin/trace: read trace context info from headers for DOH

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -27,6 +27,9 @@ type ServerHTTPS struct {
 	validRequest func(*http.Request) bool
 }
 
+// HTTPRequestKey is the context key for the current processed HTTP request (if current processed request was done over DOH)
+type HTTPRequestKey struct{}
+
 // NewServerHTTPS returns a new CoreDNS HTTPS server and compiles all plugins in to it.
 func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 	s, err := NewServer(addr, group)
@@ -153,6 +156,7 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We should expect a packet to be returned that we can send to the client.
 	ctx := context.WithValue(context.Background(), Key{}, s.Server)
 	ctx = context.WithValue(ctx, LoopKey{}, 0)
+	ctx = context.WithValue(ctx, HTTPRequestKey{}, r)
 	s.ServeDNS(ctx, dw, msg)
 
 	// See section 4.2.1 of RFC 8484.


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>


### 1. Why is this pull request needed and what does it do?
This PR enhances `trace` plugin to read HTTP headers from DNS request done over HTTPS (DoH requests) and extract trace headers passed from services before CoreDNS instance (like some loadbalancers) and if such tracing headers are found, the trace plugin starts the root span in the same trace (with the same traceID). This enables tracing systems (like Zipkin) to better connect request spans between CoreDNS and loadbalancers/proxies. This feature will enable better debugging of whole DoH request processing across the whole system flow.

In this picture you can see an example how would such a trace look like, you can see Traefik instance proxying request to a CoreDNS instance and you can see how long it took for CoreDNS to start processing the request
<img width="1701" alt="image" src="https://user-images.githubusercontent.com/5522817/174262938-9a5ad753-eef9-4514-8c13-d7168c8b9b7e.png">
 

### 2. Which issues (if any) are related?
no issue related

### 3. Which documentation changes (if any) need to be made?
no documentation changes needed

### 4. Does this introduce a backward incompatible change or deprecation?
no
