### PR TITLE
plugin/cache: Add cache disable option

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -39,6 +39,7 @@ cache [TTL] [ZONES...] {
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
     serve_stale [DURATION] [REFRESH_MODE]
     servfail DURATION
+    disable success|denial [ZONES...] 
 }
 ~~~
 
@@ -67,6 +68,8 @@ cache [TTL] [ZONES...] {
 * `servfail` cache SERVFAIL responses for **DURATION**.  Setting **DURATION** to 0 will disable caching of SERVFAIL
   responses.  If this option is not set, SERVFAIL responses will be cached for 5 seconds.  **DURATION** may not be
   greater than 5 minutes.
+* `disable`  disable the success or denial cache for the listed **ZONES**.  If no **ZONES** are given, the specified
+  cache will be disabled for all zones.
 
 ## Capacity and Eviction
 
@@ -121,6 +124,16 @@ example.org {
     cache {
         success 5000
         denial 2500
+    }
+}
+~~~
+
+Enable caching for `example.org`, but do not cache denials in `sub.example.org`:
+
+~~~ corefile
+example.org {
+    cache {
+        disable denial sub.example.org
     }
 }
 ~~~

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -39,7 +39,7 @@ cache [TTL] [ZONES...] {
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
     serve_stale [DURATION] [REFRESH_MODE]
     servfail DURATION
-    disable success|denial [ZONES...] 
+    disable success|denial [ZONES...]
 }
 ~~~
 

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -38,7 +38,8 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	ttl := 0
 	i := c.getIgnoreTTL(now, state, server)
 	if i == nil {
-		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad, wildcardFunc: wildcardFunc(ctx)}
+		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad,
+			nexcept: c.nexcept, pexcept: c.pexcept, wildcardFunc: wildcardFunc(ctx)}
 		return c.doRefresh(ctx, state, crr)
 	}
 	ttl = i.ttl(now)


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Disabling negative cache is a common request. It's an option in most dns cache implementations.

Being able to exclude some zones from cache is useful for avoiding caching responses from dynamic backends, while still caching responses from upstream servers forwarded in the same server block.

For example, the _kubernetes_ plugin maintains its own cache, which is dynamically updated in real-ish time via the k8s API watch. Redundantly caching the _kubernetes_ records with the _cache_ plugin prevents clients from seeing the latest data held in the _kubernetes_ cache. Disabling cache entirely is not ideal, since for example responses from a _forward_ plugin in the same server block would no longer be cached. IOW, in this case _cache_ should not cache Kubernetes records, but should cache everything else.

This PR adds the ability to disable the positive and/or negative caches for a list of zones.

### 2. Which issues (if any) are related?

kubernetes/kubernetes#92559

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
