### PR TITLE
prevent panics when using DoHWriter

### DIFF
--- a/core/dnsserver/https.go
+++ b/core/dnsserver/https.go
@@ -4,13 +4,11 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/coredns/coredns/plugin/pkg/nonwriter"
+	"github.com/miekg/dns"
 )
 
-// DoHWriter is a nonwriter.Writer that adds more specific LocalAddr and RemoteAddr methods.
+// DoHWriter is a dns.ResponseWriter that adds more specific LocalAddr and RemoteAddr methods.
 type DoHWriter struct {
-	nonwriter.Writer
-
 	// raddr is the remote's address. This can be optionally set.
 	raddr net.Addr
 	// laddr is our address. This can be optionally set.
@@ -18,13 +16,50 @@ type DoHWriter struct {
 
 	// request is the HTTP request we're currently handling.
 	request *http.Request
+
+	// Msg is a response to be written to the client.
+	Msg *dns.Msg
+}
+
+// WriteMsg stores the message to be written to the client.
+func (d *DoHWriter) WriteMsg(m *dns.Msg) error {
+	d.Msg = m
+	return nil
+}
+
+// Write stores the message to be written to the client.
+func (d *DoHWriter) Write(b []byte) (int, error) {
+	d.Msg = new(dns.Msg)
+	return len(b), d.Msg.Unpack(b)
 }
 
 // RemoteAddr returns the remote address.
-func (d *DoHWriter) RemoteAddr() net.Addr { return d.raddr }
+func (d *DoHWriter) RemoteAddr() net.Addr {
+	return d.raddr
+}
 
 // LocalAddr returns the local address.
-func (d *DoHWriter) LocalAddr() net.Addr { return d.laddr }
+func (d *DoHWriter) LocalAddr() net.Addr {
+	return d.laddr
+}
 
-// Request returns the HTTP request
-func (d *DoHWriter) Request() *http.Request { return d.request }
+// Request returns the HTTP request.
+func (d *DoHWriter) Request() *http.Request {
+	return d.request
+}
+
+// Close no-op implementation.
+func (d *DoHWriter) Close() error {
+	return nil
+}
+
+// TsigStatus no-op implementation.
+func (d *DoHWriter) TsigStatus() error {
+	return nil
+}
+
+// TsigTimersOnly no-op implementation.
+func (d *DoHWriter) TsigTimersOnly(_ bool) {}
+
+// Hijack no-op implementation.
+func (d *DoHWriter) Hijack() {}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR removes the embedding of `nonwriter` into `DoHWriter` and rather directly implements `dns.ResponseWriter` interface, because how it is currently used the nonwriter is not correctly initialized in [server_https](https://github.com/coredns/coredns/blob/master/core/dnsserver/server_https.go#L163) and neither it can be correctly initialized with nonwriter, because nonwriter as such requires dns.ResponseWriter for initialization, but we cannot provide any instance at that point.

This fix is inspired how the [gRPCResponse](https://github.com/coredns/coredns/blob/master/core/dnsserver/server_grpc.go#L163) is currently done for DNS over GPRC, so as another benefit, I am unifying the approach to these non-plain DNS writers

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/6118

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
`DoHWriter` as such still implements dns.ResponseWriter, so there shouldn't be problems
