### PR TITLE
Run coredns as non root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:stable-slim
+FROM --platform=$BUILDPLATFORM debian:stable-slim AS build
 SHELL [ "/bin/sh", "-ec" ]
 
 RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -7,13 +7,14 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
            TERM=linux ; \
     apt-get -qq update ; \
     apt-get -yyqq upgrade ; \
-    apt-get -yyqq install ca-certificates ; \
+    apt-get -yyqq install ca-certificates libcap2-bin; \
     apt-get clean
+COPY coredns /coredns
+RUN setcap cap_net_bind_service=+ep /coredns
 
-FROM --platform=$TARGETPLATFORM scratch
-
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-ADD coredns /coredns
-
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian11:nonroot
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /coredns /coredns
+USER nonroot:nonroot
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
To run coredns as nonroot using the nonroot distroless base image.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No
