### PR TITLE
.circleci: update k8s and kind version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ integrationDefaults: &integrationDefaults
     image: ubuntu-2004:2022.04.2
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
-    - K8S_VERSION: v1.22.0
-    - KIND_VERSION: v0.11.1
+    - K8S_VERSION: v1.26.0
+    - KIND_VERSION: v0.17.0
     - KUBECONFIG: /home/circleci/.kube/kind-config-kind
 
 setupKubernetes: &setupKubernetes


### PR DESCRIPTION
Signed-off-by: Spencer Comfort [109806759+GiddyGoatGaming@users.noreply.github.com](mailto:109806759+GiddyGoatGaming@users.noreply.github.com)

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

K8S v1.22 is now at the end of support which means it is reasonable to update it to the latest v1.26. At the same time, kind has some updates to it to better match the latest version of K8S

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

It shouldn’t
