### PR TITLE
plugin/recursion: enable server side CNAME recursive lookups

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -34,6 +34,7 @@ var Directives = []string{
 	"acl",
 	"any",
 	"chaos",
+	"recursion",
 	"loadbalance",
 	"tsig",
 	"cache",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/nsid"
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/ready"
+	_ "github.com/coredns/coredns/plugin/recursion"
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -43,6 +43,7 @@ dns64:dns64
 acl:acl
 any:any
 chaos:chaos
+recursion:recursion
 loadbalance:loadbalance
 tsig:tsig
 cache:cache

--- a/plugin/recursion/README.md
+++ b/plugin/recursion/README.md
@@ -1,0 +1,79 @@
+# recursion
+
+## Name
+
+*recursion* - queries recursively for a resource.
+
+## Description
+
+*recursion* will repeat queries which return CNAME records, instead of the requested type, and try to hunt down the requested resource and return it to the client.
+The recursive lookup is done transparently for the client.
+
+Please be careful when exposing a DNS server to an untrusted network with recursion turned on.  The limitations built in can only go so far to prevent a server from hammering the internal DNS infrastructure.
+
+Note:  DNS recursion can be expensive in both network load and CPU.  Memory maps are used to ensure that duplicate calls to the same resource are limited.  If a recursion plugin is followed by a foward out to a public internet, DNS recursion pointing to domains with layers upon layers of CNAME entries can ultimately cause DNS amplification of requests.  Likewise, recursion can speed up network resource requests as the DNS server can do all the additional queries needed to get to the intended record.
+
+## Syntax
+
+~~~
+recursion {
+    except IGNORED_NAMES...
+    max_tries MAX
+    max_depth MAX
+    max_concurrent MAX
+    timeout DURATION
+}
+~~~
+
+* **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from recursion. Requests that match none of these names will be passed through.
+
+* `max_retries` **MAX** will limit the number of attempts to resolve a DNS entry.  This only applies when a domain has multiple CNAME entry option in a reply.  Each retry will follow a random path of CNAME resolutions until the desired record type is found.  (default 3)
+
+* `max_depth` **MAX** will limit the depth of queries done.  A depth of 8 means a name can only be looked up 8 levels deep before giving up.  (default 8)
+
+* `max_concurrent` **MAX** will limit the number of concurrent queries to MAX. Any new query that would raise the number of concurrent queries above the MAX will result in a REFUSED response. This response does not count as a health failure. When choosing a value for MAX, pick a number at least greater than the expected upstream query rate * latency of the upstream servers. As an upper bound for MAX, consider that each concurrent query will use about 2kb of memory.
+
+## Examples
+
+~~~ db1.txt
+$ORIGIN example1.or.
+@       3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
+        3600 IN NS a.iana-servers.net.
+        3600 IN NS b.iana-servers.net.
+
+day     IN A 127.0.0.1
+make    IN CNAME my.example2.or.
+~~~
+
+~~~ db2.txt
+$ORIGIN example2.or.
+@       3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
+        3600 IN NS a.iana-servers.net.
+        3600 IN NS b.iana-servers.net.
+
+my      IN CNAME day.example1.or.
+~~~
+
+~~~ Corefile
+.:10053 {
+  recursion
+  file db1.txt example1.or
+  forward . 127.0.0.1:10054
+}
+
+.:10054 {
+  file db2.txt example2.or
+}
+~~~
+
+Command line dig example response:
+```
+$ dig @127.0.0.1 -p 10053 make.example1.or. +noall +answer
+
+; <<>> DiG 9.11.4-P2-RedHat-9.11.4-26.P2.el7_9.13 <<>> @127.0.0.1 -p 10053 make.example1.or. +noall +answer
+; (1 server found)
+;; global options: +cmd
+make.example1.or.       3600    IN      CNAME   my.example2.or.
+my.example2.or.         3600    IN      CNAME   day.example1.or.
+day.example1.or.        3600    IN      A       127.0.0.1
+```

--- a/plugin/recursion/README.md
+++ b/plugin/recursion/README.md
@@ -27,7 +27,7 @@ recursion {
 
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from recursion. Requests that match none of these names will be passed through.
 
-* `max_retries` **MAX** will limit the number of attempts to resolve a DNS entry.  This only applies when a domain has multiple CNAME entry option in a reply.  Each retry will follow a random path of CNAME resolutions until the desired record type is found.  (default 3)
+* `max_retries` **MAX** will limit the number of attempts to resolve a DNS entry.  This only applies when a domain has multiple CNAME entry option in a reply.  Each retry will follow a random path of CNAME resolutions until the desired record type is found.  (default 2)
 
 * `max_depth` **MAX** will limit the depth of queries done.  A depth of 8 means a name can only be looked up 8 levels deep before giving up.  (default 8)
 

--- a/plugin/recursion/handler.go
+++ b/plugin/recursion/handler.go
@@ -1,0 +1,75 @@
+package recursion
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Recursion modifies flags of dns.MsgHdr in queries and / or responses
+type Recursion struct {
+	concurrent int64 // atomic counters need to be first in struct for proper alignment
+
+	ignored       []string
+	maxDepth      uint32
+	maxTries      uint32
+	timeout       time.Duration
+	maxConcurrent int64
+
+	Next plugin.Handler
+
+	// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
+	ErrLimitExceeded error
+}
+
+// New returns a new Recursion.
+func New() *Recursion {
+	f := &Recursion{maxDepth: 8, timeout: defaultTimeout, maxTries: 1}
+	return f
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (f Recursion) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+	if !r.RecursionDesired || !f.match(state) || len(r.Question) != 1 {
+		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+	}
+
+	if f.maxConcurrent > 0 {
+		count := atomic.AddInt64(&(f.concurrent), 1)
+		defer atomic.AddInt64(&(f.concurrent), -1)
+		if count > f.maxConcurrent {
+			maxConcurrentRejectCount.Add(1)
+			return dns.RcodeRefused, f.ErrLimitExceeded
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+
+	wr := ResponseRecursionWriter{
+		ResponseWriter: w,
+		maxDepth:       f.maxDepth,
+		tries:          f.maxTries,
+		qType:          r.Question[0].Qtype,
+		qClass:         r.Question[0].Qclass,
+		next:           f.Next,
+		ctx:            ctx,
+	}
+
+	recursiveCount.Add(1)
+	code, err := plugin.NextOrFailure(f.Name(), f.Next, ctx, &wr, r)
+
+	cancel()
+
+	return code, err
+}
+
+const name = "recursion"
+
+// Name implements the plugin.Handler interface.
+func (h Recursion) Name() string { return name }

--- a/plugin/recursion/metrics.go
+++ b/plugin/recursion/metrics.go
@@ -1,0 +1,32 @@
+package recursion
+
+import (
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Variables declared for monitoring.
+var (
+	subQueryCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "recursion",
+		Name:      "subquery_total",
+		Help:      "Counter of the number of queries done to resolve recursive domains.",
+	})
+
+	recursiveCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "recursion",
+		Name:      "count",
+		Help:      "Counter of the number of queries initiating a recursive lookup.",
+	})
+
+	maxConcurrentRejectCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "recursion",
+		Name:      "max_concurrent_rejects_total",
+		Help:      "Counter of the number of queries rejected because the concurrent queries were at maximum.",
+	})
+)

--- a/plugin/recursion/metrics.go
+++ b/plugin/recursion/metrics.go
@@ -23,6 +23,13 @@ var (
 		Help:      "Counter of the number of queries initiating a recursive lookup.",
 	})
 
+	recursiveFailedCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "recursion",
+		Name:      "count",
+		Help:      "Counter of the number of queries which failed the recursive lookup.",
+	})
+
 	maxConcurrentRejectCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "recursion",

--- a/plugin/recursion/recursion.go
+++ b/plugin/recursion/recursion.go
@@ -1,0 +1,159 @@
+package recursion
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/nonwriter"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+var log = clog.NewWithPlugin("recursion")
+
+const defaultTimeout = 10 * time.Second
+
+// ResponseRecursionWriter is a response writer that allows modifying dns.MsgHdr
+type ResponseRecursionWriter struct {
+	dns.ResponseWriter
+	maxDepth uint32
+	tries    uint32
+	qType    uint16
+	qClass   uint16
+	ctx      context.Context
+
+	next plugin.Handler
+}
+
+// WriteMsg implements the dns.ResponseWriter interface.
+func (r *ResponseRecursionWriter) WriteMsg(res *dns.Msg) error {
+	// The response has already been recursively handled
+	if res.RecursionAvailable {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	res.RecursionAvailable = true // Avoid loops
+
+	// Dedup all records for conciseness
+	dedupMap := make(map[string]dns.RR)
+	res.Answer = dns.Dedup(res.Answer, dedupMap)
+
+	CNAMEs := getCnames(res.Answer)
+
+	// If there are no CNAME entries to lookup or the type has already been provided
+	if len(CNAMEs) == 0 || hasType(res.Answer, r.qType) {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	// Loop a number of tries until a record type is found
+	hasAlternates := len(CNAMEs) > 1
+	var rcode int
+	var err error
+	var answers []dns.RR
+	cachedQuery := make(map[string][]dns.RR)
+
+recursionRetry:
+	for ; r.tries > 0; r.tries-- {
+		answers = append([]dns.RR{}, res.Answer...)
+		next := &dns.Msg{Question: []dns.Question{{Name: CNAMEs[rand.Intn(len(CNAMEs))].Target, Qclass: r.qClass, Qtype: r.qType}}}
+
+		for depth := r.maxDepth; depth > 0; depth-- {
+			if err = r.ctx.Err(); err != nil {
+				rcode = dns.RcodeServerFailure
+				break recursionRetry
+			}
+
+			var subAnswer []dns.RR
+			var ok bool
+
+			// Prevent querying the same lookup twice in the same recursive call
+			if subAnswer, ok = cachedQuery[next.Question[0].Name]; !ok {
+				subQry := nonwriter.New(r.ResponseWriter)
+				subQueryCount.Add(1)
+				rcode, err = plugin.NextOrFailure(name, r.next, r.ctx, subQry, next)
+				if rcode != dns.RcodeSuccess {
+					continue recursionRetry
+				}
+
+				subAnswer = subQry.Msg.Answer
+				cachedQuery[next.Question[0].Name] = subAnswer
+			}
+
+			// Compile the answers all together
+			answers = append(answers, subAnswer...)
+			answers := dns.Dedup(answers, dedupMap)
+			subCNAMEs := getCnames(subAnswer)
+
+			// If alternate CNAMES options exist, enable retries
+			if len(subCNAMEs) > 1 {
+				hasAlternates = true
+			}
+
+			if hasType(subAnswer, r.qType) || (len(subCNAMEs) == 0 && !hasAlternates) {
+				res.RecursionAvailable = true
+				res.Answer = answers
+				return r.ResponseWriter.WriteMsg(res)
+			}
+			next.Question[0].Name = subCNAMEs[rand.Intn(len(subCNAMEs))].Target
+		}
+	}
+
+	if rcode != dns.RcodeSuccess {
+		res.Answer = answers
+		res.Rcode = rcode
+	} else {
+		res.Rcode = dns.RcodeServerFailure
+	}
+
+	r.ResponseWriter.WriteMsg(res)
+	if err != nil {
+		return fmt.Errorf("recursion failed, %s", err)
+	}
+	return fmt.Errorf("recursion failed, tries exhaused")
+}
+
+func getCnames(rr []dns.RR) (ret []*dns.CNAME) {
+	for _, r := range rr {
+		if cn, ok := r.(*dns.CNAME); ok {
+			ret = append(ret, cn)
+		}
+	}
+	return
+}
+
+func hasType(rr []dns.RR, qType uint16) bool {
+	for _, r := range rr {
+		if r.Header().Rrtype == qType {
+			return true
+		}
+	}
+	return false
+}
+
+// Write implements the dns.ResponseWriter interface.
+func (r *ResponseRecursionWriter) Write(buf []byte) (int, error) {
+	log.Warning("ResponseRecursionWriter called with Write: not ensuring recursion is handled")
+	return r.ResponseWriter.Write(buf)
+}
+
+func (f *Recursion) match(state request.Request) bool {
+	if !f.isAllowedDomain(state.Name()) {
+		return false
+	}
+
+	return true
+}
+
+func (f *Recursion) isAllowedDomain(name string) bool {
+	for _, ignore := range f.ignored {
+		if plugin.Name(ignore).Matches(name) {
+			return false
+		}
+	}
+	return true
+}

--- a/plugin/recursion/setup.go
+++ b/plugin/recursion/setup.go
@@ -1,0 +1,104 @@
+package recursion
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+)
+
+func init() { plugin.Register("recursion", setup) }
+
+func setup(c *caddy.Controller) error {
+	rec := New()
+	err := recursionParse(c, rec)
+	if err != nil {
+		return plugin.Error("recursion", err)
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		rec.Next = next
+		return rec
+	})
+
+	return nil
+}
+
+func recursionParse(c *caddy.Controller, f *Recursion) error {
+	j := 0
+	for c.Next() {
+		if j > 0 {
+			return plugin.ErrOnce
+		}
+		j++
+
+		// Refinements? In an extra block.
+		for c.NextBlock() {
+			switch c.Val() {
+			case "except":
+				ignore := c.RemainingArgs()
+				if len(ignore) == 0 {
+					return c.ArgErr()
+				}
+				for i := 0; i < len(ignore); i++ {
+					f.ignored = append(f.ignored, plugin.Host(ignore[i]).NormalizeExact()...)
+				}
+
+			case "timeout":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				dur, err := time.ParseDuration(c.Val())
+				if err != nil {
+					return err
+				}
+				if dur < 0 {
+					return fmt.Errorf("timeout can't be negative: %s", dur)
+				}
+				f.timeout = dur
+
+			case "max_tries":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				n, err := strconv.ParseUint(c.Val(), 10, 32)
+				if err != nil {
+					return err
+				}
+				f.maxTries = uint32(n)
+
+			case "max_depth":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				n, err := strconv.ParseUint(c.Val(), 10, 32)
+				if err != nil {
+					return err
+				}
+				f.maxDepth = uint32(n)
+
+			case "max_concurrent":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				n, err := strconv.Atoi(c.Val())
+				if err != nil {
+					return err
+				}
+				if n < 0 {
+					return fmt.Errorf("max_concurrent can't be negative: %d", n)
+				}
+				f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
+				f.maxConcurrent = int64(n)
+
+			default:
+				return c.Errf("unknown property '%s'", c.Val())
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enables recursive lookups by catching CNAME entries without corresponding request type entry and tries to resolve them by doing sub-queries out to the intended target.

### 2. Which issues (if any) are related?

None that I know of.

Note:  This plugin can be a replacement for `explugins/unbound` for recursive queries.  `recursion` compiles into a static binary while `explugins/unbound` has the bug in which it cannot be compiled into a static binary.

### 3. Which documentation changes (if any) need to be made?

Added README for plugin

### 4. Does this introduce a backward incompatible change or deprecation?

No.