### PR TITLE
plugin/file: make a qname search more efficient

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -31,7 +31,7 @@ type (
 	}
 )
 
-// Making qname search in map
+// Matches implements qname search in a map.
 func (f File) Matches(qname string) (*Zone, string) {
         var z *Zone
         zone := ""

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -31,36 +31,36 @@ type (
 	}
 )
 
-// Making qname search in map
+// Matches implements qname search in a map.
 func (f File) Matches(qname string) (*Zone, string) {
-        var z *Zone
-        zone := ""
+	var z *Zone
+	zone := ""
 
-        subdomain := qname
-        off := 0
-        end := false
+	subdomain := qname
+	off := 0
+	end := false
 
-        for {
-                if y, ok := f.Zones.Z[subdomain]; ok {
-                        z = y
-                        zone = subdomain
-                        break
-                }
+	for {
+		if y, ok := f.Zones.Z[subdomain]; ok {
+			z = y
+			zone = subdomain
+			break
+		}
 
-                if subdomain == "." {
-                        break
-                }
+		if subdomain == "." {
+			break
+		}
 
-                off, end = dns.NextLabel(qname, off)
-                if end {
-                        // Last dot should also be checked
-                        subdomain = "."
-                        continue
-                }
-                subdomain = qname[off:len(qname)]
-        }
+		off, end = dns.NextLabel(qname, off)
+		if end {
+			// Last dot should also be checked
+			subdomain = "."
+			continue
+		}
+		subdomain = qname[off:len(qname)]
+	}
 
-        return z, zone
+	return z, zone
 }
 
 // ServeDNS implements the plugin.Handle interface.
@@ -69,15 +69,15 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	qname := state.Name()
 
-        z, zone := f.Matches(qname)
+	z, zone := f.Matches(qname)
 
-        if zone == "" {
-                return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
-        }
+	if zone == "" {
+		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+	}
 
-        if z == nil {
-                return dns.RcodeServerFailure, nil
-        }
+	if z == nil {
+		return dns.RcodeServerFailure, nil
+	}
 
 	z, ok := f.Zones.Z[zone]
 	if !ok || z == nil {


### PR DESCRIPTION
Signed-off-by: Oleg Gorokhov <slayer@yandex-team.ru>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When a list of zones in file plugin becomes larger (e.g. two or three hundreds zones) coredns performance is seriously degrading. Benchmarks show that coredns could processed two thousands zones in with file plugin at most 8Krps and all 32 CPU cores are utilized at 100%

### 2. Which issues (if any) are related?
This aims to resolve TODO in plugin file code

### 3. Which documentation changes (if any) need to be made?
No any documentation should be changed, I suppose

### 4. Does this introduce a backward incompatible change or deprecation?
There should be no backwards incompatible change.