### PR TITLE
plugin/ready: Reset list of readiness plugins on startup

### DIFF
--- a/plugin/ready/list.go
+++ b/plugin/ready/list.go
@@ -13,6 +13,14 @@ type list struct {
 	names []string
 }
 
+// Reset resets l
+func (l *list) Reset() {
+	l.Lock()
+	defer l.Unlock()
+	l.rs = nil
+	l.names = nil
+}
+
 // Append adds a new readiness to l.
 func (l *list) Append(r Readiness, name string) {
 	l.Lock()

--- a/plugin/ready/setup.go
+++ b/plugin/ready/setup.go
@@ -25,6 +25,7 @@ func setup(c *caddy.Controller) error {
 	c.OnRestartFailed(func() error { return uniqAddr.ForEach() })
 
 	c.OnStartup(func() error {
+		plugins.Reset()
 		for _, p := range dnsserver.GetConfig(c).Handlers() {
 			if r, ok := p.(Readiness); ok {
 				plugins.Append(r, p.Name())

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -332,12 +332,11 @@ func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 	// verify that metrics have not been pushed
 }
 
-
 // TestReloadUnreadyPlugin tests that the ready plugin properly resets the list of readiness implementors during a reload.
 // If it fails to do so, ready will respond with duplicate plugin names after a reload (e.g. in this test "unready,unready").
 func TestReloadUnreadyPlugin(t *testing.T) {
 	// Add/Register a perpetually unready plugin
-	dnsserver.Directives = append( []string{"unready"}, dnsserver.Directives...)
+	dnsserver.Directives = append([]string{"unready"}, dnsserver.Directives...)
 	u := new(unready)
 	plugin.Register("unready", func(c *caddy.Controller) error {
 		dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
@@ -382,9 +381,9 @@ type unready struct {
 	next plugin.Handler
 }
 
-func (u *unready) Ready() bool{return false}
+func (u *unready) Ready() bool { return false }
 
-func (u *unready) Name() string {return "unready"}
+func (u *unready) Name() string { return "unready" }
 
 func (u *unready) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	return u.next.ServeDNS(ctx, w, r)

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -360,17 +360,10 @@ func TestReloadUnreadyPlugin(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 
-	udp, _ := CoreDNSServerPorts(c, 0)
-
-	send(t, udp)
-
 	c1, err := c.Restart(coreInput)
 	if err != nil {
 		t.Fatal(err)
 	}
-	udp, _ = CoreDNSServerPorts(c1, 0)
-
-	send(t, udp)
 
 	resp, err := http.Get("http://127.0.0.1:53185/ready")
 	if err != nil {

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -2,11 +2,16 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
 
 	"github.com/miekg/dns"
 )
@@ -325,6 +330,71 @@ func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 
 	instReload.Stop()
 	// verify that metrics have not been pushed
+}
+
+
+// TestReloadUnreadyPlugin tests that the ready plugin properly resets the list of readiness implementors during a reload.
+// If it fails to do so, ready will respond with duplicate plugin names after a reload (e.g. in this test "unready,unready").
+func TestReloadUnreadyPlugin(t *testing.T) {
+	// Add/Register a perpetually unready plugin
+	dnsserver.Directives = append( []string{"unready"}, dnsserver.Directives...)
+	u := new(unready)
+	plugin.Register("unready", func(c *caddy.Controller) error {
+		dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+			u.next = next
+			return u
+		})
+		return nil
+	})
+
+	corefile := `.:0 {
+		unready
+        whoami
+        ready 127.0.0.1:53185
+	}`
+
+	coreInput := NewInput(corefile)
+
+	c, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(c, 0)
+
+	send(t, udp)
+
+	c1, err := c.Restart(coreInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	udp, _ = CoreDNSServerPorts(c1, 0)
+
+	send(t, udp)
+
+	resp, err := http.Get("http://127.0.0.1:53185/ready")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bod, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(bod) != u.Name() {
+		t.Errorf("Expected /ready endpoint response body %q, got %q", u.Name(), bod)
+	}
+
+	c1.Stop()
+}
+
+type unready struct {
+	next plugin.Handler
+}
+
+func (u *unready) Ready() bool{return false}
+
+func (u *unready) Name() string {return "unready"}
+
+func (u *unready) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return u.next.ServeDNS(ctx, w, r)
 }
 
 const inUse = "address already in use"


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

When _ready_ starts, it adds all implementors of `readiness` to its list of plugins to check for readiness. But it never clears out the list, and accumulates references to readiness implementing plugins of prior configs on every reload (such as _kubernetes_).

Reloads can be triggered on demand, so this is a memory DoS concern.

Operationally, this could also cause readiness to perpetually fail if any of the prior instances cannot become ready (e.g. bad credentials in _kubernetes_ plugin).

### 2. Which issues (if any) are related?

#5481 

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
