### PR TITLE
plugin/forward: Add local address option

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
+    local ADDRESS
 }
 ~~~
 
@@ -95,6 +96,7 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `local` **ADDRESS** specifies the source address to use for outbound queries.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,7 +50,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
-    local ADDRESS
+    source ADDRESS
 }
 ~~~
 
@@ -96,7 +96,7 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
-* `local` **ADDRESS** specifies the source address to use for outbound queries.
+* `source` **ADDRESS** specifies the source address to use for outbound queries.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -87,11 +87,11 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 	reqTime := time.Now()
 	timeout := t.dialTimeout()
 	if proto == "tcp-tls" {
-		conn, err := dialTimeoutLocalWithTLS("tcp", t.addr, t.local, t.tlsConfig, timeout)
+		conn, err := dialTimeoutLocalWithTLS("tcp", t.addr, t.source, t.tlsConfig, timeout)
 		t.updateDialTimeout(time.Since(reqTime))
 		return &persistConn{c: conn}, false, err
 	}
-	conn, err := dialTimeoutLocal(proto, t.addr, t.local, timeout)
+	conn, err := dialTimeoutLocal(proto, t.addr, t.source, timeout)
 	t.updateDialTimeout(time.Since(reqTime))
 	return &persistConn{c: conn}, false, err
 }

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net"
 	"sync/atomic"
 	"time"
 
@@ -37,6 +38,7 @@ type Forward struct {
 	from    string
 	ignored []string
 
+	local         net.IP
 	tlsConfig     *tls.Config
 	tlsServerName string
 	maxfails      uint32

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -38,7 +38,7 @@ type Forward struct {
 	from    string
 	ignored []string
 
-	local         net.IP
+	source        net.IP
 	tlsConfig     *tls.Config
 	tlsServerName string
 	maxfails      uint32

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"crypto/tls"
+	"net"
 	"sort"
 	"time"
 
@@ -20,6 +21,7 @@ type Transport struct {
 	conns       [typeTotalCount][]*persistConn // Buckets for udp, tcp and tcp-tls.
 	expire      time.Duration                  // After this duration a connection is expired.
 	addr        string
+	local       net.IP
 	tlsConfig   *tls.Config
 
 	dial  chan string

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -21,7 +21,7 @@ type Transport struct {
 	conns       [typeTotalCount][]*persistConn // Buckets for udp, tcp and tcp-tls.
 	expire      time.Duration                  // After this duration a connection is expired.
 	addr        string
-	local       net.IP
+	source      net.IP
 	tlsConfig   *tls.Config
 
 	dial  chan string

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -154,7 +154,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 		f.proxies[i].SetExpire(f.expire)
 		f.proxies[i].health.SetRecursionDesired(f.opts.hcRecursionDesired)
-		f.proxies[i].transport.local = f.local
+		f.proxies[i].transport.source = f.source
 		// when TLS is used, checks are set to tcp-tls
 		if f.opts.forceTCP && transports[i] != transport.TLS {
 			f.proxies[i].health.SetTCPTransport()
@@ -281,14 +281,14 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		}
 		f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
-	case "local":
+	case "source":
 		if !c.NextArg() {
 			return c.ArgErr()
 		}
-		local := c.Val()
-		f.local = net.ParseIP(local)
-		if f.local == nil {
-			return c.Errf("invalid local address '%s'", local)
+		source := c.Val()
+		f.source = net.ParseIP(source)
+		if f.source == nil {
+			return c.Errf("invalid source address '%s'", source)
 		}
 
 	default:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This adds a `local` option to the `forward` plugin, to allow specifying the source address to use for outbound queries. 

This is useful on systems where a destination is reachable through multiple interfaces. It's comparable to the BIND `query-source address` option, the Unbound `outgoing-interface` option, etc.

### 2. Which issues (if any) are related?

#5895 

### 3. Which documentation changes (if any) need to be made?

Update to plugin README, included in this change.

### 4. Does this introduce a backward incompatible change or deprecation?

No