### PR TITLE
plugin/forward: add continue_on_error as an option

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -64,6 +64,7 @@ forward FROM TO... {
   an upstream to be down. If 0, the upstream will never be marked as down (nor health checked).
   Default is 2.
 * `expire` **DURATION**, expire (cached) connections after this time, the default is 10s.
+* `continue_on_error`, passes the lookup to the next plugin if the proxy response has an error.
 * `tls` **CERT** **KEY** **CA** define the TLS properties for TLS connection. From 0 to 3 arguments can be
   provided with the meaning as described below
 

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -227,6 +227,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return c.ArgErr()
 		}
 		f.opts.PreferUDP = true
+	case "continue_on_error":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.continueOnError = true
 	case "tls":
 		args := c.RemainingArgs()
 		if len(args) > 3 {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds the ability to continue processing a DNS response after a failure in the forward plugin. This change enables CoreDNS to process additional DNS lookups when a proxy fails to provide a valid response.  One can thus follow a forward plugin up with additional handlers to handle the error cases, such as by providing a "catch-all" DNS entry or an empty response.

### 2. Which issues (if any) are related?

None (that I know of)

### 3. Which documentation changes (if any) need to be made?

The plugin README has been updated.

### 4. Does this introduce a backward incompatible change or deprecation?

No