### PR TITLE
plugin/k8s_external: Fix rcode for headless services

### DIFF
--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -116,6 +116,7 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 							if !(matchPortAndProtocol(port, p.Name, protocol, p.Protocol)) {
 								continue
 							}
+							rcode = dns.RcodeSuccess
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
 							s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name, endpointHostname(addr, k.endpointNameMode)}, "/")
 

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -28,7 +28,7 @@ var extCases = []struct {
 	{
 		Qname: "svc6.testns.example.org.", Rcode: dns.RcodeSuccess,
 		Msg: []msg.Service{
-			{Host: "1:2::5", Port: 80, TTL: 5, Key: "/c/org/example/testns/svc1"},
+			{Host: "1:2::5", Port: 80, TTL: 5, Key: "/c/org/example/testns/svc6"},
 		},
 	},
 	{
@@ -46,14 +46,14 @@ var extCases = []struct {
 	{
 		Qname: "svc-headless.testns.example.com.", Rcode: dns.RcodeSuccess,
 		Msg: []msg.Service{
-			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless"},
-			{Host: "1.2.3.5", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless"},
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless/endpoint-svc-0"},
+			{Host: "1.2.3.5", Port: 80, TTL: 5, Weight: 50, Key: "/c/org/example/testns/svc-headless/endpoint-svc-1"},
 		},
 	},
 	{
-		Qname: "endpoint-0.svc-headless.testns.example.com.", Rcode: dns.RcodeSuccess,
+		Qname: "endpoint-svc-0.svc-headless.testns.example.com.", Rcode: dns.RcodeSuccess,
 		Msg: []msg.Service{
-			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 100, Key: "/c/org/example/testns/svc-headless/endpoint-0"},
+			{Host: "1.2.3.4", Port: 80, TTL: 5, Weight: 100, Key: "/c/org/example/testns/svc-headless/endpoint-svc-0"},
 		},
 	},
 	{
@@ -84,7 +84,6 @@ func TestExternal(t *testing.T) {
 			if x := tc.Msg[j].Key; x != s.Key {
 				t.Errorf("Test %d, expected key %s, got %s", i, x, s.Key)
 			}
-			return
 		}
 	}
 }


### PR DESCRIPTION
-------

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The `TestExternal` test for the kubernetes plugin had a seemingly erroneous return statement that prevented the test from verifying any but the first test case.  This PR removes that bogus return statement.

The test cases also had several typos, which this PR corrects.

Fixing `TestExternal` revealed that `External` was returning the wrong rcode in some cases.  Instead of returning NOERROR, `External` was returning NXDOMAIN for headless services.  This PR corrects that error.

### 2. Which issues (if any) are related?

https://cloud-native.slack.com/archives/C4DF7FP71/p1664570787814109

### 3. Which documentation changes (if any) need to be made?

Possibly a release note.

### 4. Does this introduce a backward incompatible change or deprecation?

Not unless someone is depending on CoreDNS to return NXDOMAIN when resolving headless services.