### PR TITLE
Make the CODEOWNERS link relative in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ issue first and "claim" it and get feedback before you invest a lot of time.
 
 **If someone already opened a pull request, but you think the pull request has stalled and you would
 like to open another pull request for the same or similar feature, get some of the maintainers (see
-[CODEOWNERS](CODEOWNERS)) involved to resolve the situation and move things forward.**
+[CODEOWNERS](../CODEOWNERS)) involved to resolve the situation and move things forward.**
 
 If possible make a pull request as small as possible, or submit multiple pull request to complete a
 feature. Smaller means: easier to understand and review. This in turn means things can be merged


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

When using GitHubs UI to read the [CONTRIBUTING.md](https://github.com/coredns/coredns/blob/7765aa87a46b82d5b63b885e8eef982cc795e600/.github/CONTRIBUTING.md#new-features) file if you click on the CODEOWNERS link it results in a 404, this fixes that by making it a relative path.

### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?

n/a

### 4. Does this introduce a backward incompatible change or deprecation?

n/a