### PR TITLE
plugin/k8s_extenral: Supports fallthrough option

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -10,8 +10,7 @@ This plugin allows an additional zone to resolve the external IP address(es) of 
 service and headless services. This plugin is only useful if the *kubernetes* plugin is also loaded.
 
 The plugin uses an external zone to resolve in-cluster IP addresses. It only handles queries for A,
-AAAA, SRV, and PTR records; all others result in NODATA responses. To make it a proper DNS zone, it handles
-SOA and NS queries for the apex of the zone.
+AAAA, SRV, and PTR records; To make it a proper DNS zone, it handles SOA and NS queries for the apex of the zone.
 
 By default the apex of the zone will look like the following (assuming the zone used is `example.org`):
 
@@ -67,6 +66,14 @@ k8s_external [ZONE...] {
 
 * if there is a headless service with external IPs set, external IPs will be resolved
 
+If the queried domain does not exist, you can fall through to next plugin by adding the `fallthrough` option.
+
+~~~
+k8s_external [ZONE...] {
+    fallthrough [ZONE...]
+}
+~~~
+
 ## Examples
 
 Enable names under `example.org` to be resolved to in-cluster DNS addresses.
@@ -105,6 +112,18 @@ zone transfers.  Notifies are not supported.
          k8s_external example.org
      }
  ~~~
+
+With the `fallthrough` option, if the queried domain does not exist, it will be passed to the next plugin that matches the zone.
+
+~~~
+. {
+   kubernetes cluster.local
+   k8s_external example.org {
+     fallthrough
+   }
+   forward . 8.8.8.8
+}
+~~~
 
 # See Also
 

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -70,10 +70,6 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return plugin.NextOrFailure(e.Name(), e.Next, ctx, w, r)
 	}
 
-	if e.externalFunc == nil {
-		return plugin.NextOrFailure(e.Name(), e.Next, ctx, w, r)
-	}
-
 	state.Zone = zone
 	for _, z := range e.Zones {
 		// TODO(miek): save this in the External struct.

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/coredns/caddy"
@@ -9,7 +10,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 )
 
-func init() { plugin.Register("k8s_external", setup) }
+const pluginName = "k8s_external"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	e, err := parse(c)
@@ -21,14 +24,18 @@ func setup(c *caddy.Controller) error {
 	c.OnStartup(func() error {
 		m := dnsserver.GetConfig(c).Handler("kubernetes")
 		if m == nil {
-			return nil
+			return plugin.Error(pluginName, errors.New("kubernetes plugin not loaded"))
 		}
-		if x, ok := m.(Externaler); ok {
-			e.externalFunc = x.External
-			e.externalAddrFunc = x.ExternalAddress
-			e.externalServicesFunc = x.ExternalServices
-			e.externalSerialFunc = x.ExternalSerial
+
+		x, ok := m.(Externaler)
+		if !ok {
+			return plugin.Error(pluginName, errors.New("kubernetes plugin does not implement the Externaler interface"))
 		}
+
+		e.externalFunc = x.External
+		e.externalAddrFunc = x.ExternalAddress
+		e.externalServicesFunc = x.ExternalServices
+		e.externalSerialFunc = x.ExternalSerial
 		return nil
 	})
 

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -70,6 +70,8 @@ func parse(c *caddy.Controller) (*External, error) {
 				e.apex = args[0]
 			case "headless":
 				e.headless = true
+			case "fallthrough":
+				e.Fall.SetZonesFromArgs(c.RemainingArgs())
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
To enable fallthrough for the`k8s_external` plugin, add the fallthrough option to the plugin configuration. This will allow DNS queries that are not handled by the plugin to be passed through to the next plugin in the Corefile. 
The fallthrough option can be useful if you want to use the`k8s_external` plugin for resolving external IP addresses, but fall back to a different plugin for other DNS queries.

### 2. Which issues (if any) are related?
#5958

### 3. Which documentation changes (if any) need to be made?

The documentation for [k8s_external](https://coredns.io/plugins/k8s_external/) should include the new options added to the`k8s_external` plugin, along with their descriptions, syntax, and usage examples.

I have made some changes to the documentation, but it may still require further improvement. Please let me know if you have any suggestions so that I can make further revisions.

### 4. Does this introduce a backward incompatible change or deprecation?

This pull request changes the behavior of `k8s_external` when a user misconfigures it. Previously, the plugin would silently move on to the next plugin, but now it will return an error message to users and terminate execution.