### PR TITLE
plugin/kubernetes: expose client-go internal request metrics

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -229,6 +229,11 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
     * `headless_with_selector`
     * `headless_without_selector`
 
+The following are client level metrics to monitor apiserver request latency & status codes. `verb` identifies the apiserver [request type](https://kubernetes.io/docs/reference/using-api/api-concepts/#single-resource-api) and `url`/`host` denotes the apiserver endpoint.
+* `coredns_kubernetes_rest_client_request_duration_seconds{verb, url}` - captures apiserver request latency perceived by client grouped by `verb` and `url`.
+* `coredns_kubernetes_rest_client_rate_limiter_duration_seconds{verb, url}` - captures apiserver request latency contributed by client side rate limiter grouped by `verb` & `url`.
+* `coredns_kubernetes_rest_client_requests_total{method, code, host}` - captures total apiserver requests grouped by `method`, `status_code` & `host`.
+
 ## Bugs
 
 The duration metric only supports the "headless\_with\_selector" service currently.

--- a/plugin/kubernetes/metrics.go
+++ b/plugin/kubernetes/metrics.go
@@ -1,0 +1,74 @@
+package kubernetes
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"k8s.io/client-go/tools/metrics"
+)
+
+var (
+	// requestLatency measures K8s rest client requests latency grouped by verb and url.
+	requestLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: plugin.Namespace,
+			Subsystem: "kubernetes",
+			Name:      "rest_client_request_duration_seconds",
+			Help:      "Request latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"verb", "url"},
+	)
+
+	// rateLimiterLatency measures K8s rest client rate limiter latency grouped by verb and url.
+	rateLimiterLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: plugin.Namespace,
+			Subsystem: "kubernetes",
+			Name:      "rest_client_rate_limiter_duration_seconds",
+			Help:      "Client side rate limiter latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"verb", "url"},
+	)
+
+	// requestResult measures K8s rest client request metrics grouped by status code, method & host.
+	requestResult = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: plugin.Namespace,
+			Subsystem: "kubernetes",
+			Name:      "rest_client_requests_total",
+			Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
+		},
+		[]string{"code", "method", "host"},
+	)
+)
+
+func init() {
+	metrics.Register(metrics.RegisterOpts{
+		RequestLatency:     &latencyAdapter{m: requestLatency},
+		RateLimiterLatency: &latencyAdapter{m: rateLimiterLatency},
+		RequestResult:      &resultAdapter{requestResult},
+	})
+}
+
+type latencyAdapter struct {
+	m *prometheus.HistogramVec
+}
+
+func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+	l.m.WithLabelValues(verb, u.Host).Observe(latency.Seconds())
+}
+
+type resultAdapter struct {
+	m *prometheus.CounterVec
+}
+
+func (r *resultAdapter) Increment(_ context.Context, code, method, host string) {
+	r.m.WithLabelValues(code, method, host).Inc()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This pull request exposes following K8s client level metrics to monitor K8s requests latency & status codes. It is useful in setting up alerts (if required) in case coredns fails to query kube-apiserver (due to networking issues or application level issues) making it to serve stale records.
```
# HELP coredns_kubernetes_rest_client_rate_limiter_duration_seconds Client side rate limiter latency in seconds. Broken down by verb and URL.
# TYPE coredns_kubernetes_rest_client_rate_limiter_duration_seconds histogram
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.001"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.002"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.004"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.008"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.016"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.032"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.064"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.128"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.256"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.512"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="+Inf"} 14
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_sum{url="10.24.1.228:6443",verb="GET"} 0.000188625
coredns_kubernetes_rest_client_rate_limiter_duration_seconds_count{url="10.24.1.228:6443",verb="GET"} 14

# HELP coredns_kubernetes_rest_client_request_duration_seconds Request latency in seconds. Broken down by verb and URL.
# TYPE coredns_kubernetes_rest_client_request_duration_seconds histogram
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.001"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.002"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.004"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.008"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.016"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.032"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.064"} 0
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.128"} 4
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.256"} 6
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="0.512"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="1.024"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="2.048"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="4.096"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="8.192"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="16.384"} 8
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="32.768"} 14
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="65.536"} 14
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="131.072"} 14
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="262.144"} 14
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="524.288"} 14
coredns_kubernetes_rest_client_request_duration_seconds_bucket{url="10.24.1.228:6443",verb="GET",le="+Inf"} 14
coredns_kubernetes_rest_client_request_duration_seconds_sum{url="10.24.1.228:6443",verb="GET"} 181.56279254400002
coredns_kubernetes_rest_client_request_duration_seconds_count{url="10.24.1.228:6443",verb="GET"} 14

# HELP coredns_kubernetes_rest_client_requests_total Number of HTTP requests, partitioned by status code, method, and host.
# TYPE coredns_kubernetes_rest_client_requests_total counter
coredns_kubernetes_rest_client_requests_total{code="200",host="10.24.1.228:6443",method="GET"} 14
coredns_kubernetes_rest_client_requests_total{code="<error>",host="10.24.1.228:6443",method="GET"} 6
```
You may refer to [this metrics initialisation](https://github.com/kubernetes/kubernetes/blob/0f373abb6a0de9a8a7eee14462701eb2875ba9d6/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go#L34) pkg to see how K8s internal components (scheduler, controller-manager etc.) expose these client level metrics.
### 2. Which issues (if any) are related?
NA
### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No.