### PR TITLE
plugin/kubernetes: rename client-go metrics label "url" to "host"

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -229,9 +229,9 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
     * `headless_with_selector`
     * `headless_without_selector`
 
-The following are client level metrics to monitor apiserver request latency & status codes. `verb` identifies the apiserver [request type](https://kubernetes.io/docs/reference/using-api/api-concepts/#single-resource-api) and `url`/`host` denotes the apiserver endpoint.
-* `coredns_kubernetes_rest_client_request_duration_seconds{verb, url}` - captures apiserver request latency perceived by client grouped by `verb` and `url`.
-* `coredns_kubernetes_rest_client_rate_limiter_duration_seconds{verb, url}` - captures apiserver request latency contributed by client side rate limiter grouped by `verb` & `url`.
+The following are client level metrics to monitor apiserver request latency & status codes. `verb` identifies the apiserver [request type](https://kubernetes.io/docs/reference/using-api/api-concepts/#single-resource-api) and `host` denotes the apiserver endpoint.
+* `coredns_kubernetes_rest_client_request_duration_seconds{verb, host}` - captures apiserver request latency perceived by client grouped by `verb` and `host`.
+* `coredns_kubernetes_rest_client_rate_limiter_duration_seconds{verb, host}` - captures apiserver request latency contributed by client side rate limiter grouped by `verb` & `host`.
 * `coredns_kubernetes_rest_client_requests_total{method, code, host}` - captures total apiserver requests grouped by `method`, `status_code` & `host`.
 
 ## Bugs

--- a/plugin/kubernetes/metrics.go
+++ b/plugin/kubernetes/metrics.go
@@ -13,28 +13,28 @@ import (
 )
 
 var (
-	// requestLatency measures K8s rest client requests latency grouped by verb and url.
+	// requestLatency measures K8s rest client requests latency grouped by verb and host.
 	requestLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: plugin.Namespace,
 			Subsystem: "kubernetes",
 			Name:      "rest_client_request_duration_seconds",
-			Help:      "Request latency in seconds. Broken down by verb and URL.",
+			Help:      "Request latency in seconds. Broken down by verb and host.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"verb", "url"},
+		[]string{"verb", "host"},
 	)
 
-	// rateLimiterLatency measures K8s rest client rate limiter latency grouped by verb and url.
+	// rateLimiterLatency measures K8s rest client rate limiter latency grouped by verb and host.
 	rateLimiterLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: plugin.Namespace,
 			Subsystem: "kubernetes",
 			Name:      "rest_client_rate_limiter_duration_seconds",
-			Help:      "Client side rate limiter latency in seconds. Broken down by verb and URL.",
+			Help:      "Client side rate limiter latency in seconds. Broken down by verb and host.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"verb", "url"},
+		[]string{"verb", "host"},
 	)
 
 	// requestResult measures K8s rest client request metrics grouped by status code, method & host.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
See https://github.com/coredns/coredns/pull/5991#issuecomment-1518706256 for more details. As we're using apiserver request url host as label value, I think it makes sense to update label name as `host` instead of `url`.  

### 2. Which issues (if any) are related?
NA.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No backward incompatible changes from last official release.