### PR TITLE
Fix a crash in rewrite plugin when rule type is missing

### DIFF
--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -104,6 +104,9 @@ func newRule(args ...string) (Rule, error) {
 		expectNumArgs = len(args) - 1
 		startArg = 2
 	case Stop:
+		if len(args) < 2 {
+			return nil, fmt.Errorf("stop rule must begin with a rule type")
+		}
 		ruleType = strings.ToLower(args[1])
 		expectNumArgs = len(args) - 1
 		startArg = 2


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

This PR tries to fix a crash in rewrite plugin when rule type is missing.


### 2. Which issues (if any) are related?
n/a

### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>