### PR TITLE
log DoH HTTP server error logs in CoreDNS format

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	stdlog "log"
 	"net"
 	"net/http"
 	"strconv"
@@ -13,6 +14,7 @@ import (
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/doh"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 	"github.com/coredns/coredns/plugin/pkg/transport"
@@ -25,6 +27,15 @@ type ServerHTTPS struct {
 	listenAddr   net.Addr
 	tlsConfig    *tls.Config
 	validRequest func(*http.Request) bool
+}
+
+// loggerAdapter is a simple adapter around CoreDNS logger made to implement io.Writer in order to log errors from HTTP server
+type loggerAdapter struct {
+}
+
+func (l *loggerAdapter) Write(p []byte) (n int, err error) {
+	clog.Debug(string(p))
+	return len(p), nil
 }
 
 // HTTPRequestKey is the context key for the current processed HTTP request (if current processed request was done over DOH)
@@ -63,6 +74,7 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  120 * time.Second,
+		ErrorLog:     stdlog.New(&loggerAdapter{}, "", 0),
 	}
 	sh := &ServerHTTPS{
 		Server: s, tlsConfig: tlsConfig, httpsServer: srv, validRequest: validator,


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
This PR changes default logger of  the HTTP server used for processing DoH requests to log error logs in a CoreDNS format (similar change to #5452), all errors are logged on DEBUG level as these errors are in most cases related to the client issues, but sometimes for debugging they can be useful.

example of behaviour before and after this change:
let's have an Corefile
```
https://.:8080 {
  log
  forward . 8.8.8.8
  debug
}
```

and when we do DoH query such as this
```
curl -k -H 'accept: application/dns-message' 'http://127.0.0.1:8080/dns-query?dns=;180BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB' -i
```

it will log
```
http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192
```

but this PR changes it that it will be logged as 
```
[DEBUG] http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192
```

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
