### PR TITLE
plugin/cache: cache now uses source query DNSSEC option for upstream

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -10,8 +10,7 @@ With *cache* enabled, all records except zone transfers and metadata records wil
 3600s. Caching is mostly useful in a scenario when fetching data from the backend (upstream,
 database, etc.) is expensive.
 
-*Cache* will change the query to enable DNSSEC (DNSSEC OK; DO) if it passes through the plugin. If
-the client didn't request any DNSSEC (records), these are filtered out when replying.
+*Cache* will pass DNSSEC (DNSSEC OK; DO) options through the plugin for upstream queries.
 
 This plugin can only be used once per Server Block.
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -76,7 +76,7 @@ func New() *Cache {
 // key returns key under which we store the item, -1 will be returned if we don't store the message.
 // Currently we do not cache Truncated, errors zone transfers or dynamic update messages.
 // qname holds the already lowercased qname.
-func key(qname string, m *dns.Msg, t response.Type) (bool, uint64) {
+func key(qname string, m *dns.Msg, t response.Type, do bool) (bool, uint64) {
 	// We don't store truncated responses.
 	if m.Truncated {
 		return false, 0
@@ -86,11 +86,21 @@ func key(qname string, m *dns.Msg, t response.Type) (bool, uint64) {
 		return false, 0
 	}
 
-	return true, hash(qname, m.Question[0].Qtype)
+	return true, hash(qname, m.Question[0].Qtype, do)
 }
 
-func hash(qname string, qtype uint16) uint64 {
+var one = []byte("1")
+var zero = []byte("0")
+
+func hash(qname string, qtype uint16, do bool) uint64 {
 	h := fnv.New64()
+
+	if do {
+		h.Write(one)
+	} else {
+		h.Write(zero)
+	}
+
 	h.Write([]byte{byte(qtype >> 8)})
 	h.Write([]byte{byte(qtype)})
 	h.Write([]byte(qname))
@@ -145,6 +155,7 @@ func newPrefetchResponseWriter(server string, state request.Request, c *Cache) *
 		Cache:          c,
 		state:          state,
 		server:         server,
+		do:             state.Do(),
 		prefetch:       true,
 		remoteAddr:     addr,
 	}
@@ -163,7 +174,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	mt, _ := response.Typify(res, w.now().UTC())
 
 	// key returns empty string for anything we don't want to cache.
-	hasKey, key := key(w.state.Name(), res, mt)
+	hasKey, key := key(w.state.Name(), res, mt, w.do)
 
 	msgTTL := dnsutil.MinimalTTL(res, mt)
 	var duration time.Duration
@@ -191,11 +202,10 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	}
 
 	// Apply capped TTL to this reply to avoid jarring TTL experience 1799 -> 8 (e.g.)
-	// We also may need to filter out DNSSEC records, see toMsg() for similar code.
 	ttl := uint32(duration.Seconds())
-	res.Answer = filterRRSlice(res.Answer, ttl, w.do, false)
-	res.Ns = filterRRSlice(res.Ns, ttl, w.do, false)
-	res.Extra = filterRRSlice(res.Extra, ttl, w.do, false)
+	res.Answer = filterRRSlice(res.Answer, ttl, false)
+	res.Ns = filterRRSlice(res.Ns, ttl, false)
+	res.Extra = filterRRSlice(res.Extra, ttl, false)
 
 	if !w.do && !w.ad {
 		// unset AD bit if requester is not OK with DNSSEC

--- a/plugin/cache/dnssec.go
+++ b/plugin/cache/dnssec.go
@@ -2,35 +2,13 @@ package cache
 
 import "github.com/miekg/dns"
 
-// isDNSSEC returns true if r is a DNSSEC record. NSEC,NSEC3,DS and RRSIG/SIG
-// are DNSSEC records. DNSKEYs is not in this list on the assumption that the
-// client explicitly asked for it.
-func isDNSSEC(r dns.RR) bool {
-	switch r.Header().Rrtype {
-	case dns.TypeNSEC:
-		return true
-	case dns.TypeNSEC3:
-		return true
-	case dns.TypeDS:
-		return true
-	case dns.TypeRRSIG:
-		return true
-	case dns.TypeSIG:
-		return true
-	}
-	return false
-}
-
-// filterRRSlice filters rrs and removes DNSSEC RRs when do is false. In the returned slice
-// the TTLs are set to ttl. If dup is true the RRs in rrs are _copied_ into the slice that is
+// filterRRSlice filters out OPT RRs, and sets all RR TTLs to ttl.
+// If dup is true the RRs in rrs are _copied_ into the slice that is
 // returned.
-func filterRRSlice(rrs []dns.RR, ttl uint32, do, dup bool) []dns.RR {
+func filterRRSlice(rrs []dns.RR, ttl uint32, dup bool) []dns.RR {
 	j := 0
 	rs := make([]dns.RR, len(rrs))
 	for _, r := range rrs {
-		if !do && isDNSSEC(r) {
-			continue
-		}
 		if r.Header().Rrtype == dns.TypeOPT {
 			continue
 		}

--- a/plugin/cache/dnssec_test.go
+++ b/plugin/cache/dnssec_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -67,19 +68,27 @@ func dnssecHandler() plugin.Handler {
 	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)
+		state := request.Request{W: &test.ResponseWriter{}, Req: r}
 
 		m.AuthenticatedData = true
-		m.Answer = make([]dns.RR, 4)
-		m.Answer[0] = test.CNAME("invent.example.org.		1781	IN	CNAME	leptone.example.org.")
-		m.Answer[1] = test.RRSIG("invent.example.org.		1781	IN	RRSIG	CNAME 8 3 1800 20201012085750 20200912082613 57411 example.org. ijSv5FmsNjFviBcOFwQgqjt073lttxTTNqkno6oMa3DD3kC+")
-		m.Answer[2] = test.A("leptone.example.org.	1781	IN	A	195.201.182.103")
-		m.Answer[3] = test.RRSIG("leptone.example.org.	1781	IN	RRSIG	A 8 3 1800 20201012093630 20200912083827 57411 example.org. eLuSOkLAzm/WIOpaZD3/4TfvKP1HAFzjkis9LIJSRVpQt307dm9WY9")
+		// If query has the DO bit, then send DNSSEC responses (RRSIGs)
+		if state.Do() {
+			m.Answer = make([]dns.RR, 4)
+			m.Answer[0] = test.CNAME("invent.example.org.		1781	IN	CNAME	leptone.example.org.")
+			m.Answer[1] = test.RRSIG("invent.example.org.		1781	IN	RRSIG	CNAME 8 3 1800 20201012085750 20200912082613 57411 example.org. ijSv5FmsNjFviBcOFwQgqjt073lttxTTNqkno6oMa3DD3kC+")
+			m.Answer[2] = test.A("leptone.example.org.	1781	IN	A	195.201.182.103")
+			m.Answer[3] = test.RRSIG("leptone.example.org.	1781	IN	RRSIG	A 8 3 1800 20201012093630 20200912083827 57411 example.org. eLuSOkLAzm/WIOpaZD3/4TfvKP1HAFzjkis9LIJSRVpQt307dm9WY9")
+		} else {
+			m.Answer = make([]dns.RR, 2)
+			m.Answer[0] = test.CNAME("invent.example.org.		1781	IN	CNAME	leptone.example.org.")
+			m.Answer[1] = test.A("leptone.example.org.	1781	IN	A	195.201.182.103")
+		}
 		w.WriteMsg(m)
 		return dns.RcodeSuccess, nil
 	})
 }
 
-func TestFliterRRSlice(t *testing.T) {
+func TestFilterRRSlice(t *testing.T) {
 	rrs := []dns.RR{
 		test.CNAME("invent.example.org.		1781	IN	CNAME	leptone.example.org."),
 		test.RRSIG("invent.example.org.		1781	IN	RRSIG	CNAME 8 3 1800 20201012085750 20200912082613 57411 example.org. ijSv5FmsNjFviBcOFwQgqjt073lttxTTNqkno6oMa3DD3kC+"),
@@ -87,7 +96,7 @@ func TestFliterRRSlice(t *testing.T) {
 		test.RRSIG("leptone.example.org.	1781	IN	RRSIG	A 8 3 1800 20201012093630 20200912083827 57411 example.org. eLuSOkLAzm/WIOpaZD3/4TfvKP1HAFzjkis9LIJSRVpQt307dm9WY9"),
 	}
 
-	filter1 := filterRRSlice(rrs, 0, true, false)
+	filter1 := filterRRSlice(rrs, 0, false)
 	if len(filter1) != 4 {
 		t.Errorf("Expected 4 RRs after filtering, got %d", len(filter1))
 	}
@@ -101,9 +110,9 @@ func TestFliterRRSlice(t *testing.T) {
 		t.Errorf("Expected 2 RRSIGs after filtering, got %d", rrsig)
 	}
 
-	filter2 := filterRRSlice(rrs, 0, false, false)
-	if len(filter2) != 2 {
-		t.Errorf("Expected 2 RRs after filtering, got %d", len(filter2))
+	filter2 := filterRRSlice(rrs, 0, false)
+	if len(filter2) != 4 {
+		t.Errorf("Expected 4 RRs after filtering, got %d", len(filter2))
 	}
 	rrsig = 0
 	for _, f := range filter2 {
@@ -111,7 +120,7 @@ func TestFliterRRSlice(t *testing.T) {
 			rrsig++
 		}
 	}
-	if rrsig != 0 {
-		t.Errorf("Expected 0 RRSIGs after filtering, got %d", rrsig)
+	if rrsig != 2 {
+		t.Errorf("Expected 2 RRSIGs after filtering, got %d", rrsig)
 	}
 }

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -28,12 +28,10 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	now := c.now().UTC()
 	server := metrics.WithServer(ctx)
 
-	// On cache miss, if the request has the OPT record and the DO bit set we leave the message as-is. If there isn't a DO bit
-	// set we will modify the request to _add_ one. This means we will always do DNSSEC lookups on cache misses.
-	// When writing to cache, any DNSSEC RRs in the response are written to cache with the response.
-	// When sending a response to a non-DNSSEC client, we remove DNSSEC RRs from the response. We use a 2048 buffer size, which is
-	// less than 4096 (and older default) and more than 1024 which may be too small. We might need to tweaks this
-	// value to be smaller still to prevent UDP fragmentation?
+	// On cache refresh, we will just use the DO bit from the incoming query for the refresh since we key our cache
+	// with the query DO bit. That means two separate cache items for the query DO bit true or false. In the situation
+	// in which upstream doesn't support DNSSEC, the two cache items will effectively be the same. Regardless, any
+	// DNSSEC RRs in the response are written to cache with the response.
 
 	ttl := 0
 	i := c.getIgnoreTTL(now, state, server)
@@ -101,9 +99,6 @@ func (c *Cache) doPrefetch(ctx context.Context, state request.Request, cw *Respo
 }
 
 func (c *Cache) doRefresh(ctx context.Context, state request.Request, cw dns.ResponseWriter) (int, error) {
-	if !state.Do() {
-		setDo(state.Req)
-	}
 	return plugin.NextOrFailure(c.Name(), c.Next, ctx, cw, state.Req)
 }
 
@@ -121,7 +116,7 @@ func (c *Cache) Name() string { return "cache" }
 
 // getIgnoreTTL unconditionally returns an item if it exists in the cache.
 func (c *Cache) getIgnoreTTL(now time.Time, state request.Request, server string) *item {
-	k := hash(state.Name(), state.QType())
+	k := hash(state.Name(), state.QType(), state.Do())
 	cacheRequests.WithLabelValues(server, c.zonesMetricLabel, c.viewMetricLabel).Inc()
 
 	if i, ok := c.ncache.Get(k); ok {
@@ -145,7 +140,7 @@ func (c *Cache) getIgnoreTTL(now time.Time, state request.Request, server string
 }
 
 func (c *Cache) exists(state request.Request) *item {
-	k := hash(state.Name(), state.QType())
+	k := hash(state.Name(), state.QType(), state.Do())
 	if i, ok := c.ncache.Get(k); ok {
 		return i.(*item)
 	}
@@ -154,22 +149,3 @@ func (c *Cache) exists(state request.Request) *item {
 	}
 	return nil
 }
-
-// setDo sets the DO bit and UDP buffer size in the message m.
-func setDo(m *dns.Msg) {
-	o := m.IsEdns0()
-	if o != nil {
-		o.SetDo()
-		o.SetUDPSize(defaultUDPBufSize)
-		return
-	}
-
-	o = &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
-	o.SetDo()
-	o.SetUDPSize(defaultUDPBufSize)
-	m.Extra = append(m.Extra, o)
-}
-
-// defaultUDPBufsize is the bufsize the cache plugin uses on outgoing requests that don't
-// have an OPT RR.
-const defaultUDPBufSize = 2048

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -87,9 +87,9 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool) *dns.Msg {
 	m1.Extra = make([]dns.RR, len(i.Extra))
 
 	ttl := uint32(i.ttl(now))
-	m1.Answer = filterRRSlice(i.Answer, ttl, do, true)
-	m1.Ns = filterRRSlice(i.Ns, ttl, do, true)
-	m1.Extra = filterRRSlice(i.Extra, ttl, do, true)
+	m1.Answer = filterRRSlice(i.Answer, ttl, true)
+	m1.Ns = filterRRSlice(i.Ns, ttl, true)
+	m1.Extra = filterRRSlice(i.Extra, ttl, true)
 
 	return m1
 }


### PR DESCRIPTION

Signed-off-by: Grant Spence <gspence@redhat.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The DNSSEC cache solution introduced in https://github.com/coredns/coredns/commit/acf9a0fa19928e605ac8ac3314890c9fef73e16b changed the logic to always tag upstream cache refreshes with DNSSEC requests. Though a clever low-code approach, it has introduced a couple of problems:
1. Counter intuitive behavior to an observer: The fact that all upstream queries get tagged as requesting DNSSEC can be confusing to an observer when clients are not requesting DNSSEC.
2. All upstream DNS requests get hardcoded to bufsize of 2048
3. It has been raised as a concern by users who are acutely bandwidth conscious, as it will cause unnecessary overhead if an upstream server serves DNSSEC, but clients never actually request it. 

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/5640

### 3. Which documentation changes (if any) need to be made?
plugin/cache/README.md

### 4. Does this introduce a backward incompatible change or deprecation?
No
