### PR TITLE
add tsig to codeowners; update chaos authors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,4 +53,5 @@ go.mod                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /plugin/tls/            @johnbelamaric
 /plugin/trace/          @johnbelamaric @zouyee @Tantalor93
 /plugin/transfer/       @miekg @chrisohaver
+/plugin/tsig/           @chrisohaver
 /plugin/whoami/         @miekg @chrisohaver @yongtang

--- a/plugin/chaos/zowners.go
+++ b/plugin/chaos/zowners.go
@@ -1,4 +1,4 @@
 package chaos
 
 // Owners are all GitHub handlers of all maintainers.
-var Owners = []string{"bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "fastest963", "greenpau", "ihac", "inigohu", "isolus", "johnbelamaric", "miekg", "mqasimsarfraz", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "snebel29", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang", "zouyee"}
+var Owners = []string{"Tantalor93", "bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "greenpau", "ihac", "inigohu", "isolus", "jameshartig", "johnbelamaric", "miekg", "mqasimsarfraz", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "snebel29", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang", "zouyee"}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Add new tsig plugin to CODEOWNERS.
Update generated authors var in chaos plugin.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
