### PR TITLE
Dockerfile: copy only CA certificate bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM debian:stable-slim
+SHELL [ "/bin/sh", "-ec" ]
 
-RUN apt-get update && apt-get -uy upgrade
-RUN apt-get -y install ca-certificates && update-ca-certificates
+RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
+           DEBIAN_FRONTEND=noninteractive \
+           DEBIAN_PRIORITY=critical \
+           TERM=linux ; \
+    apt-get -qq update ; \
+    apt-get -yyqq upgrade ; \
+    apt-get -yyqq install ca-certificates ; \
+    apt-get clean
 
 FROM scratch
 
-COPY --from=0 /etc/ssl/certs /etc/ssl/certs
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD coredns /coredns
 
 EXPOSE 53 53/udp


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Final container image receives a lot of (dangling) symlinks in /etc/ssl/certs/ while only one (regular) file is required.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.