### PR TITLE
fix a bug for udp protocol when response len is >= UDPsize

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -142,7 +142,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			return ret, err
 		}
 		// If an upstream server does not set TC bit and response length is greater than state.Size() or 512 default buffer size, we need to set TC bit for UDP protocol, and client can retry over TCP.
-		if ret.Len() > int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
+		if ret.Len() > int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP && !ret.Truncated {
 			// Truncate the response.
 			ret = truncateResponse(ret)
 			break

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -141,9 +141,8 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			}
 			return ret, err
 		}
-		// If an upstream server does not set TC bit and response length is greater or equal to state.Size() or 512 default buffer size, then we cannot be sure if the response is actually truncated or not.
-		// So we need to set TC bit for UDP protocol, and client can retry over TCP.
-		if ret.Len() >= int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
+		// If an upstream server does not set TC bit and response length is greater than state.Size() or 512 default buffer size, we need to set TC bit for UDP protocol, and client can retry over TCP.
+		if ret.Len() > int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
 			// Truncate the response.
 			ret = truncateResponse(ret)
 			break

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -143,7 +143,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		}
 		// If an upstream server does not set TC bit and response length is greater or equal to state.Size() or 512 default buffer size, then we cannot be sure if the response is actually truncated or not.
 		// So we need to set TC bit for UDP protocol, and client can retry over TCP.
-		if ret.Len() == int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
+		if ret.Len() >= int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
 			// Truncate the response.
 			ret = truncateResponse(ret)
 			break

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -141,6 +141,13 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			}
 			return ret, err
 		}
+		// If an upstream server does not set TC bit and response length is greater or equal to state.Size() or 512 default buffer size, then we cannot be sure if the response is actually truncated or not.
+		// So we need to set TC bit for UDP protocol, and client can retry over TCP.
+		if ret.Len() == int(pc.c.UDPSize) && p.transport.transportTypeFromConn(pc) == typeUDP {
+			// Truncate the response.
+			ret = truncateResponse(ret)
+			break
+		}
 		// drop out-of-order responses
 		if state.Req.Id == ret.Id {
 			break

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -130,58 +131,63 @@ func TestProxyIncrementFails(t *testing.T) {
 	}
 }
 
-func TestCoreDNSOverflow(t *testing.T) {
+func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
+
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 
 		answers := []dns.RR{
-			test.A("example.org. IN A 127.0.0.1"),
-			test.A("example.org. IN A 127.0.0.2"),
-			test.A("example.org. IN A 127.0.0.3"),
-			test.A("example.org. IN A 127.0.0.4"),
-			test.A("example.org. IN A 127.0.0.5"),
-			test.A("example.org. IN A 127.0.0.6"),
-			test.A("example.org. IN A 127.0.0.7"),
-			test.A("example.org. IN A 127.0.0.8"),
-			test.A("example.org. IN A 127.0.0.9"),
-			test.A("example.org. IN A 127.0.0.10"),
-			test.A("example.org. IN A 127.0.0.11"),
-			test.A("example.org. IN A 127.0.0.12"),
-			test.A("example.org. IN A 127.0.0.13"),
-			test.A("example.org. IN A 127.0.0.14"),
-			test.A("example.org. IN A 127.0.0.15"),
-			test.A("example.org. IN A 127.0.0.16"),
-			test.A("example.org. IN A 127.0.0.17"),
-			test.A("example.org. IN A 127.0.0.18"),
-			test.A("example.org. IN A 127.0.0.19"),
-			test.A("example.org. IN A 127.0.0.20"),
+			test.A("example123.org. IN A 127.0.0.1"),
+			test.A("example123.org. IN A 127.0.0.2"),
+			test.A("example123.org. IN A 127.0.0.3"),
+			test.A("example123.org. IN A 127.0.0.4"),
+			test.A("example123.org. IN A 127.0.0.5"),
+			test.A("example123.org. IN A 127.0.0.6"),
+			test.A("example123.org. IN A 127.0.0.7"),
+			test.A("example123.org. IN A 127.0.0.8"),
+			test.A("example123.org. IN A 127.0.0.9"),
+			test.A("example123.org. IN A 127.0.0.10"),
+			test.A("example123.org. IN A 127.0.0.11"),
+			test.A("example123.org. IN A 127.0.0.12"),
+			test.A("example123.org. IN A 127.0.0.13"),
+			test.A("example123.org. IN A 127.0.0.14"),
+			test.A("example123.org. IN A 127.0.0.15"),
+			test.A("example123.org. IN A 127.0.0.16"),
+			test.A("example123.org. IN A 127.0.0.17"),
+			test.A("example123.org. IN A 127.0.0.18"),
+			test.A("example123.org. IN A 127.0.0.19"),
+			test.A("example123.org. IN A 127.0.0.20"),
 		}
 		ret.Answer = answers
 		w.WriteMsg(ret)
 	})
-	defer s.Close()
 
+	defer s.Close()
 	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
 	p.readTimeout = 10 * time.Millisecond
 	p.Start(5 * time.Second)
+
 	defer p.Stop()
 
 	// Test different connection modes
 	testConnection := func(proto string, options Options, expectTruncated bool) {
-		t.Helper()
 
+		t.Helper()
 		queryMsg := new(dns.Msg)
-		queryMsg.SetQuestion("example.org.", dns.TypeA)
+		queryMsg.SetQuestion("example123.org.", dns.TypeA)
 
 		recorder := dnstest.NewRecorder(&test.ResponseWriter{})
 		request := request.Request{Req: queryMsg, W: recorder}
 
 		response, err := p.Connect(context.Background(), request, options)
+
 		if err != nil {
 			t.Errorf("Failed to connect to testdnsserver: %s", err)
 		}
-
+		if response.Rcode != dns.RcodeSuccess {
+			t.Errorf("Expected No error, but got %v", response.Rcode)
+		}
 		if response.Truncated != expectTruncated {
 			t.Errorf("Expected truncated response for %s, but got TC flag %v", proto, response.Truncated)
 		}
@@ -221,5 +227,171 @@ func TestShouldTruncateResponse(t *testing.T) {
 				t.Errorf("For testname '%v', expected %v but got %v", tc.testname, tc.expected, result)
 			}
 		})
+	}
+}
+
+func TestCoreDNSOverflowForDifferentRanges(t *testing.T) {
+
+	// Testing with 19 characters in the domain name.
+	// -----------------------------------------------------------------------------------------------------------
+	// Length of the response for 12 A records will be 478 bytes and UDPSize is 512.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "PreferUDP", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "BothTCPAndUDP", false)
+
+	// Length of the response for 13 A records will be 512 bytes and UDPSize is 512.
+	// This is a case where the response len is 512 bytes and protocol will be switched to TCP.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "PreferUDP", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "BothTCPAndUDP", false)
+
+	// Length of the response for 14 A records will be 546 bytes and UDPSize is 512.
+	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
+	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "PreferUDP", true)
+	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "NoOptionsSpecified", true)
+	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "BothTCPAndUDP", false)
+
+	// Testing with 12 characters in the domain name
+	// -----------------------------------------------------------------------------------------------------------
+	// Length of the response for 16 A records will be 488 bytes and UDPSize is 515.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example.org.", 16, 515, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example.org.", 16, 515, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example.org.", 16, 515, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example.org.", 16, 515, "BothTCPAndUDP", false)
+
+	// Length of the response for 17 A records will be 515 bytes and UDPSize is 515.
+	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example.org.", 17, 515, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example.org.", 17, 515, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example.org.", 17, 515, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example.org.", 17, 515, "BothTCPAndUDP", false)
+
+	// Length of the response for 18 A records will be 542 bytes and UDPSize is 515.
+	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
+	testCoreDNSOverflow(t, "example.org.", 18, 515, "PreferUDP", true)
+	testCoreDNSOverflow(t, "example.org.", 18, 515, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example.org.", 18, 515, "NoOptionsSpecified", true)
+	testCoreDNSOverflow(t, "example.org.", 18, 515, "BothTCPAndUDP", false)
+
+	// Testing with 15 characters in the domain name with UDPSize equal to 512.
+	// -----------------------------------------------------------------------------------------------------------
+	// Length of the response for 14 A records will be 482 bytes and UDPSize is 512.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example123.org.", 14, 512, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example123.org.", 14, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example123.org.", 14, 512, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example123.org.", 14, 512, "BothTCPAndUDP", false)
+
+	// Length of the response for 15 A records will be 512 bytes and UDPSize is 512.
+	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example123.org.", 15, 512, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 512, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 512, "BothTCPAndUDP", false)
+
+	// Length of the response for 16 A records will be 542 bytes and UDPSize is 512.
+	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
+	testCoreDNSOverflow(t, "example123.org.", 16, 512, "PreferUDP", true)
+	testCoreDNSOverflow(t, "example123.org.", 16, 512, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example123.org.", 16, 512, "NoOptionsSpecified", true)
+	testCoreDNSOverflow(t, "example123.org.", 16, 512, "BothTCPAndUDP", false)
+
+	// Case where UDPSize is less than 512.
+	// -----------------------------------------------------------------------------------------------------------
+	// Minimum UDPSize is 512.
+	// Length of the response for 15 A records will be 512 bytes and UDPSize is 512.
+	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example123.org.", 15, 511, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 511, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 511, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 511, "BothTCPAndUDP", false)
+
+	// Case where UDPSize is greater than 512.
+	// -----------------------------------------------------------------------------------------------------------
+	// Length of the response for 15 A records will be 512 bytes and UDPSize is 513.
+	// Minimum UDPSize is 512, but we are overriding it to 513.
+	// Response is not truncated and TC bit is not set.
+	testCoreDNSOverflow(t, "example123.org.", 15, 513, "PreferUDP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 513, "ForceTCP", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 513, "NoOptionsSpecified", false)
+	testCoreDNSOverflow(t, "example123.org.", 15, 513, "BothTCPAndUDP", false)
+
+	// Few cases where response is truncated.
+	// -----------------------------------------------------------------------------------------------------------
+	testCoreDNSOverflow(t, "e.", 29, 512, "PreferUDP", true)
+	testCoreDNSOverflow(t, "ex.", 28, 524, "PreferUDP", true)
+	testCoreDNSOverflow(t, "exa.", 27, 534, "PreferUDP", true)
+	testCoreDNSOverflow(t, "exam.", 26, 542, "PreferUDP", true)
+	testCoreDNSOverflow(t, "examp.", 25, 548, "PreferUDP", true)
+	testCoreDNSOverflow(t, "exampl.", 24, 552, "PreferUDP", true)
+	testCoreDNSOverflow(t, "example.", 23, 554, "PreferUDP", true)
+	testCoreDNSOverflow(t, "example.org.", 19, 542, "PreferUDP", true)
+
+}
+
+func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNSUDPSize uint16, proto string, expectTruncated bool) {
+
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		answers := []dns.RR{}
+
+		// Add the desired number of A records to the response.
+		for i := 0; i < noOfARecords; i++ {
+			answers = append(answers, test.A(""+domainName+" IN A 127.0.0."+strconv.Itoa(1+i)))
+		}
+
+		ret.Answer = answers
+		w.WriteMsg(ret)
+	})
+
+	defer s.Close()
+
+	// When testing for AKS scenario, use upstream Azure DNS server address "168.63.129.16" instead of s.Addr
+	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
+	p.readTimeout = 10 * time.Millisecond
+	p.Start(5 * time.Second)
+	defer p.Stop()
+
+	t.Helper()
+
+	queryMsg := new(dns.Msg)
+	queryMsg.SetQuestion(domainName, dns.TypeA)
+	recorder := dnstest.NewRecorder(&test.ResponseWriter{})
+	request := request.Request{Req: queryMsg, W: recorder}
+
+	request.Req.SetEdns0(eDNSUDPSize, true)
+
+	protocolOpt := Options{}
+	switch proto {
+	case "PreferUDP":
+		protocolOpt.PreferUDP = true
+	case "ForceTCP":
+		protocolOpt.ForceTCP = true
+	case "BothTCPAndUDP":
+		protocolOpt.PreferUDP = true
+		protocolOpt.ForceTCP = true
+	}
+
+	// Call the function defined in connect.go
+	response, err := p.Connect(context.Background(), request, protocolOpt)
+
+	if err != nil {
+		t.Errorf("Failed to connect to testdnsserver: %s", err)
+	}
+	if response.Rcode != dns.RcodeSuccess {
+		t.Errorf("Test - DomainName : %s for No of A records : %v with eDNSUDPSize : %v , Expected No error, but got %v", domainName, noOfARecords, eDNSUDPSize, response.Rcode)
+	}
+	if response.Truncated != expectTruncated {
+		t.Errorf("Test - DomainName : %s for No of A records : %v with eDNSUDPSize : %v , Expected truncated response for %s, but got TC flag %v", domainName, noOfARecords, eDNSUDPSize, proto, response.Truncated)
 	}
 }

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"math"
-	"strconv"
 	"testing"
 	"time"
 
@@ -136,26 +135,26 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 		answers := []dns.RR{
-			test.A("example123.org. IN A 127.0.0.1"),
-			test.A("example123.org. IN A 127.0.0.2"),
-			test.A("example123.org. IN A 127.0.0.3"),
-			test.A("example123.org. IN A 127.0.0.4"),
-			test.A("example123.org. IN A 127.0.0.5"),
-			test.A("example123.org. IN A 127.0.0.6"),
-			test.A("example123.org. IN A 127.0.0.7"),
-			test.A("example123.org. IN A 127.0.0.8"),
-			test.A("example123.org. IN A 127.0.0.9"),
-			test.A("example123.org. IN A 127.0.0.10"),
-			test.A("example123.org. IN A 127.0.0.11"),
-			test.A("example123.org. IN A 127.0.0.12"),
-			test.A("example123.org. IN A 127.0.0.13"),
-			test.A("example123.org. IN A 127.0.0.14"),
-			test.A("example123.org. IN A 127.0.0.15"),
-			test.A("example123.org. IN A 127.0.0.16"),
-			test.A("example123.org. IN A 127.0.0.17"),
-			test.A("example123.org. IN A 127.0.0.18"),
-			test.A("example123.org. IN A 127.0.0.19"),
-			test.A("example123.org. IN A 127.0.0.20"),
+			test.A("example.org. IN A 127.0.0.1"),
+			test.A("example.org. IN A 127.0.0.2"),
+			test.A("example.org. IN A 127.0.0.3"),
+			test.A("example.org. IN A 127.0.0.4"),
+			test.A("example.org. IN A 127.0.0.5"),
+			test.A("example.org. IN A 127.0.0.6"),
+			test.A("example.org. IN A 127.0.0.7"),
+			test.A("example.org. IN A 127.0.0.8"),
+			test.A("example.org. IN A 127.0.0.9"),
+			test.A("example.org. IN A 127.0.0.10"),
+			test.A("example.org. IN A 127.0.0.11"),
+			test.A("example.org. IN A 127.0.0.12"),
+			test.A("example.org. IN A 127.0.0.13"),
+			test.A("example.org. IN A 127.0.0.14"),
+			test.A("example.org. IN A 127.0.0.15"),
+			test.A("example.org. IN A 127.0.0.16"),
+			test.A("example.org. IN A 127.0.0.17"),
+			test.A("example.org. IN A 127.0.0.18"),
+			test.A("example.org. IN A 127.0.0.19"),
+			test.A("example.org. IN A 127.0.0.20"),
 		}
 		ret.Answer = answers
 		w.WriteMsg(ret)
@@ -171,7 +170,7 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 
 		t.Helper()
 		queryMsg := new(dns.Msg)
-		queryMsg.SetQuestion("example123.org.", dns.TypeA)
+		queryMsg.SetQuestion("example.org.", dns.TypeA)
 
 		recorder := dnstest.NewRecorder(&test.ResponseWriter{})
 		request := request.Request{Req: queryMsg, W: recorder}
@@ -221,163 +220,5 @@ func TestShouldTruncateResponse(t *testing.T) {
 				t.Errorf("For testname '%v', expected %v but got %v", tc.testname, tc.expected, result)
 			}
 		})
-	}
-}
-
-func TestCoreDNSOverflowForDifferentRanges(t *testing.T) {
-	// Testing with 19 characters in the domain name.
-	// -----------------------------------------------------------------------------------------------------------
-	// Length of the response for 12 A records will be 478 bytes and UDPSize is 512.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "PreferUDP", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 12, 512, "BothTCPAndUDP", false)
-
-	// Length of the response for 13 A records will be 512 bytes and UDPSize is 512.
-	// This is a case where the response len is 512 bytes and protocol will be switched to TCP.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "PreferUDP", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 13, 512, "BothTCPAndUDP", false)
-
-	// Length of the response for 14 A records will be 546 bytes and UDPSize is 512.
-	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
-	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "PreferUDP", true)
-	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "NoOptionsSpecified", true)
-	testCoreDNSOverflow(t, "testingexample.org.", 14, 512, "BothTCPAndUDP", false)
-
-	// Testing with 12 characters in the domain name
-	// -----------------------------------------------------------------------------------------------------------
-	// Length of the response for 16 A records will be 488 bytes and UDPSize is 515.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example.org.", 16, 515, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example.org.", 16, 515, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example.org.", 16, 515, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example.org.", 16, 515, "BothTCPAndUDP", false)
-
-	// Length of the response for 17 A records will be 515 bytes and UDPSize is 515.
-	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example.org.", 17, 515, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example.org.", 17, 515, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example.org.", 17, 515, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example.org.", 17, 515, "BothTCPAndUDP", false)
-
-	// Length of the response for 18 A records will be 542 bytes and UDPSize is 515.
-	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
-	testCoreDNSOverflow(t, "example.org.", 18, 515, "PreferUDP", true)
-	testCoreDNSOverflow(t, "example.org.", 18, 515, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example.org.", 18, 515, "NoOptionsSpecified", true)
-	testCoreDNSOverflow(t, "example.org.", 18, 515, "BothTCPAndUDP", false)
-
-	// Testing with 15 characters in the domain name with UDPSize equal to 512.
-	// -----------------------------------------------------------------------------------------------------------
-	// Length of the response for 14 A records will be 482 bytes and UDPSize is 512.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example123.org.", 14, 512, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example123.org.", 14, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example123.org.", 14, 512, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example123.org.", 14, 512, "BothTCPAndUDP", false)
-
-	// Length of the response for 15 A records will be 512 bytes and UDPSize is 512.
-	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example123.org.", 15, 512, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 512, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 512, "BothTCPAndUDP", false)
-
-	// Length of the response for 16 A records will be 542 bytes and UDPSize is 512.
-	// Overflow error will be occur and truncated response will be returned with TC bit set for UDP protocol.
-	testCoreDNSOverflow(t, "example123.org.", 16, 512, "PreferUDP", true)
-	testCoreDNSOverflow(t, "example123.org.", 16, 512, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example123.org.", 16, 512, "NoOptionsSpecified", true)
-	testCoreDNSOverflow(t, "example123.org.", 16, 512, "BothTCPAndUDP", false)
-
-	// Case where UDPSize is less than 512.
-	// -----------------------------------------------------------------------------------------------------------
-	// Minimum UDPSize is 512.
-	// Length of the response for 15 A records will be 512 bytes and UDPSize is 512.
-	// This is a case where the response len is 515 bytes and protocol will be switched to TCP.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example123.org.", 15, 511, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 511, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 511, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 511, "BothTCPAndUDP", false)
-
-	// Case where UDPSize is greater than 512.
-	// -----------------------------------------------------------------------------------------------------------
-	// Length of the response for 15 A records will be 512 bytes and UDPSize is 513.
-	// Minimum UDPSize is 512, but we are overriding it to 513.
-	// Response is not truncated and TC bit is not set.
-	testCoreDNSOverflow(t, "example123.org.", 15, 513, "PreferUDP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 513, "ForceTCP", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 513, "NoOptionsSpecified", false)
-	testCoreDNSOverflow(t, "example123.org.", 15, 513, "BothTCPAndUDP", false)
-
-	// Few cases where response is truncated.
-	// -----------------------------------------------------------------------------------------------------------
-	testCoreDNSOverflow(t, "e.", 29, 512, "PreferUDP", true)
-	testCoreDNSOverflow(t, "ex.", 28, 524, "PreferUDP", true)
-	testCoreDNSOverflow(t, "exa.", 27, 534, "PreferUDP", true)
-	testCoreDNSOverflow(t, "exam.", 26, 542, "PreferUDP", true)
-	testCoreDNSOverflow(t, "examp.", 25, 548, "PreferUDP", true)
-	testCoreDNSOverflow(t, "exampl.", 24, 552, "PreferUDP", true)
-	testCoreDNSOverflow(t, "example.", 23, 554, "PreferUDP", true)
-	testCoreDNSOverflow(t, "example.org.", 19, 542, "PreferUDP", true)
-}
-
-func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNSUDPSize uint16, proto string, expectTruncated bool) {
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
-		ret := new(dns.Msg)
-		ret.SetReply(r)
-		answers := []dns.RR{}
-
-		// Add the desired number of A records to the response.
-		for i := 0; i < noOfARecords; i++ {
-			answers = append(answers, test.A(""+domainName+" IN A 127.0.0."+strconv.Itoa(1+i)))
-		}
-		ret.Answer = answers
-		w.WriteMsg(ret)
-	})
-	defer s.Close()
-
-	// When testing for AKS scenario, use upstream Azure DNS server address "168.63.129.16:53" instead of s.Addr
-	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
-	p.readTimeout = 10 * time.Millisecond
-	p.Start(5 * time.Second)
-	defer p.Stop()
-	t.Helper()
-
-	queryMsg := new(dns.Msg)
-	queryMsg.SetQuestion(domainName, dns.TypeA)
-	recorder := dnstest.NewRecorder(&test.ResponseWriter{})
-	request := request.Request{Req: queryMsg, W: recorder}
-	request.Req.SetEdns0(eDNSUDPSize, true)
-
-	protocolOpt := Options{}
-	switch proto {
-	case "PreferUDP":
-		protocolOpt.PreferUDP = true
-	case "ForceTCP":
-		protocolOpt.ForceTCP = true
-	case "BothTCPAndUDP":
-		protocolOpt.PreferUDP = true
-		protocolOpt.ForceTCP = true
-	}
-
-	// Call the function defined in connect.go
-	response, err := p.Connect(context.Background(), request, protocolOpt)
-	if err != nil {
-		t.Errorf("Failed to connect to testdnsserver: %s", err)
-	}
-	if response.Rcode != dns.RcodeSuccess {
-		t.Errorf("Test - DomainName : %s for No of A records : %v with eDNSUDPSize : %v , Expected No error, but got %v", domainName, noOfARecords, eDNSUDPSize, response.Rcode)
-	}
-	if response.Truncated != expectTruncated {
-		t.Errorf("Test - DomainName : %s for No of A records : %v with eDNSUDPSize : %v , Expected truncated response for %s, but got TC flag %v", domainName, noOfARecords, eDNSUDPSize, proto, response.Truncated)
 	}
 }

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -356,7 +356,7 @@ func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNS
 
 	defer s.Close()
 
-	// When testing for AKS scenario, use upstream Azure DNS server address "168.63.129.16" instead of s.Addr
+	// When testing for AKS scenario, use upstream Azure DNS server address "168.63.129.16:53" instead of s.Addr
 	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
 	p.readTimeout = 10 * time.Millisecond
 	p.Start(5 * time.Second)

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -135,7 +135,6 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
-
 		answers := []dns.RR{
 			test.A("example123.org. IN A 127.0.0.1"),
 			test.A("example123.org. IN A 127.0.0.2"),
@@ -161,12 +160,10 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 		ret.Answer = answers
 		w.WriteMsg(ret)
 	})
-
 	defer s.Close()
 	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
 	p.readTimeout = 10 * time.Millisecond
 	p.Start(5 * time.Second)
-
 	defer p.Stop()
 
 	// Test different connection modes
@@ -178,7 +175,6 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 
 		recorder := dnstest.NewRecorder(&test.ResponseWriter{})
 		request := request.Request{Req: queryMsg, W: recorder}
-
 		response, err := p.Connect(context.Background(), request, options)
 
 		if err != nil {
@@ -191,7 +187,6 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 			t.Errorf("Expected truncated response for %s, but got TC flag %v", proto, response.Truncated)
 		}
 	}
-
 	// Test PreferUDP, expect truncated response
 	testConnection("PreferUDP", Options{PreferUDP: true}, true)
 
@@ -345,11 +340,9 @@ func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNS
 		for i := 0; i < noOfARecords; i++ {
 			answers = append(answers, test.A(""+domainName+" IN A 127.0.0."+strconv.Itoa(1+i)))
 		}
-
 		ret.Answer = answers
 		w.WriteMsg(ret)
 	})
-
 	defer s.Close()
 
 	// When testing for AKS scenario, use upstream Azure DNS server address "168.63.129.16:53" instead of s.Addr
@@ -357,14 +350,12 @@ func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNS
 	p.readTimeout = 10 * time.Millisecond
 	p.Start(5 * time.Second)
 	defer p.Stop()
-
 	t.Helper()
 
 	queryMsg := new(dns.Msg)
 	queryMsg.SetQuestion(domainName, dns.TypeA)
 	recorder := dnstest.NewRecorder(&test.ResponseWriter{})
 	request := request.Request{Req: queryMsg, W: recorder}
-
 	request.Req.SetEdns0(eDNSUDPSize, true)
 
 	protocolOpt := Options{}
@@ -380,7 +371,6 @@ func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNS
 
 	// Call the function defined in connect.go
 	response, err := p.Connect(context.Background(), request, protocolOpt)
-
 	if err != nil {
 		t.Errorf("Failed to connect to testdnsserver: %s", err)
 	}

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -132,7 +132,6 @@ func TestProxyIncrementFails(t *testing.T) {
 }
 
 func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
-
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
@@ -231,7 +230,6 @@ func TestShouldTruncateResponse(t *testing.T) {
 }
 
 func TestCoreDNSOverflowForDifferentRanges(t *testing.T) {
-
 	// Testing with 19 characters in the domain name.
 	// -----------------------------------------------------------------------------------------------------------
 	// Length of the response for 12 A records will be 478 bytes and UDPSize is 512.
@@ -335,11 +333,9 @@ func TestCoreDNSOverflowForDifferentRanges(t *testing.T) {
 	testCoreDNSOverflow(t, "exampl.", 24, 552, "PreferUDP", true)
 	testCoreDNSOverflow(t, "example.", 23, 554, "PreferUDP", true)
 	testCoreDNSOverflow(t, "example.org.", 19, 542, "PreferUDP", true)
-
 }
 
 func testCoreDNSOverflow(t *testing.T, domainName string, noOfARecords int, eDNSUDPSize uint16, proto string, expectTruncated bool) {
-
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -134,6 +134,7 @@ func TestCoreDNSOverflow(t *testing.T) {
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
+
 		answers := []dns.RR{
 			test.A("example.org. IN A 127.0.0.1"),
 			test.A("example.org. IN A 127.0.0.2"),
@@ -160,6 +161,7 @@ func TestCoreDNSOverflow(t *testing.T) {
 		w.WriteMsg(ret)
 	})
 	defer s.Close()
+
 	p := NewProxy("TestCoreDNSOverflow", s.Addr, transport.DNS)
 	p.readTimeout = 10 * time.Millisecond
 	p.Start(5 * time.Second)
@@ -168,13 +170,14 @@ func TestCoreDNSOverflow(t *testing.T) {
 	// Test different connection modes
 	testConnection := func(proto string, options Options, expectTruncated bool) {
 		t.Helper()
+
 		queryMsg := new(dns.Msg)
 		queryMsg.SetQuestion("example.org.", dns.TypeA)
 
 		recorder := dnstest.NewRecorder(&test.ResponseWriter{})
 		request := request.Request{Req: queryMsg, W: recorder}
-		response, err := p.Connect(context.Background(), request, options)
 
+		response, err := p.Connect(context.Background(), request, options)
 		if err != nil {
 			t.Errorf("Failed to connect to testdnsserver: %s", err)
 		}
@@ -185,6 +188,7 @@ func TestCoreDNSOverflow(t *testing.T) {
 			t.Errorf("Expected truncated response for %s, but got TC flag %v", proto, response.Truncated)
 		}
 	}
+
 	// Test PreferUDP, expect truncated response
 	testConnection("PreferUDP", Options{PreferUDP: true}, true)
 

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -130,7 +130,7 @@ func TestProxyIncrementFails(t *testing.T) {
 	}
 }
 
-func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
+func TestCoreDNSOverflow(t *testing.T) {
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
@@ -167,7 +167,6 @@ func TestCoreDNSOverflowWithoutEdns(t *testing.T) {
 
 	// Test different connection modes
 	testConnection := func(proto string, options Options, expectTruncated bool) {
-
 		t.Helper()
 		queryMsg := new(dns.Msg)
 		queryMsg.SetQuestion("example.org.", dns.TypeA)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The PR is to fix this issue - Using CoreDNS with versions greater than v1.10.1 to query corednse2e.com/corednsaks.com using AzureDNS as upstream DNS server in an AKS cluster, response is truncated to 512 bytes but TC flag is not set. 

If an upstream server does not set TC bit and only if response length is greater than pc.c.UDPSize or 512 default, then we set TC bit for UDP protocol, and client can retry over TCP. This is a corner case where offset is equal to len(msg) as calculated in unpackHeader defined here github.com/miekg/msg_helpers.go. In this case, there is no Overflow error returned, so the response will be truncated without TC bit set. 

For example  - 
- When domain name has 15 characters, offset after unpackQuestion will be 32. 
- Each loop adds 30 to offset and when number of A records in response is more than 15, then offset calculated in unpackRRslice will keep increasing in this sequence 62,92,122,152,182.....482,512
- In 16th loop, offset (32 question bytes + 30 * 16) == 512 which will be == len(msg) for default UDPsize, so in this case, there is no Overflow error returned. 
- And the response will be truncated (ie response does not contain all the A records) and TC flag is false. This is a failure scenario. 

Similarly, 
- When domain name has 19 characters, offset after unpackQuestion will be 36. 
- Each loop adds 34 to offset and when number of A records in response is more than 14, then offset calculated in unpackRRslice will keep increasing in this sequence 70,104,138,.....512
- In 14th loop, offset (36 question bytes + 34 * 14) == 512 which will be == len(msg) for default UDPsize, so in this case, there is no Overflow error returned. 
- And the response will be truncated (ie response does not contain all the A records) and TC flag is false. This is a failure scenario. 

As we can see, response is truncated and TC bit is false. 
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 35567
;; flags: qr rd ra; QUERY: 1, ANSWER: 30, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com.                        IN      A

;; ANSWER SECTION:
corednse2e.com.         30      IN      A       10.96.0.55
corednse2e.com.         30      IN      A       10.96.0.51
corednse2e.com.         30      IN      A       10.96.0.246
corednse2e.com.         30      IN      A       10.96.0.93
corednse2e.com.         30      IN      A       10.96.0.54
corednse2e.com.         30      IN      A       10.96.0.97
corednse2e.com.         30      IN      A       76.223.105.230
corednse2e.com.         30      IN      A       10.96.0.98
corednse2e.com.         30      IN      A       10.96.0.242
corednse2e.com.         30      IN      A       10.96.0.50
corednse2e.com.         30      IN      A       10.96.0.91
corednse2e.com.         30      IN      A       10.96.0.96
corednse2e.com.         30      IN      A       10.96.0.250
corednse2e.com.         30      IN      A       10.96.0.252
corednse2e.com.         30      IN      A       10.96.0.99
corednse2e.com.         30      IN      A       10.96.0.248
corednse2e.com.         30      IN      A       13.248.243.5
corednse2e.com.         30      IN      A       10.96.0.254
corednse2e.com.         30      IN      A       10.96.0.92
corednse2e.com.         30      IN      A       10.96.0.249
corednse2e.com.         30      IN      A       10.96.0.52
corednse2e.com.         30      IN      A       10.96.0.251
corednse2e.com.         30      IN      A       10.96.0.244
corednse2e.com.         30      IN      A       10.96.0.53
corednse2e.com.         30      IN      A       10.96.0.243
corednse2e.com.         30      IN      A       10.96.0.247
corednse2e.com.         30      IN      A       10.96.0.253
corednse2e.com.         30      IN      A       10.96.0.255
corednse2e.com.         30      IN      A       10.96.0.95
corednse2e.com.         30      IN      A       10.96.0.94

;; Query time: 37 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Oct 26 05:31:44 UTC 2023
;; MSG SIZE  rcvd: 512


Whereas full response should have 64 records. 
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @168.63.129.16
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @168.63.129.16
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59586
;; flags: qr rd ra; QUERY: 1, ANSWER: 64, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com.                        IN      A

;; ANSWER SECTION:
corednse2e.com.         600     IN      A       76.223.105.230
corednse2e.com.         600     IN      A       13.248.243.5
corednse2e.com.         600     IN      A       10.96.0.91
corednse2e.com.         600     IN      A       10.96.0.92
corednse2e.com.         600     IN      A       10.96.0.93
corednse2e.com.         600     IN      A       10.96.0.94
corednse2e.com.         600     IN      A       10.96.0.95
corednse2e.com.         600     IN      A       10.96.0.96
corednse2e.com.         600     IN      A       10.96.0.97
corednse2e.com.         600     IN      A       10.96.0.98
corednse2e.com.         600     IN      A       10.96.0.242
corednse2e.com.         600     IN      A       10.96.0.243
corednse2e.com.         600     IN      A       10.96.0.99
corednse2e.com.         600     IN      A       10.96.0.244
corednse2e.com.         600     IN      A       10.96.0.246
corednse2e.com.         600     IN      A       10.96.0.247
corednse2e.com.         600     IN      A       10.96.0.248
corednse2e.com.         600     IN      A       10.96.0.249
corednse2e.com.         600     IN      A       10.96.0.250
corednse2e.com.         600     IN      A       10.96.0.251
corednse2e.com.         600     IN      A       10.96.0.252
corednse2e.com.         600     IN      A       10.96.0.253
corednse2e.com.         600     IN      A       10.96.0.254
corednse2e.com.         600     IN      A       10.96.0.255
corednse2e.com.         600     IN      A       10.96.0.50
corednse2e.com.         600     IN      A       10.96.0.51
corednse2e.com.         600     IN      A       10.96.0.52
corednse2e.com.         600     IN      A       10.96.0.53
corednse2e.com.         600     IN      A       10.96.0.54
corednse2e.com.         600     IN      A       10.96.0.55
corednse2e.com.         600     IN      A       10.96.0.57
corednse2e.com.         600     IN      A       10.96.0.58
corednse2e.com.         600     IN      A       10.96.0.59
corednse2e.com.         600     IN      A       10.96.0.60
corednse2e.com.         600     IN      A       10.96.0.61
corednse2e.com.         600     IN      A       10.96.0.62
corednse2e.com.         600     IN      A       10.96.0.63
corednse2e.com.         600     IN      A       10.96.0.64
corednse2e.com.         600     IN      A       10.96.0.65
corednse2e.com.         600     IN      A       10.96.0.66
corednse2e.com.         600     IN      A       10.96.0.67
corednse2e.com.         600     IN      A       10.96.0.68
corednse2e.com.         600     IN      A       10.96.0.69
corednse2e.com.         600     IN      A       10.96.0.70
corednse2e.com.         600     IN      A       10.96.0.71
corednse2e.com.         600     IN      A       10.96.0.72
corednse2e.com.         600     IN      A       10.96.0.73
corednse2e.com.         600     IN      A       10.96.0.74
corednse2e.com.         600     IN      A       10.96.0.75
corednse2e.com.         600     IN      A       10.96.0.76
corednse2e.com.         600     IN      A       10.96.0.77
corednse2e.com.         600     IN      A       10.96.0.78
corednse2e.com.         600     IN      A       10.96.0.79
corednse2e.com.         600     IN      A       10.96.0.80
corednse2e.com.         600     IN      A       10.96.0.81
corednse2e.com.         600     IN      A       10.96.0.82
corednse2e.com.         600     IN      A       10.96.0.83
corednse2e.com.         600     IN      A       10.96.0.84
corednse2e.com.         600     IN      A       10.96.0.85
corednse2e.com.         600     IN      A       10.96.0.86
corednse2e.com.         600     IN      A       10.96.0.87
corednse2e.com.         600     IN      A       10.96.0.88
corednse2e.com.         600     IN      A       10.96.0.89
corednse2e.com.         600     IN      A       10.96.0.90

;; Query time: 38 msec
;; SERVER: 168.63.129.16#53(168.63.129.16)
;; WHEN: Thu Oct 26 05:32:22 UTC 2023
;; MSG SIZE  rcvd: 1056

With the proposed fix, below is the expected response. 
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49592
;; flags: qr tc rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com.                        IN      A

;; Query time: 82 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Oct 26 05:35:25 UTC 2023
;; MSG SIZE  rcvd: 32

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/6370

### 3. Which documentation changes (if any) need to be made?
Not sure

### 4. Does this introduce a backward incompatible change or deprecation?
No
