### PR TITLE
Update CODEOWNERS: Add steering committee members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # 5 steering committee members
-# steering committee member: <github handle>, <email>, term ends <term end date>
-# steering committee member: <github handle>, <email>, term ends <term end date>
-# steering committee member: <github handle>, <email>, term ends <term end date>
-# steering committee member: <github handle>, <email>, term ends <term end date>
-# steering committee member: <github handle>, <email>, term ends <term end date>
+# @chrisohaver, term ends 26 Sept 2023
+# @johnbelamaric, term ends 26 Sept 2023
+# @stp-ip, term ends 26 Sept 2023
+# @superq, term ends 26 Sept 2023
+# @tantalor93, term ends 26 Sept 2023
 
 *                       @bradbeam @chrisohaver @dilyevsky @jameshartig @greenpau @isolus @johnbelamaric @miekg @pmoroney @rajansandeep @stp-ip @superq @yongtang @Tantalor93
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This adds the maintainers expressing an interest in being on the steering committee per
https://github.com/coredns/coredns/issues/5614

I don't know everyone's emails, so I just left that out. I don't think it's a big deal, but if anyone finds this to be a problem, we can collect them and add them in.

All members added here are employed by different companies.  Should we also add "company" to the list?  If so, would all the members added in this PR please let me know if you consider your contributions as independent from your employer's interests. 

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
