### PR TITLE
Added trivy-nightly-scan for coredns images

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,34 @@
+name: Trivy Nightly Scan
+on:
+  schedule:
+    - cron: '0 2 * * 5'  #run at 2AM UTC on every Friday
+
+permissions: read-all
+jobs:
+  nightly-scan:
+    name: Trivy Scan nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        # It will test for only the latest version as older version is not maintained
+        versions: [latest]
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # master
+        with:
+          image-ref: 'docker.io/coredns/coredns:${{ matrix.versions }}'
+          severity: 'CRITICAL,HIGH'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,7 +1,7 @@
 name: Trivy Nightly Scan
 on:
   schedule:
-    - cron: '0 2 * * 5'  #run at 2AM UTC on every Friday
+    - cron: '0 2 * * 5'  #Run at 2AM UTC on every Friday
 
 permissions: read-all
 jobs:


### PR DESCRIPTION
This PR introduces the security scanning for coredns container images. This job will only scan the coredns `latest` images and run every week on `Friday 2AM UTC`.

Signed-off-by: Yash Singh <syash@vmware.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The CVE scanning for the coredns images will be enabled by this PR. It will make it easier to track down the HIGH and CRITICAL CVE being used.

### 2. Which issues (if any) are related?
Fixes: #5807 

**Test Result:**
![Screenshot 2022-12-16 at 9 26 34 AM](https://user-images.githubusercontent.com/99066083/208018746-f7d2c912-fd80-4064-bd46-2fbd26b3cf43.png)

