### PR TITLE
Fix typo

### DIFF
--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -68,7 +68,7 @@ Check every 10 seconds (jitter is automatically set to 10 / 2 = 5 in this case):
 ## Bugs
 
 The reload happens without data loss (i.e. DNS queries keep flowing), but there is a corner case
-where the reload fails, and you loose functionality. Consider the following Corefile:
+where the reload fails, and you lose functionality. Consider the following Corefile:
 
 ~~~ txt
 . {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
In the docs for the `reload` plugin, there is a typo. "Loose" should be "Lose".

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
n/a

### 4. Does this introduce a backward incompatible change or deprecation?
No
