### PR TITLE
Use a UID rather than "nonroot" in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_IMAGE=debian:stable-slim
-ARG BASE=gcr.io/distroless/static-debian11:nonroot
+ARG BASE=gcr.io/distroless/static-debian12:nonroot
 FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
 SHELL [ "/bin/sh", "-ec" ]
 
@@ -17,7 +17,10 @@ RUN setcap cap_net_bind_service=+ep /coredns
 FROM --platform=$TARGETPLATFORM ${BASE}
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /coredns /coredns
-USER nonroot:nonroot
+
+# The UID of "nonroot" in distroless images. Using the UID rather than the name
+# allows checks like Kubernetes "runAsNonRoot" to succeed.
+USER 65532:65532
 WORKDIR /
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Since #5969 the Dockerfile has run coredns as `USER nonroot:nonroot`, but it's not possible to enforce that with Kubernetes as it can only check UIDs. 

It changes the UID in the user line to be 65532. This matches distroless's nonroot UID:
https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8

(Note that if the Dockerfile didn't override the USER line at all, it would pick up the uid from the distroless image, which uses [a UID not a user](https://github.com/GoogleContainerTools/distroless/blob/99a023af733b9a0dcf261a8745a93168ae9fb5d7/base/base.bzl#L102) but I've kept it as is, as it's clearer to someone reading the Dockerfile.)

Also while here bump the distroless base version to match what "stable-slim" now refers to. Given coredns includes its own ca-certificates the difference is very minor.

### 2. Which issues (if any) are related?

#5969 

### 3. Which documentation changes (if any) need to be made?

n/a

### 4. Does this introduce a backward incompatible change or deprecation?

No.