### PR TITLE
plugin/kubernetes: error NXDOMAIN for TXT lookups

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -249,7 +249,7 @@ var dnsTestCases = []kubeTestCase{
 	}},
 	// A TXT record does not exist but another record for the same FQDN does
 	{Case: test.Case{
-		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeTXT,
+		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{},
 	}},

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -251,9 +251,7 @@ var dnsTestCases = []kubeTestCase{
 	{Case: test.Case{
 		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode:  dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
-        },
+		Answer: []dns.RR{},
 	}},
 	// A TXT record does not exist and neither does another record for the same FQDN
 	{Case: test.Case{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -250,7 +250,7 @@ var dnsTestCases = []kubeTestCase{
 	// A TXT record does not exist but another record for the same FQDN does
 	{Case: test.Case{
 		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeTXT,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{},
 	}},
 	// A TXT record does not exist and neither does another record for the same FQDN

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -250,7 +250,7 @@ var dnsTestCases = []kubeTestCase{
 	// A TXT record does not exist but another record for the same FQDN does
 	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeTXT,
-		Rcode:  dns.RcodeSuccess,
+		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -247,6 +247,20 @@ var dnsTestCases = []kubeTestCase{
 			test.TXT("dns-version.cluster.local 28800 IN TXT 1.1.0"),
 		},
 	}},
+	// A TXT record does not exist but another record for the same FQDN does
+	{Case: test.Case{
+		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{},
+	}},
+	// A TXT record does not exist and neither does another record for the same FQDN
+	{Case: test.Case{
+		Qname: "svc0.svc-nons.svc.cluster.local.", Qtype: dns.TypeTXT,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	}},
 	// A Service (Headless) does not exist
 	{Case: test.Case{
 		Qname: "bogusendpoint.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -251,7 +251,9 @@ var dnsTestCases = []kubeTestCase{
 	{Case: test.Case{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode:  dns.RcodeSuccess,
-		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
 	}},
 	// A TXT record does not exist and neither does another record for the same FQDN
 	{Case: test.Case{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -251,7 +251,9 @@ var dnsTestCases = []kubeTestCase{
 	{Case: test.Case{
 		Qname: "kubernetes.default.svc.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode:  dns.RcodeSuccess,
-		Answer: []dns.RR{},
+		Answer: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+        },
 	}},
 	// A TXT record does not exist and neither does another record for the same FQDN
 	{Case: test.Case{

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -100,19 +100,19 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 		// 1 label + zone, label must be "dns-version".
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 
+		// Hard code the only valid TXT - "dns-version.<zone>"
+		segs := dns.SplitDomainName(t)
+		if len(segs) == 1 && segs[0] == "dns-version" {
+				svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+				return []msg.Service{svc}, nil
+		}
+
 		// Check if we have an existing record for this query of another type
 		services, _ := k.Records(ctx, state, false)
 
 		if len(services) > 0 {
-		    // If so we return an empty NOERROR
-		    return nil, nil
-		}
-
-		// Hard code the only valid TXT - "dns-version.<zone>"
-		segs := dns.SplitDomainName(t)
-		if len(segs) == 1 && segs[0] == "dns-version" {
-		    svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
-		    return []msg.Service{svc}, nil
+				// If so we return an empty NOERROR
+				return nil, nil
 		}
 
 		// Return NXDOMAIN for no match

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -101,8 +101,7 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 
         // Check if we have an existing record for this query of another type
-        services, err := k.Records(ctx, state, false)
-		if err != nil { return nil, err }
+        services, _ := k.Records(ctx, state, false)
 
         if len(services) > 0 {
             // If so we return an empty NOERROR

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -110,7 +110,7 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 
 		// Hard code the only valid TXT - "dns-version.<zone>"
 		segs := dns.SplitDomainName(t)
-		if segs[0] == "dns-version" {
+		if len(segs) == 1 && segs[0] == "dns-version" {
 		    svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
 		    return []msg.Service{svc}, nil
 		}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -102,10 +102,10 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 
 		segs := dns.SplitDomainName(t)
 		if len(segs) != 1 {
-			return nil, nil
+			return nil, errInvalidRequest
 		}
 		if segs[0] != "dns-version" {
-			return nil, nil
+			return nil, errNoItems
 		}
 		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
 		return []msg.Service{svc}, nil

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -100,23 +100,23 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 		// 1 label + zone, label must be "dns-version".
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 
-        // Check if we have an existing record for this query of another type
-        services, _ := k.Records(ctx, state, false)
+		// Check if we have an existing record for this query of another type
+		services, _ := k.Records(ctx, state, false)
 
-        if len(services) > 0 {
-            // If so we return an empty NOERROR
-            return nil, nil
-        }
-
-        // Hard code the only valid TXT - "dns-version.<zone>"
-		segs := dns.SplitDomainName(t)
-		if segs[0] == "dns-version" {
-            svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
-            return []msg.Service{svc}, nil
+		if len(services) > 0 {
+		    // If so we return an empty NOERROR
+		    return nil, nil
 		}
 
-        // Return NXDOMAIN for no match
-        return nil, errNoItems
+		// Hard code the only valid TXT - "dns-version.<zone>"
+		segs := dns.SplitDomainName(t)
+		if segs[0] == "dns-version" {
+		    svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+		    return []msg.Service{svc}, nil
+		}
+
+		// Return NXDOMAIN for no match
+		return nil, errNoItems
 
 	case dns.TypeNS:
 		// We can only get here if the qname equals the zone, see ServeDNS in handler.go.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -100,15 +100,24 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 		// 1 label + zone, label must be "dns-version".
 		t, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 
+        // Check if we have an existing record for this query of another type
+        services, err := k.Records(ctx, state, false)
+		if err != nil { return nil, err }
+
+        if len(services) > 0 {
+            // If so we return an empty NOERROR
+            return nil, nil
+        }
+
+        // Hard code the only valid TXT - "dns-version.<zone>"
 		segs := dns.SplitDomainName(t)
-		if len(segs) != 1 {
-			return nil, errInvalidRequest
+		if segs[0] == "dns-version" {
+            svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+            return []msg.Service{svc}, nil
 		}
-		if segs[0] != "dns-version" {
-			return nil, errNoItems
-		}
-		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
-		return []msg.Service{svc}, nil
+
+        // Return NXDOMAIN for no match
+        return nil, errNoItems
 
 	case dns.TypeNS:
 		// We can only get here if the qname equals the zone, see ServeDNS in handler.go.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -103,16 +103,16 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 		// Hard code the only valid TXT - "dns-version.<zone>"
 		segs := dns.SplitDomainName(t)
 		if len(segs) == 1 && segs[0] == "dns-version" {
-				svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
-				return []msg.Service{svc}, nil
+			svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
+			return []msg.Service{svc}, nil
 		}
 
 		// Check if we have an existing record for this query of another type
 		services, _ := k.Records(ctx, state, false)
 
 		if len(services) > 0 {
-				// If so we return an empty NOERROR
-				return nil, nil
+			// If so we return an empty NOERROR
+			return nil, nil
 		}
 
 		// Return NXDOMAIN for no match


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
All non "dns-version" TXT queries should return a NXDOMAIN rather than NOERROR

### 2. Which issues (if any) are related?
#5736

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?