### PR TITLE
Updated go versions used in workflows to 1.21

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
         id: go
 
       - name: Build

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
         id: go
 
       - name: Build
@@ -36,7 +36,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
         id: go
 
       - name: Build
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
         id: go
 
       - name: Build

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '~1.20.0'
+          go-version: '~1.21.0'
 
       - name: Update Docs
         run: |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CoreDNS requires Go to compile. However, if you already have docker installed an
 setup a Go environment, you could build CoreDNS easily:
 
 ```
-$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.20 make
+$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.21 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Updates go versions used in workflows to 1.21

### 2. Which issues (if any) are related?
-

### 3. Which documentation changes (if any) need to be made?
No

### 4. Does this introduce a backward incompatible change or deprecation?
No