### PR TITLE
NXDOMAIN messages with no SOA authority are classified as NameError

### DIFF
--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -52,7 +52,7 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 	}
 
 	if mt == response.NameError || mt == response.NoData {
-		if req.Ns[0].Header().Rrtype != dns.TypeSOA || len(req.Ns) > 1 {
+		if len(req.Ns) == 0 || req.Ns[0].Header().Rrtype != dns.TypeSOA || len(req.Ns) > 1 {
 			return req
 		}
 

--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -123,6 +123,20 @@ func TestSigningEmpty(t *testing.T) {
 	}
 }
 
+func TestSigningNameErrorWithNoSoa(t *testing.T) {
+	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
+	defer rm1()
+	defer rm2()
+
+	m := &dns.Msg{}
+	m.SetQuestion("a.miek.nl.", dns.TypeA)
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	m = d.Sign(state, time.Now().UTC(), server)
+	if !section(m.Ns, 0) {
+		t.Errorf("Authority section should have 0 RRSIGs")
+	}
+}
+
 func section(rss []dns.RR, nrSigs int) bool {
 	i := 0
 	for _, r := range rss {

--- a/plugin/pkg/log/listener.go
+++ b/plugin/pkg/log/listener.go
@@ -82,7 +82,6 @@ func (ls *listeners) info(plugin string, v ...interface{}) {
 		l.Info(plugin, v...)
 	}
 	ls.RUnlock()
-
 }
 
 func (ls *listeners) infof(plugin string, format string, v ...interface{}) {

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -65,7 +65,6 @@ func testListenersCalled(t *testing.T, listenerNames []string, outputs []string)
 			t.Errorf("DeregsiterListener Error %s", err)
 		}
 	}
-
 }
 
 type mockListener struct {

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -105,7 +105,7 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 	if soa && m.Rcode == dns.RcodeSuccess {
 		return NoData, opt
 	}
-	if soa && m.Rcode == dns.RcodeNameError {
+	if m.Rcode == dns.RcodeNameError {
 		return NameError, opt
 	}
 

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -48,18 +48,6 @@ func TestTypifyRRSIG(t *testing.T) {
 	}
 }
 
-func TestTypifyImpossible(t *testing.T) {
-	// create impossible message that denies its own existence
-	m := new(dns.Msg)
-	m.SetQuestion("bar.www.example.org.", dns.TypeAAAA)
-	m.Rcode = dns.RcodeNameError                                                      // name does not exist
-	m.Answer = []dns.RR{test.CNAME("bar.www.example.org. IN CNAME foo.example.org.")} // but we add a cname with the name!
-	mt, _ := Typify(m, time.Now().UTC())
-	if mt != OtherError {
-		t.Errorf("Impossible message not typified as OtherError, got %s", mt)
-	}
-}
-
 func TestTypifyRefused(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("foo.example.org.", dns.TypeA)
@@ -67,6 +55,16 @@ func TestTypifyRefused(t *testing.T) {
 	mt, _ := Typify(m, time.Now().UTC())
 	if mt != OtherError {
 		t.Errorf("Refused message not typified as OtherError, got %s", mt)
+	}
+}
+
+func TestTypifyNameErrorWithoutSoa(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion("foo.example.org.", dns.TypeA)
+	m.Rcode = dns.RcodeNameError
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != NameError {
+		t.Errorf("NameError without SOA message not typified as NameError, got %s", mt)
 	}
 }
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR adjusts the classification of DNS messages with rcode NXDOMAIN and no SOA in the authority section to be considered as `NameError`, currently, it is classified as `OtherError`, which causes behavior pointed out by issues #5510 and #5313 . This adjustment is based on the issues stated before and also based on [RFC](https://datatracker.ietf.org/doc/html/RFC2308#section-2.1)

> Name errors (NXDOMAIN) are indicated by the presence of "Name Error" in
   the RCODE field.  In this case the domain referred to by the QNAME does
   not exist.  Note: the answer section may have SIG and CNAME RRs and
   authority section may have SOA, NXT and SIG RRsets.
   

This will cause : 
* `cache` plugin denial configuration will be applied to these messages
* `log` plugin will not classify messages like these #5510 as errors

effects on `sign`, `dns64`, and `minimal` plugins should be effectively none


### 2. Which issues (if any) are related?
#5510 and #5313

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
