### PR TITLE
plugin/hosts: fix ticker leak in golang

### DIFF
--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -26,6 +26,7 @@ func periodicHostsUpdate(h *Hosts) chan bool {
 
 	go func() {
 		ticker := time.NewTicker(h.options.reload)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-parseChan:


### PR DESCRIPTION
This PR fixes a ticker leak in golang within plugin/hosts

This PR fixes #5681.

/cc @odeke-em

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
