### PR TITLE
circelci: grep out the timestamp line when retrieving latest go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ initWorkingDir: &initWorkingDir
     GOROOT=$(go env GOROOT)
     sudo rm -r $(go env GOROOT)
     sudo mkdir $GOROOT
-    LATEST=$(curl -s https://go.dev/VERSION?m=text)
+    LATEST=$(curl -s https://go.dev/VERSION?m=text | grep -v time)
     curl https://dl.google.com/go/${LATEST}.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 integrationDefaults: &integrationDefaults


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

https://go.dev/VERSION apparently started adding a build timestamp on a second line, which breaks the constructed go download url.  This change greps out the timestamp line.

### 2. Which issues (if any) are related?

Fixes: recent circleci initialization stage errors

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
