### PR TITLE
plugin/cache: add a new keepttl option

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -39,6 +39,7 @@ cache [TTL] [ZONES...] {
     serve_stale [DURATION] [REFRESH_MODE]
     servfail DURATION
     disable success|denial [ZONES...]
+    keepttl
 }
 ~~~
 
@@ -69,6 +70,11 @@ cache [TTL] [ZONES...] {
   greater than 5 minutes.
 * `disable`  disable the success or denial cache for the listed **ZONES**.  If no **ZONES** are given, the specified
   cache will be disabled for all zones.
+* `keepttl` do not age TTL when serving responses from cache. The entry will still be removed from cache
+  when the TTL expires as normal, but until it expires responses will include the original TTL instead
+  of the remaining TTL. This can be useful if CoreDNS is used as an authoritative server and you want
+  to serve a consistent TTL to downstream clients. This is **NOT** recommended when CoreDNS is caching
+  records it is not authoritative for because it could result in downstream clients using stale answers.
 
 ## Capacity and Eviction
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -48,6 +48,9 @@ type Cache struct {
 	pexcept []string
 	nexcept []string
 
+	// Keep ttl option
+	keepttl bool
+
 	// Testing.
 	now func() time.Time
 }

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -71,6 +71,11 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		})
 	}
 
+	if c.keepttl {
+		// If keepttl is enabled we fake the current time to the stored
+		// one so that we always get the original TTL
+		now = i.stored
+	}
 	resp := i.toMsg(r, now, do, ad)
 	w.WriteMsg(resp)
 	return dns.RcodeSuccess, nil

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -240,6 +240,11 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 				default:
 					return nil, fmt.Errorf("cache type for disable must be %q or %q", Success, Denial)
 				}
+			case "keepttl":
+				if len(args) != 0 {
+					return nil, c.ArgErr()
+				}
+				ca.keepttl = true
 			default:
 				return nil, c.ArgErr()
 			}

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -231,3 +231,32 @@ func TestDisable(t *testing.T) {
 		}
 	}
 }
+
+func TestKeepttl(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+	}{
+		// positive
+		{"keepttl", false},
+		// negative
+		{"keepttl arg1", true},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", fmt.Sprintf("cache {\n%s\n}", test.input))
+		ca, err := cacheParse(c)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+			continue
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			continue
+		}
+		if test.shouldErr {
+			continue
+		}
+		if !ca.keepttl {
+			t.Errorf("Test %v: Expected keepttl enabled but disabled", i)
+		}
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Whenever CoreDNS is used as an authoritative server it could be useful to serve a consistent TTL (not decreased based on time) to clients and still use caching to spare request to the backend.

This commit adds a new option `keepttl` to the cache plugin to do just that. This new option doesn't update any caching logic but just override the cache plugin answer.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
To the cache plugin (included in this PR)

### 4. Does this introduce a backward incompatible change or deprecation?
no