### PR TITLE
patch architecture instead of using the multi-arch build of buildkit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ buildCoreDNSImage: &buildCoreDNSImage
       command: |
         cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
         make coredns SYSTEM="GOOS=linux" && \
-        DOCKER_BUILDKIT=1 docker build -t coredns . && \
+        docker build -t coredns . && \
         kind load docker-image coredns
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:stable-slim
+FROM debian:stable-slim
 SHELL [ "/bin/sh", "-ec" ]
 
 RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -10,7 +10,7 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
     apt-get -yyqq install ca-certificates ; \
     apt-get clean
 
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD coredns /coredns

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -83,7 +83,8 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
-	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
+	    docker build -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
+	    docker image save $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) | ./patch-arch.sh $${arch} | docker image load; \
 	done
 endif
 

--- a/patch-arch.sh
+++ b/patch-arch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+
+jq_overwrite() {
+	FILE=$1
+	shift
+	jq -c "$@" $FILE > $FILE.temp
+	mv $FILE.temp $FILE
+}
+
+change_arch() {
+	FILE=$1
+	ARCH=$2
+	jq_overwrite $FILE '.architecture = $arch' --arg arch $ARCH
+}
+
+ARCH=$1
+
+tempdir=$(mktemp -d)
+pushd $tempdir > /dev/null
+trap "popd > /dev/null; rm -rf $tempdir" EXIT
+
+# extract archive from stdin
+tar x
+
+# change architecture of *.json
+CONFIG=$(jq -r '.[0].Config' manifest.json)
+change_arch $CONFIG $ARCH
+
+# rename *.json
+set -- $(sha256sum $CONFIG)
+NEWCONFIG=$1.json
+mv $CONFIG $NEWCONFIG
+
+# apply new filename to manifest.json
+jq_overwrite manifest.json '.[0].Config = $config' --arg config $NEWCONFIG
+
+# change architecture of */json
+for json in */json; do
+	change_arch $json $ARCH
+done
+
+# write archive to stdout
+tar c *


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

#5691 uses buildkit's multi-arch build to correctly generate multi-arch images, but multi-arch build now takes extra time to build due to emulation of each architecture.
Even before the fix, the generated image were generated correctly except for the manifest, so simply patching the manifest will fix the problem.
This pull request will patch the manifest so that it generates the correct multi-arch images without using multi-arch build.

### 2. Which issues (if any) are related?

#5691

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Dockerfile no longer requires buildkit.