### PR TITLE
plugin/file: make a qname search more efficient

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -36,17 +36,36 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	state := request.Request{W: w, Req: r}
 
 	qname := state.Name()
-	// TODO(miek): match the qname better in the map
-	zone := plugin.Zones(f.Zones.Names).Matches(qname)
-	if zone == "" {
-		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
-	}
 
-	z, ok := f.Zones.Z[zone]
-	if !ok || z == nil {
-		return dns.RcodeServerFailure, nil
-	}
+        var z *Zone
 
+        zone := ""
+        subdomain := qname
+        off := 0
+        end := false
+
+        for {
+                if y, ok := f.Zones.Z[subdomain]; ok {
+                        z = y
+                        zone = subdomain
+                        break
+                }
+
+                off, end = dns.NextLabel(qname, off)
+                if end {
+                        break
+                }
+                subdomain = qname[off:len(qname)]
+        }
+
+        if zone == "" {
+                return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+        }
+
+        if z == nil {
+                return dns.RcodeServerFailure, nil
+        }
+	
 	// If transfer is not loaded, we'll see these, answer with refused (no transfer allowed).
 	if state.QType() == dns.TypeAXFR || state.QType() == dns.TypeIXFR {
 		return dns.RcodeRefused, nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When a list of zones in file plugin becomes larger (e.g. two or three hundreds zones) coredns performance is seriously degrading. Benchmarks show that coredns could processed two thousands zones in with file plugin  at most 8Krps and all 32 CPU cores are utilized at 100%

### 2. Which issues (if any) are related?
This aims to resolve TODO in plugin file code

### 3. Which documentation changes (if any) need to be made?
No any documentation should be changed, I suppose

### 4. Does this introduce a backward incompatible change or deprecation?
There should be no backwards incompatible change.