### PR TITLE
Include a riscv64 build as part of release

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -32,7 +32,7 @@ DOCKER:=
 NAME:=coredns
 GITHUB:=https://github.com/coredns/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -50,7 +50,7 @@ endif
 NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips riscv64
 
 all:
 	@echo Use the 'release' target to build a release


### PR DESCRIPTION
I am running coredns on my new VisionFive2 SBC which uses the riscv64 architecture.  This PR includes that architecture as part of the release Makefile.  Tested it and it works great.