### PR TITLE
plugin/cache: fix keepttl parsing

### DIFF
--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -241,6 +241,7 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 					return nil, fmt.Errorf("cache type for disable must be %q or %q", Success, Denial)
 				}
 			case "keepttl":
+				args := c.RemainingArgs()
 				if len(args) != 0 {
 					return nil, c.ArgErr()
 				}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

fixes issue where keepttl validation was validating the wrong args

### 2. Which issues (if any) are related?

fixes #6225

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no