### PR TITLE
Add weighted-round-robin policy to loadbalance plugin

### DIFF
--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -30,6 +30,30 @@ returned in the answer.
 
  * **DURATION** interval to reload `WEIGHTFILE` and update weight assignments if there are changes in the file. The default value is `30s`. A value of `0s` means to not scan for changes and reload.
 
+
+## Weightfile
+
+The generic weight file syntax:
+
+~~~
+# Comment lines are ignored
+
+domain-name1
+ip11 weight11
+ip12 weight12
+ip13 weight13
+
+domain-name2
+ip21 weight21
+ip22 weight22
+# ... etc.
+~~~
+
+where `ipXY` is an IP address for `domain-nameX` and `weightXY` is the weight value associated with that IP. The weight values are in the range of [1,255].
+
+The `weighted` policy selects one of the address record in the result list and moves it to the top (first) position in the list. The random selection takes into account the weight values assigned to the addresses in the weight file. If an address in the result list is associated with no weight value in the weight file then the default weight value "1" is assumed for it when the selection is performed.
+
+
 ## Examples
 
 Load balance replies coming back from Google Public DNS:
@@ -64,22 +88,3 @@ www.example.com
 100.64.1.3 2
 ~~~
 
-The generic weight file syntax:
-
-~~~
-# Comment lines are ignored
-
-domain-name1
-ip11 weight11
-ip12 weight12
-ip13 weight13
-
-domain-name2
-ip21 weight21
-ip22 weight22
-# ... etc.
-~~~
-
-where `ipXY` is an IP address for `domain-nameX` and `weightXY` is the weight value associated with that IP. The weight values are in the range of [1,255].
-
-The `weighted` policy selects one of the address record in the result list and moves it to the top (first) position in the list. The random selection takes into account the weight values assigned to the addresses in the weight file. If an address in the result list is associated with no weight value in the weight file then the default weight value "1" is assumed for it when the selection is performed.

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -29,13 +29,13 @@ returned in the answer.
 
 
 ~~~
-loadbalance weighted_round_robin WEIGHTFILE
+loadbalance weighted WEIGHTFILE
 ~~~
 
 * **WEIGHTFILE** is the file containing the weight values assigned to IPs for various domain names. If the path is relative, the path from the **root** plugin will be prepended to it. The format is explained below in the *Examples* section.
 
 ~~~
-loadbalance weighted_round_robin WEIGHTFILE {
+loadbalance weighted WEIGHTFILE {
 			reload DURATION
 }
 ~~~
@@ -60,7 +60,7 @@ example.com {
         file ./db.example.com {
                 reload 10s
         }
-        loadbalance weighted_round_robin ./db.example.com.weights {
+        loadbalance weighted ./db.example.com.weights {
                     reload 10s
         }
 }

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -62,14 +62,10 @@ More (optional) control for the "weighted_round_robin" policy:
 ~~~
 loadbalance weighted_round_robin WEIGHTFILE {
 			reload DURATION
-			[deterministic]
 }
 ~~~
 
 * **reload** the interval to reload **WEIGHTFILE** and update weight assignments if there are changes in the file. The default value is **30s**. A value of **0s** means to not scan for changes and reload.
-
-* **deterministic** switch to deterministic weighted-round-robin strategy. This remove randomness from answer re-ordering. A weight value defines exactly how many
-times a particular IP should be in the top record for consecutive queries to the same domain name.
 
 
 ## Examples

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -19,7 +19,40 @@ implementations (like glibc) are particular about that.
 loadbalance [POLICY]
 ~~~
 
-* **POLICY** is how to balance. The default, and only option, is "round_robin".
+* **POLICY** is how to balance. Available options are "round_robin" and "weighted_round_robin". The default is "round_robin".
+
+The "round_robin" strategy randomizes the order of  A, AAAA, and MX records applying a uniform probability distribution.
+
+The "weighted_round_robin" policy assigns weight values to IPs to control the relative likelihood of particular IPs to be returned as top
+entry (A or AAAA record) in the answer. See [Wikipedia](https://en.wikipedia.org/wiki/Weighted_round_robin) about a generic
+description of weighted round robin load balancing strategy.
+
+Additional option required by "weighted_round_robin" policy:
+
+~~~
+loadbalance weighted_round_robin WEIGHTFILE
+~~~
+
+* **WEIGHTFILE** the weight file containing the weight values assigned to IPs. If the path is relative, the path from the **root** plugin will be prepended to it.
+
+The weight file is parsed line-by-line. If the first character in the line is '#' then the line is ignored (i.e. comment line). Otherwise, if the line contains a single word then it is a domain name. If the line contains two words then the first one is an IP and the second one is a weight value for that IP. The IPs are addresses for the domain name which is defined above them in the file. Multiple domain names can be specified in the same weight file. A weight value must be in the range [1,255].
+
+If the server receives a query for which no domain name is specified in the corresponding weight file then the answer is returned unmodified. If the domain name is specified in the weight file but the answer does not include the expected top IP (or there isn't any IP/weight pair specified for the particular domain name) then the answer is returned unmodified.
+
+More (optional) control for the "weighted_round_robin" policy:
+
+~~~
+loadbalance weighted_round_robin WEIGHTFILE {
+			reload DURATION
+			[deterministic]
+}
+~~~
+
+* **reload** the interval to reload **WEIGHTFILE** and update weight assignments if there are changes in the file. The default value is **30s**. A value of **0s** means to not scan for changes and reload.
+
+* **deterministic** switch to deterministic weighted-round-robin strategy. This remove randomness from answer re-ordering. A weight value defines exactly how many
+times a particular IP should be in the top record for consecutive queries to the same domain name.
+
 
 ## Examples
 
@@ -31,3 +64,29 @@ Load balance replies coming back from Google Public DNS:
     forward . 8.8.8.8 8.8.4.4
 }
 ~~~
+
+Use weighted round robin strategy to load balance replies defined by the **file** plugin:
+
+~~~ corefile
+demo.plmt {
+        file ./demo.plmt {
+                reload 10s
+        }
+        loadbalance weighted_round_robin ./demo.plt.weights {
+                    reload 10s
+        }
+}
+~~~
+
+where the weight file **./demo.plt.weights** contains:
+
+~~~
+wwww.demo.plmt
+100.64.1.1 3
+100.64.1.2 1
+100.64.1.3 2
+~~~
+
+This assigns weight vales **3**, **1** and **2** to the IPs **100.64.1.1**, **100.64.1.2** and **100.64.1.3**, respectively. These IPs are addresses in A records for the domain name "wwww.demo.plmt". (The IPs for the A records are defined in the ./demo.plmt file using the **file** plugin in this example).
+
+In this example, the ratio between the number of answers in which **100.64.1.1**, **100.64.1.2** or **100.64.1.3** is in the top A record should converge to  **3 : 1 : 2**.  (E.g. there should be twice as many answers with **100.64.1.3** in the top A record than with **100.64.1.2**).

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -53,9 +53,7 @@ ip22 weight22
 
 where *ipXY* is an IP address for *domain-nameX* and *weightXY* is the weight value associated with that IP. The weight values are in the range of [1,255].
 
-For each new result list, the weighted-round-robin policy determines the "next expected top IP" from the weighted IPs list (defined in the weight file). Afterwards, it tries to move that particular IP to the first (top) position of the result list.
-
-If the server receives a query for which no domain name is specified in the corresponding weight file then the answer is returned unmodified. If the domain name is specified in the weight file but the answer does not include the expected top IP (or there isn't any IP/weight pair specified for the particular domain name) then the answer is returned unmodified, too.
+The weighted-round-robin policy selects one of the address record in the result list and moves it to the top (first) position in the list. The random selection takes into account the weight values assigned to the addresses in the weight file. If an address in the result list is associated with no weight value in the weight file then the default weight value "1" is assumed for it when the selection is performed.
 
 More (optional) control for the "weighted_round_robin" policy:
 

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -26,7 +26,7 @@ loadbalance [round_robin | weighted WEIGHTFILE] {
 (top) A/AAAA record in the answer. Note that it does not shuffle all the records in the answer, it is only concerned about the first A/AAAA record
 returned in the answer.
 
- * **WEIGHTFILE** is the file containing the weight values assigned to IPs for various domain names. If the path is relative, the path from the **root** plugin will be prepended to it. The format is explained below in the *Examples* section.
+ * **WEIGHTFILE** is the file containing the weight values assigned to IPs for various domain names. If the path is relative, the path from the **root** plugin will be prepended to it. The format is explained below in the *Weightfile* section.
 
  * **DURATION** interval to reload `WEIGHTFILE` and update weight assignments if there are changes in the file. The default value is `30s`. A value of `0s` means to not scan for changes and reload.
 

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -19,43 +19,20 @@ implementations (like glibc) are particular about that.
 loadbalance [POLICY]
 ~~~
 
-* **POLICY** is how to balance. Available options are "round_robin" and "weighted_round_robin". The default is "round_robin".
+* **POLICY** is how to balance. Available options are `round_robin` and `weighted`. The default is `round_robin`.
 
-The "round_robin" strategy randomizes the order of  A, AAAA, and MX records applying a uniform probability distribution.
+ The `round_robin` strategy randomizes the order of  A, AAAA, and MX records applying a uniform probability distribution.
 
-The "weighted_round_robin" policy assigns weight values to IPs to control the relative likelihood of particular IPs to be returned as the first
+ The `weighted` policy assigns weight values to IPs to control the relative likelihood of particular IPs to be returned as the first
 (top) A/AAAA record in the answer. Note that it does not shuffle all the records in the answer, it is only concerned about the first A/AAAA record
 returned in the answer.
 
-Additional option required by "weighted_round_robin" policy:
 
 ~~~
 loadbalance weighted_round_robin WEIGHTFILE
 ~~~
 
-* **WEIGHTFILE** the weight file containing the weight values assigned to IPs. If the path is relative, the path from the **root** plugin will be prepended to it.
-
-Expected weight file syntax:
-
-~~~
-# Comment lines are ignored
-
-domain-name1
-ip11 weight11
-ip12 weight12
-ip13 weight13
-
-domain-name2
-ip21 weight21
-ip22 weight22
-# ... etc.
-~~~
-
-where *ipXY* is an IP address for *domain-nameX* and *weightXY* is the weight value associated with that IP. The weight values are in the range of [1,255].
-
-The weighted-round-robin policy selects one of the address record in the result list and moves it to the top (first) position in the list. The random selection takes into account the weight values assigned to the addresses in the weight file. If an address in the result list is associated with no weight value in the weight file then the default weight value "1" is assumed for it when the selection is performed.
-
-More (optional) control for the "weighted_round_robin" policy:
+* **WEIGHTFILE** is the file containing the weight values assigned to IPs for various domain names. If the path is relative, the path from the **root** plugin will be prepended to it. The format is explained below in the *Examples* section.
 
 ~~~
 loadbalance weighted_round_robin WEIGHTFILE {
@@ -63,8 +40,7 @@ loadbalance weighted_round_robin WEIGHTFILE {
 }
 ~~~
 
-* **reload** the interval to reload **WEIGHTFILE** and update weight assignments if there are changes in the file. The default value is **30s**. A value of **0s** means to not scan for changes and reload.
-
+* **DURATION** interval to reload `WEIGHTFILE` and update weight assignments if there are changes in the file. The default value is `30s`. A value of `0s` means to not scan for changes and reload.
 
 ## Examples
 
@@ -80,25 +56,45 @@ Load balance replies coming back from Google Public DNS:
 Use weighted round robin strategy to load balance replies defined by the **file** plugin:
 
 ~~~ corefile
-demo.plmt {
-        file ./demo.plmt {
+example.com {
+        file ./db.example.com {
                 reload 10s
         }
-        loadbalance weighted_round_robin ./demo.plt.weights {
+        loadbalance weighted_round_robin ./db.example.com.weights {
                     reload 10s
         }
 }
 ~~~
 
-where the weight file **./demo.plt.weights** contains:
+where the weight file `./db.example.com.weights` contains:
 
 ~~~
-wwww.demo.plmt
+www.example.com
 100.64.1.1 3
 100.64.1.2 1
 100.64.1.3 2
 ~~~
 
-This assigns weight vales **3**, **1** and **2** to the IPs **100.64.1.1**, **100.64.1.2** and **100.64.1.3**, respectively. These IPs are addresses in A records for the domain name "wwww.demo.plmt". (The IPs for the A records are defined in the ./demo.plmt file using the **file** plugin in this example).
+This assigns weight vales `3`, `1` and `2` to the IPs `100.64.1.1`, `100.64.1.2` and `100.64.1.3`, respectively. These IPs are addresses in A records for the domain name `www.example.com`. (The IPs for the A records are defined in the `./db.example.com` file using the **file** plugin in this example).
 
-In this example, the ratio between the number of answers in which **100.64.1.1**, **100.64.1.2** or **100.64.1.3** is in the top A record should converge to  **3 : 1 : 2**.  (E.g. there should be twice as many answers with **100.64.1.3** in the top A record than with **100.64.1.2**).
+In this example, the ratio between the number of answers in which `100.64.1.1`, `100.64.1.2` or `100.64.1.3` is in the top (first) A record should converge to  `3 : 1 : 2`.  (E.g. there should be twice as many answers with `100.64.1.3` in the top A record than with `100.64.1.2`).
+
+The generic weight file syntax:
+
+~~~
+# Comment lines are ignored
+
+domain-name1
+ip11 weight11
+ip12 weight12
+ip13 weight13
+
+domain-name2
+ip21 weight21
+ip22 weight22
+# ... etc.
+~~~
+
+where `ipXY` is an IP address for `domain-nameX` and `weightXY` is the weight value associated with that IP. The weight values are in the range of [1,255].
+
+The `weighted` policy selects one of the address record in the result list and moves it to the top (first) position in the list. The random selection takes into account the weight values assigned to the addresses in the weight file. If an address in the result list is associated with no weight value in the weight file then the default weight value "1" is assumed for it when the selection is performed.

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -10,16 +10,16 @@ import (
 )
 
 // RoundRobin is a plugin to rewrite responses for "load balancing".
-type RoundRobin struct {
+type LoadBalance struct {
 	Next    plugin.Handler
 	shuffle func(*dns.Msg) *dns.Msg
 }
 
 // ServeDNS implements the plugin.Handler interface.
-func (rr RoundRobin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	rrw := &RoundRobinResponseWriter{ResponseWriter: w, shuffle: rr.shuffle}
+func (rr LoadBalance) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	rrw := &LoadBalanceResponseWriter{ResponseWriter: w, shuffle: rr.shuffle}
 	return plugin.NextOrFailure(rr.Name(), rr.Next, ctx, rrw, r)
 }
 
 // Name implements the Handler interface.
-func (rr RoundRobin) Name() string { return "loadbalance" }
+func (rr LoadBalance) Name() string { return "loadbalance" }

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -22,4 +22,4 @@ func (lb LoadBalance) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 }
 
 // Name implements the Handler interface.
-func (rr LoadBalance) Name() string { return "loadbalance" }
+func (lb LoadBalance) Name() string { return "loadbalance" }

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -34,7 +34,8 @@ type (
 	// Per domain weights and the expected top entry in the result list
 	domain struct {
 		weights []*weightItem
-		topIP
+		topIP   net.IP
+		topIPupdater
 	}
 	// Weight assigned to an address
 	weightItem struct {
@@ -42,8 +43,8 @@ type (
 		value   uint8
 	}
 	// Get the expected top IP for the next answer
-	topIP interface {
-		nextTopIP(weights []*weightItem, rn *rand.Rand) net.IP
+	topIPupdater interface {
+		nextTopIP(curd *domain, rn *rand.Rand)
 	}
 )
 

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -27,7 +27,6 @@ type (
 		reload   time.Duration
 		md5sum   [md5.Size]byte
 		domains  map[string]*domain
-		isRandom bool
 		rn       *rand.Rand
 		mutex    sync.Mutex
 	}
@@ -35,16 +34,12 @@ type (
 	domain struct {
 		weights []*weightItem
 		topIP   net.IP
-		topIPupdater
+		wsum    uint
 	}
 	// Weight assigned to an address
 	weightItem struct {
 		address net.IP
 		value   uint8
-	}
-	// Get the expected top IP for the next answer
-	topIPupdater interface {
-		nextTopIP(curd *domain, rn *rand.Rand)
 	}
 )
 

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -16,9 +16,9 @@ type LoadBalance struct {
 }
 
 // ServeDNS implements the plugin.Handler interface.
-func (rr LoadBalance) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	rrw := &LoadBalanceResponseWriter{ResponseWriter: w, shuffle: rr.shuffle}
-	return plugin.NextOrFailure(rr.Name(), rr.Next, ctx, rrw, r)
+func (lb LoadBalance) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	rw := &LoadBalanceResponseWriter{ResponseWriter: w, shuffle: lb.shuffle}
+	return plugin.NextOrFailure(lb.Name(), lb.Next, ctx, rw, r)
 }
 
 // Name implements the Handler interface.

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -4,7 +4,6 @@ package loadbalance
 import (
 	"context"
 	"crypto/md5"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -26,20 +25,21 @@ type (
 		fileName string
 		reload   time.Duration
 		md5sum   [md5.Size]byte
-		domains  map[string]*domain
-		rn       *rand.Rand
-		mutex    sync.Mutex
+		domains  map[string]weights
+		randomGen
+		mutex sync.Mutex
 	}
-	// Per domain weights and the expected top entry in the result list
-	domain struct {
-		weights []*weightItem
-		topIP   net.IP
-		wsum    uint
-	}
+	// Per domain weights
+	weights []*weightItem
 	// Weight assigned to an address
 	weightItem struct {
 		address net.IP
 		value   uint8
+	}
+	// Random uint generator
+	randomGen interface {
+		randInit()
+		randUint(limit uint) uint
 	}
 )
 

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -3,49 +3,21 @@ package loadbalance
 
 import (
 	"context"
-	"crypto/md5"
-	"net"
-	"sync"
-	"time"
 
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/miekg/dns"
 )
 
-type (
-	// RoundRobin is a plugin to rewrite responses for "load balancing".
-	RoundRobin struct {
-		Next    plugin.Handler
-		policy  string
-		weights *weightedRR
-	}
-	// "weighted-round-robin" policy specific data
-	weightedRR struct {
-		fileName string
-		reload   time.Duration
-		md5sum   [md5.Size]byte
-		domains  map[string]weights
-		randomGen
-		mutex sync.Mutex
-	}
-	// Per domain weights
-	weights []*weightItem
-	// Weight assigned to an address
-	weightItem struct {
-		address net.IP
-		value   uint8
-	}
-	// Random uint generator
-	randomGen interface {
-		randInit()
-		randUint(limit uint) uint
-	}
-)
+// RoundRobin is a plugin to rewrite responses for "load balancing".
+type RoundRobin struct {
+	Next    plugin.Handler
+	shuffle func(*dns.Msg) *dns.Msg
+}
 
 // ServeDNS implements the plugin.Handler interface.
 func (rr RoundRobin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	rrw := &RoundRobinResponseWriter{ResponseWriter: w, policy: rr.policy, weights: rr.weights}
+	rrw := &RoundRobinResponseWriter{ResponseWriter: w, shuffle: rr.shuffle}
 	return plugin.NextOrFailure(rr.Name(), rr.Next, ctx, rrw, r)
 }
 

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -10,14 +10,14 @@ const (
 	weightedRoundRobinPolicy = "weighted"
 )
 
-// RoundRobinResponseWriter is a response writer that shuffles A, AAAA and MX records.
-type RoundRobinResponseWriter struct {
+// LoadBalanceResponseWriter is a response writer that shuffles A, AAAA and MX records.
+type LoadBalanceResponseWriter struct {
 	dns.ResponseWriter
 	shuffle func(*dns.Msg) *dns.Msg
 }
 
 // WriteMsg implements the dns.ResponseWriter interface.
-func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
+func (r *LoadBalanceResponseWriter) WriteMsg(res *dns.Msg) error {
 	if res.Rcode != dns.RcodeSuccess {
 		return r.ResponseWriter.WriteMsg(res)
 	}
@@ -83,9 +83,9 @@ func roundRobinShuffle(records []dns.RR) {
 }
 
 // Write implements the dns.ResponseWriter interface.
-func (r *RoundRobinResponseWriter) Write(buf []byte) (int, error) {
+func (r *LoadBalanceResponseWriter) Write(buf []byte) (int, error) {
 	// Should we pack and unpack here to fiddle with the packet... Not likely.
-	log.Warning("RoundRobin called with Write: not shuffling records")
+	log.Warning("LoadBalance called with Write: not shuffling records")
 	n, err := r.ResponseWriter.Write(buf)
 	return n, err
 }

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	ramdomShufflePolicy      = "round_robin"
-	weightedRoundRobinPolicy = "weighted_round_robin"
+	weightedRoundRobinPolicy = "weighted"
 )
 
 // RoundRobinResponseWriter is a response writer that shuffles A, AAAA and MX records.

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -33,7 +33,13 @@ func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
 		res.Ns = roundRobin(res.Ns)
 		res.Extra = roundRobin(res.Extra)
 	case weightedRoundRobinPolicy:
-		res.Answer = r.weights.weightedRoundRobin(res.Question[0].Name, res.Answer)
+		switch res.Question[0].Qtype {
+		case dns.TypeA, dns.TypeAAAA, dns.TypeSRV:
+			res.Answer = r.weights.weightedRoundRobin(res.Question[0].Name, res.Answer)
+			res.Extra = r.weights.weightedRoundRobin(res.Question[0].Name, res.Extra)
+		default:
+			return r.ResponseWriter.WriteMsg(res)
+		}
 	}
 
 	return r.ResponseWriter.WriteMsg(res)

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -35,8 +35,8 @@ func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
 	case weightedRoundRobinPolicy:
 		switch res.Question[0].Qtype {
 		case dns.TypeA, dns.TypeAAAA, dns.TypeSRV:
-			res.Answer = r.weights.weightedRoundRobin(res.Question[0].Name, res.Answer)
-			res.Extra = r.weights.weightedRoundRobin(res.Question[0].Name, res.Extra)
+			res.Answer = r.weights.weightedRoundRobin(res.Answer)
+			res.Extra = r.weights.weightedRoundRobin(res.Extra)
 		default:
 			return r.ResponseWriter.WriteMsg(res)
 		}

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLoadBalanceRandom(t *testing.T) {
-	rm := RoundRobin{Next: handler(), shuffle: randomShuffle}
+	rm := LoadBalance{Next: handler(), shuffle: randomShuffle}
 
 	// the first X records must be cnames after this test
 	tests := []struct {
@@ -124,7 +124,7 @@ func TestLoadBalanceRandom(t *testing.T) {
 }
 
 func TestLoadBalanceXFR(t *testing.T) {
-	rm := RoundRobin{Next: handler()}
+	rm := LoadBalance{Next: handler()}
 
 	answer := []dns.RR{
 		test.SOA("skydns.test.	30	IN	SOA	ns.dns.skydns.test. hostmaster.skydns.test. 1542756695 7200 1800 86400 30"),

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLoadBalanceRandom(t *testing.T) {
-	rm := RoundRobin{Next: handler(), policy: ramdomShufflePolicy}
+	rm := RoundRobin{Next: handler(), shuffle: randomShuffle}
 
 	// the first X records must be cnames after this test
 	tests := []struct {

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestLoadBalance(t *testing.T) {
-	rm := RoundRobin{Next: handler()}
+func TestLoadBalanceRandom(t *testing.T) {
+	rm := RoundRobin{Next: handler(), policy: ramdomShufflePolicy}
 
 	// the first X records must be cnames after this test
 	tests := []struct {

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -6,12 +6,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/miekg/dns"
-
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+
+	"github.com/miekg/dns"
 )
 
 var log = clog.NewWithPlugin("loadbalance")

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -26,9 +26,7 @@ func setup(c *caddy.Controller) error {
 
 	if policy == weightedRoundRobinPolicy {
 
-		if weighted.isRandom {
-			weighted.rn = rand.New(rand.NewSource(time.Now().UnixNano()))
-		}
+		weighted.rn = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 		stopReloadChan := make(chan bool)
 		weighted.periodicWeightUpdate(stopReloadChan)
@@ -81,8 +79,7 @@ func parse(c *caddy.Controller) (string, *weightedRR, error) {
 			}
 
 			w := &weightedRR{
-				reload:   30 * time.Second,
-				isRandom: true,
+				reload: 30 * time.Second,
 			}
 
 			fileName := args[1]
@@ -106,12 +103,6 @@ func parse(c *caddy.Controller) (string, *weightedRR, error) {
 						return "", nil, c.Errf("invalid reload duration '%s'", t[0])
 					}
 					w.reload = d
-				case "deterministic":
-					t := c.RemainingArgs()
-					if len(t) > 0 {
-						return "", nil, c.Errf("unknown property '%s'", c.Val())
-					}
-					w.isRandom = false
 				default:
 					return "", nil, c.Errf("unknown property '%s'", c.Val())
 				}

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -40,7 +40,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		return RoundRobin{Next: next, shuffle: lb.shuffleFunc}
+		return LoadBalance{Next: next, shuffle: lb.shuffleFunc}
 	})
 
 	return nil

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -1,7 +1,11 @@
 package loadbalance
 
 import (
+	"errors"
 	"fmt"
+	"math/rand"
+	"path/filepath"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -10,34 +14,112 @@ import (
 )
 
 var log = clog.NewWithPlugin("loadbalance")
+var errOpen = errors.New("Weight file open error")
 
 func init() { plugin.Register("loadbalance", setup) }
 
 func setup(c *caddy.Controller) error {
-	err := parse(c)
+	policy, weighted, err := parse(c)
 	if err != nil {
 		return plugin.Error("loadbalance", err)
 	}
 
+	if policy == weightedRoundRobinPolicy {
+
+		if weighted.isRandom {
+			weighted.rn = rand.New(rand.NewSource(time.Now().UnixNano()))
+		}
+
+		stopReloadChan := make(chan bool)
+		weighted.periodicWeightUpdate(stopReloadChan)
+
+		c.OnStartup(func() error {
+			err := weighted.updateWeights()
+			if errors.Is(err, errOpen) && weighted.reload != 0 {
+				log.Warningf("Failed to open weight file:%v. Will try again in %v",
+					err, weighted.reload)
+			} else if err != nil {
+				return plugin.Error("loadbalance", err)
+			}
+			return nil
+		})
+		c.OnShutdown(func() error {
+			close(stopReloadChan)
+			return nil
+		})
+	}
+
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		return RoundRobin{Next: next}
+		return RoundRobin{Next: next, policy: policy, weights: weighted}
 	})
 
 	return nil
 }
 
-func parse(c *caddy.Controller) error {
+func parse(c *caddy.Controller) (string, *weightedRR, error) {
+
+	config := dnsserver.GetConfig(c)
+
 	for c.Next() {
 		args := c.RemainingArgs()
-		switch len(args) {
-		case 0:
-			return nil
-		case 1:
-			if args[0] != "round_robin" {
-				return fmt.Errorf("unknown policy: %s", args[0])
+		if len(args) == 0 {
+			return ramdomShufflePolicy, nil, nil
+		}
+		switch args[0] {
+		case ramdomShufflePolicy:
+			if len(args) > 1 {
+				return "", nil, c.Errf("unknown property for %s", args[0])
 			}
-			return nil
+			return ramdomShufflePolicy, nil, nil
+		case weightedRoundRobinPolicy:
+			if len(args) < 2 {
+				return "", nil, c.Err("missing weight file argument")
+			}
+
+			if len(args) > 2 {
+				return "", nil, c.Err("unexpected argument(s)")
+			}
+
+			w := &weightedRR{
+				reload:   30 * time.Second,
+				isRandom: true,
+			}
+
+			fileName := args[1]
+			if !filepath.IsAbs(fileName) && config.Root != "" {
+				fileName = filepath.Join(config.Root, fileName)
+			}
+			w.fileName = fileName
+
+			for c.NextBlock() {
+				switch c.Val() {
+				case "reload":
+					t := c.RemainingArgs()
+					if len(t) < 1 {
+						return "", nil, c.Err("reload duration value is missing")
+					}
+					if len(t) > 1 {
+						return "", nil, c.Err("unexpected argument")
+					}
+					d, err := time.ParseDuration(t[0])
+					if err != nil {
+						return "", nil, c.Errf("invalid reload duration '%s'", t[0])
+					}
+					w.reload = d
+				case "deterministic":
+					t := c.RemainingArgs()
+					if len(t) > 0 {
+						return "", nil, c.Errf("unknown property '%s'", c.Val())
+					}
+					w.isRandom = false
+				default:
+					return "", nil, c.Errf("unknown property '%s'", c.Val())
+				}
+			}
+			return weightedRoundRobinPolicy, w, nil
+		default:
+			return "", nil, fmt.Errorf("unknown policy: %s", args[0])
 		}
 	}
-	return c.ArgErr()
+	return "", nil, c.ArgErr()
 }

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -3,7 +3,6 @@ package loadbalance
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"time"
 
@@ -26,7 +25,7 @@ func setup(c *caddy.Controller) error {
 
 	if policy == weightedRoundRobinPolicy {
 
-		weighted.rn = rand.New(rand.NewSource(time.Now().UnixNano()))
+		weighted.randInit()
 
 		stopReloadChan := make(chan bool)
 		weighted.periodicWeightUpdate(stopReloadChan)
@@ -79,7 +78,8 @@ func parse(c *caddy.Controller) (string, *weightedRR, error) {
 			}
 
 			w := &weightedRR{
-				reload: 30 * time.Second,
+				reload:    30 * time.Second,
+				randomGen: &randomUint{},
 			}
 
 			fileName := args[1]

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -24,7 +24,6 @@ func setup(c *caddy.Controller) error {
 	}
 
 	if policy == weightedRoundRobinPolicy {
-
 		weighted.randInit()
 
 		stopReloadChan := make(chan bool)
@@ -54,7 +53,6 @@ func setup(c *caddy.Controller) error {
 }
 
 func parse(c *caddy.Controller) (string, *weightedRR, error) {
-
 	config := dnsserver.GetConfig(c)
 
 	for c.Next() {

--- a/plugin/loadbalance/setup_test.go
+++ b/plugin/loadbalance/setup_test.go
@@ -11,11 +11,10 @@ import (
 var testWeighted = []struct {
 	expectedWeightFile   string
 	expectedWeightReload string
-	expectedIsRandom     bool
 }{
-	{"wfile", "30s", true},
-	{"wf", "10s", true},
-	{"wf", "0s", false},
+	{"wfile", "30s"},
+	{"wf", "10s"},
+	{"wf", "0s"},
 }
 
 func TestSetup(t *testing.T) {
@@ -35,7 +34,6 @@ func TestSetup(t *testing.T) {
                                               } `, false, "weighted_round_robin", "", 1},
 		{`loadbalance weighted_round_robin wf {
                                                 reload 0s
-                                                deterministic
                                               } `, false, "weighted_round_robin", "", 2},
 		// negative
 		{`loadbalance fleeb`, true, "", "unknown policy", -1},
@@ -88,9 +86,6 @@ func TestSetup(t *testing.T) {
 			}
 			if testWeighted[i].expectedWeightReload != w.reload.String() {
 				t.Errorf("Test %d: Expected weight reload duration %s but got %s for input %s", i, testWeighted[i].expectedWeightReload, w.reload, test.input)
-			}
-			if testWeighted[i].expectedIsRandom != w.isRandom {
-				t.Errorf("Test %d: Expected isRandom:%t but got %t for input %s", i, testWeighted[i].expectedIsRandom, w.isRandom, test.input)
 			}
 		}
 	}

--- a/plugin/loadbalance/setup_test.go
+++ b/plugin/loadbalance/setup_test.go
@@ -7,24 +7,55 @@ import (
 	"github.com/coredns/caddy"
 )
 
+// weighted round robin specific test data
+var testWeighted = []struct {
+	expectedWeightFile   string
+	expectedWeightReload string
+	expectedIsRandom     bool
+}{
+	{"wfile", "30s", true},
+	{"wf", "10s", true},
+	{"wf", "0s", false},
+}
+
 func TestSetup(t *testing.T) {
 	tests := []struct {
 		input              string
 		shouldErr          bool
 		expectedPolicy     string
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
+		weightedDataIndex  int    // weighted round robin specific data index
 	}{
 		// positive
-		{`loadbalance`, false, "round_robin", ""},
-		{`loadbalance round_robin`, false, "round_robin", ""},
+		{`loadbalance`, false, "round_robin", "", -1},
+		{`loadbalance round_robin`, false, "round_robin", "", -1},
+		{`loadbalance weighted_round_robin wfile`, false, "weighted_round_robin", "", 0},
+		{`loadbalance weighted_round_robin wf {
+                                                reload 10s
+                                              } `, false, "weighted_round_robin", "", 1},
+		{`loadbalance weighted_round_robin wf {
+                                                reload 0s
+                                                deterministic
+                                              } `, false, "weighted_round_robin", "", 2},
 		// negative
-		{`loadbalance fleeb`, true, "", "unknown policy"},
-		{`loadbalance a b`, true, "", "argument count or unexpected line"},
+		{`loadbalance fleeb`, true, "", "unknown policy", -1},
+		{`loadbalance round_robin a`, true, "", "unknown property", -1},
+		{`loadbalance weighted_round_robin`, true, "", "missing weight file argument", -1},
+		{`loadbalance weighted_round_robin a b`, true, "", "unexpected argument", -1},
+		{`loadbalance weighted_round_robin wfile {
+                                                   susu
+                                                 } `, true, "", "unknown property", -1},
+		{`loadbalance weighted_round_robin wfile {
+                                                   reload a
+                                                 } `, true, "", "invalid reload duration", -1},
+		{`loadbalance weighted_round_robin wfile {
+                                                    reload 30s  a
+                                                 } `, true, "", "unexpected argument", -1},
 	}
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		err := parse(c)
+		policy, w, err := parse(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error but found %s for input %s", i, err, test.input)
@@ -37,6 +68,29 @@ func TestSetup(t *testing.T) {
 
 			if !strings.Contains(err.Error(), test.expectedErrContent) {
 				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+		}
+		if policy != test.expectedPolicy {
+			t.Errorf("Test %d: Expected policy %s but got %s for input %s", i, test.expectedPolicy, policy, test.input)
+		}
+		if policy == weightedRoundRobinPolicy {
+			if err == nil && w == nil {
+				t.Errorf("Test %d: Expected valid weight struct but got nil for input %s", i, test.input)
+			}
+			if err != nil && w != nil {
+				t.Errorf("Test %d: Expected nil for weight struct due to error for input %s", i, test.input)
+			}
+		}
+		if policy == weightedRoundRobinPolicy && test.weightedDataIndex >= 0 {
+			i := test.weightedDataIndex
+			if testWeighted[i].expectedWeightFile != w.fileName {
+				t.Errorf("Test %d: Expected weight file name %s but got %s for input %s", i, testWeighted[i].expectedWeightFile, w.fileName, test.input)
+			}
+			if testWeighted[i].expectedWeightReload != w.reload.String() {
+				t.Errorf("Test %d: Expected weight reload duration %s but got %s for input %s", i, testWeighted[i].expectedWeightReload, w.reload, test.input)
+			}
+			if testWeighted[i].expectedIsRandom != w.isRandom {
+				t.Errorf("Test %d: Expected isRandom:%t but got %t for input %s", i, testWeighted[i].expectedIsRandom, w.isRandom, test.input)
 			}
 		}
 	}

--- a/plugin/loadbalance/setup_test.go
+++ b/plugin/loadbalance/setup_test.go
@@ -28,25 +28,25 @@ func TestSetup(t *testing.T) {
 		// positive
 		{`loadbalance`, false, "round_robin", "", -1},
 		{`loadbalance round_robin`, false, "round_robin", "", -1},
-		{`loadbalance weighted_round_robin wfile`, false, "weighted_round_robin", "", 0},
-		{`loadbalance weighted_round_robin wf {
+		{`loadbalance weighted wfile`, false, "weighted", "", 0},
+		{`loadbalance weighted wf {
                                                 reload 10s
-                                              } `, false, "weighted_round_robin", "", 1},
-		{`loadbalance weighted_round_robin wf {
+                                              } `, false, "weighted", "", 1},
+		{`loadbalance weighted wf {
                                                 reload 0s
-                                              } `, false, "weighted_round_robin", "", 2},
+                                              } `, false, "weighted", "", 2},
 		// negative
 		{`loadbalance fleeb`, true, "", "unknown policy", -1},
 		{`loadbalance round_robin a`, true, "", "unknown property", -1},
-		{`loadbalance weighted_round_robin`, true, "", "missing weight file argument", -1},
-		{`loadbalance weighted_round_robin a b`, true, "", "unexpected argument", -1},
-		{`loadbalance weighted_round_robin wfile {
+		{`loadbalance weighted`, true, "", "missing weight file argument", -1},
+		{`loadbalance weighted a b`, true, "", "unexpected argument", -1},
+		{`loadbalance weighted wfile {
                                                    susu
                                                  } `, true, "", "unknown property", -1},
-		{`loadbalance weighted_round_robin wfile {
+		{`loadbalance weighted wfile {
                                                    reload a
                                                  } `, true, "", "invalid reload duration", -1},
-		{`loadbalance weighted_round_robin wfile {
+		{`loadbalance weighted wfile {
                                                     reload 30s  a
                                                  } `, true, "", "unexpected argument", -1},
 	}

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -186,6 +186,7 @@ func (w *weightedRR) updateWeights() error {
 		// initialize first expected "top" IP
 		d.nextTopIP(d, w.rn)
 	}
+	log.Infof("Successfully reloaded weight file %s", w.fileName)
 	return nil
 }
 

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/miekg/dns"
-
 	"github.com/coredns/coredns/plugin"
+
+	"github.com/miekg/dns"
 )
 
 type (

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -18,7 +18,21 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (w *weightedRR) weightedRoundRobin(qname string, in []dns.RR) []dns.RR {
+// Random uint generator
+type randomUint struct {
+	rn *rand.Rand
+}
+
+func (r *randomUint) randInit() {
+	r.rn = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func (r *randomUint) randUint(limit uint) uint {
+	return uint(r.rn.Intn(int(limit)))
+}
+
+// Apply weighted round robin policy to the answer
+func (w *weightedRR) weightedRoundRobin(in []dns.RR) []dns.RR {
 	cname := []dns.RR{}
 	address := []dns.RR{}
 	mx := []dns.RR{}
@@ -36,10 +50,12 @@ func (w *weightedRR) weightedRoundRobin(qname string, in []dns.RR) []dns.RR {
 		}
 	}
 
-	if len(address) == 0 || !w.setTopRecord(qname, address) {
+	if len(address) == 0 {
 		// no change
 		return in
 	}
+
+	w.setTopRecord(address)
 
 	out := append(cname, rest...)
 	out = append(out, address...)
@@ -48,64 +64,70 @@ func (w *weightedRR) weightedRoundRobin(qname string, in []dns.RR) []dns.RR {
 }
 
 // Move the next expected address to the first position in the result list
-func (w *weightedRR) setTopRecord(qname string, address []dns.RR) bool {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-	curd, ok := w.domains[qname]
-	if !ok || len(curd.weights) == 0 {
-		// no weights list
-		return false
-	}
+func (w *weightedRR) setTopRecord(address []dns.RR) {
 
-	expTopIP := curd.topIP
-	itop := -1
+	itop := w.topAddressIndex(address)
 
-L:
-	for i, r := range address {
-		switch r.Header().Rrtype {
-		case dns.TypeA:
-			ar := r.(*dns.A)
-			if ar.A.Equal(expTopIP) {
-				itop = i
-				break L
-			}
-		case dns.TypeAAAA:
-			ar := r.(*dns.AAAA)
-			if ar.AAAA.Equal(expTopIP) {
-				itop = i
-				break L
-			}
-		}
-	}
-
-	if itop == -1 {
-		// Expected top entry is not in the list
-		return false
+	if itop < 0 {
+		// internal error
+		return
 	}
 
 	if itop != 0 {
-		// swap expected top entry with the actual one
+		// swap the selected top entry with the actual one
 		address[0], address[itop] = address[itop], address[0]
 	}
-	// move to the next expected "top" IP
-	curd.nextTopIP(w.rn)
-
-	return true
 }
 
-// Compute the next expected top (first) IP
-func (d *domain) nextTopIP(rn *rand.Rand) {
-	v := rn.Intn(int(d.wsum))
+// Compute the top (first) address index
+func (w *weightedRR) topAddressIndex(address []dns.RR) int {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 
-	psum := 0
-	var w *weightItem
-	for _, w = range d.weights {
-		psum += int(w.value)
+	// Dertermine the weight value for each address in the answer
+	var wsum uint
+	type waddress struct {
+		index  int
+		weight uint8
+	}
+	weightedAddr := make([]waddress, len(address))
+	for i, ar := range address {
+		wa := &weightedAddr[i]
+		wa.index = i
+		wa.weight = 1 // default weight
+		var ip net.IP
+		switch ar.Header().Rrtype {
+		case dns.TypeA:
+			ip = ar.(*dns.A).A
+		case dns.TypeAAAA:
+			ip = ar.(*dns.AAAA).AAAA
+		}
+		ws := w.domains[ar.Header().Name]
+		for _, w := range ws {
+			if w.address.Equal(ip) {
+				wa.weight = w.value
+				break
+			}
+		}
+		wsum += uint(wa.weight)
+	}
+
+	// Select the first (top) IP
+	sort.Slice(weightedAddr, func(i, j int) bool {
+		return weightedAddr[i].weight > weightedAddr[j].weight
+	})
+	v := w.randUint(wsum)
+	var psum uint
+	for _, wa := range weightedAddr {
+		psum += uint(wa.weight)
 		if v < psum {
-			break
+			return int(wa.index)
 		}
 	}
-	d.topIP = w.address
+
+	// we should never reach this
+	log.Errorf("Internal error: cannot find top addres (randv:%v wsum:%v)", v, wsum)
+	return -1
 }
 
 // Start go routine to update weights from the weight file periodically
@@ -133,36 +155,9 @@ func (w *weightedRR) periodicWeightUpdate(stopReload <-chan bool) {
 
 // Update weights from weight file
 func (w *weightedRR) updateWeights() error {
-	// access to weights must be protected
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
-	isChanged, err := w.readWeightFile()
-	if err != nil || !isChanged {
-		return err
-	}
-
-	// Sort weight litst. First elements will have max weight.
-	for _, d := range w.domains {
-		sort.Slice(d.weights, func(i, j int) bool {
-			return d.weights[i].value > d.weights[j].value
-		})
-		// Calculate the sum of weights per domain
-		for _, w := range d.weights {
-			d.wsum += uint(w.value)
-		}
-		// initialize first expected "top" IP
-		d.nextTopIP(w.rn)
-	}
-	log.Infof("Successfully reloaded weight file %s", w.fileName)
-	return nil
-}
-
-// Read the weight file
-func (w *weightedRR) readWeightFile() (bool, error) {
 	reader, err := os.Open(filepath.Clean(w.fileName))
 	if err != nil {
-		return false, errOpen
+		return errOpen
 	}
 	defer reader.Close()
 
@@ -171,26 +166,37 @@ func (w *weightedRR) readWeightFile() (bool, error) {
 	tee := io.TeeReader(reader, &buf)
 	bytes, err := io.ReadAll(tee)
 	if err != nil {
-		return false, err
+		return err
 	}
 	md5sum := md5.Sum(bytes)
 	if md5sum == w.md5sum {
 		// file contents has not changed
-		return false, nil
+		return nil
 	}
 	w.md5sum = md5sum
 	scanner := bufio.NewScanner(&buf)
 
 	// Parse the weight file contents
-	return true, w.parseWeights(scanner)
+	err = w.parseWeights(scanner)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Successfully reloaded weight file %s", w.fileName)
+	return nil
 }
 
 // Parse the weight file contents
 func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
-	// Reset domains
-	w.domains = make(map[string]*domain)
+	// access to weights must be protected
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 
-	var curd *domain
+	// Reset domains
+	w.domains = make(map[string]weights)
+
+	var dname string
+	var ws weights
 	for scanner.Scan() {
 		nextLine := strings.TrimSpace(scanner.Text())
 		if len(nextLine) == 0 || nextLine[0:1] == "#" {
@@ -200,24 +206,22 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 		fields := strings.Fields(nextLine)
 		switch len(fields) {
 		case 1:
-			// (domain) name
-			dname := fields[0]
-
-			// sanity check
-			if net.ParseIP(dname) != nil {
+			// (domain) name sanity check
+			if net.ParseIP(fields[0]) != nil {
 				return fmt.Errorf("Wrong domain name:\"%s\" in weight file %s. (Maybe a missing weight value?)",
-					dname, w.fileName)
+					fields[0], w.fileName)
 			}
+			dname = fields[0]
 
 			// add the root domain if it is missing
 			if dname[len(dname)-1] != '.' {
 				dname += "."
 			}
 			var ok bool
-			curd, ok = w.domains[dname]
+			ws, ok = w.domains[dname]
 			if !ok {
-				curd = &domain{}
-				w.domains[dname] = curd
+				ws = make(weights, 0)
+				w.domains[dname] = ws
 			}
 		case 2:
 			// IP address and weight value
@@ -230,10 +234,11 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 				return fmt.Errorf("Wrong weight value:\"%s\" in weight file %s", fields[1], w.fileName)
 			}
 			witem := &weightItem{address: ip, value: uint8(weight)}
-			if curd == nil {
+			if dname == "" {
 				return fmt.Errorf("Missing domain name in weight file %s", w.fileName)
 			}
-			curd.weights = append(curd.weights, witem)
+			ws = append(ws, witem)
+			w.domains[dname] = ws
 		default:
 			return fmt.Errorf("Could not parse weight line:\"%s\" in weight file %s", nextLine, w.fileName)
 		}
@@ -248,10 +253,9 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 
 func (w *weightedRR) print() {
 	fmt.Printf("weightedRR --- fname:%s reload:%v ", w.fileName, w.reload)
-	for k, d := range w.domains {
-		fmt.Printf("domain:%s wsum:%v ", k, d.wsum)
-		fmt.Printf("weights:[")
-		for _, i := range d.weights {
+	for k, ws := range w.domains {
+		fmt.Printf("dname:%s weights:[", k)
+		for _, i := range ws {
 			fmt.Printf("%+v, ", *i)
 		}
 	}

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -1,0 +1,299 @@
+package loadbalance
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type (
+	// Determinstic weighted-round-robin
+	determininsticWRR struct {
+		index int
+		count uint8
+	}
+	// Randomized weighted-round-robin
+	randomizedWRR struct {
+		wsum uint
+	}
+)
+
+func (d *determininsticWRR) nextTopIP(weights []*weightItem, rn *rand.Rand) net.IP {
+	topIndex := d.index
+
+	// update expected top IP count
+	d.count += 1
+	if d.count == weights[topIndex].value {
+		// Move to the next expected top entry
+		if d.index+1 < len(weights) {
+			d.index += 1
+		} else {
+			// restart the weight list
+			d.index = 0
+		}
+		d.count = 0
+	}
+
+	return weights[topIndex].address
+}
+
+func (r *randomizedWRR) nextTopIP(weights []*weightItem, rn *rand.Rand) net.IP {
+	v := rn.Intn(int(r.wsum))
+
+	psum := 0
+	var w *weightItem
+	for _, w = range weights {
+		psum += int(w.value)
+		if v < psum {
+			break
+		}
+	}
+
+	return w.address
+}
+
+func (w *weightedRR) weightedRoundRobin(qname string, in []dns.RR) []dns.RR {
+	cname := []dns.RR{}
+	address := []dns.RR{}
+	mx := []dns.RR{}
+	rest := []dns.RR{}
+	for _, r := range in {
+		switch r.Header().Rrtype {
+		case dns.TypeCNAME:
+			cname = append(cname, r)
+		case dns.TypeA, dns.TypeAAAA:
+			address = append(address, r)
+		case dns.TypeMX:
+			mx = append(mx, r)
+		default:
+			rest = append(rest, r)
+		}
+	}
+
+	if !w.setTopRecord(qname, address) {
+		// no change
+		return in
+	}
+
+	out := append(cname, rest...)
+	out = append(out, address...)
+	out = append(out, mx...)
+	return out
+}
+
+// Move the next expected address to the first position in the result list
+func (w *weightedRR) setTopRecord(qname string, address []dns.RR) bool {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	curd, ok := w.domains[qname]
+	if len(address) == 0 || !ok || len(curd.weights) == 0 {
+		// empty address or weight list
+		return false
+	}
+
+	expTopIP := curd.nextTopIP(curd.weights, w.rn)
+	itop := -1
+
+L:
+	for i, r := range address {
+		switch r.Header().Rrtype {
+		case dns.TypeA:
+			ar := r.(*dns.A)
+			if ar.A.Equal(expTopIP) {
+				itop = i
+				break L
+			}
+		case dns.TypeAAAA:
+			ar := r.(*dns.AAAA)
+			if ar.AAAA.Equal(expTopIP) {
+				itop = i
+				break L
+			}
+		}
+	}
+
+	if itop == -1 {
+		// Expected top entry is not in the list
+		return false
+	}
+
+	if itop != 0 {
+		// swap expected top entry with the actual one
+		address[0], address[itop] = address[itop], address[0]
+	}
+
+	return true
+}
+
+// Start go routine to update weights from the weight file periodically
+func (w *weightedRR) periodicWeightUpdate(stopReload <-chan bool) {
+
+	if w.reload == 0 {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(w.reload)
+		for {
+			select {
+			case <-stopReload:
+				return
+			case <-ticker.C:
+				err := w.updateWeights()
+				if err != nil {
+					log.Error(err)
+				}
+			}
+		}
+	}()
+}
+
+// Update weights from weight file
+func (w *weightedRR) updateWeights() error {
+	// access to weights must be protected
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	isChanged, err := w.readWeightFile()
+	if err != nil || !isChanged {
+		return err
+	}
+
+	// Sort weight litst. First elements will have max weight.
+	for _, d := range w.domains {
+		sort.Slice(d.weights, func(i, j int) bool {
+			return d.weights[i].value > d.weights[j].value
+		})
+		// Calculate the sum of weights per domain for the ramdomized version
+		if w.isRandom {
+			dd := d.topIP.(*randomizedWRR)
+			for _, w := range d.weights {
+				dd.wsum += uint(w.value)
+			}
+		}
+	}
+	return nil
+}
+
+// Read the weight file
+func (w *weightedRR) readWeightFile() (bool, error) {
+	reader, err := os.Open(filepath.Clean(w.fileName))
+	if err != nil {
+		return false, errOpen
+	}
+	defer reader.Close()
+
+	// check if the contents has changed
+	var buf bytes.Buffer
+	tee := io.TeeReader(reader, &buf)
+	bytes, err := io.ReadAll(tee)
+	if err != nil {
+		return false, err
+	}
+	md5sum := md5.Sum(bytes)
+	if md5sum == w.md5sum {
+		// file contents has not changed
+		return false, nil
+	}
+	w.md5sum = md5sum
+	scanner := bufio.NewScanner(&buf)
+
+	// Parse the weight file contents
+	return true, w.parseWeights(scanner)
+}
+
+// Parse the weight file contents
+func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
+	// Reset domains
+	w.domains = make(map[string]*domain)
+
+	var curd *domain
+	for scanner.Scan() {
+		nextLine := strings.TrimSpace(scanner.Text())
+		if len(nextLine) == 0 || nextLine[0:1] == "#" {
+			// Empty and comment lines are ignored
+			continue
+		}
+		fields := strings.Fields(nextLine)
+		switch len(fields) {
+		case 1:
+			// (domain) name
+			dname := fields[0]
+
+			// sanity check
+			if net.ParseIP(dname) != nil {
+				return fmt.Errorf("Wrong domain name:\"%s\" in weight file %s. (Maybe a missing weight value?)",
+					dname, w.fileName)
+			}
+
+			// add the root domain if it is missing
+			if dname[len(dname)-1] != '.' {
+				dname += "."
+			}
+			var ok bool
+			curd, ok = w.domains[dname]
+			if !ok {
+				curd = &domain{}
+				if w.isRandom {
+					curd.topIP = &randomizedWRR{}
+				} else {
+					curd.topIP = &determininsticWRR{}
+				}
+				w.domains[dname] = curd
+			}
+		case 2:
+			// IP address and weight value
+			ip := net.ParseIP(fields[0])
+			if ip == nil {
+				return fmt.Errorf("Wrong IP address:\"%s\" in weight file %s", fields[0], w.fileName)
+			}
+			weight, err := strconv.ParseUint(fields[1], 10, 8)
+			if err != nil {
+				return fmt.Errorf("Wrong weight value:\"%s\" in weight file %s", fields[1], w.fileName)
+			}
+			witem := &weightItem{address: ip, value: uint8(weight)}
+			if curd == nil {
+				return fmt.Errorf("Missing domain name in weight file %s", w.fileName)
+			}
+			curd.weights = append(curd.weights, witem)
+		default:
+			return fmt.Errorf("Could not parse weight line:\"%s\" in weight file %s", nextLine, w.fileName)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("Weight file %s parsing error:%s", w.fileName, err)
+	}
+
+	return nil
+}
+
+func (w *weightedRR) print() {
+	fmt.Printf("weightedRR --- fname:%s reload:%v isRandom:%v ", w.fileName, w.reload, w.isRandom)
+	for k, d := range w.domains {
+		if !w.isRandom {
+			ti := d.topIP.(*determininsticWRR)
+			fmt.Printf("domain:%s topIndex:%v toCount:%v ", k, ti.index, ti.count)
+		} else {
+			ti := d.topIP.(*randomizedWRR)
+			fmt.Printf("domain:%s wsum:%v ", k, ti.wsum)
+		}
+		fmt.Printf("weights:[")
+		for _, i := range d.weights {
+			fmt.Printf("%+v, ", *i)
+		}
+	}
+	fmt.Printf("]\n")
+}

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -65,7 +65,6 @@ func (w *weightedRR) weightedRoundRobin(in []dns.RR) []dns.RR {
 
 // Move the next expected address to the first position in the result list
 func (w *weightedRR) setTopRecord(address []dns.RR) {
-
 	itop := w.topAddressIndex(address)
 
 	if itop < 0 {
@@ -132,7 +131,6 @@ func (w *weightedRR) topAddressIndex(address []dns.RR) int {
 
 // Start go routine to update weights from the weight file periodically
 func (w *weightedRR) periodicWeightUpdate(stopReload <-chan bool) {
-
 	if w.reload == 0 {
 		return
 	}
@@ -249,15 +247,4 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 	}
 
 	return nil
-}
-
-func (w *weightedRR) print() {
-	fmt.Printf("weightedRR --- fname:%s reload:%v ", w.fileName, w.reload)
-	for k, ws := range w.domains {
-		fmt.Printf("dname:%s weights:[", k)
-		for _, i := range ws {
-			fmt.Printf("%+v, ", *i)
-		}
-	}
-	fmt.Printf("]\n")
 }

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	testutil "github.com/coredns/coredns/plugin/test"
+
 	"github.com/miekg/dns"
 )
 

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -1,0 +1,423 @@
+package loadbalance
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	testutil "github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+)
+
+const oneDomainWRR = `
+w1,example.org
+192.168.1.15 10
+192.168.1.14 20
+`
+
+var testOneDomainWRR = map[string]*domain{
+	"w1,example.org.": &domain{
+		weights: []*weightItem{
+			&weightItem{net.ParseIP("192.168.1.14"), uint8(20)},
+			&weightItem{net.ParseIP("192.168.1.15"), uint8(10)},
+		},
+		topIP: &randomizedWRR{wsum: uint(30)},
+	},
+}
+
+const twoDomainsWRR = `
+# domain 1
+w1.example.org
+192.168.1.15   10
+192.168.1.14   20
+
+ # domain 2
+ w2.example.org
+ 192.168.2.16 11
+ 192.168.2.15 12
+ 192.168.2.14 13
+`
+
+var testTwoDomainsWRR = map[string]*domain{
+	"w1.example.org.": &domain{
+		weights: []*weightItem{
+			&weightItem{net.ParseIP("192.168.1.14"), uint8(20)},
+			&weightItem{net.ParseIP("192.168.1.15"), uint8(10)},
+		},
+		topIP: &randomizedWRR{wsum: uint(30)},
+	},
+	"w2.example.org.": &domain{
+		weights: []*weightItem{
+			&weightItem{net.ParseIP("192.168.2.14"), uint8(13)},
+			&weightItem{net.ParseIP("192.168.2.15"), uint8(12)},
+			&weightItem{net.ParseIP("192.168.2.16"), uint8(11)},
+		},
+		topIP: &randomizedWRR{wsum: uint(36)},
+	},
+}
+
+const missingWeightWRR = `
+w1,example.org
+192.168.1.14
+192.168.1.15 20
+`
+
+const missingDomainWRR = `
+# missing domain
+192.168.1.14 10
+w2,example.org
+192.168.2.14 11
+192.168.2.15 12
+`
+
+const wrongIpWRR = `
+w1,example.org
+192.168.1.300 10
+`
+
+const wrongWeightWRR = `
+w1,example.org
+192.168.1.14 300
+`
+
+func TestWeightFileUpdate(t *testing.T) {
+	tests := []struct {
+		weightFilContent   string
+		shouldErr          bool
+		expectedDomains    map[string]*domain
+		expectedErrContent string // substring from the expected error. Empty for positive cases.
+	}{
+		// positive
+		{"", false, nil, ""},
+		{oneDomainWRR, false, testOneDomainWRR, ""},
+		{twoDomainsWRR, false, testTwoDomainsWRR, ""},
+		// negative
+		{missingWeightWRR, true, nil, "Wrong domain name"},
+		{missingDomainWRR, true, nil, "Missing domain name"},
+		{wrongIpWRR, true, nil, "Wrong IP address"},
+		{wrongWeightWRR, true, nil, "Wrong weight value"},
+	}
+
+	for i, test := range tests {
+		testFile, rm, err := testutil.TempFile(".", test.weightFilContent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rm()
+		weighted := &weightedRR{fileName: testFile, isRandom: true}
+		err = weighted.updateWeights()
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error but found %s", i, err)
+		}
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found error: %v", i, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v",
+					i, test.expectedErrContent, err)
+			}
+		}
+		if test.expectedDomains != nil {
+			if len(test.expectedDomains) != len(weighted.domains) {
+				t.Errorf("Test %d: Expected len(domains): %d but got %d",
+					i, len(test.expectedDomains), len(weighted.domains))
+			} else {
+				_ = checkDomainsWRR(t, i, test.expectedDomains, weighted.domains)
+			}
+		}
+	}
+}
+
+func checkDomainsWRR(t *testing.T, testIndex int, expectedDomains, domains map[string]*domain) error {
+	var ret error
+	retError := errors.New("Check domains failed")
+	for dname, expectedDomain := range expectedDomains {
+		domain, ok := domains[dname]
+		if !ok {
+			t.Errorf("Test %d: Expected domain %s but not found it", testIndex, dname)
+			ret = retError
+		} else {
+			expectedWeights := expectedDomain.weights
+			weights := domain.weights
+			if len(expectedWeights) != len(weights) {
+				t.Errorf("Test %d: Expected len(weights): %d for domain %s but got %d",
+					testIndex, len(expectedWeights), dname, len(weights))
+				ret = retError
+			} else {
+				for i, w := range expectedWeights {
+					if !w.address.Equal(weights[i].address) || w.value != weights[i].value {
+						t.Errorf("Test %d: Weight list differs at index %d for domain %s. "+
+							"Expected: %v got: %v", testIndex, i, dname, expectedWeights[i], weights[i])
+						ret = retError
+					}
+				}
+				expectedTopIP, ok1 := expectedDomain.topIP.(*randomizedWRR)
+				topIP, ok2 := domain.topIP.(*randomizedWRR)
+				if !ok2 {
+					t.Errorf("Test %d: Expected randomized WRR for domain %s", testIndex, dname)
+					ret = retError
+				} else if ok1 && expectedTopIP.wsum != topIP.wsum {
+					t.Errorf("Test %d: Expected weight sum %d but got %d for domain %s", testIndex,
+						expectedTopIP.wsum, topIP.wsum, dname)
+					ret = retError
+				}
+			}
+		}
+	}
+
+	return ret
+}
+
+func TestPeriodicWeightUpdate(t *testing.T) {
+	testFile1, rm, err := testutil.TempFile(".", oneDomainWRR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rm()
+	testFile2, rm, err := testutil.TempFile(".", twoDomainsWRR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rm()
+
+	// configure weightedRR with "oneDomainWRR" weight file content
+	weighted := &weightedRR{fileName: testFile1, isRandom: true}
+	err = weighted.updateWeights()
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		err = checkDomainsWRR(t, 0, testOneDomainWRR, weighted.domains)
+		if err != nil {
+			t.Fatalf("Initial check domains failed")
+		}
+	}
+
+	// change weight file
+	weighted.fileName = testFile2
+	// start periodic update
+	weighted.reload = 10 * time.Millisecond
+	stopChan := make(chan bool)
+	weighted.periodicWeightUpdate(stopChan)
+	time.Sleep(20 * time.Millisecond)
+	// stop periodic update
+	close(stopChan)
+	// check updated config
+	weighted.mutex.Lock()
+	err = checkDomainsWRR(t, 0, testTwoDomainsWRR, weighted.domains)
+	weighted.mutex.Unlock()
+	if err != nil {
+		t.Fatalf("Final check domains failed")
+	}
+}
+
+func TestLoadBalanceWRR(t *testing.T) {
+	weighted := &weightedRR{}
+
+	// We test randomWRR in determinstic mode
+	rm := RoundRobin{Next: handler(), policy: weightedRoundRobinPolicy, weights: weighted}
+
+	type testQuery struct {
+		name          string // domain name to query
+		expectedTopIP string // top (first) address record. Empty if no change is expected in the answer.
+	}
+
+	oneDomain := map[string]*domain{
+		"endpoint.region2.skydns.test": &domain{
+			weights: []*weightItem{
+				&weightItem{net.ParseIP("10.240.0.2"), uint8(2)},
+				&weightItem{net.ParseIP("10.240.0.1"), uint8(1)},
+			},
+			topIP: &determininsticWRR{},
+		},
+	}
+	twoDomains := map[string]*domain{
+		"endpoint.region2.skydns.test": &domain{
+			weights: []*weightItem{
+				&weightItem{net.ParseIP("10.240.0.2"), uint8(2)},
+				&weightItem{net.ParseIP("10.240.0.1"), uint8(1)},
+			},
+			topIP: &determininsticWRR{},
+		},
+		"endpoint.region1.skydns.test": &domain{
+			weights: []*weightItem{
+				&weightItem{net.ParseIP("::2"), uint8(3)},
+				&weightItem{net.ParseIP("::1"), uint8(2)},
+			},
+			topIP: &determininsticWRR{},
+		},
+	}
+
+	// the first X records must be cnames after this test
+	tests := []struct {
+		answer        []dns.RR
+		extra         []dns.RR
+		cnameAnswer   int
+		cnameExtra    int
+		addressAnswer int
+		addressExtra  int
+		mxAnswer      int
+		mxExtra       int
+		domains       map[string]*domain
+		queries       []testQuery
+	}{
+		{
+			answer: []dns.RR{
+				testutil.CNAME("cname1.region2.skydns.test.	300	IN	CNAME		cname2.region2.skydns.test."),
+				testutil.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				testutil.CNAME("cname5.region2.skydns.test.	300	IN	CNAME		cname6.region2.skydns.test."),
+				testutil.CNAME("cname6.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				testutil.A("endpoint.region2.skydns.test.	    300	IN	A			10.240.0.2"),
+				testutil.A("endpoint.region2.skydns.test.	    300	IN	A			10.240.0.3"),
+				testutil.A("endpoint.region1.skydns.test.	    300	IN	A			10.240.1.1"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		2	mx2.region2.skydns.test."),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		3	mx3.region2.skydns.test."),
+			},
+			cnameAnswer:   4,
+			addressAnswer: 4,
+			mxAnswer:      3,
+			domains:       oneDomain,
+			queries: []testQuery{
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // weight 2 - first time
+				{"w1.region1.skydns.test", ""},                 // domain is not in the weight file -> no change
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // weight 2 -  second time
+				{"endpoint.region2.skydns.test", "10.240.0.1"}, // weight 1 - first time
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // weight 2 - first time
+			},
+		},
+		{
+			answer: []dns.RR{
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				testutil.CNAME("cname.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
+			},
+			cnameAnswer:   1,
+			addressAnswer: 1,
+			mxAnswer:      1,
+			domains:       oneDomain,
+			queries: []testQuery{
+				{"endpoint.region2.skydns.test", ""}, // no domains - empty weight file -> no change
+				{"endpoint.region2.skydns.test", ""}, // IP is not in the address list -> no change
+				{"w1.region1.skydns.test", ""},       // domain is not in the weight file -> no change
+			},
+		},
+		{
+			answer: []dns.RR{
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.2"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
+				testutil.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
+				testutil.AAAA("endpoint.region1.skydns.test.	300	IN	AAAA		::1"),
+				testutil.AAAA("endpoint.region1.skydns.test.	300	IN	AAAA		::2"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
+			},
+			extra: []dns.RR{
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				testutil.AAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::1"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				testutil.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
+				testutil.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
+				testutil.AAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::2"),
+				testutil.MX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
+			},
+			cnameAnswer:   1,
+			cnameExtra:    1,
+			addressAnswer: 5,
+			addressExtra:  4,
+			mxAnswer:      3,
+			mxExtra:       3,
+			domains:       twoDomains,
+			queries: []testQuery{
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // domain 1 weight 2 - first time
+				{"w1.region1.skydns.test", ""},                 // domain is not in the weight file -> no change
+				{"endpoint.region1.skydns.test", "::2"},        // domain 2 weight 3 -  first time
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // domain 1 weight 2 -  second time
+				{"endpoint.region1.skydns.test", "::2"},        // domain 2 weight 3 -  second time
+				{"endpoint.region2.skydns.test", "10.240.0.1"}, // domain 1 weight 1 - first time
+				{"endpoint.region1.skydns.test", "::2"},        // domain 2 weight 3 -  third time
+				{"endpoint.region2.skydns.test", "10.240.0.2"}, // weight 2 - first time
+				{"endpoint.region1.skydns.test", "::1"},        // domain 2 weight 2 - first time
+			},
+		},
+	}
+
+	rec := dnstest.NewRecorder(&testutil.ResponseWriter{})
+
+	for i, test := range tests {
+		// set domain map for weighted round robin
+		rm.weights.domains = test.domains
+		for j, query := range test.queries {
+			req := new(dns.Msg)
+			req.SetQuestion(query.name, dns.TypeSRV)
+			req.Answer = test.answer
+			req.Extra = test.extra
+
+			_, err := rm.ServeDNS(context.TODO(), rec, req)
+			if err != nil {
+				t.Errorf("Test %d: Expected no error, but got %s", i, err)
+				continue
+			}
+
+			if query.expectedTopIP != "" {
+				checkTopIP(t, i, j, rec.Msg.Answer, query.expectedTopIP)
+			}
+
+			cname, address, mx, sorted := countRecords(rec.Msg.Answer)
+			if query.expectedTopIP != "" && !sorted {
+				t.Errorf("Test %d query %d: Expected CNAMEs, then AAAAs, then MX in Answer, but got mixed", i, j)
+			}
+			if cname != test.cnameAnswer {
+				t.Errorf("Test %d query %d: Expected %d CNAMEs in Answer, but got %d", i, j, test.cnameAnswer, cname)
+			}
+			if address != test.addressAnswer {
+				t.Errorf("Test %d query %d: Expected %d A/AAAAs in Answer, but got %d", i, j, test.addressAnswer, address)
+			}
+			if mx != test.mxAnswer {
+				t.Errorf("Test %d query %d: Expected %d MXs in Answer, but got %d", i, j, test.mxAnswer, mx)
+			}
+
+			cname, address, mx, sorted = countRecords(rec.Msg.Extra)
+			// WRR never re-arrange extra records -> sorted is ignorred here
+			if cname != test.cnameExtra {
+				t.Errorf("Test %d query %d: Expected %d CNAMEs in Extra, but got %d", i, j, test.cnameAnswer, cname)
+			}
+			if address != test.addressExtra {
+				t.Errorf("Test %d query %d: Expected %d A/AAAAs in Extra, but got %d", i, j, test.addressAnswer, address)
+			}
+			if mx != test.mxExtra {
+				t.Errorf("Test %d query %d: Expected %d MXs in Extra, but got %d", i, j, test.mxAnswer, mx)
+			}
+		}
+	}
+}
+
+func checkTopIP(t *testing.T, i, j int, result []dns.RR, expectedTopIP string) {
+	expected := net.ParseIP(expectedTopIP)
+	for _, r := range result {
+		switch r.Header().Rrtype {
+		case dns.TypeA:
+			ar := r.(*dns.A)
+			if !ar.A.Equal(expected) {
+				t.Errorf("Test %d query %d: expected top IP %s but got %s", i, j, expectedTopIP, ar.A)
+			}
+			return
+		case dns.TypeAAAA:
+			ar := r.(*dns.AAAA)
+			if !ar.AAAA.Equal(expected) {
+				t.Errorf("Test %d query %d: expected top IP %s but got %s", i, j, expectedTopIP, ar.AAAA)
+			}
+			return
+		}
+	}
+	t.Errorf("Test %d query %d: expected top IP %s but got no address records", i, j, expectedTopIP)
+}

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -342,7 +342,7 @@ func TestLoadBalanceWRR(t *testing.T) {
 	shuffle := func(res *dns.Msg) *dns.Msg {
 		return weightedShuffle(res, weighted)
 	}
-	rm := RoundRobin{Next: handler(), shuffle: shuffle}
+	rm := LoadBalance{Next: handler(), shuffle: shuffle}
 
 	rec := dnstest.NewRecorder(&testutil.ResponseWriter{})
 

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -339,13 +339,16 @@ func TestLoadBalanceWRR(t *testing.T) {
 
 	testRand := &fakeRandomGen{t: t}
 	weighted := &weightedRR{randomGen: testRand}
-	rm := RoundRobin{Next: handler(), policy: weightedRoundRobinPolicy, weights: weighted}
+	shuffle := func(res *dns.Msg) *dns.Msg {
+		return weightedShuffle(res, weighted)
+	}
+	rm := RoundRobin{Next: handler(), shuffle: shuffle}
 
 	rec := dnstest.NewRecorder(&testutil.ResponseWriter{})
 
 	for i, test := range tests {
 		// set domain map for weighted round robin
-		rm.weights.domains = test.domains
+		weighted.domains = test.domains
 		testRand.testIndex = i
 		testRand.expectedLimit = test.sumWeights
 


### PR DESCRIPTION
Weighted round robin policy gives more control over the load distribution then random shuffle. Weight values assigned to IPs determine the relative likelihood of an IP being returned as top record in the answer.

Signed-off-by: Gabor Dozsa <gabor.dozsa@ibm.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR extends the **loadbalance** plugin with a new "weighted-round-robin" strategy.  

The loadbalance plugin only provides a random shuffle of records currently. Sometimes more control over the load distribution is required (e.g. hierarchical load balancing among non-uniform resources). Weighted-round-robin is a simple enough strategy where the weight value assigned to an address defines the relative likelihood of an IP being returned as top record in the answer.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/5616

### 3. Which documentation changes (if any) need to be made?

The PR proposes changes to the README of the **loadbalance** plugin.

### 4. Does this introduce a backward incompatible change or deprecation?
No