### PR TITLE
Fix temp file close error

### DIFF
--- a/plugin/file/tree/print_test.go
+++ b/plugin/file/tree/print_test.go
@@ -70,10 +70,11 @@ func TestPrint(t *testing.T) {
 
 	*/
 
-	f, err := os.Create("tmp")
+	f, err := os.CreateTemp("", "print_test_tmp")
 	if err != nil {
 		t.Error(err)
 	}
+	defer os.Remove(f.Name())
 	//Redirect the printed results to a tmp file for later comparison
 	os.Stdout = f
 
@@ -86,17 +87,14 @@ func TestPrint(t *testing.T) {
 
 	buf := make([]byte, 256)
 	f.Seek(0, 0)
-	_, er := f.Read(buf)
-	if er != nil {
+	_, err = f.Read(buf)
+	if err != nil {
+		f.Close()
 		t.Error(err)
 	}
 	height := strings.Count(string(buf), ". \n")
 	//Compare the height of the print with the actual height of the tree
 	if height != 3 {
-		f.Close()
-		os.Remove("tmp")
 		t.Fatal("The number of rows is inconsistent with the actual number of rows in the tree itself.")
 	}
-	f.Close()
-	os.Remove("tmp")
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Avoid Go 1.20 test error by not attempting to close the testing temp file unless there was an error in Read().
* Use a CreateTemp() to create unique test files.
* Defer the deletion of the temp file.
* Fix typo in `err` handling.

### 2. Which issues (if any) are related?

Workaround for: https://github.com/golang/go/issues/59938

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
