### PR TITLE
plugin/trace: make zipkin and datadog reporters log errors using CoreDNS logger

### DIFF
--- a/plugin/trace/logger.go
+++ b/plugin/trace/logger.go
@@ -1,0 +1,20 @@
+package trace
+
+import (
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+)
+
+// loggerAdapter is a simple adapter around plugin logger made to implement io.Writer and ddtrace.Logger interface
+// in order to log errors from span reporters as warnings
+type loggerAdapter struct {
+	clog.P
+}
+
+func (l *loggerAdapter) Write(p []byte) (n int, err error) {
+	l.P.Warning(string(p))
+	return len(p), nil
+}
+
+func (l *loggerAdapter) Log(msg string) {
+	l.P.Warning(msg)
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR improves `trace` plugin in a way that errors logged by zipkin/datadog span reporters are logged in a CoreDNS format and not default format of the logger from the std library

example of logs before the change

let's have Corefile
```
.:53 {
  log
 trace zipkin 127.0.0.1:9411 {
   service coredns
 }
  forward . 8.8.8.8
}
```

and when we do some DNS query, the CoreDNS will log:
```
2022/06/22 21:53:18 failed to send the request: Post "http://127.0.0.1:9411/api/v2/spans": dial tcp 127.0.0.1:9411: connect: connection refused
```

this PR improves the logging in a way that it is logged as:
```
[WARNING] plugin/trace: failed to send the request: Post "http://127.0.0.1:9411/api/v2/spans": dial tcp 127.0.0.1:9411: connect: connection refused
```
This way the logs produced by CoreDNS are in a more unified format and better parsable by other log parsers

### 2. Which issues (if any) are related?
no issue related

### 3. Which documentation changes (if any) need to be made?
none needed

### 4. Does this introduce a backward incompatible change or deprecation?
no
