### PR TITLE
Updates for using ecs in metadata

### DIFF
--- a/plugin/geoip/city.go
+++ b/plugin/geoip/city.go
@@ -55,4 +55,8 @@ func (g GeoIP) setCityMetadata(ctx context.Context, data *geoip2.City) {
 	metadata.SetValueFunc(ctx, pluginName+"/postalcode", func() string {
 		return postalCode
 	})
+	ecs := g.ecs.address + "/" + g.ecs.netmask
+	metadata.SetValueFunc(ctx, pluginName+"/ecs", func() string {
+		return ecs
+	})
 }

--- a/plugin/geoip/geoip.go
+++ b/plugin/geoip/geoip.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strconv"
 
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
@@ -23,6 +24,12 @@ type GeoIP struct {
 	Next  plugin.Handler
 	db    db
 	edns0 bool
+	ecs   ecs
+}
+
+type ecs struct {
+	address string
+	netmask string
 }
 
 type db struct {
@@ -85,6 +92,9 @@ func (g GeoIP) Metadata(ctx context.Context, state request.Request) context.Cont
 			for _, s := range o.Option {
 				if e, ok := s.(*dns.EDNS0_SUBNET); ok {
 					srcIP = e.Address
+					// Save ECS contents from request.
+					g.ecs.address = e.Address.String()
+					g.ecs.netmask = strconv.Itoa(int(e.SourceNetmask))
 					break
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

For COREDNS to respond utilizing the ECS value as shown in the example below.

```bash
# dig @8.8.8.8 o-o.myaddr.l.google.com txt +subnet=100.20.30.0/24 +short
"173.194.168.3"
"edns0-client-subnet 100.20.30.0/24"
```

q? how to use 'ecs' metadata?
a
```
  template IN TXT example.com {
        match whoami\.(.*)
        answer "{{ .Name }} 60 IN TXT {{ .Remote }}"
        answer "{{ .Name }} 60 IN TXT \"edns0-client-subnet {{ .Meta \"geoip/ecs\" }}\""
        fallthrough
  }
```

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Maybe geoip plugin's README.md is need to be updated.

### 4. Does this introduce a backward incompatible change or deprecation?

no