### PR TITLE
Handle UDP responses that overflow with tc bit

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -124,7 +124,12 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			// client retry over TCP (if that's supported) or at least receive a clean
 			// error. The connection is still good so we break before the close.
 			if proto == "udp" && strings.Contains(err.Error(), "overflow") {
-				ret.Truncated = true
+				newRet := state.Req.Copy()
+				newRet.AuthenticatedData = false
+				newRet.RecursionAvailable = ret.RecursionAvailable
+				newRet.Response = true
+				newRet.Truncated = true
+				ret = newRet
 				break
 			}
 			pc.c.Close() // not giving it back


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Prior to #5671 being merged, the cache plugin did two things that it doesn't do now:

1. Force the UDP buffer size to 2048 bytes
1. Always set the DNSSEC DO bit, which also meant that an eDNS0 OPT RR was always included with the appropriate buffer size

This caused problems for clients when the DNS server would ignore the bufsize in the OPT RR and return a UDP response >512 octets; it would fail to unpack because it didn't fit in the buffer, and also other confusion as enumerated in the PR.

However, the pre-5671 behavior would also prevent issues with noncompliant upstream DNS servers that returned UDP responses >512 octets even when the client didn't supply an eDNS0 header, because every request sent eDNS0. The too-large-for-the-client response would get put into the cache, and coredns would properly send a partial response with the truncate bit set, letting the client know it needed to retry over TCP. The retry would then be served from the cache. This only worked if cache was enabled.

This PR prevents request failure in the case of an upstream that sends an overly large UDP response - when handling the error from miekg/dns attempting to unpack the too-large message, if the error indicates an overflow we return an empty response with the truncate bit set. This behavior matches what large providers are doing (Cloudflare on 1.1.1.1, Google DNS on 8.8.8.8) and indicates to the client that it needs to try over TCP.

While this does have the downside of not getting the UDP response into cache, that's a more complicated change - coredns would have to use a large enough buffer to get the message successfully unpacked, with no idea from the client side what the maximum that could be sent by the server would be. This would lead to higher memory utilization on each query, and would be useless if cache wasn't enabled or the client wasn't able to retry via TCP (see busybox's nslookup).

I proposed two alternate solutions in #5953, and this would be a required first step for either of them:
1. Allow the configuration to force a larger buffer size - in order to avoid the problem that led to #5671 in the first place, we still need to handle overlarge responses and set the truncate bit.
2. Allow the configuration to force eDNS0 on all upstream requests - if the server sends an overly large response even with eDNS0 turned on, we still need to truncate appropriately instead of failing to respond to the client.

### 2. Which issues (if any) are related?
#5953
#5998

### 3. Which documentation changes (if any) need to be made?
I didn't see any.

### 4. Does this introduce a backward incompatible change or deprecation?
No.