### PR TITLE
plugin/tsig: Document unimplemented secondary tsig transfers

### DIFF
--- a/plugin/tsig/README.md
+++ b/plugin/tsig/README.md
@@ -2,12 +2,12 @@
 
 ## Name
 
-*tsig* - validate TSIG requests and sign responses.
+*tsig* - validate incoming TSIG signed requests and sign responses.
 
 ## Description
 
 With *tsig*, you can define a set of TSIG secret keys for validating incoming TSIG requests and signing
-responses. It can also require TSIG for certain query types, refusing requests that do not comply.
+responses. It can also require that imcoming requests be signed for certain query types, refusing requests that do not comply.
 
 ## Syntax
 

--- a/plugin/tsig/README.md
+++ b/plugin/tsig/README.md
@@ -67,9 +67,13 @@ auth.zone {
 
 ## Bugs
 
+### Secondary
+
+TSIG transfers are not yet implemented for the *secondary* plugin.  The *secondary* plugin will not sign its zone transfer requests.
+
 ### Zone Transfer Notifies
 
-With the transfer plugin, zone transfer notifications from CoreDNS are not TSIG signed.
+With the *transfer* plugin, zone transfer notifications from CoreDNS are not TSIG signed.
 
 ### Special Considerations for Forwarding Servers (RFC 8945 5.5)
 

--- a/plugin/tsig/README.md
+++ b/plugin/tsig/README.md
@@ -2,12 +2,15 @@
 
 ## Name
 
-*tsig* - validate incoming TSIG signed requests and sign responses.
+*tsig* - define TSIG keys, validate incoming TSIG signed requests and sign responses.
 
 ## Description
 
-With *tsig*, you can define a set of TSIG secret keys for validating incoming TSIG requests and signing
-responses. It can also require that imcoming requests be signed for certain query types, refusing requests that do not comply.
+With *tsig*, you can define CoreDNS's TSIG secret keys. Using those keys, *tsig* validates incoming TSIG requests and signs
+responses to those requests. It does not itself sign requests outgoing from CoreDNS; it is up to the
+respective plugins sending those requests to sign them using the keys defined by *tsig*.
+
+The *tsig* plugin can also require that incoming requests be signed for certain query types, refusing requests that do not comply.
 
 ## Syntax
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Documents that TSIG transfers are not yet implemented in the secondary plugin.
This was a known to-do, listed with other to-dos in the PR [comments](https://github.com/coredns/coredns/pull/4957#issuecomment-992852683), but I accidentally omitted this one from the docs.

### 2. Which issues (if any) are related?

#5600
#5601

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
