### PR TITLE
plugin/forward: add new metric for upstream connection failures.

### DIFF
--- a/man/coredns-forward.7
+++ b/man/coredns-forward.7
@@ -178,6 +178,8 @@ If monitoring is enabled (via the \fIprometheus\fP plugin) then the following me
 .IP \(bu 4
 \fB\fCcoredns_forward_responses_total{to, rcode}\fR - count of RCODEs per upstream.
 .IP \(bu 4
+\fB\fCcoredns_forward_connection_failures_total{proto, to, type}\fR - count of connection errors per upstream IP address.
+.IP \(bu 4
 \fB\fCcoredns_forward_healthcheck_failures_total{to}\fR - number of failed health checks per upstream.
 .IP \(bu 4
 \fB\fCcoredns_forward_healthcheck_broken_total{}\fR - counter of when all upstreams are unhealthy,

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -119,6 +119,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_forward_responses_total{to}` - Counter of responses received per upstream.
 * `coredns_forward_request_duration_seconds{to, rcode, type}` - duration per upstream, RCODE, type
 * `coredns_forward_responses_total{to, rcode}` - count of RCODEs per upstream.
+* `coredns_forward_connection_failures_total{to, proto, type}` - count of connection errors per upstream IP address.
 * `coredns_forward_healthcheck_failures_total{to}` - number of failed health checks per upstream.
 * `coredns_forward_healthcheck_broken_total{}` - counter of when all upstreams are unhealthy,
   and we are randomly (this always uses the `random` policy) spraying to an upstream.

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -28,6 +28,12 @@ var (
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time each request took.",
 	}, []string{"to", "rcode"})
+	RequestFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "connect_failures_total",
+		Help:      "Counter of connection failures per remote IP address.",
+	}, []string{"to", "proto", "type"})
 	HealthcheckFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",


### PR DESCRIPTION
Signed-off-by: Andrew Denton <adenton@redhat.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This adds a metric, `coredns_forward_connection_failures_total` that records the number of times the forward plugin failed to communicate with an upstream host, and why. For example:

```text
# HELP coredns_forward_connection_failures_total Counter of connection failures per remote IP address.
# TYPE coredns_forward_connection_failures_total counter
coredns_forward_connection_failures_total{proto="tcp",to="8.8.8.8:53",type="connect: connection refused"} 537
coredns_forward_connection_failures_total{proto="tcp",to="8.8.8.8:53",type="connect: network is unreachable"} 474
coredns_forward_connection_failures_total{proto="tcp",to="8.8.8.8:53",type="i/o timeout"} 20
coredns_forward_connection_failures_total{proto="udp",to="8.8.8.8:53",type="write: operation not permitted"} 60706
```

This can provide additional insight into resolution failures, particularly if they're intermittent, and without having to parse logs.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
README.md and coredns-forward(7) manpage have been updated.

### 4. Does this introduce a backward incompatible change or deprecation?
No