### PR TITLE
GO linting bump and removal of deprecated linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,8 +10,7 @@ jobs:
         with:
           go-version: '1.19.0'
       - uses: actions/checkout@v3
-      # See https://github.com/golangci/golangci-lint-action/issues/442#issuecomment-1203786890
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
-      - name: Run golangci-lint
-        run: golangci-lint run --version --verbose --out-format=github-actions
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          version: v1.49.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,9 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
-    - varcheck
     - whitespace
+    - unused

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -170,6 +170,7 @@ var (
 
 // Build information obtained with the help of -ldflags
 var (
+	// nolint
 	appVersion = "(untracked dev build)" // inferred at startup
 	devBuild   = true                    // inferred at startup
 

--- a/test/presubmit_test.go
+++ b/test/presubmit_test.go
@@ -125,7 +125,7 @@ func (l logfmt) Visit(n ast.Node) ast.Visitor {
 	if !ok {
 		return l
 	}
-	if id.Name != "t" { //t *testing.T
+	if id.Name != "t" { // t *testing.T
 		return l
 	}
 
@@ -180,41 +180,6 @@ func TestImportTesting(t *testing.T) {
 			t.Error(err)
 		}
 	}
-}
-
-type hasImportTestingWalker struct {
-	Errors []error
-}
-
-func (w *hasImportTestingWalker) walk(path string, info os.FileInfo, _ error) error {
-	// only for regular files, not starting with a . and those that are go files.
-	if !info.Mode().IsRegular() {
-		return nil
-	}
-	if strings.HasPrefix(path, "../.") {
-		return nil
-	}
-	if strings.Contains(path, "/vendor") {
-		return nil
-	}
-	if strings.HasSuffix(path, "_test.go") {
-		return nil
-	}
-
-	if strings.HasSuffix(path, ".go") {
-		fs := token.NewFileSet()
-		f, err := parser.ParseFile(fs, path, nil, parser.AllErrors)
-		if err != nil {
-			return err
-		}
-		for _, im := range f.Imports {
-			if im.Path.Value == `"testing"` {
-				absPath, _ := filepath.Abs(path)
-				w.Errors = append(w.Errors, fmt.Errorf("file %q is importing %q", absPath, "testing"))
-			}
-		}
-	}
-	return nil
 }
 
 func TestImportOrdering(t *testing.T) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
bumps golangci-lint to 1.49.0 and also remove workaround for supporting Go 1.19 and removes [usage of deprecated linters](https://github.com/golangci/golangci-lint/pull/3125) (deadcode, structcheck, varcheck)

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
