### PR TITLE
plugin/forward: health_check needs to normalize a specified domain name

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -48,7 +48,7 @@ forward FROM TO... {
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
-    health_check DURATION [no_rec] [domain DOMAIN]
+    health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
 }
 ~~~
@@ -88,8 +88,8 @@ forward FROM TO... {
   * `<duration>` - use a different duration for health checking, the default duration is 0.5s.
   * `no_rec` - optional argument that sets the RecursionDesired-flag of the dns-query used in health checking to `false`.
     The flag is default `true`.
-  * `domain DOMAIN` - optional arguments that sets the domain of the dns-query used in health checking.
-    If not configured, the requested domain name is `.`. `DOMAIN` is used to configure the domain name.
+  * `domain FQDN` - set the domain name used for health checks to **FQDN**.
+    If not configured, the domain name used for health checks is `.`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -14,6 +14,8 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/parse"
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/pkg/transport"
+
+	"github.com/miekg/dns"
 )
 
 func init() { plugin.Register("forward", setup) }
@@ -204,7 +206,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 				if !c.NextArg() {
 					return c.ArgErr()
 				}
-				f.opts.hcDomain = c.Val()
+				hcDomain := c.Val()
+				if _, ok := dns.IsDomainName(hcDomain); !ok {
+					return fmt.Errorf("health_check: invalid domain name %s", hcDomain)
+				}
+				f.opts.hcDomain = plugin.Name(hcDomain).Normalize()
 			default:
 				return fmt.Errorf("health_check: unknown option %s", hcOpts)
 			}


### PR DESCRIPTION
Signed-off-by: vanceli <vanceli@tencent.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
#### Why is this pull request needed 
According to the document of the [plugin forward](https://coredns.io/plugins/forward/),  we can specify the domain of `health_check`. But the document didn't say that is a Fqdn. 

And when I viewed the codes and did some tests, I found we must write a Fqdn here.
Otherwise, we will get an error when the health check sends the query that is not Fqdn. 
```
dns: domain must be fully qualified
``` 

That means all the targets are unhealthy, although it is not I/O errors we care about.

##### Reproduce:
```
Corefile: 
forward . /etc/resolv.conf {                                                                                                                                                   
      health_check 0.5s no_rec domain example.org                                                                                                                            
}
```

the metrics we saw: 
```
$ curl -s 172.16.0.25:9153/metrics | grep healthcheck_failures_total
# HELP coredns_forward_healthcheck_failures_total Counter of the number of failed healthchecks.
# TYPE coredns_forward_healthcheck_failures_total counter
coredns_forward_healthcheck_failures_total{to="10.202.16.10:53"} 3484
coredns_forward_healthcheck_failures_total{to="10.202.16.2:53"} 3373
coredns_forward_healthcheck_failures_total{to="10.202.16.8:53"} 212
```

####  what does it do

Check and normalize the specified domain name.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

Update plugin/forward/README.md and clarify the domain name of health checks.

### 4. Does this introduce a backward incompatible change or deprecation?

None
