### PR TITLE
add support unix socket for GRPC

### DIFF
--- a/plugin/grpc/README.md
+++ b/plugin/grpc/README.md
@@ -129,6 +129,14 @@ Or with multiple upstreams from the same provider
 }
 ~~~
 
+Forward requests to a local upstream listening on a Unix domain socket.
+
+~~~ corefile
+. {
+    grpc . unix:///path/to/grpc.sock
+}
+~~~
+
 ## Bugs
 
 The TLS config is global for the whole grpc proxy if you need a different `tls_servername` for

--- a/plugin/grpc/setup_test.go
+++ b/plugin/grpc/setup_test.go
@@ -25,6 +25,7 @@ func TestSetup(t *testing.T) {
 		{"grpc . 127.0.0.1:8080", false, ".", nil, ""},
 		{"grpc . [::1]:53", false, ".", nil, ""},
 		{"grpc . [2003::1]:53", false, ".", nil, ""},
+		{"grpc . unix:///var/run/g.sock", false, ".", nil, ""},
 		// negative
 		{"grpc . a27.0.0.1", true, "", nil, "not an IP"},
 		{"grpc . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, "unknown property"},

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -33,6 +33,14 @@ func HostPortOrFile(s ...string) ([]string, error) {
 	var servers []string
 	for _, h := range s {
 		trans, host := Transport(h)
+		if len(host) == 0 {
+			return servers, fmt.Errorf("invalid address: %q", h)
+		}
+
+		if trans == transport.UNIX {
+			servers = append(servers, trans+"://"+host)
+			continue
+		}
 
 		addr, _, err := net.SplitHostPort(host)
 

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -58,6 +58,16 @@ func TestHostPortOrFile(t *testing.T) {
 			"",
 			true,
 		},
+		{
+			"unix:///var/run/g.sock",
+			"unix:///var/run/g.sock",
+			false,
+		},
+		{
+			"unix://",
+			"",
+			true,
+		},
 	}
 
 	err := os.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)

--- a/plugin/pkg/parse/transport.go
+++ b/plugin/pkg/parse/transport.go
@@ -27,6 +27,9 @@ func Transport(s string) (trans string, addr string) {
 		s = s[len(transport.HTTPS+"://"):]
 
 		return transport.HTTPS, s
+	case strings.HasPrefix(s, transport.UNIX+"://"):
+		s = s[len(transport.UNIX+"://"):]
+		return transport.UNIX, s
 	}
 
 	return transport.DNS, s

--- a/plugin/pkg/transport/transport.go
+++ b/plugin/pkg/transport/transport.go
@@ -6,6 +6,7 @@ const (
 	TLS   = "tls"
 	GRPC  = "grpc"
 	HTTPS = "https"
+	UNIX  = "unix"
 )
 
 // Port numbers for the various transports.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
add support unix socket for GRPC to adapt to some local scenarios that are inconvenient to use TCP

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No
