### PR TITLE
plugin/dnstap: add tls support for outgoing connections

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -18,6 +18,7 @@ Every message is sent to the socket as soon as it comes in, the *dnstap* plugin 
 dnstap SOCKET [full] {
   [identity IDENTITY]
   [version VERSION]
+  [skipverify]
 }
 ~~~
 
@@ -25,6 +26,7 @@ dnstap SOCKET [full] {
 * `full` to include the wire-format DNS message.
 * **IDENTITY** to override the identity of the server. Defaults to the hostname.
 * **VERSION** to override the version field. Defaults to the CoreDNS version.
+* `skipverify` to skip tls verification during connection. Default to be secure
 
 ## Examples
 
@@ -58,6 +60,14 @@ Log to a socket, overriding the default identity and version.
 dnstap /tmp/dnstap.sock {
   identity my-dns-server1
   version MyDNSServer-1.2.3
+}
+~~~
+
+Log to a remote TLS endpoint.
+
+~~~ txt
+dnstap tls://127.0.0.1:6000 full {
+  skipverify
 }
 ~~~
 

--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -1,6 +1,7 @@
 package dnstap
 
 import (
+	"crypto/tls"
 	"net"
 	"sync/atomic"
 	"time"
@@ -14,6 +15,8 @@ const (
 
 	tcpTimeout   = 4 * time.Second
 	flushTimeout = 1 * time.Second
+
+	skipVerify = false // by default, every tls connection is verified to be secure
 )
 
 // tapper interface is used in testing to mock the Dnstap method.
@@ -31,6 +34,7 @@ type dio struct {
 	quit         chan struct{}
 	flushTimeout time.Duration
 	tcpTimeout   time.Duration
+	skipVerify   bool
 }
 
 // newIO returns a new and initialized pointer to a dio.
@@ -42,14 +46,32 @@ func newIO(proto, endpoint string) *dio {
 		quit:         make(chan struct{}),
 		flushTimeout: flushTimeout,
 		tcpTimeout:   tcpTimeout,
+		skipVerify:   skipVerify,
 	}
 }
 
 func (d *dio) dial() error {
-	conn, err := net.DialTimeout(d.proto, d.endpoint, d.tcpTimeout)
-	if err != nil {
-		return err
+	var conn net.Conn
+	var err error
+
+	if d.proto == "tls" {
+		config := &tls.Config{
+			InsecureSkipVerify: d.skipVerify,
+		}
+		dialer := &net.Dialer{
+			Timeout: d.tcpTimeout,
+		}
+		conn, err = tls.DialWithDialer(dialer, "tcp", d.endpoint, config)
+		if err != nil {
+			return err
+		}
+	} else {
+		conn, err = net.DialTimeout(d.proto, d.endpoint, d.tcpTimeout)
+		if err != nil {
+			return err
+		}
 	}
+
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		tcpConn.SetWriteBuffer(tcpWriteBufSize)
 		tcpConn.SetNoDelay(false)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -44,6 +44,7 @@ func TestConfig(t *testing.T) {
 			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER")},
 			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2")},
 		}},
+		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-")}}},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This pull request add TLS support to send dnstap messages 
for example this dnstap collector support that: https://github.com/dmachard/go-dns-collector (I am the author)

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

The readme of the dnstap plugin  has been updated in this PR.

### 4. Does this introduce a backward incompatible change or deprecation?

No backwards incompatible change.