### PR TITLE
oneaddr plugin

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -34,6 +34,7 @@ var Directives = []string{
 	"acl",
 	"any",
 	"chaos",
+	"oneaddr",
 	"loadbalance",
 	"tsig",
 	"cache",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/metrics"
 	_ "github.com/coredns/coredns/plugin/minimal"
 	_ "github.com/coredns/coredns/plugin/nsid"
+	_ "github.com/coredns/coredns/plugin/oneaddr"
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/ready"
 	_ "github.com/coredns/coredns/plugin/reload"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -43,6 +43,7 @@ dns64:dns64
 acl:acl
 any:any
 chaos:chaos
+oneaddr:oneaddr
 loadbalance:loadbalance
 tsig:tsig
 cache:cache

--- a/plugin/oneaddr/README.md
+++ b/plugin/oneaddr/README.md
@@ -14,3 +14,43 @@ It is intended to be used with loadbalance plugin.
 ~~~
 oneaddr
 ~~~
+
+## Examples
+
+Let's consider following configuration for example.org zone. We aim to enable
+round-robin loadbalancing, but ensure fair distribution and reveal just one
+worker server in the DNS response.
+
+Zone file `db.example.org`:
+
+~~~
+$ORIGIN example.org.
+@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
+	3600 IN NS a.iana-servers.net.
+	3600 IN NS b.iana-servers.net.
+
+www     IN A     127.0.0.1
+www     IN A     127.0.0.2
+www     IN A     127.0.0.3
+www     IN A     127.0.0.4
+www     IN A     127.0.0.5
+www     IN A     127.0.0.6
+www     IN A     127.0.0.7
+www     IN A     127.0.0.8
+www     IN A     127.0.0.9
+www     IN A     127.0.0.10
+~~~
+
+CoreDNS configuration:
+
+~~~ corefile
+example.org {
+	file db.example.org
+	loadbalance
+	oneaddr
+}
+~~~
+
+With such configuration only one A-record will be present in the DNS response.
+Since *loadbalance* module randomizes order and *oneaddr* picks first address,
+IP address in the responses will vary and distribute load across worker servers.

--- a/plugin/oneaddr/README.md
+++ b/plugin/oneaddr/README.md
@@ -1,0 +1,16 @@
+# oneaddr
+
+## Name
+
+*oneaddr* - filters response and retains only one (first) address
+
+## Description
+
+*oneaddr* will remove all addresses from response except first one.
+It is intended to be used with loadbalance plugin.
+
+## Syntax
+
+~~~
+oneaddr
+~~~

--- a/plugin/oneaddr/handler.go
+++ b/plugin/oneaddr/handler.go
@@ -1,0 +1,24 @@
+// Package oneaddr is a plugin for rewriting responses to retain only single address
+package oneaddr
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/miekg/dns"
+)
+
+// OneAddr is a plugin to rewrite responses to retain only first address in the response.
+type OneAddr struct {
+	Next plugin.Handler
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (oa OneAddr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	rw := &OneAddrResponseWriter{ResponseWriter: w}
+	return plugin.NextOrFailure(oa.Name(), oa.Next, ctx, rw, r)
+}
+
+// Name implements the Handler interface.
+func (oa OneAddr) Name() string { return "oneaddr" }

--- a/plugin/oneaddr/oneaddr.go
+++ b/plugin/oneaddr/oneaddr.go
@@ -8,9 +8,9 @@ import (
 )
 
 type dedupKey struct {
-	name string
+	name   string
 	rrtype uint16
-	class uint16
+	class  uint16
 }
 
 type dedupSet = map[dedupKey]struct{}
@@ -18,9 +18,9 @@ type dedupSet = map[dedupKey]struct{}
 func makeDedupKey(rec dns.RR) dedupKey {
 	hdr := rec.Header()
 	return dedupKey{
-		name: strings.ToLower(hdr.Name),
+		name:   strings.ToLower(hdr.Name),
 		rrtype: hdr.Rrtype,
-		class: hdr.Class,
+		class:  hdr.Class,
 	}
 }
 
@@ -56,7 +56,9 @@ func trimRecords(in []dns.RR) []dns.RR {
 		switch rec.Header().Rrtype {
 		case dns.TypeA, dns.TypeAAAA:
 			key := makeDedupKey(rec)
-			if _, ok := seen[key]; ok { continue }
+			if _, ok := seen[key]; ok {
+				continue
+			}
 			seen[key] = struct{}{}
 			fallthrough
 		default:

--- a/plugin/oneaddr/oneaddr.go
+++ b/plugin/oneaddr/oneaddr.go
@@ -1,0 +1,76 @@
+// Package oneaddr is a plugin for rewriting responses to retain only single address
+package oneaddr
+
+import (
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+type dedupKey struct {
+	name string
+	rrtype uint16
+	class uint16
+}
+
+type dedupSet = map[dedupKey]struct{}
+
+func makeDedupKey(rec dns.RR) dedupKey {
+	hdr := rec.Header()
+	return dedupKey{
+		name: strings.ToLower(hdr.Name),
+		rrtype: hdr.Rrtype,
+		class: hdr.Class,
+	}
+}
+
+// OneAddrResponseWriter is a response writer that shuffles A, AAAA and MX records.
+type OneAddrResponseWriter struct {
+	dns.ResponseWriter
+}
+
+// WriteMsg implements the dns.ResponseWriter interface.
+func (r *OneAddrResponseWriter) WriteMsg(res *dns.Msg) error {
+	if res.Rcode != dns.RcodeSuccess {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	if res.Question[0].Qtype == dns.TypeAXFR || res.Question[0].Qtype == dns.TypeIXFR {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	if res.Question[0].Qtype != dns.TypeA && res.Question[0].Qtype != dns.TypeAAAA {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	res.Answer = trimRecords(res.Answer)
+	res.Extra = trimRecords(res.Extra)
+
+	return r.ResponseWriter.WriteMsg(res)
+}
+
+func trimRecords(in []dns.RR) []dns.RR {
+	seen := make(dedupSet)
+	out := []dns.RR{}
+	for _, rec := range in {
+		switch rec.Header().Rrtype {
+		case dns.TypeA, dns.TypeAAAA:
+			key := makeDedupKey(rec)
+			if _, ok := seen[key]; ok { continue }
+			seen[key] = struct{}{}
+			fallthrough
+		default:
+			out = append(out, rec)
+		}
+	}
+
+	return out
+}
+
+// Write implements the dns.ResponseWriter interface.
+func (r *OneAddrResponseWriter) Write(buf []byte) (int, error) {
+	// Should we pack and unpack here to fiddle with the packet... Not likely.
+	log.Warning("oneaddr plugin called with Write: not shuffling records")
+	n, err := r.ResponseWriter.Write(buf)
+	return n, err
+}

--- a/plugin/oneaddr/oneaddr_test.go
+++ b/plugin/oneaddr/oneaddr_test.go
@@ -1,0 +1,123 @@
+package oneaddr
+
+import (
+	"context"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestOneAddrInvocation(t *testing.T) {
+	x := OneAddr{Next: test.ErrorHandler()}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+	if rec.Rcode != dns.RcodeServerFailure {
+		t.Errorf("unexpected Rcode in the response recorder: %d while expected %d", rec.Rcode, dns.RcodeServerFailure)
+	}
+	if rec.Msg == nil {
+		t.Fatal("unexpected nil Msg in the response recorder")
+	}
+}
+
+func TestOneAddrSimple(t *testing.T) {
+	x := OneAddr{
+		Next: test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Authoritative = true
+			m.Answer = []dns.RR{
+				test.A("example.org.		300	IN	A			10.240.0.1"),
+				test.A("example.org.		300	IN	A			10.240.0.2"),
+			}
+			w.WriteMsg(m)
+			return dns.RcodeSuccess, nil
+		}),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+	if rec.Rcode != dns.RcodeSuccess {
+		t.Errorf("unexpected Rcode in the response recorder: %d while expected %d", rec.Rcode, dns.RcodeSuccess)
+	}
+	if rec.Msg == nil {
+		t.Fatal("unexpected nil Msg in the response recorder")
+	}
+	if len(rec.Msg.Answer) != 1 {
+		t.Fatalf("unexpected length of Msg.Answer: %d", len(rec.Msg.Answer))
+	}
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Fatalf("Expected A record for first answer, got %s", dns.TypeToString[rec.Msg.Answer[0].Header().Rrtype])
+	}
+	a, ok := rec.Msg.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("type assertion failed: %T != *dns.A", rec.Msg.Answer[0])
+	}
+	if !a.A.Equal(net.IPv4(10, 240, 0, 1)) {
+		t.Fatalf("unexpected address in the answer record: %s", a.A.String())
+	}
+}
+
+func TestOneAddrComplex(t *testing.T) {
+	x := OneAddr{
+		Next: test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Authoritative = true
+			m.Answer = []dns.RR{
+				test.CNAME("www2.example.org.	300	IN	CNAME		www.example.org."),
+				test.A("www.example.org.		300	IN	A			10.240.0.1"),
+				test.A("www.example.org.		300	IN	A			10.240.0.2"),
+				test.A("www.example.org.		300	IN	A			10.240.0.3"),
+				test.AAAA("www.example.org.		300	IN	AAAA		::1"),
+				test.AAAA("www.example.org.		300	IN	AAAA		::2"),
+				test.AAAA("www.example.org.		300	IN	AAAA		::3"),
+			}
+			w.WriteMsg(m)
+			return dns.RcodeSuccess, nil
+		}),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("www2.example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+	if rec.Rcode != dns.RcodeSuccess {
+		t.Errorf("unexpected Rcode in the response recorder: %d while expected %d", rec.Rcode, dns.RcodeSuccess)
+	}
+	if rec.Msg == nil {
+		t.Fatal("unexpected nil Msg in the response recorder")
+	}
+	tc := test.Case{
+		Qname: "www2.example.org.",
+		Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("www2.example.org.	300	IN	CNAME		www.example.org."),
+			test.A("www.example.org.		300	IN	A			10.240.0.1"),
+			test.AAAA("www.example.org.		300	IN	AAAA		::1"),
+		},
+		Ns:    []dns.RR{},
+		Extra: []dns.RR{},
+	}
+	sort.Sort(test.RRSet(tc.Answer))
+	if err := test.SortAndCheck(rec.Msg, tc); err != nil {
+		t.Log(rec.Msg.String())
+		t.Errorf("sort and check failed: %v", err)
+	}
+}

--- a/plugin/oneaddr/setup.go
+++ b/plugin/oneaddr/setup.go
@@ -1,0 +1,31 @@
+package oneaddr
+
+import (
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+)
+
+var log = clog.NewWithPlugin("oneaddr")
+
+// init registers this plugin.
+func init() { plugin.Register("oneaddr", setup) }
+
+func setup(c *caddy.Controller) error {
+	c.Next() // Ignore "oneaddr" and give us the next token.
+	if c.NextArg() {
+		// If there was another token, return an error, because we don't have any configuration.
+		// Any errors returned from this setup function should be wrapped with plugin.Error, so we
+		// can present a slightly nicer error message to the user.
+		return plugin.Error("oneaddr", c.ArgErr())
+	}
+
+	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return OneAddr{Next: next}
+	})
+
+	// All OK, return a nil error.
+	return nil
+}

--- a/plugin/oneaddr/setup_test.go
+++ b/plugin/oneaddr/setup_test.go
@@ -1,0 +1,21 @@
+package oneaddr
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+// TestSetup tests the various things that should be parsed by setup.
+// Make sure you also test for parse errors.
+func TestSetup(t *testing.T) {
+	c := caddy.NewTestController("dns", `oneaddr`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `oneaddr more`)
+	if err := setup(c); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull request adds a small plugin *oneaddr* which might be useful in conjunction with *loadbalance* plugin. *oneaddr* plugin leaves only one address record in the response for each name.

It is intended to workaround a problem with DNS clients which re-order addresses from response, defying the purpose of round-robin. This way, clients will get only one address at a time, which leaves them no space to misbehave.

Another use case is load balancing across significant (tens or more) worker servers. Exposing all of them in the DNS response does not make sense, it bloats response with a lot of records which client won't use anyway.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

Probably add plugin page on coredns.io site.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
