### PR TITLE
plugin/kubernetes: filter ExternalName service queries for subdomains of subdomains

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -408,6 +408,14 @@ var dnsTestCases = []kubeTestCase{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	}},
+	// A query for a subdomain of a subdomain of an external service should not resolve to the external service
+	{Case: test.Case{
+		Qname: "subdomain.subdomain.external.testns.svc.cluster.local.", Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	}},
 }
 
 func TestServeDNS(t *testing.T) {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -445,8 +445,8 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 		// External service
 		if svc.Type == api.ServiceTypeExternalName {
-			//External services cannot have endpoints, so skip this service if an endpoint is present in the request
-			if r.endpoint != "" {
+			// External services do not have endpoints, nor can we accept port/protocol pseudo subdomains in an SRV query, so skip this service if endpoint, port, or protocol is non-empty in the request
+			if r.endpoint != "" || r.port != "" || r.protocol != "" {
 				continue
 			}
 			s := msg.Service{Key: strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/"), Host: svc.ExternalName, TTL: k.ttl}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This prevents queries for `*.*.service.namespace.svc.cluster.local` from being resolved when the service is type ExternalName. The `*` is not for a wildcard DNS query here, just to indicate that any valid dns label can be used in the query.

For example, a query for `www.google.com.default.svc.cluster.local` will currently match and return the result of an ExternalName service named `com` in the `default` namespace.

This change prevents this from happening.

### 2. Which issues (if any) are related?
fixes #6161

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no, it fixes queries that should be failing but are returning an invalid response.
