### PR TITLE
plugin/dnstap: Fix behavior when multiple dnstap plugins specified

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -61,6 +61,15 @@ dnstap /tmp/dnstap.sock {
 }
 ~~~
 
+You can use _dnstap_ more than once to define multiple taps. The following logs information including the
+wire-format DNS message about client requests and responses to */tmp/dnstap.sock*,
+and also sends client requests and responses without wire-format DNS messages to a remote FQDN.
+
+~~~ txt
+dnstap /tmp/dnstap.sock full
+dnstap tcp://example.com:6000
+~~~
+
 ## Command Line Tool
 
 Dnstap has a command line tool that can be used to inspect the logging. The tool can be found

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -98,12 +98,6 @@ func setup(c *caddy.Controller) error {
 			return nil
 		})
 
-		dnsserver.GetConfig(c).AddPlugin(
-			func(next plugin.Handler) plugin.Handler {
-				dnstap.Next = next
-				return dnstap
-			})
-
 		if i == len(dnstaps)-1 {
 			// last dnstap plugin in block: point next to next plugin
 			dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
@@ -112,9 +106,9 @@ func setup(c *caddy.Controller) error {
 			})
 		} else {
 			// not last dnstap plugin in block: point next to next dnstap
-			nextForward := dnstaps[i+1]
+			nextDnstap := dnstaps[i+1]
 			dnsserver.GetConfig(c).AddPlugin(func(plugin.Handler) plugin.Handler {
-				dnstap.Next = nextForward
+				dnstap.Next = nextDnstap
 				return dnstap
 			})
 		}

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -15,89 +15,110 @@ var log = clog.NewWithPlugin("dnstap")
 
 func init() { plugin.Register("dnstap", setup) }
 
-func parseConfig(c *caddy.Controller) (Dnstap, error) {
-	c.Next() // directive name
-	d := Dnstap{}
-	endpoint := ""
+func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
+	dnstaps := []*Dnstap{}
 
-	args := c.RemainingArgs()
+	for c.Next() { // directive name
+		d := Dnstap{}
+		endpoint := ""
 
-	if len(args) == 0 {
-		return d, c.ArgErr()
-	}
+		args := c.RemainingArgs()
 
-	endpoint = args[0]
-
-	if strings.HasPrefix(endpoint, "tcp://") {
-		// remote network endpoint
-		endpointURL, err := url.Parse(endpoint)
-		if err != nil {
-			return d, c.ArgErr()
+		if len(args) == 0 {
+			return nil, c.ArgErr()
 		}
-		dio := newIO("tcp", endpointURL.Host)
-		d = Dnstap{io: dio}
-	} else {
-		endpoint = strings.TrimPrefix(endpoint, "unix://")
-		dio := newIO("unix", endpoint)
-		d = Dnstap{io: dio}
-	}
 
-	d.IncludeRawMessage = len(args) == 2 && args[1] == "full"
+		endpoint = args[0]
 
-	hostname, _ := os.Hostname()
-	d.Identity = []byte(hostname)
-	d.Version = []byte(caddy.AppName + "-" + caddy.AppVersion)
-
-	for c.NextBlock() {
-		switch c.Val() {
-		case "identity":
-			{
-				if !c.NextArg() {
-					return d, c.ArgErr()
-				}
-				d.Identity = []byte(c.Val())
+		if strings.HasPrefix(endpoint, "tcp://") {
+			// remote network endpoint
+			endpointURL, err := url.Parse(endpoint)
+			if err != nil {
+				return nil, c.ArgErr()
 			}
-		case "version":
-			{
-				if !c.NextArg() {
-					return d, c.ArgErr()
+			dio := newIO("tcp", endpointURL.Host)
+			d = Dnstap{io: dio}
+		} else {
+			endpoint = strings.TrimPrefix(endpoint, "unix://")
+			dio := newIO("unix", endpoint)
+			d = Dnstap{io: dio}
+		}
+
+		d.IncludeRawMessage = len(args) == 2 && args[1] == "full"
+
+		hostname, _ := os.Hostname()
+		d.Identity = []byte(hostname)
+		d.Version = []byte(caddy.AppName + "-" + caddy.AppVersion)
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "identity":
+				{
+					if !c.NextArg() {
+						return nil, c.ArgErr()
+					}
+					d.Identity = []byte(c.Val())
 				}
-				d.Version = []byte(c.Val())
+			case "version":
+				{
+					if !c.NextArg() {
+						return nil, c.ArgErr()
+					}
+					d.Version = []byte(c.Val())
+				}
 			}
 		}
+		dnstaps = append(dnstaps, &d)
 	}
-
-	return d, nil
+	return dnstaps, nil
 }
 
 func setup(c *caddy.Controller) error {
-	dnstap, err := parseConfig(c)
+	dnstaps, err := parseConfig(c)
 	if err != nil {
 		return plugin.Error("dnstap", err)
 	}
 
-	c.OnStartup(func() error {
-		if err := dnstap.io.(*dio).connect(); err != nil {
-			log.Errorf("No connection to dnstap endpoint: %s", err)
-		}
-		return nil
-	})
-
-	c.OnRestart(func() error {
-		dnstap.io.(*dio).close()
-		return nil
-	})
-
-	c.OnFinalShutdown(func() error {
-		dnstap.io.(*dio).close()
-		return nil
-	})
-
-	dnsserver.GetConfig(c).AddPlugin(
-		func(next plugin.Handler) plugin.Handler {
-			dnstap.Next = next
-			return dnstap
+	for i := range dnstaps {
+		dnstap := dnstaps[i]
+		c.OnStartup(func() error {
+			if err := dnstap.io.(*dio).connect(); err != nil {
+				log.Errorf("No connection to dnstap endpoint: %s", err)
+			}
+			return nil
 		})
+
+		c.OnRestart(func() error {
+			dnstap.io.(*dio).close()
+			return nil
+		})
+
+		c.OnFinalShutdown(func() error {
+			dnstap.io.(*dio).close()
+			return nil
+		})
+
+		dnsserver.GetConfig(c).AddPlugin(
+			func(next plugin.Handler) plugin.Handler {
+				dnstap.Next = next
+				return dnstap
+			})
+
+		if i == len(dnstaps)-1 {
+			// last dnstap plugin in block: point next to next plugin
+			dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+				dnstap.Next = next
+				return dnstap
+			})
+		} else {
+			// not last dnstap plugin in block: point next to next dnstap
+			nextForward := dnstaps[i+1]
+			dnsserver.GetConfig(c).AddPlugin(func(plugin.Handler) plugin.Handler {
+				dnstap.Next = nextForward
+				return dnstap
+			})
+		}
+	}
 
 	return nil
 }

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -2,35 +2,37 @@ package dnstap
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
 )
 
-type results struct{
-endpoint string
-full     bool
-proto    string
-identity []byte
-version  []byte
+type results struct {
+	endpoint string
+	full     bool
+	proto    string
+	identity []byte
+	version  []byte
 }
 
 func TestConfig(t *testing.T) {
 	hostname, _ := os.Hostname()
 	tests := []struct {
-		in       string
-		fail     bool
+		in     string
+		fail   bool
 		expect []results
 	}{
-		{"dnstap dnstap.sock full", false, []results{{"dnstap.sock", true, "unix",  []byte(hostname), []byte("-")}}},
+		{"dnstap dnstap.sock full", false, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-")}}},
 		{"dnstap unix://dnstap.sock", false, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-")}}},
-		{"dnstap tcp://127.0.0.1:6000",false, []results{{"127.0.0.1:6000", false, "tcp",  []byte(hostname), []byte("-")}}},
-		{"dnstap tcp://[::1]:6000", false,[]results{{"[::1]:6000", false, "tcp",  []byte(hostname), []byte("-")}}},
-		{"dnstap tcp://example.com:6000", false, []results{{"example.com:6000", false, "tcp",  []byte(hostname), []byte("-")}}},
-		{"dnstap", true, []results{{"fail", false, "tcp",  []byte(hostname), []byte("-")}}},
-		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", false,[]results{{"dnstap.sock", true, "unix",  []byte("NAME"), []byte("VER")}}},
-		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\n}\n", false,[]results{{"dnstap.sock", false, "unix",  []byte("NAME"), []byte("VER")}}},
-		{"dnstap {\nidentity NAME\nversion VER\n}\n", true,[]results{{"fail", false, "tcp",  []byte("NAME"), []byte("VER")}}},
+		{"dnstap tcp://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tcp", []byte(hostname), []byte("-")}}},
+		{"dnstap tcp://[::1]:6000", false, []results{{"[::1]:6000", false, "tcp", []byte(hostname), []byte("-")}}},
+		{"dnstap tcp://example.com:6000", false, []results{{"example.com:6000", false, "tcp", []byte(hostname), []byte("-")}}},
+		{"dnstap", true, []results{{"fail", false, "tcp", []byte(hostname), []byte("-")}}},
+		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER")}}},
+		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\n}\n", false, []results{{"dnstap.sock", false, "unix", []byte("NAME"), []byte("VER")}}},
+		{"dnstap {\nidentity NAME\nversion VER\n}\n", true, []results{{"fail", false, "tcp", []byte("NAME"), []byte("VER")}}},
 		{`dnstap dnstap.sock full {
                 identity NAME
                 version VER
@@ -38,9 +40,9 @@ func TestConfig(t *testing.T) {
               dnstap tcp://127.0.0.1:6000 {
                 identity NAME2
                 version VER2
-              }`, false,[]results{
-			{"dnstap.sock", true, "unix",  []byte("NAME"), []byte("VER")},
-			{"127.0.0.1:6000", false, "tcp",  []byte("NAME2"), []byte("VER2")},
+              }`, false, []results{
+			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER")},
+			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2")},
 		}},
 	}
 	for i, tc := range tests {
@@ -73,5 +75,52 @@ func TestConfig(t *testing.T) {
 				t.Errorf("Test %d: expected version %s, got %s", i, tc.expect[i].version, x)
 			}
 		}
+	}
+}
+
+func TestMultiDnstap(t *testing.T) {
+	input := `
+      dnstap dnstap1.sock
+      dnstap dnstap2.sock
+      dnstap dnstap3.sock
+    `
+
+	c := caddy.NewTestController("dns", input)
+	setup(c)
+	dnsserver.NewServer("", []*dnsserver.Config{dnsserver.GetConfig(c)})
+
+	handlers := dnsserver.GetConfig(c).Handlers()
+	d1, ok := handlers[0].(*Dnstap)
+	if !ok {
+		t.Fatalf("expected first plugin to be Dnstap, got %v", reflect.TypeOf(d1.Next))
+	}
+
+	if d1.io.(*dio).endpoint != "dnstap1.sock" {
+		t.Errorf("expected first dnstap to \"dnstap1.sock\", got %q", d1.io.(*dio).endpoint)
+	}
+	if d1.Next == nil {
+		t.Fatal("expected first dnstap to point to next dnstap instance")
+	}
+
+	d2, ok := d1.Next.(*Dnstap)
+	if !ok {
+		t.Fatalf("expected second plugin to be Dnstap, got %v", reflect.TypeOf(d1.Next))
+	}
+	if d2.io.(*dio).endpoint != "dnstap2.sock" {
+		t.Errorf("expected second dnstap to \"dnstap2.sock\", got %q", d2.io.(*dio).endpoint)
+	}
+	if d2.Next == nil {
+		t.Fatal("expected second dnstap to point to third dnstap instance")
+	}
+
+	d3, ok := d2.Next.(*Dnstap)
+	if !ok {
+		t.Fatalf("expected third plugin to be Dnstap, got %v", reflect.TypeOf(d2.Next))
+	}
+	if d3.io.(*dio).endpoint != "dnstap3.sock" {
+		t.Errorf("expected third dnstap to \"dnstap3.sock\", got %q", d3.io.(*dio).endpoint)
+	}
+	if d3.Next != nil {
+		t.Error("expected third plugin to be last, but Next is not nil")
 	}
 }

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -49,7 +49,7 @@ type Forward struct {
 	// the maximum allowed (maxConcurrent)
 	ErrLimitExceeded error
 
-	tapPlugin *dnstap.Dnstap // when the dnstap plugin is loaded, we use to this to send messages out.
+	tapPlugins []*dnstap.Dnstap // when dnstap plugins are loaded, we use to this to send messages out.
 
 	Next plugin.Handler
 }
@@ -150,7 +150,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			child.Finish()
 		}
 
-		if f.tapPlugin != nil {
+		if len(f.tapPlugins) != 0 {
 			toDnstap(f, proxy.addr, state, opts, ret, start)
 		}
 

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -52,7 +52,7 @@ func setup(c *caddy.Controller) error {
 		c.OnStartup(func() error {
 			if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
 				if tapPlugin, ok := taph.(dnstap.Dnstap); ok {
-					f.tapPlugin = &tapPlugin
+					f.tapPlugins = append(f.tapPlugins, &tapPlugin)
 				}
 			}
 			return nil


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Prior to this fix, when more than one dnstap plugin was configured, the last instance would overwrite others instead of establishing multiple taps. With this fix, each instance of dnstap remains independent, permitting for example sending dnstap to multiple endpoints.

This PR makes no changes to the dnstap plugin core logic, it just fixes to the setup functions to properly the link multiple instances in the plugin chain.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
