### PR TITLE
fix readme after removing gofmt and gotidy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/coredns/coredns)
 ![CodeQL](https://github.com/coredns/coredns/actions/workflows/codeql-analysis.yml/badge.svg)
-![Go Fmt](https://github.com/coredns/coredns/actions/workflows/go.fmt.yml/badge.svg)
 ![Go Tests](https://github.com/coredns/coredns/actions/workflows/go.test.yml/badge.svg)
-![Go Tidy](https://github.com/coredns/coredns/actions/workflows/go.tidy.yml/badge.svg)
 [![CircleCI](https://circleci.com/gh/coredns/coredns.svg?style=shield)](https://circleci.com/gh/coredns/coredns)
 [![Code Coverage](https://img.shields.io/codecov/c/github/coredns/coredns/master.svg)](https://codecov.io/github/coredns/coredns?branch=master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/coredns/coredns.svg)](https://hub.docker.com/r/coredns/coredns)


### PR DESCRIPTION
Signed-off-by: Ondřej Benkovský <ondrej.benkovsky@jamf.com>

### 1. Why is this pull request needed and what does it do?
after removing go fmt and go tidy actions the README points to a nonexistent actions, this PR removes related badges 

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/pull/5747

### 3. Which documentation changes (if any) need to be made?
no

### 4. Does this introduce a backward incompatible change or deprecation?
no
