### PR TITLE
plugin/forward: fix ticker leak in golang

### DIFF
--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -45,6 +45,7 @@ func newTransport(addr string) *Transport {
 // connManagers manages the persistent connection cache for UDP and TCP.
 func (t *Transport) connManager() {
 	ticker := time.NewTicker(defaultExpire)
+	defer ticker.Stop()
 Wait:
 	for {
 		select {


### PR DESCRIPTION
This PR fixes a ticker leak in golang within plugin/forward

This PR fixes #5682.

/cc @odeke-em

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
