### PR TITLE
plugin/edns: remove truncating of question section on bad EDNS version

### DIFF
--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -36,8 +36,7 @@ func SupportedOption(option uint16) bool {
 
 // Version checks the EDNS version in the request. If error
 // is nil everything is OK and we can invoke the plugin. If non-nil, the
-// returned Msg is valid to be returned to the client (and should). For some
-// reason this response should not contain a question RR in the question section.
+// returned Msg is valid to be returned to the client (and should).
 func Version(req *dns.Msg) (*dns.Msg, error) {
 	opt := req.IsEdns0()
 	if opt == nil {
@@ -48,8 +47,6 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 	}
 	m := new(dns.Msg)
 	m.SetReply(req)
-	// zero out question section, wtf.
-	m.Question = nil
 
 	o := new(dns.OPT)
 	o.Hdr.Name = "."

--- a/plugin/pkg/edns/edns_test.go
+++ b/plugin/pkg/edns/edns_test.go
@@ -29,9 +29,12 @@ func TestVersionNoEdns(t *testing.T) {
 	m := ednsMsg()
 	m.Extra = nil
 
-	_, err := Version(m)
+	r, err := Version(m)
 	if err != nil {
 		t.Errorf("Expected no error, but got one: %s", err)
+	}
+	if r != nil {
+		t.Errorf("Expected nil since not an EDNS0 request, but did not got nil")
 	}
 }
 

--- a/plugin/pkg/edns/edns_test.go
+++ b/plugin/pkg/edns/edns_test.go
@@ -10,9 +10,18 @@ func TestVersion(t *testing.T) {
 	m := ednsMsg()
 	m.Extra[0].(*dns.OPT).SetVersion(2)
 
-	_, err := Version(m)
+	r, err := Version(m)
 	if err == nil {
 		t.Errorf("Expected wrong version, but got OK")
+	}
+	if r.Question == nil {
+		t.Errorf("Expected question section, but got nil")
+	}
+	if r.Rcode != dns.RcodeBadVers {
+		t.Errorf("Expected Rcode to be of BADVER (16), but got %d", r.Rcode)
+	}
+	if r.Extra == nil {
+		t.Errorf("Expected OPT section, but got nil")
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
EDNS requests of "Unknown Version" removed the query section altogether. 
Not sure why since this is not required (see [link](https://kb.isc.org/docs/edns-compatibility-dig-queries))

This causes issues with DNS solutions that use this information (initial queried name, type, and class) in order to route the response to the right client (e.g. PDNS).

The change here is to keep the initial query section as is.

### 2. Which issues (if any) are related?
[5785](https://github.com/coredns/coredns/issues/5785)

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
None that I'm aware of since the ENDS "Unknown Version" requirements are clear and do not include removing the query section.
