### PR TITLE
plugin/loadbalance: Improve weights update

### DIFF
--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -254,26 +254,26 @@ func (w *weightedRR) updateWeights() error {
 	scanner := bufio.NewScanner(&buf)
 
 	// Parse the weight file contents
-	err = w.parseWeights(scanner)
+	domains, err := w.parseWeights(scanner)
 	if err != nil {
 		return err
 	}
+
+	// access to weights must be protected
+	w.mutex.Lock()
+	w.domains = domains
+	w.mutex.Unlock()
 
 	log.Infof("Successfully reloaded weight file %s", w.fileName)
 	return nil
 }
 
 // Parse the weight file contents
-func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
-	// access to weights must be protected
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
-	// Reset domains
-	w.domains = make(map[string]weights)
-
+func (w *weightedRR) parseWeights(scanner *bufio.Scanner) (map[string]weights, error) {
 	var dname string
 	var ws weights
+	domains := make(map[string]weights)
+
 	for scanner.Scan() {
 		nextLine := strings.TrimSpace(scanner.Text())
 		if len(nextLine) == 0 || nextLine[0:1] == "#" {
@@ -285,7 +285,7 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 		case 1:
 			// (domain) name sanity check
 			if net.ParseIP(fields[0]) != nil {
-				return fmt.Errorf("Wrong domain name:\"%s\" in weight file %s. (Maybe a missing weight value?)",
+				return nil, fmt.Errorf("Wrong domain name:\"%s\" in weight file %s. (Maybe a missing weight value?)",
 					fields[0], w.fileName)
 			}
 			dname = fields[0]
@@ -295,35 +295,35 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) error {
 				dname += "."
 			}
 			var ok bool
-			ws, ok = w.domains[dname]
+			ws, ok = domains[dname]
 			if !ok {
 				ws = make(weights, 0)
-				w.domains[dname] = ws
+				domains[dname] = ws
 			}
 		case 2:
 			// IP address and weight value
 			ip := net.ParseIP(fields[0])
 			if ip == nil {
-				return fmt.Errorf("Wrong IP address:\"%s\" in weight file %s", fields[0], w.fileName)
+				return nil, fmt.Errorf("Wrong IP address:\"%s\" in weight file %s", fields[0], w.fileName)
 			}
 			weight, err := strconv.ParseUint(fields[1], 10, 8)
-			if err != nil {
-				return fmt.Errorf("Wrong weight value:\"%s\" in weight file %s", fields[1], w.fileName)
+			if err != nil || weight == 0 {
+				return nil, fmt.Errorf("Wrong weight value:\"%s\" in weight file %s", fields[1], w.fileName)
 			}
 			witem := &weightItem{address: ip, value: uint8(weight)}
 			if dname == "" {
-				return fmt.Errorf("Missing domain name in weight file %s", w.fileName)
+				return nil, fmt.Errorf("Missing domain name in weight file %s", w.fileName)
 			}
 			ws = append(ws, witem)
-			w.domains[dname] = ws
+			domains[dname] = ws
 		default:
-			return fmt.Errorf("Could not parse weight line:\"%s\" in weight file %s", nextLine, w.fileName)
+			return nil, fmt.Errorf("Could not parse weight line:\"%s\" in weight file %s", nextLine, w.fileName)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("Weight file %s parsing error:%s", w.fileName, err)
+		return nil, fmt.Errorf("Weight file %s parsing error:%s", w.fileName, err)
 	}
 
-	return nil
+	return domains, nil
 }

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -79,6 +79,11 @@ w1,example.org
 192.168.1.14 300
 `
 
+const zeroWeightWRR = `
+w1,example.org
+192.168.1.14 0
+`
+
 func TestWeightFileUpdate(t *testing.T) {
 	tests := []struct {
 		weightFilContent   string
@@ -95,6 +100,7 @@ func TestWeightFileUpdate(t *testing.T) {
 		{missingDomainWRR, true, nil, "Missing domain name"},
 		{wrongIpWRR, true, nil, "Wrong IP address"},
 		{wrongWeightWRR, true, nil, "Wrong weight value"},
+		{zeroWeightWRR, true, nil, "Wrong weight value"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Make the weights update atomic which only happens if the weight file is parsed without any error. Also, add missing check to reject zero weight values.

Signed-off-by: Gabor Dozsa <gabor.dozsa@ibm.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

It improves the weights update for the weighted policy in the loadbalance plugin. Two main changes: 
-  make the weights update "atomic" in the sense that it happens as a single assignment after the weight file get parsed successfully
-  add a missing check in the weight file parser to reject zero weight values. (Valid weight values are [1,255] as stated in the README)  

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No