### PR TITLE
plugin/k8s_external: Resolve headless services

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -65,6 +65,8 @@ k8s_external [ZONE...] {
 }
 ~~~
 
+* if there is a headless service with external IPs set, external IPs will be resolved
+
 ## Examples
 
 Enable names under `example.org` to be resolved to in-cluster DNS addresses.

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -2,12 +2,12 @@
 
 ## Name
 
-*k8s_external* - resolves load balancer and external IPs from outside Kubernetes clusters.
+*k8s_external* - resolves load balancer, external IPs from outside Kubernetes clusters and if enabled headless services.
 
 ## Description
 
 This plugin allows an additional zone to resolve the external IP address(es) of a Kubernetes
-service. This plugin is only useful if the *kubernetes* plugin is also loaded.
+service and headless services. This plugin is only useful if the *kubernetes* plugin is also loaded.
 
 The plugin uses an external zone to resolve in-cluster IP addresses. It only handles queries for A,
 AAAA, SRV, and PTR records; all others result in NODATA responses. To make it a proper DNS zone, it handles
@@ -56,6 +56,14 @@ k8s_external [ZONE...] {
 
 * **APEX** is the name (DNS label) to use for the apex records; it defaults to `dns`.
 * `ttl` allows you to set a custom **TTL** for responses. The default is 5 (seconds).
+
+If you want to enable headless service resolution, you can do so by adding `headless` option.
+
+~~~
+k8s_external [ZONE...] {
+    headless
+}
+~~~
 
 ## Examples
 

--- a/plugin/k8s_external/apex.go
+++ b/plugin/k8s_external/apex.go
@@ -18,7 +18,7 @@ func (e *External) serveApex(state request.Request) (int, error) {
 	case dns.TypeNS:
 		m.Answer = []dns.RR{e.ns(state)}
 
-		addr := e.externalAddrFunc(state)
+		addr := e.externalAddrFunc(state, e.headless)
 		for _, rr := range addr {
 			rr.Header().Ttl = e.ttl
 			rr.Header().Name = dnsutil.Join("ns1", e.apex, state.QName())
@@ -58,7 +58,7 @@ func (e *External) serveSubApex(state request.Request) (int, error) {
 			return 0, nil
 		}
 
-		addr := e.externalAddrFunc(state)
+		addr := e.externalAddrFunc(state, e.headless)
 		for _, rr := range addr {
 			rr.Header().Ttl = e.ttl
 			rr.Header().Name = state.QName()

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -17,6 +17,7 @@ func TestApex(t *testing.T) {
 	k.APIConn = &external{}
 
 	e := New()
+	e.headless = true
 	e.Zones = []string{"example.com."}
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -26,11 +26,11 @@ import (
 type Externaler interface {
 	// External returns a slice of msg.Services that are looked up in the backend and match
 	// the request.
-	External(request.Request) ([]msg.Service, int)
+	External(request.Request, bool) ([]msg.Service, int)
 	// ExternalAddress should return a string slice of addresses for the nameserving endpoint.
-	ExternalAddress(state request.Request) []dns.RR
+	ExternalAddress(state request.Request, headless bool) []dns.RR
 	// ExternalServices returns all services in the given zone as a slice of msg.Service.
-	ExternalServices(zone string) []msg.Service
+	ExternalServices(zone string, headless bool) []msg.Service
 	// ExternalSerial gets the current serial.
 	ExternalSerial(string) uint32
 }
@@ -40,16 +40,17 @@ type External struct {
 	Next  plugin.Handler
 	Zones []string
 
-	hostmaster string
-	apex       string
-	ttl        uint32
+	hostmaster 	string
+	apex       	string
+	ttl        	uint32
+	headless 	bool
 
 	upstream *upstream.Upstream
 
-	externalFunc         func(request.Request) ([]msg.Service, int)
-	externalAddrFunc     func(request.Request) []dns.RR
+	externalFunc         func(request.Request, bool) ([]msg.Service, int)
+	externalAddrFunc     func(request.Request, bool) []dns.RR
 	externalSerialFunc   func(string) uint32
-	externalServicesFunc func(string) []msg.Service
+	externalServicesFunc func(string, bool) []msg.Service
 }
 
 // New returns a new and initialized *External.
@@ -85,7 +86,7 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		}
 	}
 
-	svc, rcode := e.externalFunc(state)
+	svc, rcode := e.externalFunc(state, e.headless)
 
 	m := new(dns.Msg)
 	m.SetReply(state.Req)

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -29,8 +29,8 @@ type Externaler interface {
 	External(request.Request, bool) ([]msg.Service, int)
 	// ExternalAddress should return a string slice of addresses for the nameserving endpoint.
 	ExternalAddress(state request.Request, headless bool) []dns.RR
-	// ExternalServices returns all services in the given zone as a slice of msg.Service.
-	ExternalServices(zone string, headless bool) []msg.Service
+	// ExternalServices returns all services in the given zone as a slice of msg.Service and if enabled, headless services as a map of services.
+	ExternalServices(zone string, headless bool) ([]msg.Service, map[string][]msg.Service)
 	// ExternalSerial gets the current serial.
 	ExternalSerial(string) uint32
 }
@@ -50,7 +50,7 @@ type External struct {
 	externalFunc         func(request.Request, bool) ([]msg.Service, int)
 	externalAddrFunc     func(request.Request, bool) []dns.RR
 	externalSerialFunc   func(string) uint32
-	externalServicesFunc func(string, bool) []msg.Service
+	externalServicesFunc func(string, bool) ([]msg.Service, map[string][]msg.Service)
 }
 
 // New returns a new and initialized *External.

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -239,8 +239,8 @@ var tests = []test.Case{
 	{
 		Qname: "_http._tcp.svc-headless.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0 50 80 endpoint-svc-0.svc-headless.testns.example.com."),
-			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0 50 80 endpoint-svc-1.svc-headless.testns.example.com."),
+			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0	50	80	endpoint-svc-0.svc-headless.testns.example.com."),
+			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0	50	80	endpoint-svc-1.svc-headless.testns.example.com."),
 		},
 		Extra: []dns.RR{
 			test.A("endpoint-svc-0.svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -21,6 +21,7 @@ func TestExternal(t *testing.T) {
 
 	e := New()
 	e.Zones = []string{"example.com.", "in-addr.arpa."}
+	e.headless = true
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External
 	e.externalAddrFunc = externalAddress  // internal test function
@@ -216,18 +217,86 @@ var tests = []test.Case{
 			test.SRV("svc12.testns.example.com.	5	IN	SRV	0 100 80 dummy.hostname."),
 		},
 	},
+	// headless service
+	{
+		Qname: "svc-headless.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("svc-headless.testns.example.com.	5	IN	A	1.2.3.5"),
+		},
+	},
+	{
+		Qname: "svc-headless.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("svc-headless.testns.example.com.	5	IN	SRV	0	50	80	endpoint-svc-0.svc-headless.testns.example.com."),
+			test.SRV("svc-headless.testns.example.com.	5	IN	SRV	0	50	80	endpoint-svc-1.svc-headless.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("endpoint-svc-0.svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("endpoint-svc-1.svc-headless.testns.example.com.	5	IN	A	1.2.3.5"),
+		},
+	},
+	{
+		Qname: "_http._tcp.svc-headless.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0 50 80 endpoint-svc-0.svc-headless.testns.example.com."),
+			test.SRV("_http._tcp.svc-headless.testns.example.com.	5	IN	SRV	0 50 80 endpoint-svc-1.svc-headless.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("endpoint-svc-0.svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),
+			test.A("endpoint-svc-1.svc-headless.testns.example.com.	5	IN	A	1.2.3.5"),
+		},
+	},
+	{
+		Qname: "endpoint-svc-0.svc-headless.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("endpoint-svc-0.svc-headless.testns.example.com.		5	IN	SRV	0	100	80	endpoint-svc-0.svc-headless.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("endpoint-svc-0.svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "endpoint-svc-1.svc-headless.testns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("endpoint-svc-1.svc-headless.testns.example.com.		5	IN	SRV	0	100	80	endpoint-svc-1.svc-headless.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("endpoint-svc-1.svc-headless.testns.example.com.	5	IN	A	1.2.3.5"),
+		},
+	},
+	{
+		Qname: "endpoint-svc-0.svc-headless.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("endpoint-svc-0.svc-headless.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "endpoint-svc-1.svc-headless.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("endpoint-svc-1.svc-headless.testns.example.com.	5	IN	A	1.2.3.5"),
+		},
+	},
 }
 
 type external struct{}
 
-func (external) HasSynced() bool                                                   { return true }
-func (external) Run()                                                              {}
-func (external) Stop() error                                                       { return nil }
-func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
-func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
-func (external) Modified(bool) int64                                               { return 0 }
-func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
-func (external) EndpointsList() []*object.Endpoints                                { return nil }
+func (external) HasSynced() bool                           { return true }
+func (external) Run()                                      {}
+func (external) Stop() error                               { return nil }
+func (external) EpIndexReverse(string) []*object.Endpoints { return nil }
+func (external) SvcIndexReverse(string) []*object.Service  { return nil }
+func (external) Modified(bool) int64                       { return 0 }
+func (external) EpIndex(s string) []*object.Endpoints {
+	return epIndexExternal[s]
+}
+func (external) EndpointsList() []*object.Endpoints {
+	var eps []*object.Endpoints
+	for _, ep := range epIndexExternal {
+		eps = append(eps, ep...)
+	}
+	return eps
+}
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
 func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
 func (external) PodIndex(string) []*object.Pod                                     { return nil }
@@ -250,6 +319,41 @@ func (external) GetNamespaceByName(name string) (*object.Namespace, error) {
 	return &object.Namespace{
 		Name: name,
 	}, nil
+}
+
+var epIndexExternal = map[string][]*object.Endpoints{
+	"svc-headless.testns": {
+		{
+			Name:      "svc-headless",
+			Namespace: "testns",
+			Index:     "svc-headless.testns",
+			Subsets: []object.EndpointSubset{
+				{
+					Ports: []object.EndpointPort{
+						{
+							Port:     80,
+							Name:     "http",
+							Protocol: "TCP",
+						},
+					},
+					Addresses: []object.EndpointAddress{
+						{
+							IP:            "1.2.3.4",
+							Hostname:      "endpoint-svc-0",
+							NodeName:      "test-node",
+							TargetRefName: "endpoint-svc-0",
+						},
+						{
+							IP:            "1.2.3.5",
+							Hostname:      "endpoint-svc-1",
+							NodeName:      "test-node",
+							TargetRefName: "endpoint-svc-1",
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 var svcIndexExternal = map[string][]*object.Service{
@@ -279,6 +383,7 @@ var svcIndexExternal = map[string][]*object.Service{
 			Namespace:   "testns",
 			Type:        api.ServiceTypeLoadBalancer,
 			ExternalIPs: []string{"2.3.4.5"},
+			ClusterIPs:  []string{"10.0.0.3"},
 			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
 		},
 	},
@@ -287,8 +392,18 @@ var svcIndexExternal = map[string][]*object.Service{
 			Name:        "svc12",
 			Namespace:   "testns",
 			Type:        api.ServiceTypeLoadBalancer,
+			ClusterIPs:  []string{"10.0.0.3"},
 			ExternalIPs: []string{"dummy.hostname"},
 			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+	"svc-headless.testns": {
+		{
+			Name:       "svc-headless",
+			Namespace:  "testns",
+			Type:       api.ServiceTypeClusterIP,
+			ClusterIPs: []string{"None"},
+			Ports:      []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
 		},
 	},
 }
@@ -301,7 +416,7 @@ func (external) ServiceList() []*object.Service {
 	return svcs
 }
 
-func externalAddress(state request.Request) []dns.RR {
+func externalAddress(state request.Request, headless bool) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
 }

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -68,6 +68,8 @@ func parse(c *caddy.Controller) (*External, error) {
 					return nil, c.ArgErr()
 				}
 				e.apex = args[0]
+			case "headless":
+				e.headless = true
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())
 			}

--- a/plugin/k8s_external/setup_test.go
+++ b/plugin/k8s_external/setup_test.go
@@ -8,16 +8,20 @@ import (
 
 func TestSetup(t *testing.T) {
 	tests := []struct {
-		input        string
-		shouldErr    bool
-		expectedZone string
-		expectedApex string
+		input            string
+		shouldErr        bool
+		expectedZone     string
+		expectedApex     string
+		expectedHeadless bool
 	}{
-		{`k8s_external`, false, "", "dns"},
-		{`k8s_external example.org`, false, "example.org.", "dns"},
+		{`k8s_external`, false, "", "dns", false},
+		{`k8s_external example.org`, false, "example.org.", "dns", false},
 		{`k8s_external example.org {
 			apex testdns
-}`, false, "example.org.", "testdns"},
+}`, false, "example.org.", "testdns", false},
+		{`k8s_external example.org {
+	headless
+}`, false, "example.org.", "dns", true},
 	}
 
 	for i, test := range tests {
@@ -42,6 +46,11 @@ func TestSetup(t *testing.T) {
 		if !test.shouldErr {
 			if test.expectedApex != e.apex {
 				t.Errorf("Test %d, expected apex %q for input %s, got: %q", i, test.expectedApex, test.input, e.apex)
+			}
+		}
+		if !test.shouldErr {
+			if test.expectedHeadless != e.headless {
+				t.Errorf("Test %d, expected headless %q for input %s, got: %v", i, test.expectedApex, test.input, e.headless)
 			}
 		}
 	}

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -5,9 +5,8 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/kubernetes"
-
 	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/kubernetes"
 	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/coredns/coredns/request"
 

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -50,7 +50,7 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 
 		svcs := e.externalServicesFunc(zone, e.headless)
 		srvSeen := make(map[string]struct{})
-		// svcsGroup := make(map[string][]msg.Service)
+
 		for i := range svcs {
 			name := msg.Domain(svcs[i].Key)
 

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -40,7 +40,7 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 		ch <- []dns.RR{&dns.NS{Hdr: nsHdr, Ns: nsName}}
 
 		// Add Nameserver A/AAAA records
-		nsRecords := e.externalAddrFunc(state)
+		nsRecords := e.externalAddrFunc(state, e.headless)
 		for i := range nsRecords {
 			// externalAddrFunc returns incomplete header names, correct here
 			nsRecords[i].Header().Name = nsName
@@ -48,10 +48,12 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 			ch <- []dns.RR{nsRecords[i]}
 		}
 
-		svcs := e.externalServicesFunc(zone)
+		svcs := e.externalServicesFunc(zone, e.headless)
 		srvSeen := make(map[string]struct{})
+		// svcsGroup := make(map[string][]msg.Service)
 		for i := range svcs {
 			name := msg.Domain(svcs[i].Key)
+
 			if svcs[i].TargetStrip == 0 {
 				// Add Service A/AAAA records
 				s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -27,6 +27,7 @@ func TestTransferAXFR(t *testing.T) {
 	k.APIConn = &external{}
 
 	e := New()
+	e.headless = true
 	e.Zones = []string{"example.com."}
 	e.externalFunc = k.External
 	e.externalAddrFunc = externalAddress  // internal test function
@@ -64,6 +65,7 @@ func TestTransferAXFR(t *testing.T) {
 			if ans.Header().Rrtype == dns.TypePTR {
 				continue
 			}
+
 			expect = append(expect, ans)
 		}
 	}
@@ -92,6 +94,7 @@ func TestTransferIXFR(t *testing.T) {
 
 	e := New()
 	e.Zones = []string{"example.com."}
+	e.headless = true
 	e.externalFunc = k.External
 	e.externalAddrFunc = externalAddress  // internal test function
 	e.externalSerialFunc = externalSerial // internal test function
@@ -136,7 +139,9 @@ func difference(testRRs []dns.RR, gotRRs []dns.RR) []dns.RR {
 	}
 
 	foundRRs := []dns.RR{}
+	cmp := map[string]struct{}{}
 	for _, rr := range gotRRs {
+		cmp[rr.String()] = struct{}{}
 		if _, ok := expectedRRs[rr.String()]; !ok {
 			foundRRs = append(foundRRs, rr)
 		}

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -139,9 +139,7 @@ func difference(testRRs []dns.RR, gotRRs []dns.RR) []dns.RR {
 	}
 
 	foundRRs := []dns.RR{}
-	cmp := map[string]struct{}{}
 	for _, rr := range gotRRs {
-		cmp[rr.String()] = struct{}{}
 		if _, ok := expectedRRs[rr.String()]; !ok {
 			foundRRs = append(foundRRs, rr)
 		}

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -12,8 +12,8 @@ import (
 )
 
 // External implements the ExternalFunc call from the external plugin.
-// It returns any services matching in the services' ExternalIPs.
-func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
+// It returns any services matching in the services' ExternalIPs and if enabled, headless endpoints..
+func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Service, int) {
 	if state.QType() == dns.TypePTR {
 		ip := dnsutil.ExtractAddressFromReverse(state.Name())
 		if ip != "" {
@@ -36,7 +36,7 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 	// We are dealing with a fairly normal domain name here, but we still need to have the service
 	// and the namespace:
 	// service.namespace.<base>
-	var port, protocol string
+	var port, protocol, endpoint string
 	namespace := segs[last]
 	if !k.namespaceExposed(namespace) {
 		return nil, dns.RcodeNameError
@@ -49,7 +49,10 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 
 	service := segs[last]
 	last--
-	if last == 1 {
+	if last == 0 {
+		endpoint = stripUnderscore(segs[last])
+		last--
+	} else if last == 1 {
 		protocol = stripUnderscore(segs[last])
 		port = stripUnderscore(segs[last-1])
 		last -= 2
@@ -60,8 +63,15 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 		return nil, dns.RcodeNameError
 	}
 
+	var (
+		endpointsListFunc func() []*object.Endpoints
+		endpointsList     []*object.Endpoints
+		serviceList       []*object.Service
+	)
+
 	idx := object.ServiceKey(service, namespace)
-	serviceList := k.APIConn.SvcIndex(idx)
+	serviceList = k.APIConn.SvcIndex(idx)
+	endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EpIndex(idx) }
 
 	services := []msg.Service{}
 	zonePath := msg.Path(state.Zone, coredns)
@@ -75,16 +85,52 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 			continue
 		}
 
-		for _, ip := range svc.ExternalIPs {
-			for _, p := range svc.Ports {
-				if !(matchPortAndProtocol(port, p.Name, protocol, string(p.Protocol))) {
+		if svc.Headless() || endpoint != "" {
+			if endpointsList == nil {
+				endpointsList = endpointsListFunc()
+			}
+			// Endpoint query or headless service
+			for _, ep := range endpointsList {
+				if object.EndpointsKey(svc.Name, svc.Namespace) != ep.Index {
 					continue
 				}
-				rcode = dns.RcodeSuccess
-				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
-				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
 
-				services = append(services, s)
+				for _, eps := range ep.Subsets {
+					for _, addr := range eps.Addresses {
+
+						// See comments in parse.go parseRequest about the endpoint handling.
+						if endpoint != "" {
+							if !match(endpoint, endpointHostname(addr, k.endpointNameMode)) {
+								continue
+							}
+						}
+
+						for _, p := range eps.Ports {
+							if !(matchPortAndProtocol(port, p.Name, protocol, p.Protocol)) {
+								continue
+							}
+							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
+							s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name, endpointHostname(addr, k.endpointNameMode)}, "/")
+
+							services = append(services, s)
+						}
+					}
+				}
+			}
+			continue
+		} else {
+
+			for _, ip := range svc.ExternalIPs {
+				for _, p := range svc.Ports {
+					if !(matchPortAndProtocol(port, p.Name, protocol, string(p.Protocol))) {
+						continue
+					}
+					rcode = dns.RcodeSuccess
+					s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+					s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+
+					services = append(services, s)
+				}
 			}
 		}
 	}
@@ -96,27 +142,54 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 }
 
 // ExternalAddress returns the external service address(es) for the CoreDNS service.
-func (k *Kubernetes) ExternalAddress(state request.Request) []dns.RR {
+func (k *Kubernetes) ExternalAddress(state request.Request, headless bool) []dns.RR {
 	// If CoreDNS is running inside the Kubernetes cluster: k.nsAddrs() will return the external IPs of the services
 	// targeting the CoreDNS Pod.
 	// If CoreDNS is running outside of the Kubernetes cluster: k.nsAddrs() will return the first non-loopback IP
 	// address seen on the local system it is running on. This could be the wrong answer if coredns is using the *bind*
 	// plugin to bind to a different IP address.
-	return k.nsAddrs(true, state.Zone)
+	return k.nsAddrs(true, headless,  state.Zone)
 }
 
-// ExternalServices returns all services with external IPs
-func (k *Kubernetes) ExternalServices(zone string) (services []msg.Service) {
+// ExternalServices returns all services with external IPs and if enabled headless services
+func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []msg.Service) {
 	zonePath := msg.Path(zone, coredns)
 	for _, svc := range k.APIConn.ServiceList() {
-		for _, ip := range svc.ExternalIPs {
-			for _, p := range svc.Ports {
-				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
-				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
-				services = append(services, s)
-				s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
-				s.TargetStrip = 2
-				services = append(services, s)
+		// Endpoint query or headless service
+		if headless && svc.Headless() {
+			
+			idx := object.ServiceKey(svc.Name, svc.Namespace)
+		    endpointsList :=  k.APIConn.EpIndex(idx)
+	
+			for _, ep := range endpointsList {
+				if ep.Name != svc.Name || ep.Namespace != svc.Namespace {
+					continue
+				}
+
+				for _, eps := range ep.Subsets {
+					
+					for _, addr := range eps.Addresses {
+
+						for _, p := range eps.Ports {
+							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
+							baseSvc := strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+							s.Key = strings.Join([]string{baseSvc, endpointHostname(addr, k.endpointNameMode)}, "/")
+							services = append(services, s)
+						}
+					}
+				}
+			}
+			continue
+		} else {
+			for _, ip := range svc.ExternalIPs {
+				for _, p := range svc.Ports {
+					s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+					s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+					services = append(services, s)
+					s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+					s.TargetStrip = 2
+					services = append(services, s)
+				}
 			}
 		}
 	}

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -95,7 +95,6 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
-
 						if endpoint != "" && !match(endpoint, endpointHostname(addr, k.endpointNameMode)) {
 							continue
 						}
@@ -115,7 +114,6 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 			}
 			continue
 		} else {
-
 			for _, ip := range svc.ExternalIPs {
 				for _, p := range svc.Ports {
 					if !(matchPortAndProtocol(port, p.Name, protocol, string(p.Protocol))) {
@@ -153,7 +151,6 @@ func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []ms
 	for _, svc := range k.APIConn.ServiceList() {
 		// Endpoint query or headless service
 		if headless && svc.Headless() {
-
 			idx := object.ServiceKey(svc.Name, svc.Namespace)
 		    endpointsList :=  k.APIConn.EpIndex(idx)
 			

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -164,6 +164,9 @@ func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []ms
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
 							s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
 							services = append(services, s)
+							s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+							s.TargetStrip = 2
+							services = append(services, s)
 						}
 					}
 				}

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -11,6 +11,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+const (
+	Endpoint     = "endpoint"
+	PortProtocol = "port.protocol"
+)
+
 // External implements the ExternalFunc call from the external plugin.
 // It returns any services matching in the services' ExternalIPs and if enabled, headless endpoints..
 func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Service, int) {
@@ -33,9 +38,10 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 	if last < 0 {
 		return nil, dns.RcodeServerFailure
 	}
-	// We are dealing with a fairly normal domain name here, but we still need to have the service
-	// and the namespace:
-	// service.namespace.<base>
+	// We are dealing with a fairly normal domain name here, but we still need to have the service,
+	// namespace and if present, endpoint:
+	// service.namespace.<base> or
+	// endpoint.service.namespace.<base>
 	var port, protocol, endpoint string
 	namespace := segs[last]
 	if !k.namespaceExposed(namespace) {
@@ -64,8 +70,8 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 	}
 
 	var (
-		endpointsList     []*object.Endpoints
-		serviceList       []*object.Service
+		endpointsList []*object.Endpoints
+		serviceList   []*object.Service
 	)
 
 	idx := object.ServiceKey(service, namespace)
@@ -83,10 +89,10 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 			continue
 		}
 
-		if headless && (svc.Headless() || endpoint != "") {
+		if headless && len(svc.ExternalIPs) == 0 && (svc.Headless() || endpoint != "") {
 			if endpointsList == nil {
 				endpointsList = k.APIConn.EpIndex(idx)
-			}
+			}	
 			// Endpoint query or headless service
 			for _, ep := range endpointsList {
 				if object.EndpointsKey(svc.Name, svc.Namespace) != ep.Index {
@@ -98,7 +104,6 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 						if endpoint != "" && !match(endpoint, endpointHostname(addr, k.endpointNameMode)) {
 							continue
 						}
-						
 
 						for _, p := range eps.Ports {
 							if !(matchPortAndProtocol(port, p.Name, protocol, p.Protocol)) {
@@ -142,28 +147,40 @@ func (k *Kubernetes) ExternalAddress(state request.Request, headless bool) []dns
 	// If CoreDNS is running outside of the Kubernetes cluster: k.nsAddrs() will return the first non-loopback IP
 	// address seen on the local system it is running on. This could be the wrong answer if coredns is using the *bind*
 	// plugin to bind to a different IP address.
-	return k.nsAddrs(true, headless,  state.Zone)
+	return k.nsAddrs(true, headless, state.Zone)
 }
 
 // ExternalServices returns all services with external IPs and if enabled headless services
-func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []msg.Service) {
+func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []msg.Service, headlessServices map[string][]msg.Service) {
 	zonePath := msg.Path(zone, coredns)
+	headlessServices = make(map[string][]msg.Service)
 	for _, svc := range k.APIConn.ServiceList() {
-		// Endpoint query or headless service
-		if headless && svc.Headless() {
+		// Endpoints and headless services
+		if headless && len(svc.ExternalIPs) == 0 && svc.Headless() {
 			idx := object.ServiceKey(svc.Name, svc.Namespace)
-		    endpointsList :=  k.APIConn.EpIndex(idx)
-			
+			endpointsList := k.APIConn.EpIndex(idx)
+
 			for _, ep := range endpointsList {
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
+						// we need to have some answers grouped together
+						// 1. for endpoint requests eg. endpoint-0.service.example.com - will always have one endpoint
+						// 2. for service requests eg. service.example.com - can have multiple endpoints
+						// 3. for port.protocol requests eg. _http._tcp.service.example.com - can have multiple endpoints
 						for _, p := range eps.Ports {
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
-							s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
-							services = append(services, s)
+							baseSvc := strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+							s.Key = strings.Join([]string{baseSvc, endpointHostname(addr, k.endpointNameMode)}, "/")
+							headlessServices[strings.Join([]string{baseSvc, Endpoint}, "/")] = append(headlessServices[strings.Join([]string{baseSvc, Endpoint}, "/")], s)
+
+							// As per spec unnamed ports do not have a srv record
+							// https://github.com/kubernetes/dns/blob/master/docs/specification.md#232---srv-records
+							if p.Name == "" {
+								continue
+							}
+							s.Host = msg.Domain(s.Key)
 							s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
-							s.TargetStrip = 2
-							services = append(services, s)
+							headlessServices[strings.Join([]string{s.Key, PortProtocol}, "/")] = append(headlessServices[strings.Join([]string{s.Key, PortProtocol}, "/")], s)
 						}
 					}
 				}
@@ -182,7 +199,7 @@ func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []ms
 			}
 		}
 	}
-	return services
+	return services, headlessServices
 }
 
 //ExternalSerial returns the serial of the external zone

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -12,6 +12,13 @@ import (
 )
 
 const (
+	// Those constants are used to distinguish between records in ExternalServices headless 
+	// return values.
+	// They are always appendedn to key in a map which is 
+	// either base service key eg. /com/example/namespace/service/endpoint or
+	// /com/example/namespace/service/_http/_tcp/port.protocol
+	// this will allow us to distinguish services in implementation of Transfer protocol
+	// see plugin/k8s_external/transfer.go
 	Endpoint     = "endpoint"
 	PortProtocol = "port.protocol"
 )

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -11,14 +11,14 @@ import (
 	"github.com/miekg/dns"
 )
 
+// Those constants are used to distinguish between records in ExternalServices headless
+// return values.
+// They are always appendedn to key in a map which is
+// either base service key eg. /com/example/namespace/service/endpoint or
+// /com/example/namespace/service/_http/_tcp/port.protocol
+// this will allow us to distinguish services in implementation of Transfer protocol
+// see plugin/k8s_external/transfer.go
 const (
-	// Those constants are used to distinguish between records in ExternalServices headless 
-	// return values.
-	// They are always appendedn to key in a map which is 
-	// either base service key eg. /com/example/namespace/service/endpoint or
-	// /com/example/namespace/service/_http/_tcp/port.protocol
-	// this will allow us to distinguish services in implementation of Transfer protocol
-	// see plugin/k8s_external/transfer.go
 	Endpoint     = "endpoint"
 	PortProtocol = "port.protocol"
 )
@@ -99,7 +99,7 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 		if headless && len(svc.ExternalIPs) == 0 && (svc.Headless() || endpoint != "") {
 			if endpointsList == nil {
 				endpointsList = k.APIConn.EpIndex(idx)
-			}	
+			}
 			// Endpoint query or headless service
 			for _, ep := range endpointsList {
 				if object.EndpointsKey(svc.Name, svc.Namespace) != ep.Index {

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -99,11 +99,11 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 					for _, addr := range eps.Addresses {
 
 						// See comments in parse.go parseRequest about the endpoint handling.
-						if endpoint != "" {
-							if !match(endpoint, endpointHostname(addr, k.endpointNameMode)) {
-								continue
-							}
+						
+						if endpoint != "" && !match(endpoint, endpointHostname(addr, k.endpointNameMode)) {
+							continue
 						}
+						
 
 						for _, p := range eps.Ports {
 							if !(matchPortAndProtocol(port, p.Name, protocol, p.Protocol)) {

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -43,6 +43,22 @@ var extCases = []struct {
 	{
 		Qname: "svc0.svc-nons.example.com.", Rcode: dns.RcodeNameError,
 	},
+	{
+		Qname: "svc-headless.testns.example.com.", Rcode: dns.RcodeSuccess,
+		Msg: []msg.Service{
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless"},
+			{Host: "1.2.3.5", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless"},
+		},
+	},
+	{
+		Qname: "endpoint-0.svc-headless.testns.example.com.", Rcode: dns.RcodeSuccess,
+		Msg: []msg.Service{
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 100, Key: "/c/org/example/testns/svc-headless/endpoint-0"},
+		},
+	},
+	{
+		Qname: "endpoint-1.svc-nons.testns.example.com.", Rcode: dns.RcodeNameError,
+	},
 }
 
 func TestExternal(t *testing.T) {
@@ -75,15 +91,23 @@ func TestExternal(t *testing.T) {
 
 type external struct{}
 
-func (external) HasSynced() bool                                                   { return true }
-func (external) Run()                                                              {}
-func (external) Stop() error                                                       { return nil }
-func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
-func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
-func (external) SvcExtIndexReverse(string) []*object.Service                       { return nil }
-func (external) Modified(bool) int64                                               { return 0 }
-func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
-func (external) EndpointsList() []*object.Endpoints                                { return nil }
+func (external) HasSynced() bool                             { return true }
+func (external) Run()                                        {}
+func (external) Stop() error                                 { return nil }
+func (external) EpIndexReverse(string) []*object.Endpoints   { return nil }
+func (external) SvcIndexReverse(string) []*object.Service    { return nil }
+func (external) SvcExtIndexReverse(string) []*object.Service { return nil }
+func (external) Modified(bool) int64                         { return 0 }
+func (external) EpIndex(s string) []*object.Endpoints {
+	return epIndexExternal[s]
+}
+func (external) EndpointsList() []*object.Endpoints {
+	var eps []*object.Endpoints
+	for _, ep := range epIndexExternal {
+		eps = append(eps, ep...)
+	}
+	return eps
+}
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
 func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
 func (external) PodIndex(string) []*object.Pod                                     { return nil }
@@ -92,6 +116,41 @@ func (external) GetNamespaceByName(name string) (*object.Namespace, error) {
 	return &object.Namespace{
 		Name: name,
 	}, nil
+}
+
+var epIndexExternal = map[string][]*object.Endpoints{
+	"svc-headless.testns": {
+		{
+			Name:      "svc-headless",
+			Namespace: "testns",
+			Index:     "svc-headless.testns",
+			Subsets: []object.EndpointSubset{
+				{
+					Ports: []object.EndpointPort{
+						{
+							Port:     80,
+							Name:     "http",
+							Protocol: "TCP",
+						},
+					},
+					Addresses: []object.EndpointAddress{
+						{
+							IP:            "1.2.3.4",
+							Hostname:      "endpoint-svc-0",
+							NodeName:      "test-node",
+							TargetRefName: "endpoint-svc-0",
+						},
+						{
+							IP:            "1.2.3.5",
+							Hostname:      "endpoint-svc-1",
+							NodeName:      "test-node",
+							TargetRefName: "endpoint-svc-1",
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 var svcIndexExternal = map[string][]*object.Service{
@@ -113,6 +172,15 @@ var svcIndexExternal = map[string][]*object.Service{
 			ClusterIPs:  []string{"10.0.0.3"},
 			ExternalIPs: []string{"1:2::5"},
 			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+	"svc-headless.testns": {
+		{
+			Name:       "svc-headless",
+			Namespace:  "testns",
+			Type:       api.ServiceTypeClusterIP,
+			ClusterIPs: []string{api.ClusterIPNone},
+			Ports:      []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
 		},
 	},
 }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -54,7 +54,7 @@ func TestExternal(t *testing.T) {
 	for i, tc := range extCases {
 		state := testRequest(tc.Qname)
 
-		svc, rcode := k.External(state)
+		svc, rcode := k.External(state, true)
 
 		if x := tc.Rcode; x != rcode {
 			t.Errorf("Test %d, expected rcode %d, got %d", i, x, rcode)

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -112,7 +112,7 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 
 	case dns.TypeNS:
 		// We can only get here if the qname equals the zone, see ServeDNS in handler.go.
-		nss := k.nsAddrs(false, state.Zone)
+		nss := k.nsAddrs(false, false, state.Zone)
 		var svcs []msg.Service
 		for _, ns := range nss {
 			if ns.Header().Rrtype == dns.TypeA {
@@ -127,7 +127,7 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 	}
 
 	if isDefaultNS(state.Name(), state.Zone) {
-		nss := k.nsAddrs(false, state.Zone)
+		nss := k.nsAddrs(false, false, state.Zone)
 		var svcs []msg.Service
 		for _, ns := range nss {
 			if ns.Header().Rrtype == dns.TypeA && state.QType() == dns.TypeA {

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -103,7 +103,7 @@ func TestNsAddrs(t *testing.T) {
 	k.APIConn = &APIConnTest{}
 	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
 
-	cdrs := k.nsAddrs(false, k.Zones[0])
+	cdrs := k.nsAddrs(false, false, k.Zones[0])
 
 	if len(cdrs) != 3 {
 		t.Fatalf("Expected 3 results, got %v", len(cdrs))
@@ -143,7 +143,7 @@ func TestNsAddrsExternal(t *testing.T) {
 	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
 
 	// initially no services have an external IP ...
-	cdrs := k.nsAddrs(true, k.Zones[0])
+	cdrs := k.nsAddrs(true, false, k.Zones[0])
 
 	if len(cdrs) != 0 {
 		t.Fatalf("Expected 0 results, got %v", len(cdrs))
@@ -151,7 +151,7 @@ func TestNsAddrsExternal(t *testing.T) {
 
 	// Add an external IP to one of the services ...
 	svcs[0].ExternalIPs = []string{"1.2.3.4"}
-	cdrs = k.nsAddrs(true, k.Zones[0])
+	cdrs = k.nsAddrs(true, false, k.Zones[0])
 
 	if len(cdrs) != 1 {
 		t.Fatalf("Expected 1 results, got %v", len(cdrs))

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -32,8 +32,6 @@ func (a APIConnTest) SvcIndex(s string) []*object.Service {
 		return []*object.Service{a.ServiceList()[1]}
 	case "dns6-service.kube-system":
 		return []*object.Service{a.ServiceList()[2]}
-	case "headless-service.kube-system":
-		return []*object.Service{a.ServiceList()[3]}
 	}
 	return nil
 }
@@ -54,11 +52,6 @@ var svcs = []*object.Service{
 		Namespace:  "kube-system",
 		ClusterIPs: []string{"10::111"},
 	},
-	{
-		Name:       "headless-service",
-		Namespace:  "kube-system",
-		ClusterIPs: []string{api.ClusterIPNone},
-	},
 }
 
 func (APIConnTest) ServiceList() []*object.Service {
@@ -66,9 +59,9 @@ func (APIConnTest) ServiceList() []*object.Service {
 }
 
 func (APIConnTest) EpIndexReverse(ip string) []*object.Endpoints {
-	// if ip != "10.244.0.20" {
-	// 	return nil
-	// }
+	if ip != "10.244.0.20" {
+		return nil
+	}
 	eps := []*object.Endpoints{
 		{
 			Name:      "dns-service-slice1",
@@ -94,14 +87,6 @@ func (APIConnTest) EpIndexReverse(ip string) []*object.Endpoints {
 				{Addresses: []object.EndpointAddress{{IP: "10.244.0.20"}}},
 			},
 		},
-		{
-			Name:      "headless-service-slice1",
-			Namespace: "kube-system",
-			Index:     object.EndpointsKey("headless-service", "kube-system"),
-			Subsets: []object.EndpointSubset{
-				{Addresses: []object.EndpointAddress{{IP: "10.244.0.21"}}},
-			},
-		},
 	}
 	return eps
 }
@@ -118,10 +103,10 @@ func TestNsAddrs(t *testing.T) {
 	k.APIConn = &APIConnTest{}
 	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
 
-	cdrs := k.nsAddrs(false, true, k.Zones[0])
+	cdrs := k.nsAddrs(false, false, k.Zones[0])
 
-	if len(cdrs) != 4 {
-		t.Fatalf("Expected 4 results, got %v", len(cdrs))
+	if len(cdrs) != 3 {
+		t.Fatalf("Expected 3 results, got %v", len(cdrs))
 	}
 	cdr := cdrs[0]
 	expected := "10.0.0.111"
@@ -150,26 +135,17 @@ func TestNsAddrs(t *testing.T) {
 	if cdr.Header().Name != expected {
 		t.Errorf("Expected AAAA Header Name to be %q, got %q", expected, cdr.Header().Name)
 	}
-	cdr = cdrs[3]
-	expected = "10-244-0-21.headless-service.kube-system.svc.inter.webs.test."
-	if cdr.Header().Name != expected {
-		t.Errorf("Expected 2nd Header Name to be %q, got %q", expected, cdr.Header().Name)
-	}
-	expected = "10.244.0.21"
-	if cdr.(*dns.A).A.String() != expected {
-		t.Errorf("Expected 1st A to be %q, got %q", expected, cdr.(*dns.A).A.String())
-	}
 }
 
 func TestNsAddrsExternalHeadless(t *testing.T) {
 	k := New([]string{"example.com."})
 	k.APIConn = &APIConnTest{}
-	k.localIPs = []net.IP{net.ParseIP("10.244.0.21")}
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
 
 	// there are only headless sevices
 	cdrs := k.nsAddrs(true, true, k.Zones[0])
 
-	if len(cdrs) != 2 {
+	if len(cdrs) != 1 {
 		t.Fatalf("Expected 0 results, got %v", cdrs)
 	}
 
@@ -179,15 +155,6 @@ func TestNsAddrsExternalHeadless(t *testing.T) {
 		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
 	}
 	expected = "10-244-0-20.hdls-dns-service.kube-system.example.com."
-	if cdr.Header().Name != expected {
-		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
-	}
-	cdr = cdrs[1]
-	expected = "10.244.0.21"
-	if cdr.(*dns.A).A.String() != expected {
-		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
-	}
-	expected = "10-244-0-21.headless-service.kube-system.example.com."
 	if cdr.Header().Name != expected {
 		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
 	}
@@ -208,6 +175,34 @@ func TestNsAddrsExternal(t *testing.T) {
 	// Add an external IP to one of the services ...
 	svcs[0].ExternalIPs = []string{"1.2.3.4"}
 	cdrs = k.nsAddrs(true, false, k.Zones[0])
+
+	if len(cdrs) != 1 {
+		t.Fatalf("Expected 1 results, got %v", len(cdrs))
+	}
+	cdr := cdrs[0]
+	expected := "1.2.3.4"
+	if cdr.(*dns.A).A.String() != expected {
+		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "dns-service.kube-system.example.com."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
+	}
+}
+
+func TestNsAddrsExternalWithPreexistingExternalIP(t *testing.T) {
+	k := New([]string{"example.com."})
+	k.APIConn = &APIConnTest{}
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
+
+	svcs[0].ExternalIPs = []string{"1.2.3.4"}
+
+	// initially no services have an external IP ...
+	cdrs := k.nsAddrs(true, false, k.Zones[0])
+
+	if len(cdrs) != 1 {
+		t.Fatalf("Expected 1 results, got %v", len(cdrs))
+	}
 
 	if len(cdrs) != 1 {
 		t.Fatalf("Expected 1 results, got %v", len(cdrs))

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -161,36 +161,6 @@ func TestNsAddrs(t *testing.T) {
 	}
 }
 
-func TestNsAddrsExternal(t *testing.T) {
-	k := New([]string{"example.com."})
-	k.APIConn = &APIConnTest{}
-	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
-
-	// initially no services have an external IP ...
-	cdrs := k.nsAddrs(true, false, k.Zones[0])
-
-	if len(cdrs) != 0 {
-		t.Fatalf("Expected 0 results, got %v", len(cdrs))
-	}
-
-	// Add an external IP to one of the services ...
-	svcs[0].ExternalIPs = []string{"1.2.3.4"}
-	cdrs = k.nsAddrs(true, false, k.Zones[0])
-
-	if len(cdrs) != 1 {
-		t.Fatalf("Expected 1 results, got %v", len(cdrs))
-	}
-	cdr := cdrs[0]
-	expected := "1.2.3.4"
-	if cdr.(*dns.A).A.String() != expected {
-		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
-	}
-	expected = "dns-service.kube-system.example.com."
-	if cdr.Header().Name != expected {
-		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
-	}
-}
-
 func TestNsAddrsExternalHeadless(t *testing.T) {
 	k := New([]string{"example.com."})
 	k.APIConn = &APIConnTest{}
@@ -218,6 +188,36 @@ func TestNsAddrsExternalHeadless(t *testing.T) {
 		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
 	}
 	expected = "10-244-0-21.headless-service.kube-system.example.com."
+	if cdr.Header().Name != expected {
+		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
+	}
+}
+
+func TestNsAddrsExternal(t *testing.T) {
+	k := New([]string{"example.com."})
+	k.APIConn = &APIConnTest{}
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
+
+	// initially no services have an external IP ...
+	cdrs := k.nsAddrs(true, false, k.Zones[0])
+
+	if len(cdrs) != 0 {
+		t.Fatalf("Expected 0 results, got %v", len(cdrs))
+	}
+
+	// Add an external IP to one of the services ...
+	svcs[0].ExternalIPs = []string{"1.2.3.4"}
+	cdrs = k.nsAddrs(true, false, k.Zones[0])
+
+	if len(cdrs) != 1 {
+		t.Fatalf("Expected 1 results, got %v", len(cdrs))
+	}
+	cdr := cdrs[0]
+	expected := "1.2.3.4"
+	if cdr.(*dns.A).A.String() != expected {
+		t.Errorf("Expected A address to be %q, got %q", expected, cdr.(*dns.A).A.String())
+	}
+	expected = "dns-service.kube-system.example.com."
 	if cdr.Header().Name != expected {
 		t.Errorf("Expected record name to be %q, got %q", expected, cdr.Header().Name)
 	}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -42,7 +42,7 @@ func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, erro
 		}
 		ch <- soa
 
-		nsAddrs := k.nsAddrs(false, zone)
+		nsAddrs := k.nsAddrs(false, false, zone)
 		nsHosts := make(map[string]struct{})
 		for _, nsAddr := range nsAddrs {
 			nsHost := nsAddr.Header().Name


### PR DESCRIPTION
Signed-off-by: Tomas Kohout <tomas.kohout1995@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

We have a need for resolving headless services with the use of the k8s_external plugin. Our users use this feature with clients for MongoDB etc. because in those cases LoadBalancer IP is behaving strangely. 

### 2. Which issues (if any) are related?

I havn't found any.

### 3. Which documentation changes (if any) need to be made?

Documentation related to the k8s_external plugin.

### 4. Does this introduce a backward incompatible change or deprecation?

I don't think that this will introduce backward incompatibility because it's opt in feature.

## Call for aid

I'm strugling with the AXFR transfer test. Is there somebody who would lend me a hand please? :slightly_smiling_face:  
