### PR TITLE
refactor: Simplify `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,7 @@
-ARG DEBIAN_IMAGE=debian:stable-slim
 ARG BASE=gcr.io/distroless/static-debian11:nonroot
-FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
-SHELL [ "/bin/sh", "-ec" ]
-
-RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
-           DEBIAN_FRONTEND=noninteractive \
-           DEBIAN_PRIORITY=critical \
-           TERM=linux ; \
-    apt-get -qq update ; \
-    apt-get -yyqq upgrade ; \
-    apt-get -yyqq install ca-certificates libcap2-bin; \
-    apt-get clean
-COPY coredns /coredns
-RUN setcap cap_net_bind_service=+ep /coredns
 
 FROM --platform=$TARGETPLATFORM ${BASE}
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /coredns /coredns
+COPY coredns /coredns
 USER nonroot:nonroot
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

**TL;DR:**
- Enforcing the `NET_BIND_SERVICE` capability for any user to bind privileged ports isn't required with Docker unless running with `--network host`?
- You could have a much simpler `Dockerfile` and allow those who enforce dropping `NET_BIND_SERVICE` to still run the `coredns` binary on **unprivileged ports** which is more secure of a choice to support. `setcap` applying the capability with _effective_ + _permitted_ set is enforcing a requirement for privileges that aren't always necessary. You can still run as non-root without this.

---

[Introduced in March 2023](https://github.com/coredns/coredns/pull/5969) to support non-root feature. It seems largely unnecessary though?
- Everything removed was to support [`setcap` mandating `NET_BIND_SERVICE`](https://man7.org/linux/man-pages/man7/capabilities.7.html) on the `/coredns` binary.
- There is no need to `COPY` for `ca-certificates.crt`, the [image base `static-debian11:nonroot` already has that](https://github.com/GoogleContainerTools/distroless/blob/0e43ec744c69497ab7aa6f06fec0bd15160c8b7c/base/README.md) (_unless the `BASE` reference `ARG` is changed_). I assume that the base image won't be changing much due to the expectation of `USER nonroot:nonroot` to be successful, thus value of overwriting the contents seems questionable?
  - **EDIT:** Originally [this feature was added when the `scratch` image was used for the final stage](https://github.com/coredns/coredns/pull/5931#issuecomment-1442786431), it was more compatible then, but was not merged until the switch to `nonroot` image which added the `USER` directive.
  - **EDIT:** The `ca-certificates.crt` is [also from earlier as an improvement for the final stage with `scratch` ](https://github.com/coredns/coredns/pull/5571) of the image build. Thus no longer important.


```bash
#! /bin/bash

# Custom config:
cat > /tmp/Corefile <<EOF
.:5353 {
  whoami
}
EOF


# No problems binding with non-root to port >1024
# in container, and < 1024 on host:
docker run --rm \
  --sysctl 'net.ipv4.ip_unprivileged_port_start=1024' \
  --cap-drop NET_BIND_SERVICE \
  --user 1000:1000
  --workdir / --volume '/tmp/Corefile:/Corefile' \
  -p 53:5353/udp
  coredns/coredns:1.10.1
```

On a host network, or perhaps a different container run-time you may need to opt for the `setcap` approach? However due to the change in Docker `20.10.0` (Dec 2020), non-root users can already bind to ports below 1024:

```console
# --cap-add NET_BIND_SERVICE is default capability,
# Dropping it has no impact due to Docker modifying sysctl:
$ docker run --rm --cap-drop NET_BIND_SERVICE coredns/coredns:1.10.1
$ docker run --rm --cap-drop NET_BIND_SERVICE --user 1000:1000 coredns/coredns:1.10.1

.:53
CoreDNS-1.10.1
linux/amd64, go1.20, 055b2c3
```

Restore the sysctl restriction and the capability will have an effect when not applied:

```console
# --cap-add NET_BIND_SERVICE is default capability, reset sysctl to 1024:
$ docker run --rm --sysctl 'net.ipv4.ip_unprivileged_port_start=1024'  coredns/coredns:1.10.1
.:53
CoreDNS-1.10.1
linux/amd64, go1.20, 055b2c3


# Root (drop capability) and user (does not inherit?) - Both fail to bind now:
$ docker run --rm --sysctl 'net.ipv4.ip_unprivileged_port_start=1024' --cap-drop NET_BIND_SERVICE  coredns/coredns:1.10.1
$ docker run --rm --sysctl 'net.ipv4.ip_unprivileged_port_start=1024'  --user '1000:1000'  coredns/coredns:1.10.1
Listen: listen tcp :53: bind: permission denied
```

The only reason to use the `setcap` call in `Dockerfile` is to make the `/coredns` binary treated as a [_"capability-dumb binary"_](https://man7.org/linux/man-pages/man7/capabilities.7.html):

```console
# `setcap cap_net_bind_service=ep` via 1.11.1 tag,
# Capability requirement is enforced, sysctl has no relevance:
$ docker run --rm \
  --sysctl 'net.ipv4.ip_unprivileged_port_start=1024'  \
  --cap-add NET_BIND_SERVICE \
  coredns/coredns:1.11.1

.:53
CoreDNS-1.11.1
linux/amd64, go1.20.7, ae2bbc2

# Capability dropped, fails check and refuses to run binary:
$ docker run --rm \
  --sysctl 'net.ipv4.ip_unprivileged_port_start=1024' \
  --cap-drop NET_BIND_SERVICE \
  coredns/coredns:1.11.1

exec /coredns: operation not permitted


# Even root:
$ docker run --rm \
  --cap-drop NET_BIND_SERVICE \
  --user '0:0'
  coredns/coredns:1.11.1

exec /coredns: operation not permitted
```

- Not a helpful error message to encounter.
- Root user does not necessarily need to bind port lower than 1024 (_and with Docker can regardless by default_)
- When the capability is dropped, not even the `root` user can bypass the restriction.
- `setcap` is only in use to bypass the non-root restriction being respected (_for **any** user in the container to leverage, with any port_).

### 2. Which issues (if any) are related?

Last issue raised requesting non-root feature:
- https://github.com/coredns/coredns/issues/5968

Reference of unexpected problems from users affected by the non-root approach (_which also changed default `WORKDIR`_):
- https://github.com/coredns/coredns/issues/6249#issuecomment-1720646718
- https://github.com/coredns/coredns/pull/5969#issuecomment-1712368430

Earlier attempts to apply the change:
- https://github.com/coredns/coredns/pull/3923#issuecomment-637969242
- https://github.com/coredns/coredns/pull/4528#issue-833964301

**NOTE:** PR #4528 at least included a comment providing better context of the capability intent, but it's not been necessary since [Docker `20.10.0`](https://docs.docker.com/engine/release-notes/20.10/#security-2) (Dec 2020) which for Docker managed networks [drops the `<=1024` privileged ports](https://github.com/moby/moby/pull/41030/files#diff-9f91bff23e0bd70d6429b63d9db2d8180d2e89cdb64db4fb3e10a96f74d36271R790).

### 3. Which documentation changes (if any) need to be made?

N/A?

### 4. Does this introduce a backward incompatible change or deprecation?

- Reverts back to `1.10.1` Docker image expectation without mandatory capability enforced. The entire `build` stage is not needed, it's only purpose was to apply `setcap` to a pre-built `coredns` binary.
- Has not reverted the expectation of `1.10.1` working directory (_I could include that, should just be `WORKDIR /`_).
- The `USER nonroot:nonroot` directive shouldn't be necessary as that's already what the image should run with, I left it alone for the visibility. `EXPOSE` likewise is not necessary and is [effectively documentation](https://docs.docker.com/engine/reference/builder/#expose).