### PR TITLE
Remove trailing empty lines for linter

### DIFF
--- a/plugin/pkg/log/listener.go
+++ b/plugin/pkg/log/listener.go
@@ -82,7 +82,6 @@ func (ls *listeners) info(plugin string, v ...interface{}) {
 		l.Info(plugin, v...)
 	}
 	ls.RUnlock()
-
 }
 
 func (ls *listeners) infof(plugin string, format string, v ...interface{}) {

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -65,7 +65,6 @@ func testListenersCalled(t *testing.T, listenerNames []string, outputs []string)
 			t.Errorf("DeregsiterListener Error %s", err)
 		}
 	}
-
 }
 
 type mockListener struct {


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Removes trailing empty lines to make linter happy.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
