### PR TITLE
plugin/etcd: update documentation

### DIFF
--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -62,7 +62,7 @@ The *etcd* plugin leverages directory structure to look for related entries. For
 an entry `/skydns/test/skydns/mx` would have entries like `/skydns/test/skydns/mx/a`,
 `/skydns/test/skydns/mx/b` and so on. Similarly a directory `/skydns/test/skydns/mx1` will have all
 `mx1` entries. Note this plugin will search through the entire (sub)tree for records. In case of the
-first example, a query for `mx.skydns.text` will return both the contents of the `a` and `b` records.
+first example, a query for `mx.skydns.test` will return both the contents of the `a` and `b` records.
 If the directory extends deeper those records are returned as well.
 
 With etcd3, support for [hierarchical keys are


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
If an entry `/skydns/test/skydns/mx` have entries `/skydns/test/skydns/mx/a` and `/skydns/test/skydns/mx/b`, a query for `mx.skydns.text` will return `REFUSED` instead of records of `a` and `b` while a query for `mx.skydns.test` will return expected records.

### 2. Which issues (if any) are related?
None
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
None
