### PR TITLE
Identity and version support for the dnstap plugin

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -15,11 +15,16 @@ Every message is sent to the socket as soon as it comes in, the *dnstap* plugin 
 ## Syntax
 
 ~~~ txt
-dnstap SOCKET [full]
+dnstap SOCKET [full] {
+  [identity IDENTITY]
+  [version VERSION]
+}
 ~~~
 
 * **SOCKET** is the socket (path) supplied to the dnstap command line tool.
 * `full` to include the wire-format DNS message.
+* **IDENTITY** to override the identity of the server. Defaults to the hostname.
+* **VERSION** to override the version field. Defaults to the CoreDNS version.
 
 ## Examples
 
@@ -45,6 +50,15 @@ Log to a remote endpoint by FQDN.
 
 ~~~ txt
 dnstap tcp://example.com:6000 full
+~~~
+
+Log to a socket, overriding the default identity and version.
+
+~~~ txt
+dnstap /tmp/dnstap.sock {
+  identity my-dns-server1
+  version MyDNSServer-1.2.3
+}
 ~~~
 
 ## Command Line Tool

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -18,12 +18,14 @@ type Dnstap struct {
 
 	// IncludeRawMessage will include the raw DNS message into the dnstap messages if true.
 	IncludeRawMessage bool
+	Identity string
+	Version string
 }
 
 // TapMessage sends the message m to the dnstap interface.
 func (h Dnstap) TapMessage(m *tap.Message) {
 	t := tap.Dnstap_MESSAGE
-	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m})
+	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: []byte(h.Identity), Version: []byte(h.Version)})
 }
 
 func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -18,14 +18,14 @@ type Dnstap struct {
 
 	// IncludeRawMessage will include the raw DNS message into the dnstap messages if true.
 	IncludeRawMessage bool
-	Identity string
-	Version string
+	Identity []byte
+	Version []byte
 }
 
 // TapMessage sends the message m to the dnstap interface.
 func (h Dnstap) TapMessage(m *tap.Message) {
 	t := tap.Dnstap_MESSAGE
-	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: []byte(h.Identity), Version: []byte(h.Version)})
+	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: h.Identity, Version: h.Version})
 }
 
 func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -20,9 +20,13 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 	d := Dnstap{}
 	endpoint := ""
 
-	if !c.Args(&endpoint) {
+	args := c.RemainingArgs()
+
+	if len(args) == 0 {
 		return d, c.ArgErr()
 	}
+
+	endpoint = args[0]
 
 	if strings.HasPrefix(endpoint, "tcp://") {
 		// remote network endpoint
@@ -38,21 +42,23 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 		d = Dnstap{io: dio}
 	}
 
-	d.IncludeRawMessage = c.NextArg() && c.Val() == "full"
-	
-	hostname, _ := os.Hostname() 
+	d.IncludeRawMessage = len(args) == 2 && args[1] == "full"
+
+	hostname, _ := os.Hostname()
 	d.Identity = []byte(hostname)
 	d.Version = []byte(caddy.AppName + "-" + caddy.AppVersion)
-	
+
 	for c.NextBlock() {
 		switch c.Val() {
-			case "identity": {
+		case "identity":
+			{
 				if !c.NextArg() {
 					return d, c.ArgErr()
 				}
 				d.Identity = []byte(c.Val())
 			}
-			case "version": {
+		case "version":
+			{
 				if !c.NextArg() {
 					return d, c.ArgErr()
 				}

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -2,6 +2,7 @@ package dnstap
 
 import (
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/coredns/caddy"
@@ -38,6 +39,26 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 	}
 
 	d.IncludeRawMessage = c.NextArg() && c.Val() == "full"
+	
+	d.Identity, _ = os.Hostname()
+	d.Version = caddy.AppName + "-" + caddy.AppVersion 
+	
+	for c.NextBlock() {
+		switch c.Val() {
+			case "identity": {
+				if !c.NextArg() {
+					return d, c.ArgErr()
+				}
+				d.Identity = c.Val()
+			}
+  		case "version": {
+				if !c.NextArg() {
+					return d, c.ArgErr()
+				}
+				d.Version = c.Val()
+			}
+		}
+	}
 
 	return d, nil
 }

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -40,8 +40,9 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 
 	d.IncludeRawMessage = c.NextArg() && c.Val() == "full"
 	
-	d.Identity, _ = os.Hostname()
-	d.Version = caddy.AppName + "-" + caddy.AppVersion 
+	hostname, _ := os.Hostname() 
+	d.Identity = []byte(hostname)
+	d.Version = []byte(caddy.AppName + "-" + caddy.AppVersion)
 	
 	for c.NextBlock() {
 		switch c.Val() {
@@ -49,13 +50,13 @@ func parseConfig(c *caddy.Controller) (Dnstap, error) {
 				if !c.NextArg() {
 					return d, c.ArgErr()
 				}
-				d.Identity = c.Val()
+				d.Identity = []byte(c.Val())
 			}
-  		case "version": {
+			case "version": {
 				if !c.NextArg() {
 					return d, c.ArgErr()
 				}
-				d.Version = c.Val()
+				d.Version = []byte(c.Val())
 			}
 		}
 	}

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -1,12 +1,14 @@
 package dnstap
 
 import (
+	"os"
 	"testing"
 
 	"github.com/coredns/caddy"
 )
 
 func TestConfig(t *testing.T) {
+	hostname, _ := os.Hostname()
 	tests := []struct {
 		in       string
 		endpoint string
@@ -16,14 +18,15 @@ func TestConfig(t *testing.T) {
 		identity []byte
 		version  []byte
 	}{
-		{"dnstap dnstap.sock full", "dnstap.sock", true, "unix", false},
-		{"dnstap unix://dnstap.sock", "dnstap.sock", false, "unix", false},
-		{"dnstap tcp://127.0.0.1:6000", "127.0.0.1:6000", false, "tcp", false},
-		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false},
-		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false},
-		{"dnstap", "fail", false, "tcp", true},
-		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, []byte("NAME"), []byte("VER")},
-		{"dnstap { identity NAME version VER }", "fail", false, "tcp", true},
+		{"dnstap dnstap.sock full", "dnstap.sock", true, "unix", false, []byte(hostname), []byte("-")},
+		{"dnstap unix://dnstap.sock", "dnstap.sock", false, "unix", false, []byte(hostname), []byte("-")},
+		{"dnstap tcp://127.0.0.1:6000", "127.0.0.1:6000", false, "tcp", false, []byte(hostname), []byte("-")},
+		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false, []byte(hostname), []byte("-")},
+		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false, []byte(hostname), []byte("-")},
+		{"dnstap", "fail", false, "tcp", true, []byte(hostname), []byte("-")},
+		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", "dnstap.sock", true, "unix", false, []byte("NAME"), []byte("VER")},
+		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\n}\n", "dnstap.sock", false, "unix", false, []byte("NAME"), []byte("VER")},
+		{"dnstap {\nidentity NAME\nversion VER\n}\n", "fail", false, "tcp", true, []byte("NAME"), []byte("VER")},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)
@@ -47,10 +50,10 @@ func TestConfig(t *testing.T) {
 		if x := tap.IncludeRawMessage; x != tc.full {
 			t.Errorf("Test %d: expected IncludeRawMessage %t, got %t", i, tc.full, x)
 		}
-		if x := tap.Identity; x != tc.identity {
+		if x := string(tap.Identity); x != string(tc.identity) {
 			t.Errorf("Test %d: expected identity %s, got %s", i, tc.identity, x)
 		}
-		if x := tap.Version; x != tc.version {
+		if x := string(tap.Version); x != string(tc.version) {
 			t.Errorf("Test %d: expected version %s, got %s", i, tc.version, x)
 		}
 	}

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -22,8 +22,8 @@ func TestConfig(t *testing.T) {
 		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false},
 		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false},
 		{"dnstap", "fail", false, "tcp", true},
-		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, "NAME", "VER"}
-		{"dnstap { identity NAME version VER }", "fail", false, "tcp", true}
+		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, "NAME", "VER"},
+		{"dnstap { identity NAME version VER }", "fail", false, "tcp", true},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -13,8 +13,8 @@ func TestConfig(t *testing.T) {
 		full     bool
 		proto    string
 		fail     bool
-		identity string
-		version  string
+		identity []byte
+		version  []byte
 	}{
 		{"dnstap dnstap.sock full", "dnstap.sock", true, "unix", false},
 		{"dnstap unix://dnstap.sock", "dnstap.sock", false, "unix", false},
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false},
 		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false},
 		{"dnstap", "fail", false, "tcp", true},
-		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, "NAME", "VER"},
+		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, []byte("NAME"), []byte("VER")},
 		{"dnstap { identity NAME version VER }", "fail", false, "tcp", true},
 	}
 	for i, tc := range tests {

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -13,6 +13,8 @@ func TestConfig(t *testing.T) {
 		full     bool
 		proto    string
 		fail     bool
+		identity string
+		version  string
 	}{
 		{"dnstap dnstap.sock full", "dnstap.sock", true, "unix", false},
 		{"dnstap unix://dnstap.sock", "dnstap.sock", false, "unix", false},
@@ -20,6 +22,8 @@ func TestConfig(t *testing.T) {
 		{"dnstap tcp://[::1]:6000", "[::1]:6000", false, "tcp", false},
 		{"dnstap tcp://example.com:6000", "example.com:6000", false, "tcp", false},
 		{"dnstap", "fail", false, "tcp", true},
+		{"dnstap dnstap.sock { identity NAME version VER }", "dnstap.sock", false, "unix", false, "NAME", "VER"}
+		{"dnstap { identity NAME version VER }", "fail", false, "tcp", true}
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)
@@ -42,6 +46,12 @@ func TestConfig(t *testing.T) {
 		}
 		if x := tap.IncludeRawMessage; x != tc.full {
 			t.Errorf("Test %d: expected IncludeRawMessage %t, got %t", i, tc.full, x)
+		}
+		if x := tap.Identity; x != tc.identity {
+			t.Errorf("Test %d: expected identity %s, got %s", i, tc.identity, x)
+		}
+		if x := tap.Version; x != tc.version {
+			t.Errorf("Test %d: expected version %s, got %s", i, tc.version, x)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR makes dnstap send identity and version information with dnstap messages. Defaulting to the server hostname and the CoreDNS version, it also adds the ability to override with your custom strings.

```
dnstap dnstap.sock {
  identity NAME
  version VERSION
 }
```

### 2. Which issues (if any) are related?
This addresses issue #1060

### 3. Which documentation changes (if any) need to be made?
The dnstap plugin documentation needs to be updated to reflect you can add identity and version parameters in a block.

### 4. Does this introduce a backward incompatible change or deprecation?
If the block is not specified, the dnstap plugin will continue to function as it used to, however now sending the hostname and coredns version as the identity and version in dnstap messages.

