### PR TITLE
Plugin dnstap: add support for "extra" field in payload

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -18,6 +18,7 @@ Every message is sent to the socket as soon as it comes in, the *dnstap* plugin 
 dnstap SOCKET [full] {
   [identity IDENTITY]
   [version VERSION]
+  [extra EXTRA]
   [skipverify]
 }
 ~~~
@@ -60,6 +61,14 @@ Log to a socket, overriding the default identity and version.
 dnstap /tmp/dnstap.sock {
   identity my-dns-server1
   version MyDNSServer-1.2.3
+}
+~~~
+
+Log to a socket, customize the "extra" field in dnstap payload.
+
+~~~ txt
+dnstap /tmp/dnstap.sock {
+  extra forward/upstream
 }
 ~~~
 

--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -136,7 +136,7 @@ And then in your plugin:
 ~~~ go
 import (
   "github.com/coredns/coredns/plugin/dnstap/msg"
-	"github.com/coredns/coredns/request"
+  "github.com/coredns/coredns/request"
 
   tap "github.com/dnstap/golang-dnstap"
 )

--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -27,6 +27,7 @@ dnstap SOCKET [full] {
 * `full` to include the wire-format DNS message.
 * **IDENTITY** to override the identity of the server. Defaults to the hostname.
 * **VERSION** to override the version field. Defaults to the CoreDNS version.
+* **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
 * `skipverify` to skip tls verification during connection. Default to be secure
 
 ## Examples

--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -136,7 +136,6 @@ And then in your plugin:
 ~~~ go
 import (
   "github.com/coredns/coredns/plugin/dnstap/msg"
-  "github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/request"
 
   tap "github.com/dnstap/golang-dnstap"
@@ -157,7 +156,7 @@ func (x ExamplePlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
         tapPlugin.TapMessage(q)
 
         // OR: to interpret the metadata in "extra" field, give more context info
-        tapPlugin.TapMessageWithMetadata(q, ctx, request.Request{W: w, Req: query}, dnstest.NewRecorder(w))
+        tapPlugin.TapMessageWithMetadata(ctx, q, request.Request{W: w, Req: query})
     }
     // ...
 }

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -26,20 +26,20 @@ type Dnstap struct {
 	ExtraFormat       string
 }
 
-// TapMessage sends the message m to the dnstap interface, without interpreting the "Extra" field using metadata.
+// TapMessage sends the message m to the dnstap interface, without populating "Extra" field.
 func (h Dnstap) TapMessage(m *tap.Message) {
 	h.TapMessageWithMetadata(nil, m, request.Request{})
 }
 
-// TapMessageWithMetadata sends the message m to the dnstap interface, with "Extra" field being interpreted by the provided metadata context.
+// TapMessageWithMetadata sends the message m to the dnstap interface, with "Extra" field being populated.
 func (h Dnstap) TapMessageWithMetadata(ctx context.Context, m *tap.Message, state request.Request) {
 	t := tap.Dnstap_MESSAGE
 	extraStr := h.ExtraFormat
-	if ctx != nil {
-		extraStr = h.repl.Replace(ctx, state, nil, extraStr)
-	}
 	var extra []byte
 	if extraStr != "" {
+		if ctx != nil {
+			extraStr = h.repl.Replace(ctx, state, nil, extraStr)
+		}
 		extra = []byte(extraStr)
 	}
 	dt := &tap.Dnstap{

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -20,12 +20,20 @@ type Dnstap struct {
 	IncludeRawMessage bool
 	Identity          []byte
 	Version           []byte
+	Extra             []byte
 }
 
 // TapMessage sends the message m to the dnstap interface.
 func (h Dnstap) TapMessage(m *tap.Message) {
 	t := tap.Dnstap_MESSAGE
-	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: h.Identity, Version: h.Version})
+	dt := &tap.Dnstap{
+		Type: &t,
+		Message: m,
+		Identity: h.Identity,
+		Version: h.Version,
+		Extra: h.Extra,
+	}
+	h.io.Dnstap(dt)
 }
 
 func (h Dnstap) tapQuery(w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -28,7 +28,7 @@ type Dnstap struct {
 
 // TapMessage sends the message m to the dnstap interface, without populating "Extra" field.
 func (h Dnstap) TapMessage(m *tap.Message) {
-	h.TapMessageWithMetadata(nil, m, request.Request{})
+	h.TapMessageWithMetadata(context.TODO(), m, request.Request{})
 }
 
 // TapMessageWithMetadata sends the message m to the dnstap interface, with "Extra" field being populated.
@@ -37,17 +37,17 @@ func (h Dnstap) TapMessageWithMetadata(ctx context.Context, m *tap.Message, stat
 	extraStr := h.ExtraFormat
 	var extra []byte
 	if extraStr != "" {
-		if ctx != nil {
+		if ctx != context.TODO() {
 			extraStr = h.repl.Replace(ctx, state, nil, extraStr)
 		}
 		extra = []byte(extraStr)
 	}
 	dt := &tap.Dnstap{
-		Type: &t,
-		Message: m,
+		Type:     &t,
+		Message:  m,
 		Identity: h.Identity,
-		Version: h.Version,
-		Extra: extra,
+		Version:  h.Version,
+		Extra:    extra,
 	}
 	h.io.Dnstap(dt)
 }

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -114,7 +114,7 @@ func testMessage() *tap.Message {
 }
 
 func TestTapMessage(t *testing.T) {
-	extraFormat := "extra_field_{/metadata/test}_{type}_{name}_{class}_{proto}_{size}_{remote}_{port}_{local}"
+	extraFormat := "extra_field_no_replacement_{/metadata/test}_{type}_{name}_{class}_{proto}_{size}_{remote}_{port}_{local}"
 	tapq := &tap.Dnstap{
 		Message: testMessage(),
 		// extra field would not be replaced, since TapMessage won't pass context

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 	test "github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/plugin/metadata"
 
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
 )
 
-func testCase(t *testing.T, tapq, tapr *tap.Message, q, r *dns.Msg) {
+func testCase(t *testing.T, tapq, tapr *tap.Dnstap, q, r *dns.Msg) {
 	w := writer{t: t}
 	w.queue = append(w.queue, tapq, tapr)
 	h := Dnstap{
@@ -21,8 +22,16 @@ func testCase(t *testing.T, tapq, tapr *tap.Message, q, r *dns.Msg) {
 			return 0, w.WriteMsg(r)
 		}),
 		io: &w,
+		ExtraFormat: "extra_field_{/metadata/test}_{type}_{name}_{class}_{proto}_{size}_{remote}_{port}_{local}",
 	}
-	_, err := h.ServeDNS(context.TODO(), &test.ResponseWriter{}, q)
+	ctx := metadata.ContextWithMetadata(context.TODO())
+	ok := metadata.SetValueFunc(ctx, "metadata/test", func() string {
+		return "MetadataValue"
+	})
+	if !ok {
+		t.Fatal("Failed to set metadata")
+	}
+	_, err := h.ServeDNS(ctx, &test.ResponseWriter{}, q)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +39,7 @@ func testCase(t *testing.T, tapq, tapr *tap.Message, q, r *dns.Msg) {
 
 type writer struct {
 	t     *testing.T
-	queue []*tap.Message
+	queue []*tap.Dnstap
 }
 
 func (w *writer) Dnstap(e *tap.Dnstap) {
@@ -38,7 +47,7 @@ func (w *writer) Dnstap(e *tap.Dnstap) {
 		w.t.Error("Message not expected")
 	}
 
-	ex := w.queue[0]
+	ex := w.queue[0].Message
 	got := e.Message
 
 	if string(ex.QueryAddress) != string(got.QueryAddress) {
@@ -53,6 +62,9 @@ func (w *writer) Dnstap(e *tap.Dnstap) {
 	if *ex.SocketFamily != *got.SocketFamily {
 		w.t.Errorf("Expected socket family %d, got %d", *ex.SocketFamily, *got.SocketFamily)
 	}
+	if string(w.queue[0].Extra) != string(e.Extra) {
+		w.t.Errorf("Expected extra %s, got %s", w.queue[0].Extra, e.Extra)
+	}
 	w.queue = w.queue[1:]
 }
 
@@ -64,10 +76,16 @@ func TestDnstap(t *testing.T) {
 			test.A("example.org. 3600	IN	A 10.0.0.1"),
 		},
 	}.Msg()
-	tapq := testMessage() // leave type unset for deepEqual
-	msg.SetType(tapq, tap.Message_CLIENT_QUERY)
-	tapr := testMessage()
-	msg.SetType(tapr, tap.Message_CLIENT_RESPONSE)
+	tapq := &tap.Dnstap {
+		Message: testMessage(), // leave type unset for deepEqual
+		Extra: []byte("extra_field_MetadataValue_A_example.org._IN_udp_29_10.240.0.1_40212_127.0.0.1"),
+	}
+	msg.SetType(tapq.Message, tap.Message_CLIENT_QUERY)
+	tapr := &tap.Dnstap {
+		Message: testMessage(),
+		Extra: []byte("extra_field_MetadataValue_A_example.org._IN_udp_29_10.240.0.1_40212_127.0.0.1"),
+	}
+	msg.SetType(tapr.Message, tap.Message_CLIENT_RESPONSE)
 	testCase(t, tapq, tapr, q, r)
 }
 
@@ -81,4 +99,25 @@ func testMessage() *tap.Message {
 		QueryAddress:   net.ParseIP("10.240.0.1"),
 		QueryPort:      &port,
 	}
+}
+
+func TestTapMessage(t *testing.T) {
+	tapq := &tap.Dnstap {
+		Message: testMessage(),
+		// extra field would be replaced, since TapMessage does not pass context
+		Extra: []byte("extra_field_{/metadata/test}_{type}_{name}_{class}_{proto}_{size}_{remote}_{port}_{local}"),
+	}
+	msg.SetType(tapq.Message, tap.Message_CLIENT_QUERY)
+
+	w := writer{t: t}
+	w.queue = append(w.queue, tapq)
+	h := Dnstap{
+		Next: test.HandlerFunc(func(_ context.Context,
+			w dns.ResponseWriter, r *dns.Msg) (int, error) {
+			return 0, w.WriteMsg(r)
+		}),
+		io: &w,
+		ExtraFormat: "extra_field_{/metadata/test}_{type}_{name}_{class}_{proto}_{size}_{remote}_{port}_{local}",
+	}
+	h.TapMessage(tapq.Message)
 }

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/replacer"
 )
 
 var log = clog.NewWithPlugin("dnstap")
@@ -21,6 +22,7 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 	for c.Next() { // directive name
 		d := Dnstap{}
 		endpoint := ""
+		d.repl = replacer.New()
 
 		args := c.RemainingArgs()
 
@@ -84,7 +86,7 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 					if !c.NextArg() {
 						return nil, c.ArgErr()
 					}
-					d.Extra = []byte(c.Val())
+					d.ExtraFormat = c.Val()
 				}
 			}
 		}

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -79,6 +79,13 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 					}
 					d.Version = []byte(c.Val())
 				}
+			case "extra":
+				{
+					if !c.NextArg() {
+						return nil, c.ArgErr()
+					}
+					d.Extra = []byte(c.Val())
+				}
 			}
 		}
 		dnstaps = append(dnstaps, &d)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -82,8 +82,8 @@ func TestConfig(t *testing.T) {
 			if x := string(tap.Version); x != string(tc.expect[i].version) {
 				t.Errorf("Test %d: expected version %s, got %s", i, tc.expect[i].version, x)
 			}
-			if x := string(tap.Extra); x != string(tc.expect[i].extra) {
-				t.Errorf("Test %d: expected extra %s, got %s", i, tc.expect[i].extra, x)
+			if x := tap.ExtraFormat; x != string(tc.expect[i].extra) {
+				t.Errorf("Test %d: expected extra format %s, got %s", i, tc.expect[i].extra, x)
 			}
 		}
 	}

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -49,6 +49,9 @@ func TestConfig(t *testing.T) {
 			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), []byte("EXTRA2")},
 		}},
 		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-"), nil}}},
+		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
+		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
+		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type results struct {
-	endpoint string
+	endpoint    string
 	full        bool
 	proto       string
 	identity    []byte

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -31,6 +31,7 @@ func TestConfig(t *testing.T) {
 		{"dnstap tcp://[::1]:6000", false, []results{{"[::1]:6000", false, "tcp", []byte(hostname), []byte("-"), nil}}},
 		{"dnstap tcp://example.com:6000", false, []results{{"example.com:6000", false, "tcp", []byte(hostname), []byte("-"), nil}}},
 		{"dnstap", true, []results{{"fail", false, "tcp", []byte(hostname), []byte("-"), nil}}},
+		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), nil}}},
 		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},
 		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", false, "unix", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},
 		{"dnstap {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", true, []results{{"fail", false, "tcp", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -11,11 +11,11 @@ import (
 
 type results struct {
 	endpoint string
-	full     bool
-	proto    string
-	identity []byte
-	version  []byte
-	extra    []byte
+	full        bool
+	proto       string
+	identity    []byte
+	version     []byte
+	extraFormat string
 }
 
 func TestConfig(t *testing.T) {
@@ -25,33 +25,33 @@ func TestConfig(t *testing.T) {
 		fail   bool
 		expect []results
 	}{
-		{"dnstap dnstap.sock full", false, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap unix://dnstap.sock", false, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap tcp://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tcp", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap tcp://[::1]:6000", false, []results{{"[::1]:6000", false, "tcp", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap tcp://example.com:6000", false, []results{{"example.com:6000", false, "tcp", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap", true, []results{{"fail", false, "tcp", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), nil}}},
-		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},
-		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", false, "unix", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},
-		{"dnstap {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", true, []results{{"fail", false, "tcp", []byte("NAME"), []byte("VER"), []byte("EXTRA")}}},
+		{"dnstap dnstap.sock full", false, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap unix://dnstap.sock", false, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap tcp://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tcp", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap tcp://[::1]:6000", false, []results{{"[::1]:6000", false, "tcp", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap tcp://example.com:6000", false, []results{{"example.com:6000", false, "tcp", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap", true, []results{{"fail", false, "tcp", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), ""}}},
+		{"dnstap dnstap.sock full {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), "EXTRA"}}},
+		{"dnstap dnstap.sock {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", false, []results{{"dnstap.sock", false, "unix", []byte("NAME"), []byte("VER"), "EXTRA"}}},
+		{"dnstap {\nidentity NAME\nversion VER\nextra EXTRA\n}\n", true, []results{{"fail", false, "tcp", []byte("NAME"), []byte("VER"), "EXTRA"}}},
 		{`dnstap dnstap.sock full {
                 identity NAME
                 version VER
-				extra EXTRA
+                extra EXTRA
               }
               dnstap tcp://127.0.0.1:6000 {
                 identity NAME2
                 version VER2
-				extra EXTRA2
+                extra EXTRA2
               }`, false, []results{
-			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), []byte("EXTRA")},
-			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), []byte("EXTRA2")},
+			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), "EXTRA"},
+			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), "EXTRA2"},
 		}},
-		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
-		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), nil}}},
+		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), ""}}},
+		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), ""}}},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)
@@ -82,8 +82,8 @@ func TestConfig(t *testing.T) {
 			if x := string(tap.Version); x != string(tc.expect[i].version) {
 				t.Errorf("Test %d: expected version %s, got %s", i, tc.expect[i].version, x)
 			}
-			if x := tap.ExtraFormat; x != string(tc.expect[i].extra) {
-				t.Errorf("Test %d: expected extra format %s, got %s", i, tc.expect[i].extra, x)
+			if x := tap.ExtraFormat; x != tc.expect[i].extraFormat {
+				t.Errorf("Test %d: expected extra format %s, got %s", i, tc.expect[i].extraFormat, x)
 			}
 		}
 	}

--- a/plugin/dnstap/writer.go
+++ b/plugin/dnstap/writer.go
@@ -15,7 +15,7 @@ import (
 type ResponseWriter struct {
 	queryTime time.Time
 	query     *dns.Msg
-	ctx       *context.Context
+	ctx       context.Context
 	dns.ResponseWriter
 	Dnstap
 }
@@ -39,6 +39,6 @@ func (w *ResponseWriter) WriteMsg(resp *dns.Msg) error {
 
 	msg.SetType(r, tap.Message_CLIENT_RESPONSE)
 	state := request.Request{W: w.ResponseWriter, Req: w.query}
-	w.TapMessageWithMetadata(*(w.ctx), r, state)
+	w.TapMessageWithMetadata(w.ctx, r, state)
 	return nil
 }

--- a/plugin/dnstap/writer.go
+++ b/plugin/dnstap/writer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
-	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/request"
 
 	tap "github.com/dnstap/golang-dnstap"
@@ -40,7 +39,6 @@ func (w *ResponseWriter) WriteMsg(resp *dns.Msg) error {
 
 	msg.SetType(r, tap.Message_CLIENT_RESPONSE)
 	state := request.Request{W: w.ResponseWriter, Req: w.query}
-	rrw := dnstest.NewRecorder(w.ResponseWriter)
-	w.TapMessageWithMetadata(r, *(w.ctx), state, rrw)
+	w.TapMessageWithMetadata(*(w.ctx), r, state)
 	return nil
 }

--- a/plugin/forward/dnstap.go
+++ b/plugin/forward/dnstap.go
@@ -15,7 +15,7 @@ import (
 )
 
 // toDnstap will send the forward and received message to the dnstap plugin.
-func toDnstap(ctx context.Context, f *Forward, host string, state request.Request, opts proxy.Options, reply *dns.Msg, start time.Time, w dns.ResponseWriter) {
+func toDnstap(ctx context.Context, f *Forward, host string, state request.Request, opts proxy.Options, reply *dns.Msg, start time.Time) {
 	h, p, _ := net.SplitHostPort(host)      // this is preparsed and can't err here
 	port, _ := strconv.ParseUint(p, 10, 32) // same here
 	ip := net.ParseIP(h)

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -167,7 +167,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		}
 
 		if len(f.tapPlugins) != 0 {
-			toDnstap(f, proxy.Addr(), state, opts, ret, start, ctx, w)
+			toDnstap(ctx, f, proxy.Addr(), state, opts, ret, start, w)
 		}
 
 		upstreamErr = err

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -167,7 +167,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		}
 
 		if len(f.tapPlugins) != 0 {
-			toDnstap(f, proxy.Addr(), state, opts, ret, start)
+			toDnstap(f, proxy.Addr(), state, opts, ret, start, ctx, w)
 		}
 
 		upstreamErr = err

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -167,7 +167,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		}
 
 		if len(f.tapPlugins) != 0 {
-			toDnstap(ctx, f, proxy.Addr(), state, opts, ret, start, w)
+			toDnstap(ctx, f, proxy.Addr(), state, opts, ret, start)
 		}
 
 		upstreamErr = err

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -85,7 +85,7 @@ func appendValue(b []byte, state request.Request, rr *dnstest.Recorder, label st
 		}
 		return append(b, EmptyValue...)
 	}
-	
+
 	if (request.Request{}) == state {
 		return append(b, EmptyValue...)
 	}

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -59,31 +59,6 @@ var labels = map[string]struct{}{
 // appendValue appends the current value of label.
 func appendValue(b []byte, state request.Request, rr *dnstest.Recorder, label string) []byte {
 	switch label {
-	case "{type}":
-		return append(b, state.Type()...)
-	case "{name}":
-		return append(b, state.Name()...)
-	case "{class}":
-		return append(b, state.Class()...)
-	case "{proto}":
-		return append(b, state.Proto()...)
-	case "{size}":
-		return strconv.AppendInt(b, int64(state.Req.Len()), 10)
-	case "{remote}":
-		return appendAddrToRFC3986(b, state.IP())
-	case "{port}":
-		return append(b, state.Port()...)
-	case "{local}":
-		return appendAddrToRFC3986(b, state.LocalIP())
-	// Header placeholders (case-insensitive).
-	case headerReplacer + "id}":
-		return strconv.AppendInt(b, int64(state.Req.Id), 10)
-	case headerReplacer + "opcode}":
-		return strconv.AppendInt(b, int64(state.Req.Opcode), 10)
-	case headerReplacer + "do}":
-		return strconv.AppendBool(b, state.Do())
-	case headerReplacer + "bufsize}":
-		return strconv.AppendInt(b, int64(state.Size()), 10)
 	// Recorded replacements.
 	case "{rcode}":
 		if rr == nil || rr.Msg == nil {
@@ -109,6 +84,38 @@ func appendValue(b []byte, state request.Request, rr *dnstest.Recorder, label st
 			return appendFlags(b, rr.Msg.MsgHdr)
 		}
 		return append(b, EmptyValue...)
+	}
+	
+	if (request.Request{}) == state {
+		return append(b, EmptyValue...)
+	}
+
+	switch label {
+	case "{type}":
+		return append(b, state.Type()...)
+	case "{name}":
+		return append(b, state.Name()...)
+	case "{class}":
+		return append(b, state.Class()...)
+	case "{proto}":
+		return append(b, state.Proto()...)
+	case "{size}":
+		return strconv.AppendInt(b, int64(state.Req.Len()), 10)
+	case "{remote}":
+		return appendAddrToRFC3986(b, state.IP())
+	case "{port}":
+		return append(b, state.Port()...)
+	case "{local}":
+		return appendAddrToRFC3986(b, state.LocalIP())
+	// Header placeholders (case-insensitive).
+	case headerReplacer + "id}":
+		return strconv.AppendInt(b, int64(state.Req.Id), 10)
+	case headerReplacer + "opcode}":
+		return strconv.AppendInt(b, int64(state.Req.Opcode), 10)
+	case headerReplacer + "do}":
+		return strconv.AppendBool(b, state.Do())
+	case headerReplacer + "bufsize}":
+		return strconv.AppendInt(b, int64(state.Size()), 10)
 	default:
 		return append(b, EmptyValue...)
 	}

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -247,6 +247,8 @@ func TestLabels(t *testing.T) {
 
 	for lbl := range labels {
 		repl := replacer.Replace(ctx, state, w, lbl)
+		// test empty state won't panic
+		replacer.Replace(ctx, request.Request{}, w, lbl)
 		if lbl == "{duration}" {
 			if repl[len(repl)-1] != 's' {
 				t.Errorf("Expected seconds, got %q", repl)

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -247,10 +247,6 @@ func TestLabels(t *testing.T) {
 
 	for lbl := range labels {
 		repl := replacer.Replace(ctx, state, w, lbl)
-		// test empty state and/or recorder won't panic
-		replacer.Replace(ctx, request.Request{}, w, lbl)
-		replacer.Replace(ctx, state, nil, lbl)
-		replacer.Replace(ctx, request.Request{}, nil, lbl)
 		if lbl == "{duration}" {
 			if repl[len(repl)-1] != 's' {
 				t.Errorf("Expected seconds, got %q", repl)
@@ -259,6 +255,12 @@ func TestLabels(t *testing.T) {
 		}
 		if repl != expect[lbl] {
 			t.Errorf("Expected value %q, got %q", expect[lbl], repl)
+		}
+
+		// test empty state and nil recorder won't panic
+		repl_empty := replacer.Replace(ctx, request.Request{}, nil, lbl)
+		if repl_empty != EmptyValue {
+			t.Errorf("Expected empty value %q, got %q", EmptyValue, repl_empty)
 		}
 	}
 }

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -247,8 +247,10 @@ func TestLabels(t *testing.T) {
 
 	for lbl := range labels {
 		repl := replacer.Replace(ctx, state, w, lbl)
-		// test empty state won't panic
+		// test empty state and/or recorder won't panic
 		replacer.Replace(ctx, request.Request{}, w, lbl)
+		replacer.Replace(ctx, state, nil, lbl)
+		replacer.Replace(ctx, request.Request{}, nil, lbl)
 		if lbl == "{duration}" {
 			if repl[len(repl)-1] != 's' {
 				t.Errorf("Expected seconds, got %q", repl)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
As proposed in #6092 , this PR adds supports to customize "extra" field in dnstap payload, the field could be set in the config file.

The "extra" field in defined in [dnstap.proto](https://github.com/dnstap/dnstap.pb/blob/master/dnstap.proto#L40).

### 2. Which issues (if any) are related?
#6092 

### 3. Which documentation changes (if any) need to be made?
The plugin README: https://github.com/coredns/coredns/blob/master/plugin/dnstap/README.md

### 4. Does this introduce a backward incompatible change or deprecation?
No