### PR TITLE
Handle UDP responses that overflow with TC bit

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -187,17 +187,13 @@ const cumulativeAvgWeight = 4
 // This is to mitigate the effects of an upstream server sending UDP responses that exceed the maximum size of 512 bytes.
 func truncateResponse(response *dns.Msg) *dns.Msg {
 
-	truncatedResponse := response.Copy()
-
-	// Clear out Answer, Extra, and AuthenticatedData sections
-	truncatedResponse.Answer = nil
-	truncatedResponse.Extra = nil
-
-	// Clearing AD bit to indicate that the response is not authenticated.
-	truncatedResponse.AuthenticatedData = false
+	// Clear out Answer, Extra, and Ns sections
+	response.Answer = nil
+	response.Extra = nil
+	response.Ns = nil
 
 	// Set TC bit to indicate truncation.
-	truncatedResponse.Truncated = true
+	response.Truncated = true
 
-	return truncatedResponse
+	return response
 }

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -127,9 +127,9 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 				// client retry over TCP (if that's supported) or at least receive a clean
 				// error. The connection is still good so we break before the close.
 
-				if shouldTruncateResponse(err) {
-					// Only if response message id matches the request message id - return a truncated response.
-					if ret != nil && (state.Req.Id == ret.Id) {
+				// Only if response message id matches the request message id - check for truncation and truncate response.
+				if ret != nil && (state.Req.Id == ret.Id) {
+					if shouldTruncateResponse(err) {
 						ret = truncateResponse(ret)
 						break
 					}

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -151,7 +151,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 					}
 				}
 			}
-
+}
 			pc.c.Close() // not giving it back
 			if err == io.EOF && cached {
 				return nil, ErrCachedClosed

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -120,13 +120,11 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		ret, err = pc.c.ReadMsg()
 		if err != nil {
 			if proto == "udp" {
-
 				// For UDP, if the error is an overflow, we probably have an upstream misbehaving in some way.
 				// (e.g. sending >512 byte responses without an eDNS0 OPT RR).
 				// Instead of returning an error, return an empty response with TC bit set. This will make the
 				// client retry over TCP (if that's supported) or at least receive a clean
 				// error. The connection is still good so we break before the close.
-
 				isDNSBufferError := false
 				isDNSOverflowError := false
 
@@ -146,7 +144,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 					}
 				}
 			}
-}
+
 			pc.c.Close() // not giving it back
 			if err == io.EOF && cached {
 				return nil, ErrCachedClosed

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -147,6 +147,9 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 				if state.Req.Id == ret.Id {
 					newRet := state.Req.Copy()
 
+					newRet.RecursionAvailable = ret.RecursionAvailable
+					newRet.Response = ret.Response
+
 					// Set TC bit to indicate truncation.
 					newRet.Truncated = true
 

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -120,6 +120,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		ret, err = pc.c.ReadMsg()
 		if err != nil {
 			if proto == "udp" {
+
 				// For UDP, if the error is an overflow, we probably have an upstream misbehaving in some way.
 				// (e.g. sending >512 byte responses without an eDNS0 OPT RR).
 				// Instead of returning an error, return an empty response with TC bit set. This will make the

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -129,17 +129,12 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 
 				isDNSBufferError := false
 				isDNSOverflowError := false
-				var perr *dns.Error
 
 				// This is to handle a scenario in which upstream sets the TC bit, but doesn't truncate the response
 				// and we get ErrBuf instead of overflow.
-				if errors.As(err, &perr) {
-					if errors.Is(err, dns.ErrBuf) {
-						isDNSBufferError = true
-					}
-				}
-
-				if strings.Contains(err.Error(), "overflow") {
+				if _, isDNSErr := err.(*dns.Error); isDNSErr && errors.Is(err, dns.ErrBuf) {
+					isDNSBufferError = true
+				} else if strings.Contains(err.Error(), "overflow") {
 					isDNSOverflowError = true
 				}
 

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -129,7 +129,9 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 
 				// Only if response message id matches the request message id - check for truncation and truncate response.
 				if ret != nil && (state.Req.Id == ret.Id) {
+					// Check if the response should be truncated based on the error.
 					if shouldTruncateResponse(err) {
+						// Truncate the response.
 						ret = truncateResponse(ret)
 						break
 					}

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -136,12 +136,6 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			if proto == "udp" && ((strings.Contains(err.Error(), "overflow")) || dnsErrBufOccured) {
 				newRet := state.Req.Copy()
 
-				// Clear AD bit in case request had set the AD bit. The empty response is not authenticated.
-				newRet.AuthenticatedData = false
-
-				// Clear AA bit in case request had set the AA bit.
-				newRet.Authoritative = false
-
 				newRet.RecursionAvailable = ret.RecursionAvailable
 				newRet.Response = true
 

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -128,3 +128,52 @@ func TestProxyIncrementFails(t *testing.T) {
 		})
 	}
 }
+
+func TestCoreDNSOverflow(t *testing.T) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.1"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.2"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.3"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.4"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.5"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.6"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.7"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.8"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.9"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.10"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.11"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.12"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.13"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.14"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.15"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.16"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.17"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.18"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.19"))
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.20"))
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
+	p.readTimeout = 10 * time.Millisecond
+	p.Start(5 * time.Second)
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	req := request.Request{Req: m, W: rec}
+
+	resp, err := p.Connect(context.Background(), req, Options{PreferUDP: true})
+	if err != nil {
+		t.Errorf("Failed to connect to testdnsserver: %s", err)
+	}
+
+	// Verify that the TC (truncated) flag is set in the response
+	if !resp.Truncated {
+		t.Errorf("Expected truncated response, but the TC flag is not set")
+	}
+}

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -193,7 +193,7 @@ func TestCoreDNSOverflow(t *testing.T) {
 	// Test ForceTCP, expect no truncated response
 	testConnection("ForceTCP", Options{ForceTCP: true}, false)
 
-	// Test No options specified, expect no truncated response
+	// Test No options specified, expect truncated response
 	testConnection("NoOptionsSpecified", Options{}, true)
 
 	// Test both TCP and UDP provided, expect no truncated response


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Description in this PR - https://github.com/coredns/coredns/pull/6003
Code changes in plugin/pkg/proxy/connect.go file is copied from above PR - https://github.com/coredns/coredns/pull/6003

This PR - https://github.com/coredns/coredns/pull/6100 was closed by mistake. So submitting a new PR here with the same code changes. 

Getting this PR https://github.com/miekg/dns/pull/1475 reviewed is taking time. Can we get the bug fix merged here with "overflow" string comparison. And we can address this "To accurately identify the error by type rather than string compares" as a follow up PR while I work with maintainers of miekg package. 

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/5953
https://github.com/coredns/coredns/issues/5998

### 3. Which documentation changes (if any) need to be made?
Not sure. 

### 4. Does this introduce a backward incompatible change or deprecation?
No.
