### PR TITLE
plugin/acl : add support for Extended DNS Errors

### DIFF
--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -69,9 +69,9 @@ RulesCheckLoop:
 		switch action {
 		case actionBlock:
 			{
-				m := new(dns.Msg)
-				m.SetRcode(r, dns.RcodeRefused)
-				m = m.SetEdns0(4096, true)
+				m := new(dns.Msg).
+					SetRcode(r, dns.RcodeRefused).
+					SetEdns0(4096, true)
 				ede := dns.EDNS0_EDE{InfoCode: dns.ExtendedErrorCodeBlocked}
 				m.IsEdns0().Option = append(m.IsEdns0().Option, &ede)
 				w.WriteMsg(m)
@@ -84,9 +84,9 @@ RulesCheckLoop:
 			}
 		case actionFilter:
 			{
-				m := new(dns.Msg)
-				m.SetRcode(r, dns.RcodeSuccess)
-				m = m.SetEdns0(4096, true)
+				m := new(dns.Msg).
+					SetRcode(r, dns.RcodeSuccess).
+					SetEdns0(4096, true)
 				ede := dns.EDNS0_EDE{InfoCode: dns.ExtendedErrorCodeFiltered}
 				m.IsEdns0().Option = append(m.IsEdns0().Option, &ede)
 				w.WriteMsg(m)

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -71,6 +71,9 @@ RulesCheckLoop:
 			{
 				m := new(dns.Msg)
 				m.SetRcode(r, dns.RcodeRefused)
+				m = m.SetEdns0(4096, true)
+				ede := dns.EDNS0_EDE{InfoCode: dns.ExtendedErrorCodeBlocked}
+				m.IsEdns0().Option = append(m.IsEdns0().Option, &ede)
 				w.WriteMsg(m)
 				RequestBlockCount.WithLabelValues(metrics.WithServer(ctx), zone).Inc()
 				return dns.RcodeSuccess, nil
@@ -83,6 +86,9 @@ RulesCheckLoop:
 			{
 				m := new(dns.Msg)
 				m.SetRcode(r, dns.RcodeSuccess)
+				m = m.SetEdns0(4096, true)
+				ede := dns.EDNS0_EDE{InfoCode: dns.ExtendedErrorCodeFiltered}
+				m.IsEdns0().Option = append(m.IsEdns0().Option, &ede)
 				w.WriteMsg(m)
 				RequestFilterCount.WithLabelValues(metrics.WithServer(ctx), zone).Inc()
 				return dns.RcodeSuccess, nil


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
This PR adds support for Extended DNS Errors (as defined in https://datatracker.ietf.org/doc/html/rfc8914.html)  to the ACL plugin in a way that when DNS request is either blocked/filtered by the ACL plugin, the response contains Blocked, Filtered Extended DNS Error code. This will provide additional info to the client about the cause of the error.

For example, let's have Corefile
```
.:53 {
  acl {
    block net 127.0.0.1/24
  }
  log
  forward . 8.8.8.8
}
```
then example of blocked response looks like this (see OPT section):
```
dig @127.0.0.1 google.com

; <<>> DiG 9.17.17 <<>> @127.0.0.1 google.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: REFUSED, id: 1148
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
; EDE: 15 (Blocked)
;; QUESTION SECTION:
;google.com.			IN	A

;; Query time: 2 msec
;; SERVER: 127.0.0.1#53(127.0.0.1) (UDP)
;; WHEN: Sat Jul 23 16:36:20 CEST 2022
;; MSG SIZE  rcvd: 45
```

### 2. Which issues (if any) are related?
no issue

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
should be backward compatible
