### PR TITLE
plugin/etcd: implicit requirement on etcd 3.5 not documented

### DIFF
--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -119,13 +119,11 @@ etcd skydns.local {
     endpoint http://localhost:2379 http://localhost:4001
 ...
 ~~~
-Before getting started with these examples, please setup `etcdctl` (with `etcdv3` API) as explained
+Before getting started with these examples, please setup `etcdctl` (with `etcdv3` API and version `3.5.0` or later) as explained
 [here](https://coreos.com/etcd/docs/latest/dev-guide/interacting_v3.html). This will help you to put
 sample keys in your etcd server.
 
-If you prefer, you can use `curl` to populate the `etcd` server, but with `curl` the
-endpoint URL depends on the version of `etcd`. For instance, `etcd v3.2` or before uses only
-[CLIENT-URL]/v3alpha/* while `etcd v3.5` or later uses [CLIENT-URL]/v3/* . Also, Key and Value must
+If you prefer, you can use `curl` to populate the `etcd` server. For instance, `etcd v3.5` or later uses [CLIENT-URL]/v3/* . Also, Key and Value must
 be base64 encoded in the JSON payload. With `etcdctl` these details are automatically taken care
 of. You can check [this document](https://github.com/coreos/etcd/blob/master/Documentation/dev-guide/api_grpc_gateway.md#notes)
 for details.


### PR DESCRIPTION
**What would you like to be added**: I would like to have the version requirement for `etcd` be more clearly stated for the plugin in the documentation. It seems to require `3.5`.

**Why is this needed**: It would have saved some time for me, as it's not clear from the documentation that the plugin seems to only work with the more recent version.

So, what I did: I installed `etcd` from my package manager, which happened to resolve to version `3.3.27`. I set up the cluster, then proceeded to install `coredns`, which my package manager resolved to version `1.10.0`. I read through the examples and documentation on the coredns `etcd` plugin page on what to do. Here, this is where I made a mistake: when the `etcdctl put` request did not resolve on my nodes, I should have been alarmed. What I did was proceed to use the `set` subcommand. While the `etcd` clearly did save my requests, what I did not get was a DNS response despite several iterations on my configuration.

After troubleshooting this for around two hours I started to consider patching my software, when I realized that my package manager had the more recent versions under special namespace. After updating to `3.5.6`, the examples started working, as the `put` subcommand resolved.

To possibly save other people's time, I would like to make it explicit that an `etcd` version with the `put` subcommand is required. The current documentation makes it seem like it's not, whereas from my today's anecdotal experience it is.