### PR TITLE
Use http constants instead of string

### DIFF
--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -22,7 +22,7 @@ func TestHealth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to query %s: %v", address, err)
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Errorf("Invalid status code: expecting '200', got '%d'", response.StatusCode)
 	}
 	content, err := io.ReadAll(response.Body)

--- a/plugin/ready/ready_test.go
+++ b/plugin/ready/ready_test.go
@@ -32,7 +32,7 @@ func TestReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to query %s: %v", address, err)
 	}
-	if response.StatusCode != 503 {
+	if response.StatusCode != http.StatusServiceUnavailable {
 		t.Errorf("Invalid status code: expecting %d, got %d", 503, response.StatusCode)
 	}
 	response.Body.Close()
@@ -48,7 +48,7 @@ func TestReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to query %s: %v", address, err)
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Errorf("Invalid status code: expecting %d, got %d", 200, response.StatusCode)
 	}
 	response.Body.Close()
@@ -62,7 +62,7 @@ func TestReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to query %s: %v", address, err)
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Errorf("Invalid status code: expecting %d, got %d", 200, response.StatusCode)
 	}
 	response.Body.Close()

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -19,7 +19,6 @@
 //
 //	result := Scrape("http://localhost:9153/metrics")
 //	v := MetricValue("coredns_cache_capacity", result)
-//
 package test
 
 import (
@@ -217,7 +216,7 @@ func makeBuckets(m *dto.Metric) map[string]string {
 
 func fetchMetricFamilies(url string, ch chan<- *dto.MetricFamily) {
 	defer close(ch)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return
 	}

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -152,7 +153,7 @@ func TestTrace_DOH_TraceHeaderExtraction(t *testing.T) {
 	}
 	q := new(dns.Msg).SetQuestion("example.net.", dns.TypeA)
 
-	req := httptest.NewRequest("POST", "/dns-query", nil)
+	req := httptest.NewRequest(http.MethodPost, "/dns-query", nil)
 
 	outsideSpan := m.StartSpan("test-header-span")
 	outsideSpan.Tracer().Inject(outsideSpan.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Using strings as arguments to http package functions is error-prone, so call http package functions in the standard way

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
