### PR TITLE
plugin/etcd: the etcd client adds the DialKeepAliveTime parameter

### DIFF
--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -101,7 +101,7 @@ func newEtcdClient(endpoints []string, cc *tls.Config, username, password string
 	etcdCfg := etcdcv3.Config{
 		Endpoints:         endpoints,
 		TLS:               cc,
-		DialKeepAliveTime: etcdTimeout + etcdTimeout/2,
+		DialKeepAliveTime: etcdTimeout,
 	}
 	if username != "" && password != "" {
 		etcdCfg.Username = username

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -99,8 +99,9 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 
 func newEtcdClient(endpoints []string, cc *tls.Config, username, password string) (*etcdcv3.Client, error) {
 	etcdCfg := etcdcv3.Config{
-		Endpoints: endpoints,
-		TLS:       cc,
+		Endpoints:         endpoints,
+		TLS:               cc,
+		DialKeepAliveTime: etcdTimeout + etcdTimeout/2,
 	}
 	if username != "" && password != "" {
 		etcdCfg.Username = username


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When the etcd node network is unavailable, such as abnormal shutdown, etcd client will still use the connection of the node, resulting in service unavailability.

It can be simulated with the following command
```bash
iptables -A INPUT -p tcp --dport 2379 -j DROP
```
### 2. Which issues (if any) are related?
None
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
None