### PR TITLE
plugin/auto: warn when auto is unable to read elements of the directory tree

### DIFF
--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -23,11 +23,7 @@ func (a Auto) Walk() error {
 		if e != nil {
 			log.Warningf("error reading %v: %v", path, e)
 		}
-		if info == nil {
-			return nil
-		}
-
-		if info.IsDir() {
+		if info == nil || info.IsDir() {
 			return nil
 		}
 

--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -19,8 +19,15 @@ func (a Auto) Walk() error {
 		toDelete[n] = true
 	}
 
-	filepath.Walk(a.loader.directory, func(path string, info os.FileInfo, _ error) error {
-		if info == nil || info.IsDir() {
+	filepath.Walk(a.loader.directory, func(path string, info os.FileInfo, e error) error {
+		if e != nil {
+			log.Warningf("error reading %v: %v", path, e)
+		}
+		if info == nil {
+			return nil
+		}
+
+		if info.IsDir() {
 			return nil
 		}
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Log a warning when _auto_ is unable to read elements of its directory tree.  Displaying a warning message will help with troubleshooting directory/file permission issues. Currently, no message is logged when the configured directory, or elements within are not listable/readable.

### 2. Which issues (if any) are related?

closes #6318

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
