### PR TITLE
plugin/acl: adding ability to drop queries

### DIFF
--- a/plugin/acl/README.md
+++ b/plugin/acl/README.md
@@ -25,7 +25,7 @@ acl [ZONES...] {
 ```
 
 - **ZONES** zones it should be authoritative for. If empty, the zones from the configuration block are used.
-- **ACTION** (*allow*, *block*, or *filter*) defines the way to deal with DNS queries matched by this rule. The default action is *allow*, which means a DNS query not matched by any rules will be allowed to recurse. The difference between *block* and *filter* is that block returns status code of *REFUSED* while filter returns an empty set *NOERROR*
+- **ACTION** (*allow*, *block*, *filter*, or *drop*) defines the way to deal with DNS queries matched by this rule. The default action is *allow*, which means a DNS query not matched by any rules will be allowed to recurse. The difference between *block* and *filter* is that block returns status code of *REFUSED* while filter returns an empty set *NOERROR*. *drop* however returns no response to the client.
 - **QTYPE** is the query type to match for the requests to be allowed or blocked. Common resource record types are supported. `*` stands for all record types. The default behavior for an omitted `type QTYPE...` is to match all kinds of DNS queries (same as `type *`).
 - **SOURCE** is the source IP address to match for the requests to be allowed or blocked. Typical CIDR notation and single IP address are supported. `*` stands for all possible source IP addresses.
 
@@ -85,6 +85,16 @@ example.org {
 }
 ~~~
 
+Drop all DNS queries from 192.0.2.0/24:
+
+~~~ corefile
+. {
+    acl {
+        drop net 192.0.2.0/24
+    }
+}
+~~~
+
 ## Metrics
 
 If monitoring is enabled (via the _prometheus_ plugin) then the following metrics are exported:
@@ -94,5 +104,7 @@ If monitoring is enabled (via the _prometheus_ plugin) then the following metric
 - `coredns_acl_filtered_requests_total{server, zone, view}` - counter of DNS requests being filtered.
 
 - `coredns_acl_allowed_requests_total{server, view}` - counter of DNS requests being allowed.
+
+- `coredns_acl_dropped_requests_total{server, zone, view}` - counter of DNS requests being dropped.
 
 The `server` and `zone` labels are explained in the _metrics_ plugin documentation.

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -49,6 +49,8 @@ const (
 	actionBlock
 	// actionFilter returns empty sets for queries towards protected DNS zones.
 	actionFilter
+	// actionDrop does not respond for queries towards the protected DNS zones.
+	actionDrop
 )
 
 var log = clog.NewWithPlugin("acl")
@@ -67,6 +69,11 @@ RulesCheckLoop:
 
 		action := matchWithPolicies(rule.policies, w, r)
 		switch action {
+		case actionDrop:
+			{
+				RequestDropCount.WithLabelValues(metrics.WithServer(ctx), zone, metrics.WithView(ctx)).Inc()
+				return dns.RcodeSuccess, nil
+			}
 		case actionBlock:
 			{
 				m := new(dns.Msg).

--- a/plugin/acl/metrics.go
+++ b/plugin/acl/metrics.go
@@ -29,4 +29,11 @@ var (
 		Name:      "allowed_requests_total",
 		Help:      "Counter of DNS requests being allowed.",
 	}, []string{"server", "view"})
+	// RequestDropCount is the number of DNS requests being dropped.
+	RequestDropCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "dropped_requests_total",
+		Help:      "Counter of DNS requests being dropped.",
+	}, []string{"server", "zone", "view"})
 )

--- a/plugin/acl/setup.go
+++ b/plugin/acl/setup.go
@@ -56,8 +56,10 @@ func parse(c *caddy.Controller) (ACL, error) {
 				p.action = actionBlock
 			} else if action == "filter" {
 				p.action = actionFilter
+			} else if action == "drop" {
+				p.action = actionDrop
 			} else {
-				return a, c.Errf("unexpected token %q; expect 'allow', 'block', or 'filter'", c.Val())
+				return a, c.Errf("unexpected token %q; expect 'allow', 'block', 'filter' or 'drop'", c.Val())
 			}
 
 			p.qtypes = make(map[uint16]struct{})

--- a/plugin/acl/setup_test.go
+++ b/plugin/acl/setup_test.go
@@ -58,6 +58,13 @@ func TestSetup(t *testing.T) {
 			false,
 		},
 		{
+			"Drop 1",
+			`acl {
+				drop type * net 192.168.0.0/16
+			}`,
+			false,
+		},
+		{
 			"fine-grained 1",
 			`acl a.example.org {
 				block type * net 192.168.1.0/24
@@ -172,6 +179,13 @@ func TestSetup(t *testing.T) {
 			`acl {
 				allow net 2001:db8:abcd:0012::0/64
 				block
+			}`,
+			false,
+		},
+		{
+			"Drop 1 IPv6",
+			`acl {
+				drop net 2001:db8:abcd:0012::0/64
 			}`,
 			false,
 		},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Both block and filter actions write responses to the client based upon the source IP address of the UDP packet containing the query.  An attacker spoofing the source IP address to that of their target, can elicit a response to be sent to the victim host, known as DNS Reflection.  If an attacker is able to elicit a large response from a relatively small query, with a spoofed source IP address, they are able to increase the amount of data sent to the victim, known as DNS Amplification.  Scaling this from one to many queries allows an attacker to perform an effective Denial of Service (DoS) attack against their target.

Adding the drop action enables CoreDNS to ignore queries of a given type or network range from being processed and a response written, where an operator knows ahead of time, should not originate or be destined to.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Updated acl plugin documentation to describe the `drop` action and the difference from `block` and `filter` along with example configuration.  A new metric is also listed for the total number of dropped requests, an indicator when significant number of queries are ignored.

### 4. Does this introduce a backward incompatible change or deprecation?

No