### PR TITLE
implement Name function on secondary plugin

### DIFF
--- a/plugin/secondary/secondary.go
+++ b/plugin/secondary/secondary.go
@@ -8,3 +8,6 @@ import "github.com/coredns/coredns/plugin/file"
 type Secondary struct {
 	file.File
 }
+
+// Name implements the Handler interface.
+func (s Secondary) Name() string { return "secondary" }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
implement Name() func of handler interface on secondary plugin

### 2. Which issues (if any) are related?
[prometheus metric](https://coredns.io/plugins/metrics/) `coredns_plugin_enabled` shows zones loaded with `secondary` as `file`

### 3. Which documentation changes (if any) need to be made?
NA

### 4. Does this introduce a backward incompatible change or deprecation?
NA
