### PR TITLE
Add test for DNS over TLS

### DIFF
--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestDNSoverTLS(t *testing.T) {
+	testcases := []struct {
+		name         string
+		config       string
+		Qname        string
+		Qtype        uint16
+		Answer       []dns.RR
+		AnswerLength int
+	}{
+		{
+			name: "Test whoami with DNS over TLS",
+			config: `tls://.:1053 {
+                tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem
+                whoami
+            }`,
+			Qname:        "example.com.",
+			Qtype:        dns.TypeA,
+			Answer:       []dns.RR{},
+			AnswerLength: 0,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ex, _, tcp, err := CoreDNSServerAndPorts(tc.config)
+			if err != nil {
+				t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+			}
+			defer ex.Stop()
+
+			m := new(dns.Msg)
+			m.SetQuestion(tc.Qname, tc.Qtype)
+			client := dns.Client{
+				Net:       "tcp-tls",
+				TLSConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			r, _, err := client.Exchange(m, tcp)
+
+			if err != nil {
+				t.Fatalf("Could not exchange msg: %s", err)
+			}
+
+			if n := len(r.Answer); n != tc.AnswerLength {
+				t.Fatalf("Expected %v answers, got %v", tc.AnswerLength, n)
+			}
+			if n := len(r.Extra); n != 2 {
+				t.Errorf("Expected 2 RRs in additional section, but got %d", n)
+			}
+
+		})
+	}
+}

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -8,55 +8,39 @@ import (
 )
 
 func TestDNSoverTLS(t *testing.T) {
-	testcases := []struct {
-		name         string
-		config       string
-		Qname        string
-		Qtype        uint16
-		Answer       []dns.RR
-		AnswerLength int
-	}{
-		{
-			name: "Test whoami with DNS over TLS",
-			config: `tls://.:1053 {
-                tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem
-                whoami
-            }`,
-			Qname:        "example.com.",
-			Qtype:        dns.TypeA,
-			Answer:       []dns.RR{},
-			AnswerLength: 0,
-		},
+	corefile := `tls://.:1053 {
+        tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem
+        whoami
+    }`
+	qname := "example.com."
+	qtype := dns.TypeA
+	answerLength := 0
+
+	ex, _, tcp, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			ex, _, tcp, err := CoreDNSServerAndPorts(tc.config)
-			if err != nil {
-				t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-			}
-			defer ex.Stop()
+	defer ex.Stop()
 
-			m := new(dns.Msg)
-			m.SetQuestion(tc.Qname, tc.Qtype)
-			client := dns.Client{
-				Net:       "tcp-tls",
-				TLSConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-			r, _, err := client.Exchange(m, tcp)
+	m := new(dns.Msg)
+	m.SetQuestion(qname, qtype)
+	client := dns.Client{
+		Net:       "tcp-tls",
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	r, _, err := client.Exchange(m, tcp)
 
-			if err != nil {
-				t.Fatalf("Could not exchange msg: %s", err)
-			}
+	if err != nil {
+		t.Fatalf("Could not exchange msg: %s", err)
+	}
 
-			if n := len(r.Answer); n != tc.AnswerLength {
-				t.Fatalf("Expected %v answers, got %v", tc.AnswerLength, n)
-			}
-			if n := len(r.Extra); n != 2 {
-				t.Errorf("Expected 2 RRs in additional section, but got %d", n)
-			}
-			if r.Rcode != dns.RcodeSuccess {
-				t.Errorf("Expected success but got %d", r.Rcode)
-			}
-		})
+	if n := len(r.Answer); n != answerLength {
+		t.Fatalf("Expected %v answers, got %v", answerLength, n)
+	}
+	if n := len(r.Extra); n != 2 {
+		t.Errorf("Expected 2 RRs in additional section, but got %d", n)
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Errorf("Expected success but got %d", r.Rcode)
 	}
 }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -54,7 +54,9 @@ func TestDNSoverTLS(t *testing.T) {
 			if n := len(r.Extra); n != 2 {
 				t.Errorf("Expected 2 RRs in additional section, but got %d", n)
 			}
-
+			if r.Rcode != dns.RcodeSuccess {
+				t.Errorf("Expected success but got %d", r.Rcode)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Marius Kimmina <mar.kimmina@gmail.com>

### 1. Why is this pull request needed and what does it do?
It adds a test for serving DNS over TLS (using the tls and whoami plugin). I was not able to find any test for this before.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No
