### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -18,14 +18,10 @@ www IN A 127.0.0.1
 `
 
 func TestWalk(t *testing.T) {
-	tempdir, err := createFiles()
+	tempdir, err := createFiles(t)
 	if err != nil {
-		if tempdir != "" {
-			os.RemoveAll(tempdir)
-		}
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempdir)
 
 	ldr := loader{
 		directory: tempdir,
@@ -65,11 +61,8 @@ func TestWalkNonExistent(t *testing.T) {
 	a.Walk()
 }
 
-func createFiles() (string, error) {
-	dir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		return dir, err
-	}
+func createFiles(t *testing.T) (string, error) {
+	dir := t.TempDir()
 
 	for _, name := range dbFiles {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
@@ -77,10 +70,10 @@ func createFiles() (string, error) {
 		}
 	}
 	// symlinks
-	if err = os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "db.example.com")); err != nil {
+	if err := os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "db.example.com")); err != nil {
 		return dir, err
 	}
-	if err = os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "aa.example.com")); err != nil {
+	if err := os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "aa.example.com")); err != nil {
 		return dir, err
 	}
 

--- a/plugin/auto/watcher_test.go
+++ b/plugin/auto/watcher_test.go
@@ -8,14 +8,10 @@ import (
 )
 
 func TestWatcher(t *testing.T) {
-	tempdir, err := createFiles()
+	tempdir, err := createFiles(t)
 	if err != nil {
-		if tempdir != "" {
-			os.RemoveAll(tempdir)
-		}
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempdir)
 
 	ldr := loader{
 		directory: tempdir,
@@ -54,14 +50,10 @@ func TestWatcher(t *testing.T) {
 }
 
 func TestSymlinks(t *testing.T) {
-	tempdir, err := createFiles()
+	tempdir, err := createFiles(t)
 	if err != nil {
-		if tempdir != "" {
-			os.RemoveAll(tempdir)
-		}
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempdir)
 
 	ldr := loader{
 		directory: tempdir,

--- a/plugin/grpc/proxy_test.go
+++ b/plugin/grpc/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
 	"path"
 	"testing"
 
@@ -72,11 +71,7 @@ func (m testServiceClient) Query(ctx context.Context, in *pb.DnsPacket, opts ...
 }
 
 func TestProxyUnix(t *testing.T) {
-	tdir, err := os.MkdirTemp("", "tmp*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	fd := path.Join(tdir, "test.grpc")
 	listener, err := net.Listen("unix", fd)

--- a/plugin/pkg/tls/tls_test.go
+++ b/plugin/pkg/tls/tls_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/coredns/coredns/plugin/test"
 )
 
-func getPEMFiles(t *testing.T) (rmFunc func(), cert, key, ca string) {
-	tempDir, rmFunc, err := test.WritePEMFiles("")
+func getPEMFiles(t *testing.T) (cert, key, ca string) {
+	tempDir, err := test.WritePEMFiles(t)
 	if err != nil {
 		t.Fatalf("Could not write PEM files: %s", err)
 	}
@@ -21,8 +21,7 @@ func getPEMFiles(t *testing.T) (rmFunc func(), cert, key, ca string) {
 }
 
 func TestNewTLSConfig(t *testing.T) {
-	rmFunc, cert, key, ca := getPEMFiles(t)
-	defer rmFunc()
+	cert, key, ca := getPEMFiles(t)
 
 	_, err := NewTLSConfig(cert, key, ca)
 	if err != nil {
@@ -31,8 +30,7 @@ func TestNewTLSConfig(t *testing.T) {
 }
 
 func TestNewTLSClientConfig(t *testing.T) {
-	rmFunc, _, _, ca := getPEMFiles(t)
-	defer rmFunc()
+	_, _, ca := getPEMFiles(t)
 
 	_, err := NewTLSClientConfig(ca)
 	if err != nil {
@@ -41,8 +39,7 @@ func TestNewTLSClientConfig(t *testing.T) {
 }
 
 func TestNewTLSConfigFromArgs(t *testing.T) {
-	rmFunc, cert, key, ca := getPEMFiles(t)
-	defer rmFunc()
+	cert, key, ca := getPEMFiles(t)
 
 	_, err := NewTLSConfigFromArgs()
 	if err != nil {
@@ -81,8 +78,7 @@ func TestNewTLSConfigFromArgs(t *testing.T) {
 }
 
 func TestNewHTTPSTransport(t *testing.T) {
-	rmFunc, _, _, ca := getPEMFiles(t)
-	defer rmFunc()
+	_, _, ca := getPEMFiles(t)
 
 	cc, err := NewTLSClientConfig(ca)
 	if err != nil {

--- a/plugin/test/file.go
+++ b/plugin/test/file.go
@@ -3,6 +3,7 @@ package test
 import (
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 // TempFile will create a temporary file on disk and returns the name and a cleanup function to remove it later.
@@ -18,12 +19,9 @@ func TempFile(dir, content string) (string, func(), error) {
 	return f.Name(), rmFunc, nil
 }
 
-// WritePEMFiles creates a tmp dir with ca.pem, cert.pem, and key.pem and the func to remove it
-func WritePEMFiles(dir string) (string, func(), error) {
-	tempDir, err := os.MkdirTemp(dir, "go-test-pemfiles")
-	if err != nil {
-		return "", nil, err
-	}
+// WritePEMFiles creates a tmp dir with ca.pem, cert.pem, and key.pem
+func WritePEMFiles(t *testing.T) (string, error) {
+	tempDir := t.TempDir()
 
 	data := `-----BEGIN CERTIFICATE-----
 MIIC9zCCAd+gAwIBAgIJALGtqdMzpDemMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV
@@ -45,7 +43,7 @@ I1rs/VUGKzcJGVIWbHrgjP68CTStGAvKgbsTqw7aLXTSqtPw88N9XVSyRg==
 -----END CERTIFICATE-----`
 	path := filepath.Join(tempDir, "ca.pem")
 	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
-		return "", nil, err
+		return "", err
 	}
 	data = `-----BEGIN CERTIFICATE-----
 MIICozCCAYsCCQCRlf5BrvPuqjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdr
@@ -65,8 +63,8 @@ zhDEPP4FhY+Sz+y1yWirphl7A1aZwhXVPcfWIGqpQ3jzNwUeocbH27kuLh+U4hQo
 qeg10RdFnw==
 -----END CERTIFICATE-----`
 	path = filepath.Join(tempDir, "cert.pem")
-	if err = os.WriteFile(path, []byte(data), 0644); err != nil {
-		return "", nil, err
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		return "", err
 	}
 
 	data = `-----BEGIN RSA PRIVATE KEY-----
@@ -97,10 +95,9 @@ E/WObVJXDnBdViu0L9abE9iaTToBVri4cmlDlZagLuKVR+TFTCN/DSlVZTDkqkLI
 8chzqtkH6b2b2R73hyRysWjsomys34ma3mEEPTX/aXeAF2MSZ/EWT9yL
 -----END RSA PRIVATE KEY-----`
 	path = filepath.Join(tempDir, "key.pem")
-	if err = os.WriteFile(path, []byte(data), 0644); err != nil {
-		return "", nil, err
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		return "", err
 	}
 
-	rmFunc := func() { os.RemoveAll(tempDir) }
-	return tempDir, rmFunc, nil
+	return tempDir, nil
 }

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestAuto(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	corefile := `org:0 {
 		auto {
@@ -70,11 +66,7 @@ func TestAuto(t *testing.T) {
 
 func TestAutoNonExistentZone(t *testing.T) {
 	t.Parallel()
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	corefile := `.:0 {
 		auto {
@@ -109,11 +101,7 @@ func TestAutoNonExistentZone(t *testing.T) {
 func TestAutoAXFR(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	corefile := `org:0 {
 		auto {

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	content := `
 example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 1 3600 3600 3600 3600
@@ -23,7 +19,7 @@ google.com. IN A 172.217.25.110
 `
 
 	path := filepath.Join(tmpdir, "file")
-	if err = os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("Could not write to temp file: %s", err)
 	}
 	defer os.Remove(path)

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -71,11 +71,7 @@ func TestMetricsRefused(t *testing.T) {
 }
 
 func TestMetricsAuto(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "coredns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	corefile := `org:0 {
 		auto {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `t.TempDir` function from the `testing` package to create temporary directory. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	dir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(dir)

	// now
	dir := t.TempDir()
}
```

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?


### 4. Does this introduce a backward incompatible change or deprecation?

No.