### PR TITLE
plugin/dnstap: fix formatting with go fmt

### DIFF
--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -18,8 +18,8 @@ type Dnstap struct {
 
 	// IncludeRawMessage will include the raw DNS message into the dnstap messages if true.
 	IncludeRawMessage bool
-	Identity []byte
-	Version []byte
+	Identity          []byte
+	Version           []byte
 }
 
 // TapMessage sends the message m to the dnstap interface.


### PR DESCRIPTION
Signed-off-by: Marius Kimmina <mar.kimmina@gmail.com>

### 1. Why is this pull request needed and what does it do?
While working on another plugin I run `go fmt ./...` on the repo and noticed changes in dnstap. 
So here is a quick format fix.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
None