### PR TITLE
plugin/forward: fix broken tap plugins when dnstap plugins specified

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -102,8 +102,8 @@ x :=  &ExamplePlugin{}
 
 c.OnStartup(func() error {
     if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
-        if tapPlugin, ok := taph.(dnstap.Dnstap); ok {
-            x.tapPlugins = append(x.tapPlugins, &tapPlugin)
+        for tapPlugin, ok := taph.(*dnstap.Dnstap); ok; tapPlugin, ok = tapPlugin.Next.(*dnstap.Dnstap) {
+            x.tapPlugins = append(x.tapPlugins, tapPlugin)
         }
     }
     return nil

--- a/plugin/forward/dnstap.go
+++ b/plugin/forward/dnstap.go
@@ -14,9 +14,6 @@ import (
 
 // toDnstap will send the forward and received message to the dnstap plugin.
 func toDnstap(f *Forward, host string, state request.Request, opts options, reply *dns.Msg, start time.Time) {
-	// Query
-	q := new(tap.Message)
-	msg.SetQueryTime(q, start)
 	h, p, _ := net.SplitHostPort(host)      // this is preparsed and can't err here
 	port, _ := strconv.ParseUint(p, 10, 32) // same here
 	ip := net.ParseIP(h)
@@ -34,12 +31,14 @@ func toDnstap(f *Forward, host string, state request.Request, opts options, repl
 		ta = &net.TCPAddr{IP: ip, Port: int(port)}
 	}
 
-	// Forwarder dnstap messages are from the perspective of the downstream server
-	// (upstream is the forward server)
-	msg.SetQueryAddress(q, state.W.RemoteAddr())
-	msg.SetResponseAddress(q, ta)
-
 	for _, t := range f.tapPlugins {
+		// Query
+		q := new(tap.Message)
+		msg.SetQueryTime(q, start)
+		// Forwarder dnstap messages are from the perspective of the downstream server
+		// (upstream is the forward server)
+		msg.SetQueryAddress(q, state.W.RemoteAddr())
+		msg.SetResponseAddress(q, ta)
 		if t.IncludeRawMessage {
 			buf, _ := state.Req.Pack()
 			q.QueryMessage = buf

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -67,9 +67,10 @@ func (f *Forward) SetProxy(p *Proxy) {
 }
 
 // SetTapPlugin appends one or more dnstap plugins to the tap plugin list.
-func (f *Forward) SetTapPlugin(h plugin.Handler) {
-	for tapPlugin, ok := h.(*dnstap.Dnstap); ok; tapPlugin, ok = tapPlugin.Next.(*dnstap.Dnstap) {
-		f.tapPlugins = append(f.tapPlugins, tapPlugin)
+func (f *Forward) SetTapPlugin(tapPlugin *dnstap.Dnstap) {
+	f.tapPlugins = append(f.tapPlugins, tapPlugin)
+	if nextPlugin, ok := tapPlugin.Next.(*dnstap.Dnstap); ok {
+		f.SetTapPlugin(nextPlugin)
 	}
 }
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -66,6 +66,13 @@ func (f *Forward) SetProxy(p *Proxy) {
 	p.start(f.hcInterval)
 }
 
+// SetTapPlugin appends one or more dnstap plugins to the tap plugin list.
+func (f *Forward) SetTapPlugin(h plugin.Handler) {
+	for tapPlugin, ok := h.(*dnstap.Dnstap); ok; tapPlugin, ok = tapPlugin.Next.(*dnstap.Dnstap) {
+		f.tapPlugins = append(f.tapPlugins, tapPlugin)
+	}
+}
+
 // Len returns the number of configured proxies.
 func (f *Forward) Len() int { return len(f.proxies) }
 

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -1,12 +1,13 @@
 package forward
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/coredns/caddy"
 	"github.com/coredns/caddy/caddyfile"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin/dnstap"
-	"strings"
-	"testing"
 )
 
 func TestList(t *testing.T) {

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -3,6 +3,7 @@ package forward
 import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin/dnstap"
 	"testing"
 )
 
@@ -42,7 +43,7 @@ func TestSetTapPlugin(t *testing.T) {
 
 	if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
 		f := New()
-		f.SetTapPlugin(taph)
+		f.SetTapPlugin(taph.(*dnstap.Dnstap))
 		if len(f.tapPlugins) != 2 {
 			t.Fatalf("Expected: 2 results, got: %v", len(f.tapPlugins))
 		}

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -1,6 +1,8 @@
 package forward
 
 import (
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
 	"testing"
 )
 
@@ -20,5 +22,34 @@ func TestList(t *testing.T) {
 		if p.addr != expect[i].addr {
 			t.Fatalf("Expected proxy %v to be '%v', got: '%v'", i, expect[i].addr, p.addr)
 		}
+	}
+}
+
+func TestSetTapPlugin(t *testing.T) {
+	input := `
+      dnstap /tmp/dnstap.sock full
+      dnstap tcp://example.com:6000
+    `
+	c := caddy.NewTestController("dns", input)
+	dnstapSetup, err := caddy.DirectiveAction("dns", "dnstap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = dnstapSetup(c); err != nil {
+		t.Fatal(err)
+	}
+	dnsserver.NewServer("", []*dnsserver.Config{dnsserver.GetConfig(c)})
+
+	if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
+		f := New()
+		f.SetTapPlugin(taph)
+		if len(f.tapPlugins) != 2 {
+			t.Fatalf("Expected: 2 results, got: %v", len(f.tapPlugins))
+		}
+		if f.tapPlugins[0] != taph || f.tapPlugins[0].Next != f.tapPlugins[1] {
+			t.Fatal("Unexpected order of dnstap plugins")
+		}
+	} else {
+		t.Error("Expected first plugin to be dnstap")
 	}
 }

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -32,7 +32,7 @@ func TestSetTapPlugin(t *testing.T) {
 	input := `forward . 127.0.0.1
 	dnstap /tmp/dnstap.sock full
 	dnstap tcp://example.com:6000
-    `
+	`
 	stanzas := strings.Split(input, "\n")
 	c := caddy.NewTestController("dns", strings.Join(stanzas[1:], "\n"))
 	dnstapSetup, err := caddy.DirectiveAction("dns", "dnstap")

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/dnstap"
 	"github.com/coredns/coredns/plugin/pkg/parse"
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/pkg/transport"
@@ -51,9 +50,7 @@ func setup(c *caddy.Controller) error {
 		})
 		c.OnStartup(func() error {
 			if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
-				if tapPlugin, ok := taph.(dnstap.Dnstap); ok {
-					f.tapPlugins = append(f.tapPlugins, &tapPlugin)
-				}
+				f.SetTapPlugin(taph)
 			}
 			return nil
 		})

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/dnstap"
 	"github.com/coredns/coredns/plugin/pkg/parse"
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/pkg/transport"
@@ -50,7 +51,7 @@ func setup(c *caddy.Controller) error {
 		})
 		c.OnStartup(func() error {
 			if taph := dnsserver.GetConfig(c).Handler("dnstap"); taph != nil {
-				f.SetTapPlugin(taph)
+				f.SetTapPlugin(taph.(*dnstap.Dnstap))
 			}
 			return nil
 		})


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Prior to this fix, when one or more dnstap plugins were configured, the dnstap in forward plugin is not working due to the following reasons:

1. The type assertion of `Dnstap` is incorrect, which causes an empty plugin list.
2. No iteration over the plugin chain. The plugin list only contains the first dnstap plugin.
3. The query tap message instance is shared across multiple dnstap plugins. If one of the tap plugins overwrites the `QueryMessage` field of the query message, the remaining plugins will use the same message regardless of its own configuration.

This PR fixes the type assertion and iterates over the plugin chain to form a full list of tap plugins. As for the third problem, a new tap message instance will be created for each plugin, just like the response message.

### 2. Which issues (if any) are related?

#5773

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
