### PR TITLE
plugin/tls/etcd/forward/grpc: respect the path specified by root plugin

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -19,6 +19,7 @@
 # Local plugin example:
 # log:log
 
+root:root
 metadata:metadata
 geoip:geoip
 cancel:cancel
@@ -26,7 +27,6 @@ tls:tls
 reload:reload
 nsid:nsid
 bufsize:bufsize
-root:root
 bind:bind
 debug:debug
 trace:trace

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"crypto/tls"
+	"path/filepath"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -29,6 +30,7 @@ func setup(c *caddy.Controller) error {
 }
 
 func etcdParse(c *caddy.Controller) (*Etcd, error) {
+	config := dnsserver.GetConfig(c)
 	etc := Etcd{PathPrefix: "skydns"}
 	var (
 		tlsConfig *tls.Config
@@ -66,6 +68,11 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 				c.RemainingArgs()
 			case "tls": // cert key cacertfile
 				args := c.RemainingArgs()
+				for i := range args {
+					if !filepath.IsAbs(args[i]) && config.Root != "" {
+						args[i] = filepath.Join(config.Root, args[i])
+					}
+				}
 				tlsConfig, err = mwtls.NewTLSConfigFromArgs(args...)
 				if err != nil {
 					return &Etcd{}, err

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -166,6 +167,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 }
 
 func parseBlock(c *caddy.Controller, f *Forward) error {
+	config := dnsserver.GetConfig(c)
 	switch c.Val() {
 	case "except":
 		ignore := c.RemainingArgs()
@@ -231,7 +233,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		if len(args) > 3 {
 			return c.ArgErr()
 		}
-
+		for i := range args {
+			if !filepath.IsAbs(args[i]) && config.Root != "" {
+				args[i] = filepath.Join(config.Root, args[i])
+			}
+		}
 		tlsConfig, err := pkgtls.NewTLSConfigFromArgs(args...)
 		if err != nil {
 			return err

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"crypto/tls"
 	"fmt"
+	"path/filepath"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -110,7 +111,11 @@ func parseBlock(c *caddy.Controller, g *GRPC) error {
 		if len(args) > 3 {
 			return c.ArgErr()
 		}
-
+		for i := range args {
+			if !filepath.IsAbs(args[i]) && dnsserver.GetConfig(c).Root != "" {
+				args[i] = filepath.Join(dnsserver.GetConfig(c).Root, args[i])
+			}
+		}
 		tlsConfig, err := pkgtls.NewTLSConfigFromArgs(args...)
 		if err != nil {
 			return err

--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	ctls "crypto/tls"
+	"path/filepath"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -55,6 +56,11 @@ func parseTLS(c *caddy.Controller) error {
 				}
 			default:
 				return c.Errf("unknown option '%s'", c.Val())
+			}
+		}
+		for i := range args {
+			if !filepath.IsAbs(args[i]) && config.Root != "" {
+				args[i] = filepath.Join(config.Root, args[i])
 			}
 		}
 		tls, err := tls.NewTLSConfigFromArgs(args...)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use the path specified by the root plugin to look for certs

### 2. Which issues (if any) are related?

#5910 

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

For this to work, the plugin root must come before the tls plugin in plugin.cfg. 
There may also be folks who are using the root and tls plugin at the moment with their current behaviour, this change could lead to problems for them.
