### PR TITLE
Do not expand query UDP buffer size if already set to a smaller value

### DIFF
--- a/plugin/bufsize/bufsize.go
+++ b/plugin/bufsize/bufsize.go
@@ -1,4 +1,4 @@
-// Package bufsize implements a plugin that modifies EDNS0 buffer size.
+// Package bufsize implements a plugin that clamps EDNS0 buffer size preventing packet fragmentation.
 package bufsize
 
 import (
@@ -17,10 +17,9 @@ type Bufsize struct {
 
 // ServeDNS implements the plugin.Handler interface.
 func (buf Bufsize) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	if option := r.IsEdns0(); option != nil {
+	if option := r.IsEdns0(); option != nil && int(option.UDPSize()) > buf.Size {
 		option.SetUDPSize(uint16(buf.Size))
 	}
-
 	return plugin.NextOrFailure(buf.Name(), buf.Next, ctx, w, r)
 }
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Narkiewicz <knarkiewicz@bloomberg.net>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It prevents `bufsz` plugin from expanding a UDP buffer size if it is already set to a smaller value.

### 2. Which issues (if any) are related?
None, we found that the plugin expands the buffer size that other clients try to keep at smaller value.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
No. This change should only improve interoperability.