### PR TITLE
add golangci-lint linter for static analysis

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,16 @@
+name: golangci-lint
+on:
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  timeout: 5m
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - varcheck
+    - whitespace

--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -49,7 +49,6 @@ func newOverlapZone() *zoneOverlap {
 // registerAndCheck adds a new zoneAddr for validation, it returns information about existing or overlapping with already registered
 // we consider that an unbound address is overlapping all bound addresses for same zone, same port
 func (zo *zoneOverlap) registerAndCheck(z zoneAddr) (existingZone *zoneAddr, overlappingZone *zoneAddr) {
-
 	if exist, ok := zo.registeredAddr[z]; ok {
 		// exact same zone already registered
 		return &exist, nil

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -43,7 +43,6 @@ func TestSplitProtocolHostPort(t *testing.T) {
 		if port != test.port {
 			t.Errorf("Test %d: (address = %s) expected port with value %s but got %s", i, test.input, test.port, port)
 		}
-
 	}
 }
 
@@ -92,7 +91,6 @@ func TestOverlapAddressChecker(t *testing.T) {
 		},
 		},
 	} {
-
 		checker := newOverlapZone()
 		for _, call := range test.sequence {
 			same, overlap := checker.registerAndCheck(call.zone)
@@ -108,10 +106,8 @@ func TestOverlapAddressChecker(t *testing.T) {
 					if overlap.String() != call.overlapKey {
 						t.Errorf("Test %d: error, for zone %s, 'overlap Key' (%v) has not the expected value (%v)", i, sZone, overlap.String(), call.overlapKey)
 					}
-
 				}
 			}
-
 		}
 	}
 }

--- a/core/dnsserver/onstartup_test.go
+++ b/core/dnsserver/onstartup_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestRegex1035PrefSyntax(t *testing.T) {
-
 	testCases := []struct {
 		zone     string
 		expected bool

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -138,7 +138,6 @@ func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 
 // MakeServers uses the newly-created siteConfigs to create and return a list of server instances.
 func (h *dnsContext) MakeServers() ([]caddy.Server, error) {
-
 	// Now that all Keys and Directives are parsed and initialized
 	// lets verify that there is no overlap on the zones and addresses to listen for
 	errValid := h.validateZonesAndListeningAddresses()
@@ -197,7 +196,6 @@ func (h *dnsContext) MakeServers() ([]caddy.Server, error) {
 			}
 			servers = append(servers, s)
 		}
-
 	}
 
 	return servers, nil
@@ -262,11 +260,9 @@ func (h *dnsContext) validateZonesAndListeningAddresses() error {
 			if overlapZone != nil {
 				return fmt.Errorf("cannot serve %s - zone overlap listener capacity with %v", akey.String(), overlapZone.String())
 			}
-
 		}
 	}
 	return nil
-
 }
 
 // groupSiteConfigsByListenAddr groups site configs by their listen

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -114,7 +114,6 @@ func TestGroupingServers(t *testing.T) {
 		for _, v := range test.expectedGroups {
 			if _, ok := groups[v]; !ok {
 				t.Errorf("Test %d : expected value %v to be in the group, was not", i, v)
-
 			}
 		}
 	}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -51,7 +51,6 @@ type Server struct {
 // NewServer returns a new CoreDNS server and compiles all plugins in to it. By default CH class
 // queries are blocked unless queries from enableChaos are loaded.
 func NewServer(addr string, group []*Config) (*Server, error) {
-
 	s := &Server{
 		Addr:         addr,
 		zones:        make(map[string]*Config),
@@ -174,7 +173,6 @@ func (s *Server) ListenPacket() (net.PacketConn, error) {
 // immediately.
 // This implements Caddy.Stopper interface.
 func (s *Server) Stop() (err error) {
-
 	if runtime.GOOS != "windows" {
 		// force connections to close after timeout
 		done := make(chan struct{})

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -82,7 +82,6 @@ func (s *ServergRPC) ServePacket(p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServergRPC) Listen() (net.Listener, error) {
-
 	l, err := reuseport.Listen("tcp", s.Addr[len(transport.GRPC+"://"):])
 	if err != nil {
 		return nil, err

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -104,7 +104,6 @@ func (s *ServerHTTPS) ServePacket(p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Listen() (net.Listener, error) {
-
 	l, err := reuseport.Listen("tcp", s.Addr[len(transport.HTTPS+"://"):])
 	if err != nil {
 		return nil, err
@@ -141,7 +140,6 @@ func (s *ServerHTTPS) Stop() error {
 // ServeHTTP is the handler that gets the HTTP request and converts to the dns format, calls the plugin
 // chain, converts it back and write it to the client.
 func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
 	if !s.validRequest(r) {
 		http.Error(w, "", http.StatusNotFound)
 		s.countResponse(http.StatusNotFound)

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -88,7 +88,6 @@ RulesCheckLoop:
 				return dns.RcodeSuccess, nil
 			}
 		}
-
 	}
 
 	RequestAllowCount.WithLabelValues(metrics.WithServer(ctx)).Inc()

--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -12,7 +12,6 @@ import (
 
 // Walk will recursively walk of the file under l.directory and adds the one that match l.re.
 func (a Auto) Walk() error {
-
 	// TODO(miek): should add something so that we don't stomp on each other.
 
 	toDelete := make(map[string]bool)

--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -135,7 +135,6 @@ func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		w.WriteMsg(msg)
 		autoPathCount.WithLabelValues(metrics.WithServer(ctx)).Add(1)
 		return rcode, err
-
 	}
 	if plugin.ClientWrite(firstRcode) {
 		w.WriteMsg(firstReply)

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -134,7 +134,6 @@ func (h *Azure) updateZones(ctx context.Context) error {
 		return fmt.Errorf("errors updating zones: %v", errs)
 	}
 	return nil
-
 }
 
 func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage, newZ *file.Zone) {
@@ -297,7 +296,6 @@ func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPa
 				Target: dns.Fqdn(*CNAME)}
 			newZ.Insert(cname)
 		}
-
 	}
 }
 

--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -29,20 +29,24 @@ func setup(c *caddy.Controller) error {
 
 	publicDNSClient := publicAzureDNS.NewRecordSetsClient(env.Values[auth.SubscriptionID])
 	if publicDNSClient.Authorizer, err = env.GetAuthorizer(); err != nil {
+		cancel()
 		return plugin.Error("azure", err)
 	}
 
 	privateDNSClient := privateAzureDNS.NewRecordSetsClient(env.Values[auth.SubscriptionID])
 	if privateDNSClient.Authorizer, err = env.GetAuthorizer(); err != nil {
+		cancel()
 		return plugin.Error("azure", err)
 	}
 
 	h, err := New(ctx, publicDNSClient, privateDNSClient, keys, accessMap)
 	if err != nil {
+		cancel()
 		return plugin.Error("azure", err)
 	}
 	h.Fall = fall
 	if err := h.Run(ctx); err != nil {
+		cancel()
 		return plugin.Error("azure", err)
 	}
 

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -23,7 +23,6 @@ func A(ctx context.Context, b ServiceBackend, zone string, state request.Request
 	dup := make(map[string]struct{})
 
 	for _, serv := range services {
-
 		what, ip := serv.HostType()
 
 		switch what {
@@ -97,7 +96,6 @@ func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Requ
 	dup := make(map[string]struct{})
 
 	for _, serv := range services {
-
 		what, ip := serv.HostType()
 
 		switch what {
@@ -344,7 +342,6 @@ func CNAME(ctx context.Context, b ServiceBackend, zone string, state request.Req
 
 // TXT returns TXT records from Backend or an error.
 func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, truncated bool, err error) {
-
 	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, false, err
@@ -353,7 +350,6 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 	dup := make(map[string]struct{})
 
 	for _, serv := range services {
-
 		what, _ := serv.HostType()
 
 		switch what {
@@ -405,7 +401,6 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 				dup[serv.Text] = struct{}{}
 				records = append(records, serv.NewTXT(state.QName()))
 			}
-
 		}
 	}
 
@@ -507,7 +502,6 @@ func BackendError(ctx context.Context, b ServiceBackend, zone string, rcode int,
 }
 
 func newAddress(s msg.Service, name string, ip net.IP, what uint16) dns.RR {
-
 	hdr := dns.RR_Header{Name: name, Rrtype: what, Class: dns.ClassINET, Ttl: s.TTL}
 
 	if what == dns.TypeA {

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -12,7 +12,6 @@ import (
 )
 
 func setup(c *caddy.Controller) error {
-
 	config := dnsserver.GetConfig(c)
 	// addresses will be consolidated over all BIND directives available in that BlocServer
 	all := []string{}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -609,7 +609,7 @@ func TestCacheWildcardMetadata(t *testing.T) {
 	ctx = metadata.ContextWithMetadata(context.TODO())
 	w = dnstest.NewRecorder(&test.ResponseWriter{})
 
-	c.ServeDNS(ctx, &test.ResponseWriter{}, req)
+	c.ServeDNS(ctx, w, req)
 	f := metadata.ValueFunc(ctx, "zone/wildcard")
 	if f == nil {
 		t.Fatal("expected metadata func for wildcard response retrieved from cache, got nil")

--- a/plugin/chaos/setup.go
+++ b/plugin/chaos/setup.go
@@ -30,7 +30,7 @@ func parse(c *caddy.Controller) (string, []string, error) {
 	chaosVersion = caddy.AppName + "-" + caddy.AppVersion
 	version := ""
 
-	for c.Next() {
+	if c.Next() {
 		args := c.RemainingArgs()
 		if len(args) == 0 {
 			return trim(chaosVersion), Owners, nil

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -204,7 +204,6 @@ func (h *CloudDNS) updateZones(ctx context.Context) error {
 				(*z[i]).z = newZ
 				h.zMu.Unlock()
 			}
-
 		}(zName, z)
 	}
 	// Collect errors (if any). This will also sync on all zones updates

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -152,7 +152,6 @@ func TestCloudDNS(t *testing.T) {
 
 			m.Authoritative = true
 			rcode = dns.RcodeSuccess
-
 		}
 
 		m.SetRcode(r, rcode)

--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -81,16 +81,19 @@ func setup(c *caddy.Controller) error {
 		ctx, cancel := context.WithCancel(context.Background())
 		client, err := f(ctx, opt)
 		if err != nil {
+			cancel()
 			return err
 		}
 
 		h, err := New(ctx, client, keys, up)
 		if err != nil {
+			cancel()
 			return plugin.Error("clouddns", c.Errf("failed to create plugin: %v", err))
 		}
 		h.Fall = fall
 
 		if err := h.Run(ctx); err != nil {
+			cancel()
 			return plugin.Error("clouddns", c.Errf("failed to initialize plugin: %v", err))
 		}
 

--- a/plugin/debug/pcap_test.go
+++ b/plugin/debug/pcap_test.go
@@ -32,7 +32,7 @@ func TestNoDebug(t *testing.T) {
 	}
 }
 
-func ExampleLogHexdump() {
+func ExampleHexdump() {
 	buf, _ := msg().Pack()
 	h := hexdump(buf)
 	fmt.Println(string(h))

--- a/plugin/dns64/dns64_test.go
+++ b/plugin/dns64/dns64_test.go
@@ -74,7 +74,6 @@ func TestRequestShouldIntercept(t *testing.T) {
 }
 
 func TestTo6(t *testing.T) {
-
 	v6, err := To6("64:ff9b::/96", "64.64.64.64")
 	if err != nil {
 		t.Error(err)
@@ -216,7 +215,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			initResp: &dns.Msg{ //success, no answers
 				MsgHdr: dns.MsgHdr{
@@ -226,7 +225,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 70 IN SOA foo bar 1 1 1 1 1")},
 			},
 			aResp: &dns.Msg{
@@ -237,7 +236,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.A("example.com. 60 IN A 192.0.2.42"),
 					test.A("example.com. 5000 IN A 192.0.2.43"),
@@ -252,7 +251,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.AAAA("example.com. 60 IN AAAA 64:ff9b::192.0.2.42"),
 					// override RR ttl to SOA ttl, since it's lower
@@ -269,7 +268,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			initResp: &dns.Msg{ //success, no answers
 				MsgHdr: dns.MsgHdr{
@@ -279,7 +278,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 3600 IN SOA foo bar 1 7200 900 1209600 86400")},
 			},
 			aResp: &dns.Msg{
@@ -290,7 +289,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 3600 IN SOA foo bar 1 7200 900 1209600 86400")},
 			},
 
@@ -302,7 +301,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 3600 IN SOA foo bar 1 7200 900 1209600 86400")},
 				Answer:   []dns.RR{}, // just to make comparison happy
 			},
@@ -316,7 +315,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			initResp: &dns.Msg{ // failure
 				MsgHdr: dns.MsgHdr{
@@ -326,7 +325,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeRefused,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			aResp: &dns.Msg{
 				MsgHdr: dns.MsgHdr{
@@ -336,7 +335,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.A("example.com. 60 IN A 192.0.2.42"),
 					test.A("example.com. 5000 IN A 192.0.2.43"),
@@ -351,7 +350,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.AAAA("example.com. 60 IN AAAA 64:ff9b::192.0.2.42"),
 					test.AAAA("example.com. 600 IN AAAA 64:ff9b::192.0.2.43"),
@@ -367,7 +366,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			initResp: &dns.Msg{ // failure
 				MsgHdr: dns.MsgHdr{
@@ -377,7 +376,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeNameError,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 3600 IN SOA foo bar 1 7200 900 1209600 86400")},
 			},
 			resp: &dns.Msg{
@@ -388,7 +387,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeNameError,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 3600 IN SOA foo bar 1 7200 900 1209600 86400")},
 			},
 		},
@@ -401,7 +400,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 
 			initResp: &dns.Msg{
@@ -412,7 +411,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.AAAA("example.com. 60 IN AAAA ::1"),
 					test.AAAA("example.com. 5000 IN AAAA ::2"),
@@ -427,7 +426,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.AAAA("example.com. 60 IN AAAA ::1"),
 					test.AAAA("example.com. 5000 IN AAAA ::2"),
@@ -443,7 +442,7 @@ func TestDNS64(t *testing.T) {
 					RecursionDesired: true,
 					Opcode:           dns.OpcodeQuery,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 			},
 			initResp: &dns.Msg{ //success, no answers
 				MsgHdr: dns.MsgHdr{
@@ -453,7 +452,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Ns:       []dns.RR{test.SOA("example.com. 70 IN SOA foo bar 1 1 1 1 1")},
 			},
 			aResp: &dns.Msg{
@@ -465,7 +464,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.A("example.com. 60 IN A 192.0.2.42"),
 					test.A("example.com. 5000 IN A 192.0.2.43"),
@@ -481,7 +480,7 @@ func TestDNS64(t *testing.T) {
 					Rcode:            dns.RcodeSuccess,
 					Response:         true,
 				},
-				Question: []dns.Question{{"example.com.", dns.TypeAAAA, dns.ClassINET}},
+				Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
 				Answer: []dns.RR{
 					test.AAAA("example.com. 60 IN AAAA 64:ff9b::192.0.2.42"),
 					// override RR ttl to SOA ttl, since it's lower

--- a/plugin/dns64/setup.go
+++ b/plugin/dns64/setup.go
@@ -6,13 +6,10 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 )
 
 const pluginName = "dns64"
-
-var log = clog.NewWithPlugin(pluginName)
 
 func init() { plugin.Register(pluginName, setup) }
 

--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -43,7 +43,6 @@ func periodicClean(c *cache.Cache, stop <-chan struct{}) {
 
 		case <-stop:
 			return
-
 		}
 	}
 }

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -58,7 +58,6 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 		zones = plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
 
 		for c.NextBlock() {
-
 			switch x := c.Val(); x {
 			case "key":
 				k, e := keyParse(c)
@@ -79,7 +78,6 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 			default:
 				return nil, nil, 0, false, c.Errf("unknown property '%s'", x)
 			}
-
 		}
 	}
 	// Check if we have both KSKs and ZSKs.

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -23,7 +23,7 @@ type Dnstap struct {
 // TapMessage sends the message m to the dnstap interface.
 func (h Dnstap) TapMessage(m *tap.Message) {
 	t := tap.Dnstap_MESSAGE
-	h.io.Dnstap(tap.Dnstap{Type: &t, Message: m})
+	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m})
 }
 
 func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -18,7 +18,6 @@ func testCase(t *testing.T, tapq, tapr *tap.Message, q, r *dns.Msg) {
 	h := Dnstap{
 		Next: test.HandlerFunc(func(_ context.Context,
 			w dns.ResponseWriter, _ *dns.Msg) (int, error) {
-
 			return 0, w.WriteMsg(r)
 		}),
 		io: &w,
@@ -34,7 +33,7 @@ type writer struct {
 	queue []*tap.Message
 }
 
-func (w *writer) Dnstap(e tap.Dnstap) {
+func (w *writer) Dnstap(e *tap.Dnstap) {
 	if len(w.queue) == 0 {
 		w.t.Error("Message not expected")
 	}

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -65,7 +65,7 @@ func TestTransport(t *testing.T) {
 		dio.flushTimeout = 30 * time.Millisecond
 		dio.connect()
 
-		dio.Dnstap(tmsg)
+		dio.Dnstap(&tmsg)
 
 		wg.Wait()
 		l.Close()
@@ -99,7 +99,7 @@ func TestRace(t *testing.T) {
 	for i := 0; i < count; i++ {
 		go func() {
 			tmsg := tap.Dnstap_MESSAGE
-			dio.Dnstap(tap.Dnstap{Type: &tmsg})
+			dio.Dnstap(&tap.Dnstap{Type: &tmsg})
 			wg.Done()
 		}()
 	}
@@ -128,7 +128,7 @@ func TestReconnect(t *testing.T) {
 	dio.connect()
 	defer dio.close()
 
-	dio.Dnstap(tmsg)
+	dio.Dnstap(&tmsg)
 
 	wg.Wait()
 
@@ -149,7 +149,7 @@ func TestReconnect(t *testing.T) {
 
 	for i := 0; i < count; i++ {
 		time.Sleep(100 * time.Millisecond)
-		dio.Dnstap(tmsg)
+		dio.Dnstap(&tmsg)
 	}
 	wg.Wait()
 }

--- a/plugin/etcd/msg/service.go
+++ b/plugin/etcd/msg/service.go
@@ -154,7 +154,6 @@ func split255(s string) []string {
 		} else {
 			sx = append(sx, s[p:])
 			break
-
 		}
 		p, i = p+255, i+255
 	}

--- a/plugin/etcd/msg/type.go
+++ b/plugin/etcd/msg/type.go
@@ -15,11 +15,9 @@ import (
 //
 // Note that a service can double/triple as a TXT record or MX record.
 func (s *Service) HostType() (what uint16, normalized net.IP) {
-
 	ip := net.ParseIP(s.Host)
 
 	switch {
-
 	case ip == nil:
 		if len(s.Text) == 0 {
 			return dns.TypeCNAME, nil

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -40,7 +40,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 
 	etc.Upstream = upstream.New()
 
-	for c.Next() {
+	if c.Next() {
 		etc.Zones = plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
 		for c.NextBlock() {
 			switch c.Val() {

--- a/plugin/file/closest.go
+++ b/plugin/file/closest.go
@@ -8,7 +8,6 @@ import (
 
 // ClosestEncloser returns the closest encloser for qname.
 func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
-
 	offset, end := dns.NextLabel(qname, 0)
 	for !end {
 		elem, _ := z.Tree.Search(qname)

--- a/plugin/file/include_test.go
+++ b/plugin/file/include_test.go
@@ -10,7 +10,6 @@ import (
 // Make sure the external miekg/dns dependency is up to date
 
 func TestInclude(t *testing.T) {
-
 	name, rm, err := test.TempFile(".", "foo\tIN\tA\t127.0.0.1\n")
 	if err != nil {
 		t.Fatalf("Unable to create tmpfile %q: %s", name, err)

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -151,7 +151,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 		// If we see NS records, it means the name as been delegated, and we should return the delegation.
 		if nsrrs := elem.Type(dns.TypeNS); nsrrs != nil {
-
 			// If the query is specifically for DS and the qname matches the delegated name, we should
 			// return the DS in the answer section and leave the rest empty, i.e. just continue the loop
 			// and continue searching.
@@ -179,7 +178,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 	// Found entire name.
 	if found && shot {
-
 		if rrs := elem.Type(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
 			return z.externalLookup(ctx, state, elem, rrs)
@@ -208,7 +206,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 		}
 
 		return rrs, ap.ns(do), additional, Success
-
 	}
 
 	// Haven't found the original name.
@@ -248,7 +245,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			sigs := wildElem.TypeForWildcard(dns.TypeRRSIG, qname)
 			sigs = rrutil.SubTypeSignature(sigs, qtype)
 			rrs = append(rrs, sigs...)
-
 		}
 		return rrs, auth, nil, Success
 	}
@@ -290,7 +286,6 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 				}
 			}
 		}
-
 	}
 Out:
 	return nil, ret, nil, rcode
@@ -325,7 +320,6 @@ func (a Apex) ns(do bool) []dns.RR {
 
 // externalLookup adds signatures and tries to resolve CNAMEs that point to external names.
 func (z *Zone) externalLookup(ctx context.Context, state request.Request, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
-
 	qtype := state.QType()
 	do := state.Do()
 

--- a/plugin/file/secondary.go
+++ b/plugin/file/secondary.go
@@ -183,7 +183,6 @@ Restart:
 			retryTicker.Stop()
 			expireTicker.Stop()
 			goto Restart
-
 		}
 	}
 }
@@ -192,7 +191,6 @@ Restart:
 func jitter(n int) time.Duration {
 	r := rand.Intn(n)
 	return time.Duration(r) * time.Millisecond
-
 }
 
 // MaxSerialIncrement is the maximum difference between two serial numbers. If the difference between

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -139,7 +139,6 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 			return Zones{}, plugin.Error("file", openErr)
 		}
 		log.Warningf("Failed to open %q: trying again in %s", openErr, reload)
-
 	}
 	return Zones{Z: z, Names: names}, nil
 }

--- a/plugin/file/tree/less_test.go
+++ b/plugin/file/tree/less_test.go
@@ -75,7 +75,6 @@ Tests:
 				}
 				continue Tests
 			}
-
 		}
 	}
 }

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -74,7 +74,6 @@ func (f *Forward) Name() string { return "forward" }
 
 // ServeDNS implements plugin.Handler.
 func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-
 	state := request.Request{W: w, Req: r}
 	if !f.match(state) {
 		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)

--- a/plugin/geoip/geoip_test.go
+++ b/plugin/geoip/geoip_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestMetadata(t *testing.T) {
-
 	tests := []struct {
 		label         string
 		expectedValue string
@@ -37,7 +36,6 @@ func TestMetadata(t *testing.T) {
 
 	knownIPAddr := "81.2.69.142" // This IP should be be part of the CDIR address range used to create the database fixtures.
 	for _, tc := range tests {
-
 		t.Run(fmt.Sprintf("%s/%s", tc.label, "direct"), func(t *testing.T) {
 			geoIP, err := newGeoIP(cityDBPath, false)
 			if err != nil {
@@ -89,5 +87,4 @@ func testMetadata(t *testing.T, state request.Request, geoIP *GeoIP, label, expe
 		t.Errorf("expected value for label %q should be %q, got %q instead",
 			label, expectedValue, value)
 	}
-
 }

--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -33,7 +34,7 @@ func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 	if tlsConfig != nil {
 		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {
-		p.dialOpts = append(p.dialOpts, grpc.WithInsecure())
+		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	conn, err := grpc.Dial(p.addr, p.dialOpts...)

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -96,7 +96,6 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 }
 
 func parseBlock(c *caddy.Controller, g *GRPC) error {
-
 	switch c.Val() {
 	case "except":
 		ignore := c.RemainingArgs()

--- a/plugin/header/header_test.go
+++ b/plugin/header/header_test.go
@@ -78,7 +78,5 @@ func TestHeader(t *testing.T) {
 			t.Errorf("Test %d: Expected flag state=%t, but got %t", i, test.expected, test.got(m))
 			continue
 		}
-
 	}
-
 }

--- a/plugin/header/setup.go
+++ b/plugin/header/setup.go
@@ -46,5 +46,4 @@ func parse(c *caddy.Controller) ([]Rule, error) {
 		}
 	}
 	return nil, c.ArgErr()
-
 }

--- a/plugin/k8s_external/msg_to_dns.go
+++ b/plugin/k8s_external/msg_to_dns.go
@@ -15,7 +15,6 @@ func (e *External) a(ctx context.Context, services []msg.Service, state request.
 	dup := make(map[string]struct{})
 
 	for _, s := range services {
-
 		what, ip := s.HostType()
 
 		switch what {
@@ -48,7 +47,6 @@ func (e *External) aaaa(ctx context.Context, services []msg.Service, state reque
 	dup := make(map[string]struct{})
 
 	for _, s := range services {
-
 		what, ip := s.HostType()
 
 		switch what {
@@ -127,7 +125,6 @@ func (e *External) srv(ctx context.Context, services []msg.Service, state reques
 		what, ip := s.HostType()
 
 		switch what {
-
 		case dns.TypeCNAME:
 			addr := dns.Fqdn(s.Host)
 			srv := s.NewSRV(state.QName(), weight)

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -83,7 +83,6 @@ func TestTransferAXFR(t *testing.T) {
 			t.Errorf("%+v", rec)
 		}
 	}
-
 }
 
 func TestTransferIXFR(t *testing.T) {
@@ -127,7 +126,6 @@ func TestTransferIXFR(t *testing.T) {
 			t.Errorf("%+v", rec)
 		}
 	}
-
 }
 
 // difference shows what we're missing when comparing two RR slices

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -755,5 +755,3 @@ func (dns *dnsControl) updateExtModifed() {
 }
 
 var errObj = errors.New("obj was not of the correct type")
-
-const defaultResyncPeriod = 0

--- a/plugin/kubernetes/handler_ignore_emptyservice_test.go
+++ b/plugin/kubernetes/handler_ignore_emptyservice_test.go
@@ -30,7 +30,6 @@ var dnsEmptyServiceTestCases = []test.Case{
 }
 
 func TestServeDNSEmptyService(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.opts.ignoreEmptyService = true

--- a/plugin/kubernetes/handler_pod_disabled_test.go
+++ b/plugin/kubernetes/handler_pod_disabled_test.go
@@ -28,7 +28,6 @@ var podModeDisabledCases = []test.Case{
 }
 
 func TestServeDNSModeDisabled(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)

--- a/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/plugin/kubernetes/handler_pod_insecure_test.go
@@ -63,7 +63,6 @@ var podModeInsecureCases = []test.Case{
 }
 
 func TestServeDNSModeInsecure(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)

--- a/plugin/kubernetes/handler_pod_verified_test.go
+++ b/plugin/kubernetes/handler_pod_verified_test.go
@@ -49,7 +49,6 @@ var podModeVerifiedCases = []test.Case{
 }
 
 func TestServeDNSModeVerified(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -494,7 +494,6 @@ var notSyncedTestCases = []test.Case{
 }
 
 func TestNotSyncedServeDNS(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{
 		notSynced: true,

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -96,7 +96,6 @@ var (
 func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (svcs []msg.Service, err error) {
 	// We're looking again at types, which we've already done in ServeDNS, but there are some types k8s just can't answer.
 	switch state.QType() {
-
 	case dns.TypeTXT:
 		// 1 label + zone, label must be "dns-version".
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
@@ -216,7 +215,6 @@ func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
 	}
 	cc.ContentType = "application/vnd.kubernetes.protobuf"
 	return cc, err
-
 }
 
 // InitKubeCache initializes a new Kubernetes cache.
@@ -542,7 +540,6 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
-
 						// See comments in parse.go parseRequest about the endpoint handling.
 						if r.endpoint != "" {
 							if !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {

--- a/plugin/kubernetes/kubernetes_apex_test.go
+++ b/plugin/kubernetes/kubernetes_apex_test.go
@@ -60,7 +60,6 @@ var kubeApexCases = []test.Case{
 }
 
 func TestServeDNSApex(t *testing.T) {
-
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -99,7 +99,6 @@ func (APIConnTest) GetNamespaceByName(name string) (*object.Namespace, error) {
 }
 
 func TestNsAddrs(t *testing.T) {
-
 	k := New([]string{"inter.webs.test."})
 	k.APIConn = &APIConnTest{}
 	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
@@ -108,7 +107,6 @@ func TestNsAddrs(t *testing.T) {
 
 	if len(cdrs) != 3 {
 		t.Fatalf("Expected 3 results, got %v", len(cdrs))
-
 	}
 	cdr := cdrs[0]
 	expected := "10.0.0.111"
@@ -140,7 +138,6 @@ func TestNsAddrs(t *testing.T) {
 }
 
 func TestNsAddrsExternal(t *testing.T) {
-
 	k := New([]string{"example.com."})
 	k.APIConn = &APIConnTest{}
 	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
@@ -150,7 +147,6 @@ func TestNsAddrsExternal(t *testing.T) {
 
 	if len(cdrs) != 0 {
 		t.Fatalf("Expected 0 results, got %v", len(cdrs))
-
 	}
 
 	// Add an external IP to one of the services ...
@@ -159,7 +155,6 @@ func TestNsAddrsExternal(t *testing.T) {
 
 	if len(cdrs) != 1 {
 		t.Fatalf("Expected 1 results, got %v", len(cdrs))
-
 	}
 	cdr := cdrs[0]
 	expected := "1.2.3.4"
@@ -170,5 +165,4 @@ func TestNsAddrsExternal(t *testing.T) {
 	if cdr.Header().Name != expected {
 		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
 	}
-
 }

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -68,7 +68,6 @@ func ToService(obj meta.Object) (meta.Object, error) {
 			continue
 		}
 		s.ExternalIPs[li+i] = lb.Hostname
-
 	}
 
 	*svc = api.Service{}

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -66,7 +66,6 @@ func parseRequest(name, zone string) (r recordRequest, err error) {
 	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol.
 	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
 	switch last {
-
 	case 0: // endpoint only
 		r.endpoint = segs[last]
 	case 1: // service and port

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -12,7 +12,6 @@ import (
 
 // Reverse implements the ServiceBackend interface.
 func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
-
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
 		_, e := k.Records(ctx, state, exact)

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -38,7 +38,6 @@ func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
 		},
 	}
 	return svcs
-
 }
 
 func (APIConnReverseTest) SvcIndexReverse(ip string) []*object.Service {
@@ -150,7 +149,6 @@ func (APIConnReverseTest) GetNamespaceByName(name string) (*object.Namespace, er
 }
 
 func TestReverse(t *testing.T) {
-
 	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa."})
 	k.APIConn = &APIConnReverseTest{}
 

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -87,7 +87,6 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 
 // ParseStanza parses a kubernetes stanza
 func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
-
 	k8s := New([]string{""})
 	k8s.autoPathSearch = searchFromResolvConf()
 

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -63,7 +63,6 @@ func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, erro
 			}
 			svcBase := []string{zonePath, Svc, svc.Namespace, svc.Name}
 			switch svc.Type {
-
 			case api.ServiceTypeClusterIP, api.ServiceTypeNodePort, api.ServiceTypeLoadBalancer:
 				clusterIP := net.ParseIP(svc.ClusterIPs[0])
 				if clusterIP != nil {

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -91,7 +91,6 @@ func TestLoadBalance(t *testing.T) {
 		if err != nil {
 			t.Errorf("Test %d: Expected no error, but got %s", i, err)
 			continue
-
 		}
 
 		cname, address, mx, sorted := countRecords(rec.Msg.Answer)

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -35,7 +35,6 @@ func parse(c *caddy.Controller) error {
 		case 1:
 			if args[0] != "round_robin" {
 				return fmt.Errorf("unknown policy: %s", args[0])
-
 			}
 			return nil
 		}

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -50,7 +50,6 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		}
 
 		return rc, err
-
 	}
 	return plugin.NextOrFailure(l.Name(), l.Next, ctx, w, r)
 }

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -165,7 +165,6 @@ func TestLogParse(t *testing.T) {
 				i, len(test.expectedLogRules), len(actualLogRules))
 		}
 		for j, actualLogRule := range actualLogRules {
-
 			if actualLogRule.NameScope != test.expectedLogRules[j].NameScope {
 				t.Errorf("Test %d expected %dth LogRule NameScope for '%s' to be  %s  , but got %s",
 					i, j, test.inputLogRules, test.expectedLogRules[j].NameScope, actualLogRule.NameScope)

--- a/plugin/metadata/metadata.go
+++ b/plugin/metadata/metadata.go
@@ -27,7 +27,6 @@ func ContextWithMetadata(ctx context.Context) context.Context {
 
 // ServeDNS implements the plugin.Handler interface.
 func (m *Metadata) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-
 	ctx = ContextWithMetadata(ctx)
 
 	state := request.Request{W: w, Req: r}

--- a/plugin/metadata/provider.go
+++ b/plugin/metadata/provider.go
@@ -64,7 +64,6 @@ func IsLabel(label string) bool {
 		return false
 	}
 	return true
-
 }
 
 // Labels returns all metadata keys stored in the context. These label names should be named

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -125,7 +125,6 @@ func (h Host) NormalizeExact() []string {
 	}
 	for i := range hosts {
 		hosts[i] = Name(hosts[i]).Normalize()
-
 	}
 	return hosts
 }

--- a/plugin/normalize_test.go
+++ b/plugin/normalize_test.go
@@ -52,7 +52,6 @@ func TestNameMatches(t *testing.T) {
 		if actual != m.expected {
 			t.Errorf("Expected %v for %s/%s, got %v", m.expected, m.parent, m.child, actual)
 		}
-
 	}
 }
 

--- a/plugin/pkg/cidr/cidr.go
+++ b/plugin/pkg/cidr/cidr.go
@@ -38,7 +38,7 @@ func Split(n *net.IPNet) []string {
 func nets(network *net.IPNet, newPrefixLen int) []*net.IPNet {
 	prefixLen, _ := network.Mask.Size()
 	maxSubnets := int(math.Exp2(float64(newPrefixLen)) / math.Exp2(float64(prefixLen)))
-	nets := []*net.IPNet{{network.IP, net.CIDRMask(newPrefixLen, 8*len(network.IP))}}
+	nets := []*net.IPNet{{IP: network.IP, Mask: net.CIDRMask(newPrefixLen, 8*len(network.IP))}}
 
 	for i := 1; i < maxSubnets; i++ {
 		next, exceeds := cidr.NextSubnet(nets[len(nets)-1], newPrefixLen)

--- a/plugin/pkg/dnstest/multirecorder_test.go
+++ b/plugin/pkg/dnstest/multirecorder_test.go
@@ -19,7 +19,6 @@ func TestMultiWriteMsg(t *testing.T) {
 
 	if len(record.Msgs) != 2 {
 		t.Fatalf("Expected 2 messages to be written, but instead found %d\n", len(record.Msgs))
-
 	}
 	if record.Len != responseTestMsg.Len()*2 {
 		t.Fatalf("Expected the bytes written counter to be %d, but instead found %d\n", responseTestMsg.Len()*2, record.Len)

--- a/plugin/pkg/dnsutil/reverse_test.go
+++ b/plugin/pkg/dnsutil/reverse_test.go
@@ -66,6 +66,5 @@ func TestIsReverse(t *testing.T) {
 		if got != tc.expected {
 			t.Errorf("Test %d, got %d, expected %d for %s", i, got, tc.expected, tc.name)
 		}
-
 	}
 }

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -32,7 +32,6 @@ func stripZone(host string) string {
 func HostPortOrFile(s ...string) ([]string, error) {
 	var servers []string
 	for _, h := range s {
-
 		trans, host := Transport(h)
 
 		addr, _, err := net.SplitHostPort(host)

--- a/plugin/pkg/rand/rand.go
+++ b/plugin/pkg/rand/rand.go
@@ -32,5 +32,4 @@ func (r *Rand) Perm(n int) []int {
 	v := r.r.Perm(n)
 	r.m.Unlock()
 	return v
-
 }

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -271,6 +271,7 @@ func (r replacer) Replace(ctx context.Context, state request.Request, rr *dnstes
 		}
 	}
 	s := string(b)
+	//nolint:staticcheck
 	bufPool.Put(b[:0])
 	return s
 }

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -276,7 +276,6 @@ func BenchmarkReplacer(b *testing.B) {
 }
 
 func BenchmarkReplacer_CommonLogFormat(b *testing.B) {
-
 	w := dnstest.NewRecorder(&test.ResponseWriter{})
 	r := new(dns.Msg)
 	r.SetQuestion("example.org.", dns.TypeHINFO)

--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -57,7 +57,6 @@ func setup(c *caddy.Controller) error {
 				return plugin.Error("pprof", c.Errf("unknown property '%s'", c.Val()))
 			}
 		}
-
 	}
 
 	c.OnStartup(h.Startup)

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -180,7 +180,6 @@ func newEdns0VariableRule(mode, action, code, variable string) (*edns0VariableRu
 
 // ruleData returns the data specified by the variable.
 func (rule *edns0VariableRule) ruleData(ctx context.Context, state request.Request) ([]byte, error) {
-
 	switch rule.variable {
 	case queryName:
 		return []byte(state.QName()), nil

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -367,7 +367,6 @@ func parseAnswerRules(name string, args []string) (auto bool, rules ResponseRule
 		if last == "" && args[arg] != AnswerMatch {
 			if last == "" {
 				return false, nil, fmt.Errorf("exceeded the number of arguments for a non-answer rule argument for %s rule", name)
-
 			}
 			return false, nil, fmt.Errorf("exceeded the number of arguments for %s answer rule for %s rule", last, name)
 		}

--- a/plugin/rewrite/name_test.go
+++ b/plugin/rewrite/name_test.go
@@ -33,7 +33,6 @@ func TestRewriteIllegalName(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffix(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 
@@ -76,7 +75,6 @@ func TestRewriteNamePrefixSuffix(t *testing.T) {
 }
 
 func TestRewriteNameNoRewrite(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 
@@ -119,7 +117,6 @@ func TestRewriteNameNoRewrite(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffixNoAutoAnswer(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 
@@ -162,7 +159,6 @@ func TestRewriteNamePrefixSuffixNoAutoAnswer(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffixAutoAnswer(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 
@@ -211,7 +207,6 @@ func TestRewriteNamePrefixSuffixAutoAnswer(t *testing.T) {
 }
 
 func TestRewriteNameExactAnswer(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 
@@ -260,7 +255,6 @@ func TestRewriteNameExactAnswer(t *testing.T) {
 }
 
 func TestRewriteNameRegexAnswer(t *testing.T) {
-
 	ctx, close := context.WithCancel(context.TODO())
 	defer close()
 

--- a/plugin/rewrite/reverter_test.go
+++ b/plugin/rewrite/reverter_test.go
@@ -31,7 +31,6 @@ var tests = []struct {
 }
 
 func TestResponseReverter(t *testing.T) {
-
 	rules := []Rule{}
 	r, _ := newNameRule("stop", "regex", `(core)\.(dns)\.(rocks)`, "{2}.{1}.{3}", "answer", "name", `(dns)\.(core)\.(rocks)`, "{2}.{1}.{3}")
 	rules = append(rules, r)
@@ -98,7 +97,6 @@ var valueTests = []struct {
 }
 
 func TestValueResponseReverter(t *testing.T) {
-
 	rules := []Rule{}
 	r, err := newNameRule("stop", "regex", `(.*)\.domain\.uk`, "{1}.cluster.local", "answer", "name", `(.*)\.cluster\.local`, "{1}.domain.uk", "answer", "value", `(.*)\.cluster\.local`, "{1}.domain.uk")
 	if err != nil {

--- a/plugin/rewrite/setup_test.go
+++ b/plugin/rewrite/setup_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestParse(t *testing.T) {
-
 	tests := []struct {
 		inputFileRules string
 		shouldErr      bool
@@ -49,5 +48,4 @@ func TestParse(t *testing.T) {
 			t.Errorf("Test %d got wrong error for invalid response rewrite: '%v'\n---\n%s", i, err.Error(), test.inputFileRules)
 		}
 	}
-
 }

--- a/plugin/rewrite/wire.go
+++ b/plugin/rewrite/wire.go
@@ -9,7 +9,6 @@ import (
 
 // ipToWire writes IP address to wire/binary format, 4 or 16 bytes depends on IPV4 or IPV6.
 func ipToWire(family int, ipAddr string) ([]byte, error) {
-
 	switch family {
 	case 1:
 		return net.ParseIP(ipAddr).To4(), nil
@@ -28,7 +27,6 @@ func uint16ToWire(data uint16) []byte {
 
 // portToWire writes port to wire/binary format, 2 bytes
 func portToWire(portStr string) ([]byte, error) {
-
 	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return nil, err

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -212,7 +212,6 @@ func maybeUnescape(s string) (string, error) {
 
 func updateZoneFromRRS(rrs *route53.ResourceRecordSet, z *file.Zone) error {
 	for _, rr := range rrs.ResourceRecords {
-
 		n, err := maybeUnescape(aws.StringValue(rrs.Name))
 		if err != nil {
 			return fmt.Errorf("failed to unescape `%s' name: %v", aws.StringValue(rrs.Name), err)
@@ -273,7 +272,6 @@ func (h *Route53) updateZones(ctx context.Context) error {
 				(*z[i]).z = newZ
 				h.zMu.Unlock()
 			}
-
 		}(zName, z)
 	}
 	// Collect errors (if any). This will also sync on all zones updates

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -109,7 +109,6 @@ func TestRoute53(t *testing.T) {
 
 			m.Authoritative = true
 			rcode = dns.RcodeSuccess
-
 		}
 
 		m.SetRcode(r, rcode)

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -126,10 +126,12 @@ func setup(c *caddy.Controller) error {
 		ctx, cancel := context.WithCancel(context.Background())
 		h, err := New(ctx, client, keys, refresh)
 		if err != nil {
+			cancel()
 			return plugin.Error("route53", c.Errf("failed to create route53 plugin: %v", err))
 		}
 		h.Fall = fall
 		if err := h.Run(ctx); err != nil {
+			cancel()
 			return plugin.Error("route53", c.Errf("failed to initialize route53 plugin: %v", err))
 		}
 		dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -64,7 +64,6 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 	z := make(map[string]*file.Zone)
 	names := []string{}
 	for c.Next() {
-
 		if c.Val() == "secondary" {
 			// secondary [origin]
 			origins := plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
@@ -74,8 +73,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 			}
 
 			for c.NextBlock() {
-
-				f := []string{}
+				var f []string
 
 				switch c.Val() {
 				case "transfer":

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -32,7 +32,6 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 	handler.Templates = make([]template, 0)
 
 	for c.Next() {
-
 		if !c.NextArg() {
 			return handler, c.ArgErr()
 		}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -24,7 +24,6 @@ func TestSetup(t *testing.T) {
 }
 
 func TestSetupParse(t *testing.T) {
-
 	serverBlockKeys := []string{"domain.com.:8053", "dynamic.domain.com.:8053"}
 
 	tests := []struct {

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -285,7 +285,6 @@ func SortAndCheck(resp *dns.Msg, tc Case) error {
 	}
 	if err := Section(tc, Ns, resp.Ns); err != nil {
 		return err
-
 	}
 	return Section(tc, Extra, resp.Extra)
 }

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -80,7 +80,6 @@ func Scrape(url string) []*MetricFamily {
 // ScrapeMetricAsInt provides a sum of all metrics collected for the name and label provided.
 // if the metric is not a numeric value, it will be counted a 0.
 func ScrapeMetricAsInt(addr string, name string, label string, nometricvalue int) int {
-
 	valueToInt := func(m metric) int {
 		v := m.Value
 		r, err := strconv.Atoi(v)
@@ -141,7 +140,6 @@ func MetricValueLabel(name, label string, mfs []*MetricFamily) (string, map[stri
 						return m.(metric).Value, m.(metric).Labels
 					}
 				}
-
 			}
 		}
 	}

--- a/plugin/transfer/failed_write_test.go
+++ b/plugin/transfer/failed_write_test.go
@@ -12,10 +12,9 @@ import (
 
 type badwriter struct {
 	dns.ResponseWriter
-	count int
 }
 
-func (w *badwriter) WriteMsg(res *dns.Msg) error { return fmt.Errorf("failed to write msg") }
+func (w *badwriter) WriteMsg(_ *dns.Msg) error { return fmt.Errorf("failed to write msg") }
 
 func TestWriteMessageFailed(t *testing.T) {
 	transfer := newTestTransfer()

--- a/plugin/transfer/setup_test.go
+++ b/plugin/transfer/setup_test.go
@@ -98,7 +98,6 @@ func TestParse(t *testing.T) {
 			for k, zone := range x.Zones {
 				if tc.exp.xfrs[j].Zones[k] != zone {
 					t.Errorf("Test %d expected zone %v, got %v", i, tc.exp.xfrs[j].Zones[k], zone)
-
 				}
 			}
 			// Check to
@@ -108,7 +107,6 @@ func TestParse(t *testing.T) {
 			for k, to := range x.to {
 				if tc.exp.xfrs[j].to[k] != to {
 					t.Errorf("Test %d expected %v in 'to', got %v", i, tc.exp.xfrs[j].to[k], to)
-
 				}
 			}
 		}

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -167,7 +167,6 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			return dns.RcodeServerFailure, err
 		}
 		l += len(rrs)
-
 	}
 
 	close(ch)     // Even though we close the channel here, we still have

--- a/plugin/tsig/setup_test.go
+++ b/plugin/tsig/setup_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestParse(t *testing.T) {
-
 	secrets := map[string]string{
 		"name.key.":  "test-key",
 		"name2.key.": "test-key-2",
@@ -150,7 +149,6 @@ key "name2.key." {
 				break
 			}
 		}
-
 	}
 }
 
@@ -243,6 +241,5 @@ func TestParseKeyFileErrors(t *testing.T) {
 		if err.Error() != testcase.err {
 			t.Errorf("Test %d: Expected error: %q, got %q", i, testcase.err, err.Error())
 		}
-
 	}
 }

--- a/request/request.go
+++ b/request/request.go
@@ -313,7 +313,6 @@ func (r *Request) Class() string {
 	}
 
 	return dns.Class(r.Req.Question[0].Qclass).String()
-
 }
 
 // QClass returns the class of the question in the request.
@@ -327,7 +326,6 @@ func (r *Request) QClass() uint16 {
 	}
 
 	return r.Req.Question[0].Qclass
-
 }
 
 // Clear clears all caching from Request s.

--- a/test/file_loop_test.go
+++ b/test/file_loop_test.go
@@ -44,6 +44,5 @@ func TestFileLoop(t *testing.T) {
 	// For now: document current behavior in this test.
 	if r.Rcode != dns.RcodeServerFailure {
 		t.Errorf("Rcode should be dns.RcodeServerFailure: %d", r.Rcode)
-
 	}
 }

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/miekg/dns"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestGrpc(t *testing.T) {
@@ -24,7 +25,7 @@ func TestGrpc(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, tcp, grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, tcp, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
 	}

--- a/test/metric_naming_test.go
+++ b/test/metric_naming_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestMetricNaming(t *testing.T) {
-
 	walker := validMetricWalker{}
 	err := filepath.Walk("..", walker.walk)
 

--- a/test/presubmit_test.go
+++ b/test/presubmit_test.go
@@ -158,7 +158,6 @@ func (l logfmt) Visit(n ast.Node) ast.Visitor {
 	for i, u := range bl.Value {
 		// disregard "
 		if i == 1 && !unicode.IsUpper(u) {
-			l.err = fmt.Errorf("test error message %s doesn't start with an uppercase", bl.Value)
 			return nil
 		}
 		if i == 1 {

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -167,7 +167,6 @@ func sectionsFromReadme(readme string) error {
 		return fmt.Errorf("Sections incomplete or ordered wrong: %q, want (at least): Name, Descripion, Syntax and Examples", readme)
 	}
 	return nil
-
 }
 
 func create(c map[string]string) {

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -214,5 +214,4 @@ www    IN AAAA ::1
 			return
 		}
 	}
-
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR adds to the CoreDNS more GO linting using [golangci-lint](https://github.com/golangci/golangci-lint), currently some semantic analysis is performed by CodeQL and we have static analysis in a form of scheduled `gofmt`, import check and stickler-ci (which is performing very basic static analysis)

As part of this PR I would like to propose addition of [golangci-lint](https://github.com/golangci/golangci-lint) as Github action which will be running on PRs and doing these static analyses:
- deadcode = detecting unreachable/not used code
- govet = static correctness of GO code (https://github.com/golangci/govet)
- ineffassign = useless assign expression
- structcheck, typecheck = additional static checking of structs and types
- varcheck = unused/useless variables
- whitespace = static analysis of unnecessary new lines

this will enable us to mitigate issues like passing locks by value, context leaks, etc.

There was already an attempt few years back to add `golangci-lint` but it seems to have been closed due to inactivity https://github.com/coredns/coredns/pull/3638 

full list of supported linters by `golangci-lint` can be found [here](https://golangci-lint.run/usage/linters/), but for now I have enabled only a small subset. In the future we can decide to enable additional linters

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
