### PR TITLE
Use the correct root domain name in the proxy plugin's TestHealthX tests

### DIFF
--- a/plugin/pkg/proxy/health_test.go
+++ b/plugin/pkg/proxy/health_test.go
@@ -23,7 +23,7 @@ func TestHealth(t *testing.T) {
 	})
 	defer s.Close()
 
-	hc := NewHealthChecker("TestHealth", transport.DNS, true, "")
+	hc := NewHealthChecker("TestHealth", transport.DNS, true, ".")
 	hc.SetReadTimeout(10 * time.Millisecond)
 	hc.SetWriteTimeout(10 * time.Millisecond)
 
@@ -53,7 +53,7 @@ func TestHealthTCP(t *testing.T) {
 	})
 	defer s.Close()
 
-	hc := NewHealthChecker("TestHealthTCP", transport.DNS, true, "")
+	hc := NewHealthChecker("TestHealthTCP", transport.DNS, true, ".")
 	hc.SetTCPTransport()
 	hc.SetReadTimeout(10 * time.Millisecond)
 	hc.SetWriteTimeout(10 * time.Millisecond)
@@ -84,7 +84,7 @@ func TestHealthNoRecursion(t *testing.T) {
 	})
 	defer s.Close()
 
-	hc := NewHealthChecker("TestHealthNoRecursion", transport.DNS, false, "")
+	hc := NewHealthChecker("TestHealthNoRecursion", transport.DNS, false, ".")
 	hc.SetReadTimeout(10 * time.Millisecond)
 	hc.SetWriteTimeout(10 * time.Millisecond)
 
@@ -108,7 +108,7 @@ func TestHealthTimeout(t *testing.T) {
 	})
 	defer s.Close()
 
-	hc := NewHealthChecker("TestHealthTimeout", transport.DNS, false, "")
+	hc := NewHealthChecker("TestHealthTimeout", transport.DNS, false, ".")
 	hc.SetReadTimeout(10 * time.Millisecond)
 	hc.SetWriteTimeout(10 * time.Millisecond)
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When packing the empty domain name, [miekg/dns](https://github.com/miekg/dns) can end up creating corrupt DNS messages. With some planned unpacking changes, this now trips an error condition and causes these tests to fail. Correct this by using the root domain explicitly as this gets properly encoded on the wire.

### 2. Which issues (if any) are related?

miekg/dns#1507

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.