### PR TITLE
plugin/etcd: fix NS records when PathPrefix contains multiple path components

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -243,7 +243,7 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 
 		case dns.TypeA, dns.TypeAAAA:
 			addr := serv.Host
-			serv.Host = msg.Domain(serv.Key)
+			serv.Host = serv.Domain()
 			srv := serv.NewSRV(state.QName(), weight)
 
 			if ok := isDuplicate(dup, srv.Target, "", srv.Port); !ok {
@@ -309,7 +309,7 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 
 		case dns.TypeA, dns.TypeAAAA:
 			addr := serv.Host
-			serv.Host = msg.Domain(serv.Key)
+			serv.Host = serv.Domain()
 			mx := serv.NewMX(state.QName())
 
 			if ok := isDuplicate(dup, mx.Mx, "", mx.Preference); !ok {
@@ -451,7 +451,7 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 			return nil, nil, fmt.Errorf("NS record must be an IP address: %s", serv.Host)
 
 		case dns.TypeA, dns.TypeAAAA:
-			serv.Host = msg.Domain(serv.Key)
+			serv.Host = serv.Domain()
 			ns := serv.NewNS(state.QName())
 			extra = append(extra, newAddress(serv, ns.Ns, ip, what))
 			if _, ok := seen[ns.Ns]; ok {

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -139,6 +139,7 @@ Nodes:
 			return nil, fmt.Errorf("%s: %s", n.Key, err.Error())
 		}
 		serv.Key = string(n.Key)
+		serv.RName = msg.DomainWithPrefix(serv.Key, e.PathPrefix)
 		if _, ok := bx[*serv]; ok {
 			continue
 		}

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -312,7 +312,7 @@ func newEtcdPlugin() *Etcd {
 
 	return &Etcd{
 		Upstream:   upstream.New(),
-		PathPrefix: "skydns",
+		PathPrefix: "skydns/zone1",
 		Zones:      []string{"skydns.test.", "skydns_extra.test.", "skydns_zonea.test.", "skydns_zoneb.test.", "skydns_zonec.test.", "skydns_zoned.test.", "in-addr.arpa."},
 		Client:     client,
 	}

--- a/plugin/etcd/msg/path.go
+++ b/plugin/etcd/msg/path.go
@@ -32,6 +32,21 @@ func Domain(s string) string {
 	return dnsutil.Join(l[1 : len(l)-1]...)
 }
 
+// DomainWithPrefix behaves like Domain, but handles prefixes with multiple path components.
+func DomainWithPrefix(s, prefix string) string {
+	if strings.HasSuffix(prefix, "/") {
+		prefix = prefix[0 : len(prefix)-1]
+	}
+	l := strings.Split(s[len(prefix):], "/")
+	if l[len(l)-1] == "" {
+		l = l[:len(l)-1]
+	}
+	for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
+		l[i], l[j] = l[j], l[i]
+	}
+	return dnsutil.Join(l[0 : len(l)-1]...)
+}
+
 // PathWithWildcard acts as Path, but if a name contains wildcards (* or any), the name will be
 // chopped of before the (first) wildcard, and we do a higher level search and
 // later find the matching names.  So service.*.skydns.local, will look for all

--- a/plugin/etcd/msg/path_test.go
+++ b/plugin/etcd/msg/path_test.go
@@ -22,3 +22,15 @@ func TestDomain(t *testing.T) {
 		t.Errorf("Failure to get domain from etcd key (without trailing '/'), expect: 'service.staging.cluster.local.' actually get: '%s'", result2)
 	}
 }
+
+func TestDomainWithPrefix(t *testing.T) {
+	result1 := DomainWithPrefix("/skydns/zone1/local/cluster/staging/service", "/skydns/zone1/")
+	if result1 != "service.staging.cluster.local." {
+		t.Errorf("Failure to get domain from etcd key (with customized prefix, with a trailing '/'), expect: 'service.staging.cluster.local.', actually get: '%s'", result1)
+	}
+
+	result2 := DomainWithPrefix("/skydns/zone1/local/cluster/staging/service", "/skydns/zone1")
+	if result2 != "service.staging.cluster.local." {
+		t.Errorf("Failure to get domain from etcd key (with customized prefix, without trailing '/'), expect: 'service.staging.cluster.local.' actually get: '%s'", result2)
+	}
+}

--- a/plugin/etcd/msg/service.go
+++ b/plugin/etcd/msg/service.go
@@ -34,6 +34,10 @@ type Service struct {
 
 	// Etcd key where we found this service and ignored from json un-/marshalling
 	Key string `json:"-"`
+
+	// RName is the correct record name, if inferring it from msg.Domain() would return
+	// an incorrect result.
+	RName string `json:"-"`
 }
 
 // NewSRV returns a new SRV record based on the Service.
@@ -90,6 +94,16 @@ func (s *Service) NewNS(name string) *dns.NS {
 		host = targetStrip(host, s.TargetStrip)
 	}
 	return &dns.NS{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: s.TTL}, Ns: host}
+}
+
+// Domain returns the correct record name for the record. Individual plugins can override
+// this with the RName property, or preserve the default behavior of using msg.Domain() if
+// overriding isn't necessary.
+func (s *Service) Domain() string {
+	if s.RName != "" {
+		return s.RName
+	}
+	return Domain(s.Key)
 }
 
 // Group checks the services in sx, it looks for a Group attribute on the shortest

--- a/plugin/etcd/other_test.go
+++ b/plugin/etcd/other_test.go
@@ -66,6 +66,9 @@ var servicesOther = []*msg.Service{
 	{Text: strings.Repeat("0", 600), Key: "large600.skydns.test."},
 	{Text: strings.Repeat("0", 2000), Key: "large2000.skydns.test."},
 
+	// ns
+	{Host: "172.17.1.1", Key: "ipv4.ns.dns.skydns.test.", RName: "ipv4.ns.dns.skydns.test."},
+
 	// duplicate ip address
 	{Host: "10.11.11.10", Key: "http.multiport.http.skydns.test.", Port: 80},
 	{Host: "10.11.11.10", Key: "https.multiport.http.skydns.test.", Port: 443},
@@ -128,6 +131,17 @@ var dnsTestCasesOther = []test.Case{
 		Qname: "large400.skydns.test.", Qtype: dns.TypeTXT,
 		Answer: []dns.RR{
 			test.TXT(fmt.Sprintf("large400.skydns.test. 300 IN TXT \"%s\"", strings.Repeat("0", 400))),
+		},
+	},
+	// NS queries transform the nameserver key back to a name. Ensure this is done
+	// correctly. Incorrect would look like "ipv4.ns.dns.skydns.test.zone1."
+	{
+		Qname: "skydns.test.", Qtype: dns.TypeNS,
+		Answer: []dns.RR{
+			test.NS("skydns.test. 300 IN NS ipv4.ns.dns.skydns.test."),
+		},
+		Extra: []dns.RR{
+			test.A("ipv4.ns.dns.skydns.test. 300 IN A 172.17.1.1"),
 		},
 	},
 	// Duplicate IP address test

--- a/plugin/k8s_external/msg_to_dns.go
+++ b/plugin/k8s_external/msg_to_dns.go
@@ -141,7 +141,7 @@ func (e *External) srv(ctx context.Context, services []msg.Service, state reques
 			}
 		case dns.TypeA, dns.TypeAAAA:
 			addr := s.Host
-			s.Host = msg.Domain(s.Key)
+			s.Host = s.Domain()
 			srv := s.NewSRV(state.QName(), weight)
 
 			if ok := isDuplicate(dup, srv.Target, "", srv.Port); !ok {

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -54,7 +54,7 @@ func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error)
 		srvSeen := make(map[string]struct{})
 
 		for i := range svcs {
-			name := msg.Domain(svcs[i].Key)
+			name := svcs[i].Domain()
 
 			if svcs[i].TargetStrip == 0 {
 				// Add Service A/AAAA records

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -186,7 +186,7 @@ func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []ms
 							if p.Name == "" {
 								continue
 							}
-							s.Host = msg.Domain(s.Key)
+							s.Host = s.Domain()
 							s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
 							headlessServices[strings.Join([]string{s.Key, PortProtocol}, "/")] = append(headlessServices[strings.Join([]string{s.Key, PortProtocol}, "/")], s)
 						}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -91,7 +91,7 @@ func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, erro
 
 						s.Key = strings.Join(append(svcBase, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
 
-						ch <- []dns.RR{s.NewSRV(msg.Domain(s.Key), 100)}
+						ch <- []dns.RR{s.NewSRV(s.Domain(), 100)}
 					}
 
 					//  Skip endpoint discovery if clusterIP is defined
@@ -135,7 +135,7 @@ func (k *Kubernetes) Transfer(zone string, serial uint32) (<-chan []dns.RR, erro
 
 				s := msg.Service{Key: strings.Join(svcBase, "/"), Host: svc.ExternalName, TTL: k.ttl}
 				if t, _ := s.HostType(); t == dns.TypeCNAME {
-					ch <- []dns.RR{s.NewCNAME(msg.Domain(s.Key), s.Host)}
+					ch <- []dns.RR{s.NewCNAME(s.Domain(), s.Host)}
 				}
 			}
 		}
@@ -152,11 +152,11 @@ func emitAddressRecord(c chan<- []dns.RR, s msg.Service) string {
 	dnsType, _ := s.HostType()
 	switch dnsType {
 	case dns.TypeA:
-		r := s.NewA(msg.Domain(s.Key), ip)
+		r := s.NewA(s.Domain(), ip)
 		c <- []dns.RR{r}
 		return r.Hdr.Name
 	case dns.TypeAAAA:
-		r := s.NewAAAA(msg.Domain(s.Key), ip)
+		r := s.NewAAAA(s.Domain(), ip)
 		c <- []dns.RR{r}
 		return r.Hdr.Name
 	}


### PR DESCRIPTION
The `plugin/etcd/msg.Domain()` function currently operates on the assumption that the prefix always contains a single path component: `/foo` or `foo`, not `foo/bar`. However, nothing prohibits the etcd plugin from being configured with a PathPrefix like `/skydns/foo`.

When the `etcd` plugin is configured this way, NS queries expose all of the path components after the first one. So a prefix of `/skydns/foo` and a zone of `bar.local` results in an NS record at `/skydns/foo/local/bar/dns/ns` and returns `ns.dns.bar.local.foo.` as the nameserver, where the correct answer would be `ns.dns.bar.local.`.

To handle these cases, we add a new `RName` property to the `Service` struct, which allows the plugin to override the name that would be generated by `msg.Domain()`. The method `.Domain()` on that struct returns the `RName` property if it's non-empty, and otherwise calls `msg.Domain()` to invoke the previous default behavior.

At present, the etcd plugin is the only plugin that has been updated to override RName. Other plugins may need this fixed as well; a new DomainWithPrefix public helper function is exported from `msg` to fit this use case.

The existing `TestOtherLookup` test case has been modified to verify the new etcd plugin behavior.

Signed-Off-By: Dan Fuhry <dan@fuhry.com>

### 1. Why is this pull request needed and what does it do?

This pull request is needed because the etcd plugin currently behaves incorrectly under a valid configuration.

It fixes the incorrect behavior by allowing plugins to override the record name.

### 2. Which issues (if any) are related?

A quick search for "etcd" in currently open issues shows no results.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.