### PR TITLE
Bind on hostname

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -7,35 +7,36 @@
 ## Description
 
 Normally, the listener binds to the wildcard host. However, you may want the listener to bind to
-another IP instead.
+another IP address instead.
 
-If several addresses are provided, a listener will be open on each of the IP provided.
+To specify the IP address of the listener the `bind` directive accepts an IP address, interface name or hostname.  Interface names and hostnames will be resolved to IP addresses. A listener will be open on each provided and resolved IP address.
 
-Each address has to be an IP or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
+Bind by interface name, binds to the IP addresses on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
 
-If the given argument is an interface name, and that interface has serveral IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for IPv6 link-local addresses on that interface.
+Bind by hostname, binds to the IP addresses resolved by the default resolver at the time of startup or reload.
+
+If the given argument is an interface name or hostname, and that interface or hostname has serveral IP addresses, CoreDNS will listen on all of the IP addresses (including IPv4 and IPv6), except for IPv6 link-local addresses on an interface.
 
 ## Syntax
 
 In its basic form, a simple bind uses this syntax:
 
 ~~~ txt
-bind ADDRESS|IFACE  ...
+bind ADDRESS|IFACE|HOSTNAME  ...
 ~~~
 
 You can also exclude some addresses with their IP address or interface name in expanded syntax:
 
 ~~~
-bind ADDRESS|IFACE ... {
-    except ADDRESS|IFACE ...
+bind ADDRESS|IFACE|HOSTNAME ... {
+    except ADDRESS|IFACE|HOSTNAME ...
 }
 ~~~
 
-
-
-* **ADDRESS|IFACE** is an IP address or interface name to bind to.
+* **ADDRESS|IFACE|HOSTNAME** is an IP address, interface or hostname to bind to.
 When several addresses are provided a listener will be opened on each of the addresses. Please read the *Description* for more details.
-* `except`, excludes interfaces or IP addresses to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
+* `except`, excludes IP addresses, interfaces or hostnames to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
+
 ## Examples
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):
@@ -78,6 +79,16 @@ You can exclude some addresses by their IP or interface name (The following will
 . {
     bind lo {
         except 127.0.0.1
+    }
+}
+~~~
+
+Bind to localhost except for the local IPv6 host address `::1`.
+
+~~~ corefile
+. {
+    bind localhost {
+        except ::1
     }
 }
 ~~~

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -92,10 +92,12 @@ func listIP(args []string, ifaces []net.Interface) ([]string, error) {
 			}
 		}
 		if !isIface {
-			if net.ParseIP(a) == nil {
+			if net.ParseIP(a) != nil {
+				all = append(all, a)
+			} else {
 				return nil, fmt.Errorf("not a valid IP address or interface name: %q", a)
 			}
-			all = append(all, a)
+
 		}
 	}
 	return all, nil

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -53,14 +53,14 @@ func parse(c *caddy.Controller) (*bind, error) {
 	b := &bind{}
 	b.addrs = c.RemainingArgs()
 	if len(b.addrs) == 0 {
-		return nil, errors.New("at least one address or interface name is expected")
+		return nil, errors.New("at least one IP address, interface or hostname is expected")
 	}
 	for c.NextBlock() {
 		switch c.Val() {
 		case "except":
 			b.except = c.RemainingArgs()
 			if len(b.except) == 0 {
-				return nil, errors.New("at least one address or interface must be given to except subdirective")
+				return nil, errors.New("at least one IP address, interface or hostname must be given to except subdirective")
 			}
 		default:
 			return nil, fmt.Errorf("invalid option %q", c.Val())

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -95,9 +95,12 @@ func listIP(args []string, ifaces []net.Interface) ([]string, error) {
 			if net.ParseIP(a) != nil {
 				all = append(all, a)
 			} else {
-				return nil, fmt.Errorf("not a valid IP address or interface name: %q", a)
+				addrs, err := net.LookupHost(a)
+				if err != nil {
+					return nil, fmt.Errorf("not a valid IP address, interface or hostname: %q", a)
+				}
+				all = append(all, addrs...)
 			}
-
 		}
 	}
 	return all, nil

--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -21,6 +21,7 @@ func TestSetup(t *testing.T) {
 		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, true},
 		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, false},
 		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, false},
+		{"bind localhost {\nexcept ::1\n}\n", []string{"127.0.0.1"}, false},
 	} {
 		c := caddy.NewTestController("dns", test.config)
 		err := setup(c)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The bind plugin currently supports either literal IP addresses or interface names to open a listener on.  This pull request adds the ability to add a listener for an IP address (or IP addresses) resolved through a given hostname.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

Updated bind plugin documentation to indicate hostname support and usage.

### 4. Does this introduce a backward incompatible change or deprecation?

Order is preserved in resolution of the `bind` and `except` sub-directive with the hostname being resolved last.  Any interface/hostname collision (i.e interface `lo` and a hostname `lo`) will maintain backwards compatibility in that the interface takes precedence.

Users specifying an invalid hostname to bind for the system receive the same error message as if given an incorrect IP address.
