### PR TITLE
Bump circle-ci image and update README to build using latest go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ initWorkingDir: &initWorkingDir
 
 integrationDefaults: &integrationDefaults
   machine:
-    image: ubuntu-2004:202201-02
+    image: ubuntu-2004:2022.04.2
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
     - K8S_VERSION: v1.22.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ CoreDNS requires Go to compile. However, if you already have docker installed an
 setup a Go environment, you could build CoreDNS easily:
 
 ```
-$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.17 make
+$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.18 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
This PR specifies a [newer](https://discuss.circleci.com/t/ubuntu-linux-vm-machine-images-2022-april-q2-update/43749) circle-ci image with go 1.18 to run integration tests on, the one we [are currently](https://discuss.circleci.com/t/linux-machine-executor-images-2022-january-q1-update/42831) using had go 1.17

Also bumped the version in `go.mod` for consistency

### 2. Which issues (if any) are related?
no issue, follow up to https://github.com/coredns/coredns/commit/d89f899dc44a75a7f0a02885f04162930917c7df

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
