### PR TITLE
install faillint properly

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Test With Coverage
         run: |
-          go install github.com/fatih/faillint@latest || true
+          go install github.com/fatih/faillint@latest
           for d in request core coremain plugin test; do \
              ( cd $d; go test -coverprofile=cover.out -covermode=atomic -race ./...; [ -f cover.out ] && cat cover.out >> ../coverage.txt ); \
           done

--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Test With Coverage
         run: |
+          go install github.com/fatih/faillint@latest || true
           for d in request core coremain plugin test; do \
              ( cd $d; go test -coverprofile=cover.out -covermode=atomic -race ./...; [ -f cover.out ] && cat cover.out >> ../coverage.txt ); \
           done

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test
         run: |
-          go install github.com/fatih/faillint@latest || true
+          go install github.com/fatih/faillint@latest
           ( cd test; go test -race ./... )
 
   test-makefile-release:

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test
         run: |
-          go install github.com/fatih/faillint || true
+          go install github.com/fatih/faillint@latest || true
           ( cd test; go test -race ./... )
 
   test-makefile-release:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
during execution of test coverage some tests are skipped due to missing `faillint` installed
<img width="901" alt="image" src="https://github.com/coredns/coredns/assets/5522817/f3ed8cb0-330f-4a89-bcda-c2d1f10560cd">

and installation of faillint for E2E tests does not work properly either without specification of version
<img width="814" alt="image" src="https://github.com/coredns/coredns/assets/5522817/e0ac844b-8e26-4498-b128-5ae37f2ca721">


### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
