### PR TITLE
Revert "build(deps): bump ossf/scorecard-action from 1.1.2 to 2.0.2"

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@68bf5b3327e4fd443d2add8ab122280547b4a16d
+        uses: ossf/scorecard-action@ce330fde6b1a5c9c75b417e7efc510b822a35564
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Reverts coredns/coredns#5613, where we jumped to ossf/scorecard-action v2.
The action has since failing because V2 requires additional privileges to run. Reverting it back to 1.1.2 until that can be addressed by a coredns admin. 