### PR TITLE
fix ports panic

### DIFF
--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -66,7 +66,19 @@ func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
 	} else {
 		e.Subsets[0].Ports = make([]EndpointPort, len(ends.Ports))
 		for k, p := range ends.Ports {
-			ep := EndpointPort{Port: *p.Port, Name: *p.Name, Protocol: string(*p.Protocol)}
+			port := int32(-1)
+			name := ""
+			protocol := ""
+			if p.Port != nil {
+				port = *p.Port
+			}
+			if p.Name != nil {
+				name = *p.Name
+			}
+			if p.Protocol != nil {
+				protocol = string(*p.Protocol)
+			}
+			ep := EndpointPort{Port: port, Name: name, Protocol: protocol}
 			e.Subsets[0].Ports[k] = ep
 		}
 	}
@@ -146,7 +158,6 @@ func (e *Endpoints) DeepCopyObject() runtime.Object {
 			ep := EndpointPort{Port: p.Port, Name: p.Name, Protocol: p.Protocol}
 			sub.Ports[k] = ep
 		}
-
 		e1.Subsets[i] = sub
 	}
 	return e1


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
When i use core-dns, It has panic.、
```
[DEBUG] plugin/hosts: Parsed hosts file into 18 entries
E0625 06:27:00.891513       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 90 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1c446c0?, 0x3239710})
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xfd9545?})
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1c446c0, 0x3239710})
	/tmp/tmp.cFViCJ9Hi2/go/src/runtime/panic.go:838 +0x207
github.com/coredns/coredns/plugin/kubernetes/object.EndpointSliceToEndpoints({0x2360af0?, 0xc00095ac98?})
	/tmp/tmp.cFViCJ9Hi2/g/src/github.com/coredns/coredns/plugin/kubernetes/object/endpoint.go:125 +0x7e2
github.com/coredns/coredns/plugin/kubernetes/object.DefaultProcessor.func1.1({0x1c6f840?, 0xc000165260?})
	/tmp/tmp.cFViCJ9Hi2/g/src/github.com/coredns/coredns/plugin/kubernetes/object/informer.go:41 +0x482
k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc000717180, 0xc0003bf240)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/client-go@v0.24.0/tools/cache/delta_fifo.go:554 +0x566
k8s.io/client-go/tools/cache.(*controller).processLoop(0xc0007199e0)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/client-go@v0.24.0/tools/cache/controller.go:184 +0x36
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x40d625?)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:155 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xfd6f85?, {0x2336f40, 0xc00071b7a0}, 0x1, 0xc0003a0120)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000719a48?, 0x3b9aca00, 0x0, 0x20?, 0x7f304ad270a0?)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*controller).Run(0xc0007199e0, 0xc0003a0120)
	/tmp/tmp.cFViCJ9Hi2/g/pkg/mod/k8s.io/client-go@v0.24.0/tools/cache/controller.go:155 +0x2c5
github.com/coredns/coredns/plugin/kubernetes.(*dnsControl).Run.func1()
	/tmp/tmp.cFViCJ9Hi2/g/src/github.com/coredns/coredns/plugin/kubernetes/controller.go:405 +0x57
created by github.com/coredns/coredns/plugin/kubernetes.(*dnsControl).Run
	/tmp/tmp.cFViCJ9Hi2/g/src/github.com/coredns/coredns/plugin/kubernetes/controller.go:403 +0xe5
```

**core-dns version:v1.9.3**
### 1. Why is this pull request needed and what does it do?
avoid panic.
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
