### PR TITLE
plugin/reload : stop scheduler on shutdown

### DIFF
--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -83,6 +83,7 @@ func hook(event caddy.EventName, info interface{}) error {
 
 	go func() {
 		tick := time.NewTicker(r.interval())
+		defer tick.Stop()
 
 		for {
 			select {


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
from the functional point of view, there is no change, but from the correctness, it seems reasonable to close the scheduler when we are done with it

### 2. Which issues (if any) are related?
#5680

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
