### PR TITLE
Workaround for incorrect architecture on Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ buildCoreDNSImage: &buildCoreDNSImage
       command: |
         cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
         make coredns SYSTEM="GOOS=linux" && \
-        docker build -t coredns . && \
+        DOCKER_BUILDKIT=1 docker build -t coredns . && \
         kind load docker-image coredns
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM --platform=$BUILDPLATFORM debian:stable-slim
 SHELL [ "/bin/sh", "-ec" ]
 
 RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -10,7 +10,7 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
     apt-get -yyqq install ca-certificates ; \
     apt-get clean
 
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD coredns /coredns

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -83,7 +83,7 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    docker build -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
+	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
 	done
 endif
 
@@ -102,10 +102,6 @@ else
 	done
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_VERSIONED)
-	for arch in $(LINUX_ARCH); do \
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
-		docker manifest annotate --arch $${arch} $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
-	done
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
 	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"$(DOCKER_LOGIN)\",\"password\":\"$(DOCKER_PASSWORD)\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

`Makefile.docker` generates correct manifest file, however, when underlying images have incorrect architecture tag, docker would still complain about it.

There's nothing wrong with `coredns/coredns:1.10.0` Docker manifest:

```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:12fa9b2b130df04d58cc01e117b4ac91d6657e0ca0a6c71bd7da8f4f475b925a",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:8bde154851ede54e4415ce5f7648c12657d1e7191d40945683e4d74281137d27",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:7c08553af640aba900c5898abe72819412074299cff70567204f2b62e95861e8",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:2720fd1828a477889a1ec9d7315c13e75fcc2ad40d99eed089440ecc565b34c4",
         "platform": {
            "architecture": "mips64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:d722c98f2168f112a73d9afbd75fafe4c1fabbcb55a3cb44e414c738dcd9336b",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:bd46ba8d550f7cd5b7f365e127aa9acffff0c4c1896474eb67d0dd265a452a67",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```

I got an ARM64 SBC, pulled the image and run it:

```shell
$ docker run coredns/coredns:1.10.0
Unable to find image 'coredns/coredns:1.10.0' locally
1.10.0: Pulling from coredns/coredns
9731739b2823: Pull complete
4dfb45b72a09: Pull complete
Digest: sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955
Status: Downloaded newer image for coredns/coredns:1.10.0
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
.:53
CoreDNS-1.10.0
linux/arm64, go1.19.1, 596a9f9
```

It works, so docker indeed pulled the image with correct platform. However, it still complains it is a `linux/amd64` image. Run `docker image inspect coredns/coredns:1.10.0` to see the detail of the image, and the architecture is still `amd64`.

```json
[
    {
        "Id": "sha256:2153c5811fa0a70aeae253bab9c2265fc6162c5b64d9f456a6c16f2f77b0e509",
        "RepoTags": [
            "coredns/coredns:1.10.0"
        ],
        "RepoDigests": [
            "coredns/coredns@sha256:017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2022-09-19T12:49:54.105196729Z",
        "Container": "0c2c87afe48cdd64bc921dcdb8cc016761f7fdc1ff196624a266ff7ad5a44d25",
        "ContainerConfig": {
            "Hostname": "0c2c87afe48c",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "53/tcp": {},
                "53/udp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "/bin/sh",
                "-c",
                "#(nop) ",
                "ENTRYPOINT [\"/coredns\"]"
            ],
            "Image": "sha256:1c961f3beb976f1b3ec5833aa49ef7ffedf106d4eaa1f6d54c5d2e3a7b893152",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": [
                "/coredns"
            ],
            "OnBuild": null,
            "Labels": {}
        },
        "DockerVersion": "20.10.17+azure-3",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "53/tcp": {},
                "53/udp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": null,
            "Image": "sha256:1c961f3beb976f1b3ec5833aa49ef7ffedf106d4eaa1f6d54c5d2e3a7b893152",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": [
                "/coredns"
            ],
            "OnBuild": null,
            "Labels": null
        },
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 48762489,
        "VirtualSize": 48762489,
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/07380564f5fdf080532ad08a348e49cba9db04fe9a462bc145407be4ae9af7d6/diff",
                "MergedDir": "/var/lib/docker/overlay2/74504e68029deb072359a92e99dc6e3dc0dab9001ca7bf6e90503e85714604c3/merged",
                "UpperDir": "/var/lib/docker/overlay2/74504e68029deb072359a92e99dc6e3dc0dab9001ca7bf6e90503e85714604c3/diff",
                "WorkDir": "/var/lib/docker/overlay2/74504e68029deb072359a92e99dc6e3dc0dab9001ca7bf6e90503e85714604c3/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:d36071bbf41810d9b17dd8a0d0bab69945e0f8f1907aa1b87f11c0a27728b9ca",
                "sha256:330cd0dc955551f82764d5011e7f21a398da33926ce839b8e25faa6a4415de68"
            ]
        },
        "Metadata": {
            "LastTagTime": "0001-01-01T00:00:00Z"
        }
    }
]
```

It seems that specifying architecture when creating manifest would not override underlying images' architecture. The only thing it does is informing docker which image to pull. Then we probably have no option but fixing the underlying images' architecture.

I've also tested some other combinations, and the result is briefly described below:

1. Do not use BuildKit, specify specific architecture (for example, `linux/amd64` for certs and `linux/arm64` for scratch) in `Dockerfile` only. The resulting images are all `linux/amd64`, which is my host platform.

2. Do not use BuildKit, specify target platform (for example, `--platform linux/arm64`) when invoking `docker build` command (That's exactly what #4897 do). Docker complained about platform mismatch and would not generate a complete image.

3. Do not use BuildKit, specify specific architecture (for example, `linux/amd64` for certs and `linux/arm64` for scratch) in `Dockerfile`, and also specify target platform (for example, `--platform linux/arm64`) when invoking `docker build` command. Docker complained about platform mismatch and would not generate a complete image.

4.  Use BuildKit, specify target platform (for example, `--platform linux/arm64`) when invoking `docker build` command. Also make sure emulators are installed. Images are now built with correct architecture. However, it is slow and inefficient since `ca-certificates` are platform-independent and there is no need to emulate every architecture and copy the file out.

For the multi-arch tag, pushing exactly the same manifest to GitHub Container Registry would show correct OS/Arch, but that's probably because it reads the manifest only and would not take underlying images into consideration.

### 2. Which issues (if any) are related?

#4897
#5363
#5413 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Modified Dockerfile requires [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).