### PR TITLE
update outdated blog links in documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ We're most active on Github (and Slack):
 More resources can be found:
 
 - Website: <https://coredns.io>
-- Blog: <https://blog.coredns.io>
+- Blog: <https://coredns.io/blog/>
 - Twitter: [@corednsio](https://twitter.com/corednsio)
 - Mailing list/group: <coredns-discuss@googlegroups.com> (not very active)
 

--- a/plugin.md
+++ b/plugin.md
@@ -30,8 +30,8 @@ code.
 
 See a couple of blog posts on how to write and add plugin to CoreDNS:
 
-* <https://blog.coredns.io/2017/03/01/how-to-add-plugins-to-coredns/>
-* <https://blog.coredns.io/2016/12/19/writing-plugins-for-coredns/>, slightly older, but useful.
+* <https://coredns.io/2017/03/01/how-to-add-plugins-to-coredns/>
+* <https://coredns.io/2016/12/19/writing-plugins-for-coredns/>, slightly older, but useful.
 
 ## Logging
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The old blog site (blog.coredns.io) is moved to coredns.io/blog and the old domain name is not working.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
no