### PR TITLE
Bump golang to 1.19

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
         id: go
 
       - name: Check out code

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
         id: go
 
       - name: Check out code
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
         id: go
 
       - name: Check out code
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
         id: go
 
       - name: Check out code

--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
         id: go
 
       - name: Checkout

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,9 +8,10 @@ jobs:
     steps:
       - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18'
+          go-version: '1.19.0'
       - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.46.2
+      # See https://github.com/golangci/golangci-lint-action/issues/442#issuecomment-1203786890
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+      - name: Run golangci-lint
+        run: golangci-lint run --version --verbose --out-format=github-actions

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: '1.18.0'
+          go-version: '1.19.0'
 
       - name: Update Docs
         run: |


### PR DESCRIPTION
Since golang 1.19 has been released, this PR bumps the go version for our CI build:

https://go.dev/blog/go1.19

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
