### PR TITLE
plugin/forward: fails to forward requests when the fail counter overflows

### DIFF
--- a/plugin/pkg/proxy/health.go
+++ b/plugin/pkg/proxy/health.go
@@ -105,7 +105,7 @@ func (h *dnsHc) Check(p *Proxy) error {
 	err := h.send(p.addr)
 	if err != nil {
 		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)
-		atomic.AddUint32(&p.fails, 1)
+		p.incrementFails()
 		return err
 	}
 

--- a/plugin/pkg/proxy/proxy.go
+++ b/plugin/pkg/proxy/proxy.go
@@ -93,6 +93,16 @@ func (p *Proxy) SetReadTimeout(duration time.Duration) {
 	p.readTimeout = duration
 }
 
+// incrementFails increments the number of fails safely.
+func (p *Proxy) incrementFails() {
+	curVal := atomic.LoadUint32(&p.fails)
+	if curVal > curVal+1 {
+		// overflow occurred, do not update the counter again
+		return
+	}
+	atomic.AddUint32(&p.fails, 1)
+}
+
 const (
 	maxTimeout = 2 * time.Second
 )


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

If a proxy repeatedly fails, it will be removed from the forward list. However, if the fail counter (uint32) overflows, the fail counter of proxy will be reset to an overflowed value of `0`. 
For example: https://go.dev/play/p/aDvMM3TeJHf?v=goprev

This can cause the proxy to be added back to the forward list and may result in some recursive requests failing during the duration of `duration` multiplied by `max_fails`.

### 2. Which issues (if any) are related?

No

### 3. Which documentation changes (if any) need to be made?

No

### 4. Does this introduce a backward incompatible change or deprecation?

No, it does not. However, it enhances the stability and reliability of the system.

BTW, I suggest introducing a success counter for the `health_check` probe to determine if a failed proxy is ready after multiple successful probes, instead of relying on just one successful probe.