### PR TITLE
plugin/forward race policy

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -47,7 +47,7 @@ forward FROM TO... {
     max_fails INTEGER
     tls CERT KEY CA
     tls_servername NAME
-    policy random|round_robin|sequential
+    policy random|round_robin|sequential|race
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
 }
@@ -84,6 +84,7 @@ forward FROM TO... {
   * `random` is a policy that implements random upstream selection.
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
+  * `race` is a policy that try all hosts at once and pick the fastest result.
 * `health_check` configure the behaviour of health checking of the upstream servers
   * `<duration>` - use a different duration for health checking, the default duration is 0.5s.
   * `no_rec` - optional argument that sets the RecursionDesired-flag of the dns-query used in health checking to `false`.

--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -65,4 +65,13 @@ func (r *sequential) List(p []*Proxy) []*Proxy {
 	return p
 }
 
+// race is a policy that try all hosts at once and pick the fastest result.
+type race struct{}
+
+func (r *race) String() string { return "race" }
+
+func (r *race) List(p []*Proxy) []*Proxy {
+	return p
+}
+
 var rn = rand.New(time.Now().UnixNano())

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -265,6 +265,8 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			f.p = &roundRobin{}
 		case "sequential":
 			f.p = &sequential{}
+		case "race":
+			f.p = &race{}
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
`plugin/forward` supports race policy
1. we have multiple upstream hosts
2. we want to send request to all of them at once, and pick the fastest result
3. so we can use race policy
4. just like `dnsmasq` multiple upstream hosts usage

### 2. Which issues (if any) are related?
no issues

### 3. Which documentation changes (if any) need to be made?
`plugin/forward/README.md` already update

### 4. Does this introduce a backward incompatible change or deprecation?
no
