### PR TITLE
Update workflow versioning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@1360a344ccb0ab6e9475edef90ad2f46bf8003b1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       RELEASE: ${{ github.event.inputs.release || github.event.release.tag_name }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: actions/checkout@v3
       - name: Build Docker Images
         run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker release
       - name: Show Docker Images

--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -8,14 +8,14 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
-        with:
-          go-version: '1.20.0'
-        id: go
-
       - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.20.0'
+        id: go
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -8,14 +8,14 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
-        with:
-          go-version: '1.20.0'
-        id: go
-
       - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.20.0'
+        id: go
 
       - name: Build
         run: go build -v ./...
@@ -30,14 +30,14 @@ jobs:
     name: Test Plugins
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
-        with:
-          go-version: '1.20.0'
-        id: go
-
       - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.20.0'
+        id: go
 
       - name: Build
         run: go build -v ./...
@@ -49,14 +49,14 @@ jobs:
     name: Test e2e
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
-        with:
-          go-version: '1.20.0'
-        id: go
-
       - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.20.0'
+        id: go
 
       - name: Build
         run: go build -v ./...
@@ -70,11 +70,11 @@ jobs:
     name: Test Makefile.release
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
       - name: Install dependencies
         run: sudo apt-get install make curl
-
-      - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Test Makefile.release
         run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,10 +6,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.0'
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+          go-version: '~1.20.0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -13,12 +13,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.20.0'
+          go-version: '~1.20.0'
 
       - name: Update Docs
         run: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v3
       - name: 'Yamllint'
         uses: karancode/yamllint-github-action@fdef6bc189425ecc84cc4543b2674566c0827053
         with:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
* Use major version pinning for actions to reduce dependeabot churn.
* Use tilde matching for Go versions to use the latest patch release.
* Checkout before installing Go to fix go module caching.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
