### PR TITLE
Change default value to 1232

### DIFF
--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -1,11 +1,15 @@
 # bufsize
 ## Name
-*bufsize* - sizes EDNS0 buffer size to prevent IP fragmentation.
+*bufsize* - limits EDNS0 buffer size to prevent IP fragmentation.
 
 ## Description
-*bufsize* limits a requester's UDP payload size.
+*bufsize* limits a requester's UDP payload size to within a maximum value.
+If a request with an OPT RR has a bufsize greater than the limit, the bufsize
+of the request will be reduced. Otherwise the request is unaffected.
 It prevents IP fragmentation, mitigating certain DNS vulnerabilities.
-This will only affect queries that have an OPT RR.
+It cannot increase UDP size requested by the client, it can be reduced only.
+This will only affect queries that have
+an OPT RR ([EDNS(0)](https://www.rfc-editor.org/rfc/rfc6891)).
 
 ## Syntax
 ```txt
@@ -13,14 +17,14 @@ bufsize [SIZE]
 ```
 
 **[SIZE]** is an int value for setting the buffer size.
-The default value is 512, and the value must be within 512 - 4096.
+The default value is 1232, and the value must be within 512 - 4096.
 Only one argument is acceptable, and it covers both IPv4 and IPv6.
 
 ## Examples
 Enable limiting the buffer size of outgoing query to the resolver (172.31.0.10):
 ```corefile
 . {
-    bufsize 512
+    bufsize 1100
     forward . 172.31.0.10
     log
 }
@@ -29,7 +33,7 @@ Enable limiting the buffer size of outgoing query to the resolver (172.31.0.10):
 Enable limiting the buffer size as an authoritative nameserver:
 ```corefile
 . {
-    bufsize 512
+    bufsize 1220
     file db.example.org
     log
 }

--- a/plugin/bufsize/setup.go
+++ b/plugin/bufsize/setup.go
@@ -24,12 +24,13 @@ func setup(c *caddy.Controller) error {
 }
 
 func parse(c *caddy.Controller) (int, error) {
-	const defaultBufSize = 512
+	// value from http://www.dnsflagday.net/2020/
+	const defaultBufSize = 1232
 	for c.Next() {
 		args := c.RemainingArgs()
 		switch len(args) {
 		case 0:
-			// Nothing specified; use 512 as default
+			// Nothing specified; use defaultBufSize
 			return defaultBufSize, nil
 		case 1:
 			// Specified value is needed to verify

--- a/plugin/bufsize/setup_test.go
+++ b/plugin/bufsize/setup_test.go
@@ -14,10 +14,11 @@ func TestSetupBufsize(t *testing.T) {
 		expectedData       int
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-		{`bufsize`, false, 512, ""},
-		{`bufsize "1232"`, false, 1232, ""},
+		{`bufsize`, false, 1232, ""},
+		{`bufsize "1220"`, false, 1220, ""},
 		{`bufsize "5000"`, true, -1, "plugin"},
 		{`bufsize "512 512"`, true, -1, "plugin"},
+		{`bufsize "511"`, true, -1, "plugin"},
 		{`bufsize "abc123"`, true, -1, "plugin"},
 	}
 


### PR DESCRIPTION
As specified by [DNS flag day 2020](http://www.dnsflagday.net/2020/#action-dns-software-vendors), good and decent default value avoiding fragmentation issues should be 1232. It is quite likely 1500 would work reliably on local ethernet networks.

Value 512 is set implicitly and must be used for all clients, which did not include OPT RR with explicit value they support.

Since MR #5368 it should work correctly.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Changes EDNS0 default value to recommended value.

### 2. Which issues (if any) are related?
- #5366
- https://github.com/coredns/coredns/issues/5953

### 3. Which documentation changes (if any) need to be made?
- https://github.com/coredns/coredns.io/issues/295

### 4. Does this introduce a backward incompatible change or deprecation?
It removes the confusion around EDNS0 size. It may create behaviour change.