### PR TITLE
plugin/view : fix README

### DIFF
--- a/plugin/view/README.md
+++ b/plugin/view/README.md
@@ -118,7 +118,7 @@ functions defined below.
 * `port() string`: client's port
 * `proto() string`: protocol used (tcp or udp)
 * `server_ip() string`: server's IP address; for IPv6 addresses these are enclosed in brackets: `[::1]`
-* `server_port() string` : client's port
+* `server_port() string` : server's port
 * `size() int`: request size in bytes
 * `type() string`: type of the request (A, AAAA, TXT, ...)
 


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

README of `view` plugin mentions that `server_port` is a client port, I think it is more correct to say that it is a port on a server-side
