### PR TITLE
[DoH] Make protocol parsing more flexible

### DIFF
--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -16,18 +17,30 @@ const MimeType = "application/dns-message"
 // Path is the URL path that should be used.
 const Path = "/dns-query"
 
-// NewRequest returns a new DoH request given a method, URL (without any paths, so exclude /dns-query) and dns.Msg.
+// NewRequest returns a new DoH request given a HTTP method, URL and dns.Msg.
+//
+// The URL should not have a path, so please exclude /dns-query. The URL will
+// be prefixed with https:// by default, unless it's already prefixed with
+// either http:// or https://.
 func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 	buf, err := m.Pack()
 	if err != nil {
 		return nil, err
 	}
 
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		url = fmt.Sprintf("https://%s", url)
+	}
+
 	switch method {
 	case http.MethodGet:
 		b64 := base64.RawURLEncoding.EncodeToString(buf)
 
-		req, err := http.NewRequest(http.MethodGet, "https://"+url+Path+"?dns="+b64, nil)
+		req, err := http.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf("%s%s?dns=%s", url, Path, b64),
+			nil,
+		)
 		if err != nil {
 			return req, err
 		}
@@ -37,7 +50,11 @@ func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 		return req, nil
 
 	case http.MethodPost:
-		req, err := http.NewRequest(http.MethodPost, "https://"+url+Path+"?bla=foo:443", bytes.NewReader(buf))
+		req, err := http.NewRequest(
+			http.MethodPost,
+			fmt.Sprintf("%s%s?bla=foo:443", url, Path),
+			bytes.NewReader(buf),
+		)
 		if err != nil {
 			return req, err
 		}

--- a/plugin/pkg/doh/doh_test.go
+++ b/plugin/pkg/doh/doh_test.go
@@ -7,46 +7,40 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestPostRequest(t *testing.T) {
-	m := new(dns.Msg)
-	m.SetQuestion("example.org.", dns.TypeDNSKEY)
-
-	req, err := NewRequest(http.MethodPost, "https://example.org:443", m)
-	if err != nil {
-		t.Errorf("Failure to make request: %s", err)
+func TestDoH(t *testing.T) {
+	tests := map[string]struct {
+		method string
+		url    string
+	}{
+		"POST request over HTTPS":       {method: http.MethodPost, url: "https://example.org:443"},
+		"POST request over HTTP":        {method: http.MethodPost, url: "http://example.org:443"},
+		"POST request without protocol": {method: http.MethodPost, url: "example.org:443"},
+		"GET request over HTTPS":        {method: http.MethodGet, url: "https://example.org:443"},
+		"GET request over HTTP":         {method: http.MethodGet, url: "http://example.org"},
+		"GET request without protocol":  {method: http.MethodGet, url: "example.org:443"},
 	}
 
-	m, err = RequestToMsg(req)
-	if err != nil {
-		t.Fatalf("Failure to get message from request: %s", err)
-	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetQuestion("example.org.", dns.TypeDNSKEY)
 
-	if x := m.Question[0].Name; x != "example.org." {
-		t.Errorf("Qname expected %s, got %s", "example.org.", x)
-	}
-	if x := m.Question[0].Qtype; x != dns.TypeDNSKEY {
-		t.Errorf("Qname expected %d, got %d", x, dns.TypeDNSKEY)
-	}
-}
+			req, err := NewRequest(test.method, test.url, m)
+			if err != nil {
+				t.Errorf("Failure to make request: %s", err)
+			}
 
-func TestGetRequest(t *testing.T) {
-	m := new(dns.Msg)
-	m.SetQuestion("example.org.", dns.TypeDNSKEY)
+			m, err = RequestToMsg(req)
+			if err != nil {
+				t.Fatalf("Failure to get message from request: %s", err)
+			}
 
-	req, err := NewRequest(http.MethodGet, "https://example.org:443", m)
-	if err != nil {
-		t.Errorf("Failure to make request: %s", err)
-	}
-
-	m, err = RequestToMsg(req)
-	if err != nil {
-		t.Fatalf("Failure to get message from request: %s", err)
-	}
-
-	if x := m.Question[0].Name; x != "example.org." {
-		t.Errorf("Qname expected %s, got %s", "example.org.", x)
-	}
-	if x := m.Question[0].Qtype; x != dns.TypeDNSKEY {
-		t.Errorf("Qname expected %d, got %d", x, dns.TypeDNSKEY)
+			if x := m.Question[0].Name; x != "example.org." {
+				t.Errorf("Qname expected %s, got %s", "example.org.", x)
+			}
+			if x := m.Question[0].Qtype; x != dns.TypeDNSKEY {
+				t.Errorf("Qname expected %d, got %d", x, dns.TypeDNSKEY)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This change avoid the hard coding of HTTPS as the protocol, which will e.g. make testing in external libraries easier and it will allow for additional flexibility in whether HTTP or HTTPS should be used for the call.

`https://` will still be the default protocol and thus the change is backwards compatible.

The change is also updating the test to be a table based test with more scenarios and also utilizing Go sub tests for nicer test output.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.