### PR TITLE
plugin/reload: make reload work after SIGUSR1

### DIFF
--- a/test/reload/main_test.go
+++ b/test/reload/main_test.go
@@ -1,0 +1,126 @@
+package reload_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coredns/caddy"
+	_ "github.com/coredns/coredns/core/plugin"
+	"github.com/google/uuid"
+)
+
+var (
+	startInstance   func() error
+	stopInstance    func()
+	waitForInstance func(timeout time.Duration) error
+	updateCorefile  func(corefile string)
+)
+
+func TestMain(m *testing.M) {
+	var instance *caddy.Instance
+	var wait = make(chan *caddy.Instance, 1)
+	var hook caddy.EventHook
+	var corefilePath string
+
+	hook = func(eventType caddy.EventName, eventInfo interface{}) error {
+		switch eventType {
+		case caddy.InstanceStartupEvent:
+			instance = eventInfo.(*caddy.Instance)
+			// (re)register hook when a restart happens (needed because the USR1 signal handler clears hooks before restarting)
+			instance.OnRestart = append(instance.OnRestart, func() error {
+				registerEventHook("reload_test", hook)
+				return nil
+			})
+			select {
+			case <-wait:
+			default:
+			}
+			wait <- instance
+		}
+		return nil
+	}
+
+	registerEventHook("reload_test", hook)
+
+	startInstance = func() error {
+		if instance != nil {
+			panic("instance already running")
+		}
+		coreInput, err := caddy.LoadCaddyfile("dns")
+		if err != nil {
+			return err
+		}
+		_, err = caddy.Start(coreInput)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	stopInstance = func() {
+		if instance == nil {
+			return
+		}
+		err := instance.Stop()
+		if err != nil {
+			panic(err)
+		}
+		errs := instance.ShutdownCallbacks()
+		if len(errs) > 0 {
+			panic(errs)
+		}
+		instance = nil
+	}
+
+	waitForInstance = func(timeout time.Duration) error {
+		select {
+		case <-wait:
+			return nil
+		case <-time.After(timeout):
+			return fmt.Errorf("timeout")
+		}
+	}
+
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	updateCorefile = func(corefile string) {
+		if corefilePath != "" {
+			err := os.Remove(corefilePath)
+			if err != nil {
+				panic(err)
+			}
+		}
+		corefilePath = tmpdir + "/Corefile-" + uuid.New().String()
+		err := os.WriteFile(corefilePath, []byte(corefile), 0644)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	caddy.RegisterCaddyfileLoader("test", caddy.LoaderFunc(func(serverType string) (caddy.Input, error) {
+		corefile, err := os.ReadFile(corefilePath)
+		return caddy.CaddyfileInput{Filepath: corefilePath, Contents: corefile, ServerTypeName: "dns"}, err
+	}))
+
+	os.Exit(m.Run())
+}
+
+// TODO: it would be nicer if github.com/coredns/caddy would expose some method RegisterEventHookIfNotRegistered()
+func registerEventHook(name string, hook caddy.EventHook) (changed bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			if s, ok := r.(string); !ok || s != "hook named "+name+" already registered" {
+				panic(r)
+			}
+		}
+	}()
+	caddy.RegisterEventHook(name, hook)
+	changed = true
+	return
+}

--- a/test/reload/sigusr1_test.go
+++ b/test/reload/sigusr1_test.go
@@ -1,0 +1,55 @@
+package reload_test
+
+import (
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/coredns/caddy"
+)
+
+func TestReloadAfterSignal(t *testing.T) {
+	updateCorefile(`.:0 {
+		erratic
+		reload 2s 1s
+	}`)
+
+	err := startInstance()
+	if err != nil {
+		t.Fatalf("Could not start CoreDNS instance: %s", err)
+	}
+	defer stopInstance()
+	// wait for instance to be started
+	err = waitForInstance(5 * time.Second)
+	if err != nil {
+		t.Fatalf("Error waiting for instance: %s", err)
+	}
+
+	caddy.TrapSignals()
+	defer signal.Reset()
+	// caddy.TrapSignals() does not establish signal handlers synchronously; that means it calls
+	// signal.Notify() in a go routine (which could/should be changed); to avoid/minimize race ceonditions
+	// we insert a safety sleep here
+	time.Sleep(1 * time.Second)
+	err = syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	if err != nil {
+		t.Fatalf("Error sending USR1 signal: %s", err)
+	}
+	// wait for instance after SIGUSR1
+	err = waitForInstance(5 * time.Second)
+	if err != nil {
+		t.Fatalf("Error waiting for instance: %s", err)
+	}
+
+	// trigger another reload
+	updateCorefile(`.:0 {
+		forward . 8.8.8.8
+		reload 2s 1s
+	}`)
+	// wait for instance after reload (this proves that reload plugin works after SIGUSR1 triggered reload)
+	err = waitForInstance(5 * time.Second)
+	if err != nil {
+		t.Fatalf("Error waiting for instance: %s", err)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Try to fix #6263: it introduces two relevant changes:
1. Register the reload event hook (https://github.com/coredns/coredns/blob/master/plugin/reload/reload.go#L63) not only once (as it happens today, see https://github.com/coredns/coredns/blob/master/plugin/reload/setup.go#L69), but every time the `setup` function of the plugin is called.
This addresses the problem that the USR1 signal handler currently flushes all event hooks (https://github.com/coredns/caddy/blob/master/sigtrap_posix.go#L84).
For the moment, a workaround (https://github.com/cbarbian-sap/coredns/blob/a2f8cf8f35f1a3393d875bb466509afab68eede8/plugin/reload/setup.go#L78) is needed to do this re-registration, because https://github.com/coredns/caddy currently only offers the function `RegisterEventHook()` which panics in case of duplicate registration.  In case this PR is accepted, it might be worth to expose such a function ('register event hook if not yet registered') directly in the coredns/caddy module.
2. Terminate the background reload event handler (https://github.com/coredns/coredns/blob/master/plugin/reload/reload.go#L84) more aggressively, whenever the instance it handles is shutdown: https://github.com/cbarbian-sap/coredns/blob/a2f8cf8f35f1a3393d875bb466509afab68eede8/plugin/reload/reload.go#L78. This is IMHO not wrong, as I do not see why that go routine should continue to run if the instance it is managing is already stopped. With that change, the whole part around the `OnFinalShutdown` callback registration in `setup.go` becomes entirely obsolete.

NB: this PR assumes that shutdown callbacks will be called at most once (since the callback proposed by this PR does a send to a buffered channel (`quit`) of length 1). Is that assumption valid?

### 2. Which issues (if any) are related?

Issue #6263 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Hopefully not.
