### PR TITLE
plugin/hosts: add Readiness implementation, add no_file option

### DIFF
--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -47,6 +47,7 @@ entries) and cannot be created manually.
 ~~~
 hosts [FILE [ZONES...]] {
     [INLINE]
+    no_file
     ttl SECONDS
     no_reverse
     reload DURATION
@@ -62,6 +63,8 @@ hosts [FILE [ZONES...]] {
 * **INLINE** the hosts file contents inlined in Corefile. If there are any lines before fallthrough
    then all of them will be treated as the additional content for hosts file. The specified hosts
    file path will still be read but entries will be overridden.
+* `no_file` instructs the plugin not to load any hosts files. If `no_file` is set **FILE** should not be set and
+  and at least one **INLINE** rule must be defined.
 * `ttl` change the DNS TTL of the records generated (forward and reverse). The default is 3600 seconds (1 hour).
 * `reload` change the period between each hostsfile reload. A time of zero seconds disables the
   feature. Examples of valid durations: "300ms", "1.5h" or "2h45m". See Go's

--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -82,6 +82,13 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 - `coredns_hosts_entries{}` - The combined number of entries in hosts and Corefile.
 - `coredns_hosts_reload_timestamp_seconds{}` - The timestamp of the last reload of hosts file.
 
+## Ready
+
+This plugin reports readiness to the ready plugin. This will happen after,
+
+1. all inline rules have been successfully loaded, and
+2. if `no_file` is **not** set; the hosts file has been successfully loaded.
+
 ## Examples
 
 Load `/etc/hosts` file.

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -98,7 +98,7 @@ type Hostsfile struct {
 	inline *Map
 
 	// path to the hosts file
-	path string
+	path *string
 
 	// mtime and size are only read and modified by a single goroutine
 	mtime time.Time
@@ -109,7 +109,7 @@ type Hostsfile struct {
 
 // readHosts determines if the cached data needs to be updated based on the size and modification time of the hostsfile.
 func (h *Hostsfile) readHosts() {
-	file, err := os.Open(h.path)
+	file, err := os.Open(*h.path)
 	if err != nil {
 		// We already log a warning if the file doesn't exist or can't be opened on setup. No need to return the error here.
 		return

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -211,7 +211,7 @@ func testStaticAddr(t *testing.T, ent staticIPEntry, h *Hostsfile) {
 		ent.out[i] = plugin.Name(ent.out[i]).Normalize()
 	}
 	if !reflect.DeepEqual(hosts, ent.out) {
-		t.Errorf("%s, lookupStaticAddr(%s) = %v; want %v", h.path, ent.in, hosts, h)
+		t.Errorf("%s, lookupStaticAddr(%s) = %v; want %v", *h.path, ent.in, hosts, h)
 	}
 }
 

--- a/plugin/hosts/ready.go
+++ b/plugin/hosts/ready.go
@@ -1,0 +1,8 @@
+package hosts
+
+// Ready returns true if the number of received queries is in the range [3, 5). All other values return false.
+func (h Hosts) Ready() bool {
+	h.RLock()
+	defer h.RUnlock()
+	return h.ready == readyAll
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This change:
1. adds a `no_file` option to the `hosts` plugin that prevents loading of any hosts file and instead relies entirely on inline hosts definitions
2. adds an implementation for the `ready.Readiness` interface that signals ready once both the `hosts`-file and all inline definitions have been /successfully/ loaded. This means if the hosts file does not exist (yet), it will only signal ready once it does and has been loaded. If `no_file` is set that  part of the readiness check is skipped.

This probably should be two PRs though I don't really know how to split them properly, because I don't know how to create dependant PRs on Github.

### 2. Which issues (if any) are related?

None (that I know of)

### 3. Which documentation changes (if any) need to be made?

The plugin README has been updated. Is anything else needed?

### 4. Does this introduce a backward incompatible change or deprecation?

A Coredns setup that uses the `hosts` and `ready` plugins but can't guarantee the existence of the `hosts` file would've signaled success on the `ready` endpoint while emitting a warning about the missing `hosts` file.
With this change the `ready` endpoint will never return a `200 OK` response. This could cause readiness checks to fail.

One way to fix this could be to disable the readiness check by default and adding a new option `ready_check_file` that enables the readiness check on the hosts file.