### PR TITLE
Drop obsolete client-go auth plugins

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -17,9 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
-	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The OpenStack plugin is no longer available, even in version 0.24.4 of client-go; see
https://github.com/kubernetes/client-go/blob/v0.24.4/plugin/pkg/client/auth/openstack/openstack_stub.go It is replaced by the client-keystone-auth credential plugin. The plugin has been entirely removed in client-go 0.26.0, which breaks the build when any other dependency pulls in client-go 0.26.0 or later.

The GCP plugin is deprecated in K8s 1.22+ and unavailable in 1.26+ (although it is still stubbed in client-go 0.26.0). It is replaced by the gke-gcloud-auth-plugin credential plugin.

### 2. Which issues (if any) are related?

None that I’m aware of.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

It drops direct support for GCP and OpenStack authentication, but they were already unusable anyway (the stubbed plugins always return an error).