### PR TITLE
Move flags to coremain

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -1,7 +1,6 @@
 package dnsserver
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"time"
@@ -20,9 +19,6 @@ const serverType = "dns"
 // Any flags defined here, need to be namespaced to the serverType other
 // wise they potentially clash with other server types.
 func init() {
-	flag.StringVar(&Port, serverType+".port", DefaultPort, "Default port")
-	flag.StringVar(&Port, "p", DefaultPort, "Default port")
-
 	caddy.RegisterServerType(serverType, caddy.ServerType{
 		Directives: func() []string { return Directives },
 		DefaultInput: func() caddy.Input {

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -16,8 +16,6 @@ import (
 
 const serverType = "dns"
 
-// Any flags defined here, need to be namespaced to the serverType other
-// wise they potentially clash with other server types.
 func init() {
 	caddy.RegisterServerType(serverType, caddy.ServerType{
 		Directives: func() []string { return Directives },

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -28,6 +28,9 @@ func init() {
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
 
+	flag.StringVar(&dnsserver.Port, serverType+".port", dnsserver.DefaultPort, "Default port")
+	flag.StringVar(&dnsserver.Port, "p", dnsserver.DefaultPort, "Default port")
+
 	caddy.AppName = coreName
 	caddy.AppVersion = CoreVersion
 }


### PR DESCRIPTION
Signed-off-by: David Hadas <david.hadas@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Allow using `core/dnsserver` as a go package imported by other programs - leave flags out of the package such that importing program can decide which flags they use and for what. 

### 2. Which issues (if any) are related?

#5853

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?
None