### PR TITLE
plugin/metrics : make plugin enabled metric view aware

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -21,7 +21,7 @@ the following metrics are exported:
 * `coredns_dns_response_size_bytes{server, zone, view, proto}` - response size in bytes.
 * `coredns_dns_responses_total{server, zone, view, rcode, plugin}` - response per zone, rcode and plugin.
 * `coredns_dns_https_responses_total{server, status}` - responses per server and http status code.
-* `coredns_plugin_enabled{server, zone, name}` - indicates whether a plugin is enabled on per server and zone basis.
+* `coredns_plugin_enabled{server, zone, view, name}` - indicates whether a plugin is enabled on per server, zone and view basis.
 
 Almost each counter has a label `zone` which is the zonename used for the request/response.
 

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -39,7 +39,7 @@ func setup(c *caddy.Controller) error {
 		for _, h := range conf.ListenHosts {
 			addrstr := conf.Transport + "://" + net.JoinHostPort(h, conf.Port)
 			for _, p := range conf.Handlers() {
-				vars.PluginEnabled.WithLabelValues(addrstr, conf.Zone, p.Name()).Set(1)
+				vars.PluginEnabled.WithLabelValues(addrstr, conf.Zone, conf.ViewName, p.Name()).Set(1)
 			}
 		}
 		return nil
@@ -49,7 +49,7 @@ func setup(c *caddy.Controller) error {
 		for _, h := range conf.ListenHosts {
 			addrstr := conf.Transport + "://" + net.JoinHostPort(h, conf.Port)
 			for _, p := range conf.Handlers() {
-				vars.PluginEnabled.WithLabelValues(addrstr, conf.Zone, p.Name()).Set(1)
+				vars.PluginEnabled.WithLabelValues(addrstr, conf.Zone, conf.ViewName, p.Name()).Set(1)
 			}
 		}
 		return nil

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -64,7 +64,7 @@ var (
 		Namespace: plugin.Namespace,
 		Name:      "plugin_enabled",
 		Help:      "A metric that indicates whether a plugin is enabled on per server and zone basis.",
-	}, []string{"server", "zone", "name"})
+	}, []string{"server", "zone", "view", "name"})
 
 	HTTPSResponsesCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
As a follow-up to @chrisohaver PR adding new view functionality, I'd like to also extend metric `coredns_plugin_enabled` to consider new view functionality, as different plugins can be applied to the same zone based on the view

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/pull/5538#issuecomment-1236343921

### 3. Which documentation changes (if any) need to be made?
added new labels into plugin README

### 4. Does this introduce a backward incompatible change or deprecation?
no
