### PR TITLE
plugin/health: Don't go lameduck when reloading

### DIFF
--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -70,3 +70,15 @@ func (h *health) OnFinalShutdown() error {
 	h.nlSetup = false
 	return nil
 }
+
+func (h *health) OnReload() error {
+	if !h.nlSetup {
+		return nil
+	}
+
+	h.stop()
+
+	h.ln.Close()
+	h.nlSetup = false
+	return nil
+}

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -20,7 +20,7 @@ func setup(c *caddy.Controller) error {
 	h := &health{Addr: addr, lameduck: lame}
 
 	c.OnStartup(h.OnStartup)
-	c.OnRestart(h.OnFinalShutdown)
+	c.OnRestart(h.OnReload)
 	c.OnFinalShutdown(h.OnFinalShutdown)
 	c.OnRestartFailed(h.OnStartup)
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

When _reloading_ health, don't pause for lameduck duration.  Only go into lameduck mode on FinalShutdown.
During a reload, going into lameduck just delays the loading of the new config, and during the lameduck sleep, the old config is still served.

The new function `OnReload` is a copy of `OnFinalShutdown` with the lameduck pause removed.

### 2. Which issues (if any) are related?

Related to #5471

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
