### PR TITLE
Support deprecated "service.alpha.kubernetes.io/tolerate-unready-endpoints" annotation

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -684,6 +684,7 @@ var epsIndex = map[string][]*object.Endpoints{
 		Name:      "kubedns",
 		Namespace: "kube-system",
 		Index:     object.EndpointsKey("kubedns", "kube-system"),
+		Ready:     true,
 	}},
 	"svc1.testns": {{
 		Subsets: []object.EndpointSubset{
@@ -699,6 +700,7 @@ var epsIndex = map[string][]*object.Endpoints{
 		Name:      "svc1-slice1",
 		Namespace: "testns",
 		Index:     object.EndpointsKey("svc1", "testns"),
+		Ready:     true,
 	}},
 	"svcempty.testns": {{
 		Subsets: []object.EndpointSubset{
@@ -712,6 +714,7 @@ var epsIndex = map[string][]*object.Endpoints{
 		Name:      "svcempty-slice1",
 		Namespace: "testns",
 		Index:     object.EndpointsKey("svcempty", "testns"),
+		Ready:     true,
 	}},
 	"hdls1.testns": {{
 		Subsets: []object.EndpointSubset{
@@ -732,6 +735,7 @@ var epsIndex = map[string][]*object.Endpoints{
 		Name:      "hdls1-slice1",
 		Namespace: "testns",
 		Index:     object.EndpointsKey("hdls1", "testns"),
+		Ready:     true,
 	}},
 	"hdlsprtls.testns": {{
 		Subsets: []object.EndpointSubset{
@@ -745,6 +749,7 @@ var epsIndex = map[string][]*object.Endpoints{
 		Name:      "hdlsprtls-slice1",
 		Namespace: "testns",
 		Index:     object.EndpointsKey("hdlsprtls", "testns"),
+		Ready:     true,
 	}},
 }
 

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -540,12 +540,11 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 					continue
 				}
 
-				if !ep.Ready && !svc.HasAlphaPublishUnreadyAddressesAnnotation {
-					continue
-				}
-
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
+						if !addr.Ready && !svc.HasAlphaPublishUnreadyAddressesAnnotation {
+							continue
+						}
 
 						// See comments in parse.go parseRequest about the endpoint handling.
 						if r.endpoint != "" {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -540,6 +540,10 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 					continue
 				}
 
+				if !ep.Ready && !svc.HasAlphaPublishUnreadyAddressesAnnotation {
+					continue
+				}
+
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
 

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -135,6 +135,7 @@ func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
 			Name:      "svc1-slice1",
 			Namespace: "testns",
 			Index:     object.EndpointsKey("svc1", "testns"),
+			Ready:     true,
 		},
 		{
 			Subsets: []object.EndpointSubset{
@@ -150,6 +151,7 @@ func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
 			Name:      "hdls1-slice1",
 			Namespace: "testns",
 			Index:     object.EndpointsKey("hdls1", "testns"),
+			Ready:     true,
 		},
 		{
 			Subsets: []object.EndpointSubset{
@@ -159,6 +161,7 @@ func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
 					},
 				},
 			},
+			Ready: true,
 		},
 	}
 	return eps
@@ -180,6 +183,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 			Name:      "svc1-slice1",
 			Namespace: "testns",
 			Index:     object.EndpointsKey("svc1", "testns"),
+			Ready:     true,
 		},
 		{
 			Subsets: []object.EndpointSubset{
@@ -195,6 +199,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 			Name:      "hdls1-slice1",
 			Namespace: "testns",
 			Index:     object.EndpointsKey("hdls1", "testns"),
+			Ready:     true,
 		},
 		{
 			Subsets: []object.EndpointSubset{
@@ -210,6 +215,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 			Name:      "hdls1-slice2",
 			Namespace: "testns",
 			Index:     object.EndpointsKey("hdls1", "testns"),
+			Ready:     true,
 		},
 		{
 			Subsets: []object.EndpointSubset{
@@ -219,6 +225,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 					},
 				},
 			},
+			Ready: true,
 		},
 	}
 	return eps

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -19,7 +19,6 @@ type Endpoints struct {
 	Index     string
 	IndexIP   []string
 	Subsets   []EndpointSubset
-	Ready     bool
 
 	*Empty
 }
@@ -37,6 +36,7 @@ type EndpointAddress struct {
 	Hostname      string
 	NodeName      string
 	TargetRefName string
+	Ready         bool
 }
 
 // EndpointPort is a tuple that describes a single port.
@@ -74,7 +74,7 @@ func ToEndpoints(obj meta.Object) (meta.Object, error) {
 		}
 
 		for j, a := range eps.Addresses {
-			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname}
+			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname, Ready: true}
 			if a.NodeName != nil {
 				ea.NodeName = *a.NodeName
 			}
@@ -129,9 +129,9 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		e.Ready = endpointsliceReady(end.Conditions.Ready)
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
+			ea.Ready = endpointsliceReady(end.Conditions.Ready)
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname
 			}
@@ -178,9 +178,9 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		e.Ready = endpointsliceReady(end.Conditions.Ready)
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
+			ea.Ready = endpointsliceReady(end.Conditions.Ready)
 			if end.Hostname != nil {
 				ea.Hostname = *end.Hostname
 			}
@@ -241,7 +241,7 @@ func (e *Endpoints) DeepCopyObject() runtime.Object {
 			Ports:     make([]EndpointPort, len(eps.Ports)),
 		}
 		for j, a := range eps.Addresses {
-			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname, NodeName: a.NodeName, TargetRefName: a.TargetRefName}
+			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname, NodeName: a.NodeName, TargetRefName: a.TargetRefName, Ready: a.Ready}
 			sub.Addresses[j] = ea
 		}
 		for k, p := range eps.Ports {

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -19,6 +19,7 @@ type Endpoints struct {
 	Index     string
 	IndexIP   []string
 	Subsets   []EndpointSubset
+	Ready     bool
 
 	*Empty
 }
@@ -128,9 +129,7 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if !endpointsliceReady(end.Conditions.Ready) {
-			continue
-		}
+		e.Ready = endpointsliceReady(end.Conditions.Ready)
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {
@@ -179,9 +178,7 @@ func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
 	}
 
 	for _, end := range ends.Endpoints {
-		if !endpointsliceReady(end.Conditions.Ready) {
-			continue
-		}
+		e.Ready = endpointsliceReady(end.Conditions.Ready)
 		for _, a := range end.Addresses {
 			ea := EndpointAddress{IP: a}
 			if end.Hostname != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

A deprecated annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints`
With the 1.8.5 release of coredns an EndpointSlice support was introduced. EndpointSlices do not respect this deprecated annotation. The condition.ready field is not set to true if there is an annotation. Endpoint controller respects it.

Once we've updated coredns to >1.8.5, a lot of stuff stopped working. As it turns out, a lot of older Charts use this annotation, and migrating them all at once is quite prohibitive.

Is it possible for coredns to support this annotation?

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

It does not.