### PR TITLE
Add build-arg BASE_IMAGE and BUILDER_IMAGE to Makefile.docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=$BUILDPLATFORM debian:stable-slim AS build
+ARG BASE_IMAGE
+ARG BUILDER_IMAGE
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS build
 SHELL [ "/bin/sh", "-ec" ]
 
 RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -12,7 +14,7 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
 COPY coredns /coredns
 RUN setcap cap_net_bind_service=+ep /coredns
 
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian11:nonroot
+FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /coredns /coredns
 USER nonroot:nonroot

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -35,6 +35,8 @@ GITHUB:=https://github.com/coredns/coredns/releases/download
 LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
+BASE_IMAGE:=gcr.io/distroless/static-debian11:nonroot
+BUILDER_IMAGE:=debian:stable-slim
 
 all:
 	@echo Use the 'release' target to download released binaries and build containers per arch, 'docker-push' to build and push a multi arch manifest.
@@ -83,7 +85,7 @@ else
 	docker version
 	for arch in $(LINUX_ARCH); do \
 	    cp Dockerfile build/docker/$${arch} ; \
-	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
+	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) build/docker/$${arch} ;\
 	done
 endif
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add the flexibility to specify `BASE_IMAGE` and `BUILDER_IMAGE` arguments while building docker images.

### 2. Which issues (if any) are related?
N/A but can create one if needed.

### 3. Which documentation changes (if any) need to be made?
Change is self-explanatory and doesn't require additional documentation.

### 4. Does this introduce a backward incompatible change or deprecation?
No.
