### PR TITLE
plugin/dnssec: on delegation, sign DS or NSEC of no DS.

### DIFF
--- a/plugin/dnssec/black_lies_test.go
+++ b/plugin/dnssec/black_lies_test.go
@@ -71,16 +71,188 @@ func TestBlackLiesNoError(t *testing.T) {
 	}
 }
 
+func TestBlackLiesApexNsec(t *testing.T) {
+	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
+	defer rm1()
+	defer rm2()
+
+	m := testNsecMsg()
+	m.SetQuestion("miek.nl.", dns.TypeNSEC)
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	m = d.Sign(state, time.Now().UTC(), server)
+	if len(m.Ns) > 0 {
+		t.Error("Authority section should be empty")
+	}
+	if len(m.Answer) != 2 {
+		t.Errorf("Answer section should have 2 RRs")
+	}
+	sig, nsec := false, false
+	for _, rr := range m.Answer {
+		if _, ok := rr.(*dns.RRSIG); ok {
+			sig = true
+		}
+		if rnsec, ok := rr.(*dns.NSEC); ok {
+			nsec = true
+			var bitpresent uint
+			for _, typeBit := range rnsec.TypeBitMap {
+				switch typeBit {
+				case dns.TypeSOA:
+					bitpresent |= 4
+				case dns.TypeNSEC:
+					bitpresent |= 1
+				case dns.TypeRRSIG:
+					bitpresent |= 2
+				}
+			}
+			if bitpresent != 7 {
+				t.Error("NSEC must have SOA, RRSIG and NSEC in its bitmap")
+			}
+		}
+	}
+	if !sig || !nsec {
+		t.Errorf("Expected RRSIG and NSEC in answer section")
+	}
+}
+
+func TestBlackLiesNsec(t *testing.T) {
+	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
+	defer rm1()
+	defer rm2()
+
+	m := testNsecMsg()
+	m.SetQuestion("www.miek.nl.", dns.TypeNSEC)
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	m = d.Sign(state, time.Now().UTC(), server)
+	if len(m.Ns) > 0 {
+		t.Error("Authority section should be empty")
+	}
+	if len(m.Answer) != 2 {
+		t.Errorf("Answer section should have 2 RRs")
+	}
+	sig, nsec := false, false
+	for _, rr := range m.Answer {
+		if _, ok := rr.(*dns.RRSIG); ok {
+			sig = true
+		}
+		if rnsec, ok := rr.(*dns.NSEC); ok {
+			nsec = true
+			var bitpresent uint
+			for _, typeBit := range rnsec.TypeBitMap {
+				switch typeBit {
+				case dns.TypeNSEC:
+					bitpresent |= 1
+				case dns.TypeRRSIG:
+					bitpresent |= 2
+				}
+			}
+			if bitpresent != 3 {
+				t.Error("NSEC must have RRSIG and NSEC in its bitmap")
+			}
+		}
+	}
+	if !sig || !nsec {
+		t.Errorf("Expected RRSIG and NSEC in answer section")
+	}
+}
+
+func TestBlackLiesApexDS(t *testing.T) {
+	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
+	defer rm1()
+	defer rm2()
+
+	m := testApexDSMsg()
+	m.SetQuestion("miek.nl.", dns.TypeDS)
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	m = d.Sign(state, time.Now().UTC(), server)
+	if !section(m.Ns, 2) {
+		t.Errorf("Authority section should have 2 sigs")
+	}
+	var nsec *dns.NSEC
+	for _, r := range m.Ns {
+		if r.Header().Rrtype == dns.TypeNSEC {
+			nsec = r.(*dns.NSEC)
+		}
+	}
+	if nsec == nil {
+		t.Error("Expected NSEC, got none")
+	} else if correctNsecForDS(nsec) {
+		t.Error("NSEC DS at the apex zone should cover all apex type.")
+	}
+}
+
+func TestBlackLiesDS(t *testing.T) {
+	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
+	defer rm1()
+	defer rm2()
+
+	m := testApexDSMsg()
+	m.SetQuestion("sub.miek.nl.", dns.TypeDS)
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	m = d.Sign(state, time.Now().UTC(), server)
+	if !section(m.Ns, 2) {
+		t.Errorf("Authority section should have 2 sigs")
+	}
+	var nsec *dns.NSEC
+	for _, r := range m.Ns {
+		if r.Header().Rrtype == dns.TypeNSEC {
+			nsec = r.(*dns.NSEC)
+		}
+	}
+	if nsec == nil {
+		t.Error("Expected NSEC, got none")
+	} else if !correctNsecForDS(nsec) {
+		t.Error("NSEC DS should cover delegation type only.")
+	}
+}
+
+func correctNsecForDS(nsec *dns.NSEC) bool {
+	var bitmask uint
+	/* Coherent TypeBitMap for NSEC of DS should contain at least:
+	 * {TypeNS, TypeNSEC, TypeRRSIG} and no SOA.
+	 * Any missing type will confuse resolver because
+	 * it will prove that the dns query cannot be a delegation point,
+	 * which will break trust resolution for unsigned delegated domain.
+	 * No SOA is obvious for none apex query.
+	 */
+	for _, typeBitmask := range nsec.TypeBitMap {
+		switch typeBitmask {
+		case dns.TypeNS:
+			bitmask |= 1
+		case dns.TypeNSEC:
+			bitmask |= 2
+		case dns.TypeRRSIG:
+			bitmask |= 4
+		case dns.TypeSOA:
+			return false
+		}
+	}
+	return bitmask == 7
+}
+
 func testNxdomainMsg() *dns.Msg {
 	return &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
 		Question: []dns.Question{{Name: "ww.miek.nl.", Qclass: dns.ClassINET, Qtype: dns.TypeTXT}},
-		Ns: []dns.RR{test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1461471181 14400 3600 604800 14400")},
+		Ns:       []dns.RR{test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1461471181 14400 3600 604800 14400")},
 	}
 }
 
 func testSuccessMsg() *dns.Msg {
 	return &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
 		Question: []dns.Question{{Name: "www.miek.nl.", Qclass: dns.ClassINET, Qtype: dns.TypeTXT}},
-		Answer: []dns.RR{test.TXT(`www.miek.nl.	1800	IN	TXT	"response"`)},
+		Answer:   []dns.RR{test.TXT(`www.miek.nl.	1800	IN	TXT	"response"`)},
+	}
+}
+
+func testNsecMsg() *dns.Msg {
+	return &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
+		Question: []dns.Question{{Name: "www.miek.nl.", Qclass: dns.ClassINET, Qtype: dns.TypeNSEC}},
+		Ns:       []dns.RR{test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1461471181 14400 3600 604800 14400")},
+	}
+}
+
+func testApexDSMsg() *dns.Msg {
+	return &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError},
+		Question: []dns.Question{{Name: "miek.nl.", Qclass: dns.ClassINET, Qtype: dns.TypeDS}},
+		Ns:       []dns.RR{test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1461471181 14400 3600 604800 14400")},
 	}
 }

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -48,6 +48,22 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 
 	mt, _ := response.Typify(req, time.Now().UTC()) // TODO(miek): need opt record here?
 	if mt == response.Delegation {
+		// We either sign DS or NSEC of DS.
+		ttl := req.Ns[0].Header().Ttl
+
+		ds := []dns.RR{}
+		for i := range req.Ns {
+			if req.Ns[i].Header().Rrtype == dns.TypeDS {
+				ds = append(ds, req.Ns[i])
+			}
+		}
+		if len(ds) == 0 {
+			if sigs, err := d.nsec(state, mt, ttl, incep, expir, server); err == nil {
+				req.Ns = append(req.Ns, sigs...)
+			}
+		} else if sigs, err := d.sign(ds, state.Zone, ttl, incep, expir, server); err == nil {
+			req.Ns = append(req.Ns, sigs...)
+		}
 		return req
 	}
 
@@ -66,6 +82,10 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 		}
 		if len(req.Ns) > 1 { // actually added nsec and sigs, reset the rcode
 			req.Rcode = dns.RcodeSuccess
+			if state.QType() == dns.TypeNSEC { // If original query was NSEC move Ns to Answer without SOA
+				req.Answer = req.Ns[len(req.Ns)-2 : len(req.Ns)]
+				req.Ns = nil
+			}
 		}
 		return req
 	}

--- a/plugin/dnssec/handler_test.go
+++ b/plugin/dnssec/handler_test.go
@@ -38,6 +38,73 @@ var dnsTestCases = []test.Case{
 		},
 	},
 	{
+		Qname: "miek.nl.", Qtype: dns.TypeNS, Do: true,
+		Answer: []dns.RR{
+			test.NS("miek.nl.	1800	IN      NS      linode.atoom.net."),
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	NS 13 2 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+		},
+	},
+	{
+		Qname: "deleg.miek.nl.", Qtype: dns.TypeNS, Do: true,
+		Ns: []dns.RR{
+			test.DS("deleg.miek.nl.	1800	IN      DS      18512 13 2 D4E806322598BC97A003EF1ACDFF352EEFF7B42DBB0D41B8224714C36AEF08D9"),
+			test.NS("deleg.miek.nl.	1800	IN      NS      ns01.deleg.miek.nl."),
+			test.RRSIG("deleg.miek.nl.	1800	IN	RRSIG	DS 13 3 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+		},
+	},
+	{
+		Qname: "unsigned.miek.nl.", Qtype: dns.TypeNS, Do: true,
+		Ns: []dns.RR{
+			test.NS("unsigned.miek.nl.	1800	IN      NS      ns01.deleg.miek.nl."),
+			test.NSEC("unsigned.miek.nl.	1800	IN	NSEC	unsigned\\000.miek.nl. NS RRSIG NSEC"),
+			test.RRSIG("unsigned.miek.nl.	1800	IN	RRSIG	NSEC 13 3 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+		},
+	},
+	{ // DS should not come from dnssec plugin
+		Qname: "deleg.miek.nl.", Qtype: dns.TypeDS,
+		Answer: []dns.RR{
+			test.DS("deleg.miek.nl.	1800	IN      DS      18512 13 2 D4E806322598BC97A003EF1ACDFF352EEFF7B42DBB0D41B8224714C36AEF08D9"),
+		},
+		Ns: []dns.RR{
+			test.NS("miek.nl.	1800	IN	NS	linode.atoom.net."),
+		},
+	},
+	{
+		Qname: "unsigned.miek.nl.", Qtype: dns.TypeDS,
+		Ns: []dns.RR{
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+	{
+		Qname: "miek.nl.", Qtype: dns.TypeDS, Do: true,
+		Ns: []dns.RR{
+			test.NSEC("miek.nl.	1800	IN	NSEC	\\000.miek.nl. A HINFO NS SOA MX TXT AAAA LOC SRV CERT SSHFP RRSIG NSEC DNSKEY TLSA HIP OPENPGPKEY SPF"),
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	NSEC 13 2 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	SOA 13 2 3600 20171220141741 20171212111741 18512 miek.nl. 8bLTReqmuQtw=="),
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+		},
+	},
+	{
+		Qname: "deleg.miek.nl.", Qtype: dns.TypeDS, Do: true,
+		Answer: []dns.RR{
+			test.DS("deleg.miek.nl.	1800	IN      DS      18512 13 2 D4E806322598BC97A003EF1ACDFF352EEFF7B42DBB0D41B8224714C36AEF08D9"),
+			test.RRSIG("deleg.miek.nl.	1800	IN	RRSIG	DS 13 3 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+		},
+		Ns: []dns.RR{
+			test.NS("miek.nl.	1800	IN	NS	linode.atoom.net."),
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	NS 13 2 3600 20161217114912 20161209084912 18512 miek.nl. ad9gA8VWgF1H8ze9/0Rk2Q=="),
+		},
+	},
+	{
+		Qname: "unsigned.miek.nl.", Qtype: dns.TypeDS, Do: true,
+		Ns: []dns.RR{
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	SOA 13 2 3600 20171220141741 20171212111741 18512 miek.nl. 8bLTReqmuQtw=="),
+			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
+			test.NSEC("unsigned.miek.nl.	1800	IN	NSEC	\\000.unsigned.miek.nl. NS RRSIG NSEC"),
+			test.RRSIG("unsigned.miek.nl.	1800	IN	RRSIG	NSEC 13 3 1800 20220101121212 20220201121212 18512 miek.nl. RandomNotChecked"),
+		},
+	},
+	{
 		Qname: "miek.nl.", Qtype: dns.TypeMX,
 		Answer: []dns.RR{
 			test.MX("miek.nl.	1800	IN	MX	1 aspmx.l.google.com."),
@@ -179,4 +246,8 @@ $ORIGIN miek.nl.
 
 a               IN      A       139.162.196.78
                 IN      AAAA    2a01:7e00::f03c:91ff:fef1:6735
-www             IN      CNAME   a`
+www             IN      CNAME   a
+deleg			IN		NS		ns01.deleg
+				IN		DS		18512 13 2 D4E806322598BC97A003EF1ACDFF352EEFF7B42DBB0D41B8224714C36AEF08D9
+unsigned		IN		NS		ns01.deleg
+`


### PR DESCRIPTION
* When returning NS for delegation point, we sign any DS Record or if not found we generate a NSEC proving absence of DS. This follow behaviour describe in rfc4035 (Section 3.1.4)
* DS request at apex behave as before.
* Fix edge case of requesting NSEC which prove that NSEC does not exist.

Signed-off-by: Jeremiejig <me@jeremiejig.fr>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This commit fix incorrect behaviour of plugin/dnssec which lead to a **broken** chain of trust 
for an unsigned delegated zone.
It was also the occasion to properly add DS/NSEC RRSig signature when answering a delegation
matching [rfc4035](https://www.rfc-editor.org/rfc/rfc4035) (See section 3.1.4)

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
