### PR TITLE
Makefile: allow to use custom GITCOMMIT & BUILDOPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Makefile for building CoreDNS
-GITCOMMIT:=$(shell git describe --dirty --always)
+GITCOMMIT?=$(shell git describe --dirty --always)
 BINARY:=coredns
 SYSTEM:=
 CHECKS:=check
-BUILDOPTS:=-v
+BUILDOPTS?=-v
 GOPATH?=$(HOME)/go
 MAKEPWD:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 CGO_ENABLED?=0


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Not able to customize BUILDOPTS & GITCOMMIT unless I patch Makefile which led to this PR

### 2. Which issues (if any) are related?
Not able to customize BUILDOPTS & GITCOMMIT

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
