### PR TITLE
plugin/health: Poll localhost by default

### DIFF
--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -32,8 +32,7 @@ func (h *health) overloaded(ctx context.Context) {
 		Transport: bypassProxy,
 	}
 
-	url := "http://" + h.Addr + "/health"
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, h.healthURI.String(), nil)
 	tick := time.NewTicker(1 * time.Second)
 	defer tick.Stop()
 
@@ -49,14 +48,14 @@ func (h *health) overloaded(ctx context.Context) {
 			if err != nil {
 				HealthDuration.Observe(time.Since(start).Seconds())
 				HealthFailures.Inc()
-				log.Warningf("Local health request to %q failed: %s", url, err)
+				log.Warningf("Local health request to %q failed: %s", req.URL.String(), err)
 				continue
 			}
 			resp.Body.Close()
 			elapsed := time.Since(start)
 			HealthDuration.Observe(elapsed.Seconds())
 			if elapsed > time.Second { // 1s is pretty random, but a *local* scrape taking that long isn't good
-				log.Warningf("Local health request to %q took more than 1s: %s", url, elapsed)
+				log.Warningf("Local health request to %q took more than 1s: %s", req.URL.String(), elapsed)
 			}
 
 		case <-ctx.Done():

--- a/plugin/health/overloaded_test.go
+++ b/plugin/health/overloaded_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -21,6 +22,13 @@ func Test_health_overloaded_cancellation(t *testing.T) {
 		Addr: ts.URL,
 		stop: cancel,
 	}
+
+	var err error
+	h.healthURI, err = url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.healthURI.Path = "/health"
 
 	stopped := make(chan struct{})
 	go func() {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Logs like this:

```
[WARNING] plugin/health: Local health request to "http://:8080/health" failed: Get "http://:8080/health": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
[WARNING] plugin/health: Local health request to "http://:8080/health" took more than 1s: 1.957510747s
```

show an invalid URI.  From [the URI RFC 3986][1]:

> If the URI scheme defines a default for host, then that default applies when the host subcomponent is undefined or when the registered name is empty (zero length).  For example, the "file" URI scheme is defined so that no authority, an empty host, and "localhost" all mean the end-user's machine, whereas the "http" scheme considers a missing authority or empty host invalid.

And from the HTTP constraint is echoed in [the HTTP RFC 9110][2]:

> A sender MUST NOT generate an "http" URI with an empty host identifier. A recipient that processes such a URI reference MUST reject it as invalid.

There is apparently something in the Go request tooling that allows host-less HTTP requests to go through, but defaulting to localhost makes things explicit in CoreDNS code, and will give us valid URIs in the logs (which log reading admins will hopefully find less confusing) when health checks fail or are slow.

[1]: https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
[2]: https://www.rfc-editor.org/rfc/rfc9110#name-http-uri-scheme

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.