### PR TITLE
build: cp Dockerfile in docker-build target

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -73,7 +73,6 @@ endif
 		mkdir build/docker/$${arch}; \
 		curl -L $(GITHUB)/v$(VERSION)/coredns_$(VERSION)_linux_$${arch}.tgz > build/docker/$${arch}/coredns.tgz && \
 			( cd build/docker/$${arch}; tar xf coredns.tgz && rm coredns.tgz ); \
-			cp Dockerfile build/docker/$${arch} ; \
 	done
 
 .PHONY: docker-build
@@ -83,12 +82,16 @@ ifeq ($(DOCKER),)
 else
 	docker version
 	for arch in $(LINUX_ARCH); do \
+	    cp Dockerfile build/docker/$${arch} ; \
 	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
 	done
 endif
 
 .PHONY: docker-push
 docker-push:
+ifeq ($(VERSION),)
+	$(error "Please specify a version use. Use VERSION=<version>")
+endif
 ifeq ($(DOCKER),)
 	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
 else


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This pull request moves the `cp Dockerfile` command to the `docker-build` Makefile target, which is the one that actually needs the `Dockerfile`. This makes the target useful to build docker images from local binaries (without using `image-download`.) It also adds a check to make sure `VERSION` is set. This check was present for other targets, but missing from `docker-push`.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None. Default Docker build is unchanged.

### 4. Does this introduce a backward incompatible change or deprecation?
For most builds this change makes no difference, since the usual `release` target first invokes `image-download` and then `docker-build`, so the effect is the sam. There's a small change in behaviour when you invoke those targets separately, since the `image-download` no longer copies the `Dockerfile` into the downloaded folders (which from the name was a bit unexpected anyway.)