### PR TITLE
plugin/template : add support for extended DNS errors

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -17,6 +17,7 @@ template CLASS TYPE [ZONE...] {
     additional RR
     authority RR
     rcode CODE
+    ederror EXTENDED_ERROR_CODE [EXTRA_REASON]
     fallthrough [FALLTHROUGH-ZONE...]
 }
 ~~~
@@ -31,6 +32,8 @@ template CLASS TYPE [ZONE...] {
   in a response with an empty answer section.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
   per the `RcodeToString` map defined by the `miekg/dns` package in `msg.go`.
+* `ederror` **EXTENDED_ERROR_CODE** is an extended DNS error code as a number defined in `RFC8914` (0, 1, 2,..., 24).
+              **EXTRA_REASON** is an additional string explaining reason for receiving given extended DNS error.
 * `fallthrough` Continue with the next _template_ instance if the _template_'s **ZONE** matches a query name but no regex match.
   If there is no next _template_, continue resolution with the next plugin. If **[FALLTHROUGH-ZONE...]** are listed (for example
   `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough. Without
@@ -104,6 +107,7 @@ The `.invalid` domain is a reserved TLD (see [RFC 2606 Reserved Top Level DNS Na
     template ANY ANY invalid {
       rcode NXDOMAIN
       authority "invalid. 60 {{ .Class }} SOA ns.invalid. hostmaster.invalid. (1 60 60 60 60)"
+      ederror 21 "Blocked according to RFC2606"
     }
 }
 ~~~

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -33,7 +33,7 @@ template CLASS TYPE [ZONE...] {
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
   per the `RcodeToString` map defined by the `miekg/dns` package in `msg.go`.
 * `ederror` **EXTENDED_ERROR_CODE** is an extended DNS error code as a number defined in `RFC8914` (0, 1, 2,..., 24).
-              **EXTRA_REASON** is an additional string explaining reason for receiving given extended DNS error.
+              **EXTRA_REASON** is an additional string explaining the reason for returning the error.
 * `fallthrough` Continue with the next _template_ instance if the _template_'s **ZONE** matches a query name but no regex match.
   If there is no next _template_, continue resolution with the next plugin. If **[FALLTHROUGH-ZONE...]** are listed (for example
   `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough. Without

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"regexp"
+	"strconv"
 	gotmpl "text/template"
 
 	"github.com/coredns/caddy"
@@ -122,6 +123,22 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 					return handler, c.Errf("unknown rcode %s", c.Val())
 				}
 				t.rcode = rcode
+
+			case "ederror":
+				args := c.RemainingArgs()
+				if len(args) != 1 && len(args) != 2 {
+					return handler, c.ArgErr()
+				}
+
+				code, err := strconv.ParseUint(args[0], 10, 16)
+				if err != nil {
+					return handler, c.Errf("error parsing extended DNS error code %s, %v\n", c.Val(), err)
+				}
+				if len(args) == 2 {
+					t.ederror = &ederror{code: uint16(code), reason: args[1]}
+				} else {
+					t.ederror = &ederror{code: uint16(code)}
+				}
 
 			case "fallthrough":
 				t.fall.SetZonesFromArgs(c.RemainingArgs())

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -161,6 +161,30 @@ func TestSetupParse(t *testing.T) {
 				}`,
 			false,
 		},
+		{
+			`template ANY ANY invalid {
+					rcode NXDOMAIN
+					authority "invalid. 60 {{ .Class }} SOA ns.invalid. hostmaster.invalid. (1 60 60 60 60)"
+					ederror 21 "Blocked according to RFC2606"
+			  	}`,
+			false,
+		},
+		{
+			`template ANY ANY invalid {
+					rcode NXDOMAIN
+					authority "invalid. 60 {{ .Class }} SOA ns.invalid. hostmaster.invalid. (1 60 60 60 60)"
+					ederror invalid "Blocked according to RFC2606"
+			  	}`,
+			true,
+		},
+		{
+			`template ANY ANY invalid {
+					rcode NXDOMAIN
+					authority "invalid. 60 {{ .Class }} SOA ns.invalid. hostmaster.invalid. (1 60 60 60 60)"
+					ederror too many arguments
+			  	}`,
+			true,
+		},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputFileRules)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Hello, in Jamf we are using `template` plugin to block certain special domain resolutions (`invalid.`, `local.`) and this improvement came to my mind. I would appreciate your feedback 🙂 

This PR enhances `template` plugin with functionality to setup templates with Extended DNS Errors as defined in [RFC8914](https://datatracker.ietf.org/doc/rfc8914/), this enables CoreDNS server administrators to provide additional information to clients when they decide to block certain domains using `template` plugin (for example blocking special domain resolutions due to RFC - like `invalid.` or other administrator's use cases) 

Example of usage:
We can define Corefile
```
.:53 {
  forward . 8.8.8.8

  template ANY ANY invalid {
    rcode NXDOMAIN
    authority "invalid. 60 {{ .Class }} SOA ns.invalid. hostmaster.invalid. (1 60 60 60 60)"
    ederror 21 "Blocked according to RFC2606"
  }
}
```
and when resolving a special domain you will receive enhanced response `dig @127.0.0.1 test.invalid` with additional info
```
; <<>> DiG 9.18.7 <<>> @127.0.0.1 test.invalid
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 22818
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
; EDE: 21 (Not Supported): (Blocked according to RFC6761)
;; QUESTION SECTION:
;test.invalid.			IN	A

;; AUTHORITY SECTION:
invalid.		60	IN	SOA	ns.invalid. hostmaster.invalid. 1 60 60 60 60

;; Query time: 0 msec
;; SERVER: 127.0.0.1#53(127.0.0.1) (UDP)
;; WHEN: Sun Oct 02 17:51:19 CEST 2022
;; MSG SIZE  rcvd: 146
```

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
enhanced documentation of `template` plugin

### 4. Does this introduce a backward incompatible change or deprecation?
no, this is added as a new property of a `template` plugin, if it is not used, it behaves same as before
