### PR TITLE
ossf/scorecard: Fix permissions for v2

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -19,6 +19,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This adds `id-token: write` per v 2.0 requirements: https://github.com/marketplace/actions/ossf-scorecard-action#breaking-changes-in-v2

>Starting from scorecard-action:v2, GITHUB_TOKEN permissions or job permissions needs to include id-token: write for publish_results: true. This is needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.


### 2. Which issues (if any) are related?

This may resolve the failing ossf/scorecard tests failing since v2 was merged.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
