### PR TITLE
plugin/template: Add CNAME example to README

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -242,6 +242,22 @@ Named capture groups can be used to template one response for multiple patterns.
 }
 ~~~
 
+### Fabricate a CNAME
+
+This example responds with a CNAME to `google.com` for any DNS query made exactly for `foogle.com`.
+The answer will also contain a record for `google.com` if the upstream nameserver can return a record for it of the
+requested type.
+
+~~~ corefile
+. {
+  template IN ANY foogle.com {
+    match "^foogle\.com\.$"
+    answer "foogle.com 60 IN CNAME google.com"
+  }
+  forward . 8.8.8.8
+}
+~~~
+
 ## Also see
 
 * [Go regexp](https://golang.org/pkg/regexp/) for details about the regex implementation


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Just adds an example CNAME template since the behavior is slightly different from other record templates (i.e. it does the CNAME lookup, and includes the target record in the answer if upstream can resolve it).

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
