### PR TITLE
plugin/kubernetes : make kubernetes client log in CoreDNS format

### DIFF
--- a/plugin/kubernetes/logger.go
+++ b/plugin/kubernetes/logger.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import (
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+
+	"github.com/go-logr/logr"
+)
+
+// loggerAdapter is a simple wrapper around CoreDNS plugin logger made to implement logr.LogSink interface, which is used
+// as part of klog library for logging in Kubernetes client. By using this adapter CoreDNS is able to log messages/errors from
+// kubernetes client in a CoreDNS logging format
+type loggerAdapter struct {
+	clog.P
+}
+
+func (l *loggerAdapter) Init(_ logr.RuntimeInfo) {
+}
+
+func (l *loggerAdapter) Enabled(_ int) bool {
+	// verbosity is controlled inside klog library, we do not need to do anything here
+	return true
+}
+
+func (l *loggerAdapter) Info(_ int, msg string, _ ...interface{}) {
+	l.P.Info(msg)
+}
+
+func (l *loggerAdapter) Error(_ error, msg string, _ ...interface{}) {
+	l.P.Error(msg)
+}
+
+func (l *loggerAdapter) WithValues(_ ...interface{}) logr.LogSink {
+	return l
+}
+
+func (l *loggerAdapter) WithName(_ string) logr.LogSink {
+	return l
+}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 
+	"github.com/go-logr/logr"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
@@ -32,7 +32,7 @@ func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	// Do not call klog.InitFlags(nil) here.  It will cause reload to panic.
-	klog.SetOutput(os.Stdout)
+	klog.SetLogger(logr.New(&loggerAdapter{log}))
 
 	k, err := kubernetesParse(c)
 	if err != nil {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR improves the logging of `kubernetes` plugin in a way that log messages logged by [Kubernetes client](https://github.com/kubernetes/client-go) are logged in a CoreDNS format, this change should simplify CoreDNS log investigation and automatized processing

example of logs of kubernetes plugin before the change:
```
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
W0626 21:49:43.814875   59475 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
E0626 21:49:43.815149   59475 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
W0626 21:49:44.889435   59475 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
E0626 21:49:44.889470   59475 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
W0626 21:49:47.500570   59475 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
E0626 21:49:47.500624   59475 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[WARNING] plugin/kubernetes: starting server with unsynced Kubernetes API
```

after this change it will be logged like this:
```
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[ERROR] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[ERROR] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[INFO] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[ERROR] plugin/kubernetes: pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "ondrej.benkovsky@wandera.com" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
[INFO] plugin/kubernetes: waiting for Kubernetes API before starting server
[WARNING] plugin/kubernetes: starting server with unsynced Kubernetes API
```

### 2. Which issues (if any) are related?
no issue

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
