### PR TITLE
plugin/auto: Send notifies after adding all zones

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -45,6 +45,9 @@ func setup(c *caddy.Controller) error {
 		if err != nil {
 			return err
 		}
+		if err := a.Notify(); err != nil {
+			log.Warning(err)
+		}
 		if a.loader.ReloadInterval == 0 {
 			return nil
 		}
@@ -57,6 +60,9 @@ func setup(c *caddy.Controller) error {
 					return
 				case <-ticker.C:
 					a.Walk()
+					if err := a.Notify(); err != nil {
+						log.Warning(err)
+					}
 				}
 			}
 		}()

--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -59,8 +59,6 @@ func (a Auto) Walk() error {
 			a.metrics.AddZone(origin)
 		}
 
-		a.transfer.Notify(origin)
-
 		log.Infof("Inserting zone `%s' from: %s", origin, path)
 
 		toDelete[origin] = false

--- a/plugin/auto/xfr.go
+++ b/plugin/auto/xfr.go
@@ -17,3 +17,15 @@ func (a Auto) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
 	}
 	return z.Transfer(serial)
 }
+
+// Notify sends notifies for all zones with secondaries configured with the transfer plugin
+func (a Auto) Notify() error {
+	var err error
+	for _, origin := range a.Zones.Names() {
+		e := a.transfer.Notify(origin)
+		if e != nil {
+			err = e
+		}
+	}
+	return err
+}

--- a/plugin/transfer/notify.go
+++ b/plugin/transfer/notify.go
@@ -8,8 +8,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// Notify will send notifies to all configured to hosts IP addresses. If the zone isn't known
-// to t an error will be returned. The string zone must be lowercased.
+// Notify will send notifies to all configured to hosts IP addresses. The string zone must be lowercased.
 func (t *Transfer) Notify(zone string) error {
 	if t == nil { // t might be nil, mostly expected in tests, so intercept and to a noop in that case
 		return nil
@@ -21,7 +20,8 @@ func (t *Transfer) Notify(zone string) error {
 
 	x := longestMatch(t.xfrs, zone)
 	if x == nil {
-		return fmt.Errorf("no such zone registred in the transfer plugin: %s", zone)
+		// return without error if there is no matching zone
+		return nil
 	}
 
 	var err1 error


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Per #5767, Defer sending notifies until after all zones are loaded, so availability of later zones will not be delayed by timeouts to secondaries of earlier zones.

There is little to no coverage for notifies (because adding it tests for this is challenging). ~So before merge, need to do manual testing here to ensure nothing is broken and changes work as expected.~ [DONE]

### 2. Which issues (if any) are related?

#5767

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no