### PR TITLE
plugin/auto: fix ticker leak in golang

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -50,6 +50,7 @@ func setup(c *caddy.Controller) error {
 		}
 		go func() {
 			ticker := time.NewTicker(a.loader.ReloadInterval)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-walkChan:


### PR DESCRIPTION
This PR fixes a ticker leak in golang within plugin/auto.

This PR fixes #5683.

/cc @odeke-em

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>