### PR TITLE
bump golangci-lint and disable setup-go cache

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,8 +9,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
+          cache: false
           go-version: '~1.21.0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.52.2
+          version: v1.55.2


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
this should mitigate problems with random build failures when running linter, from my experience this happens due to conflicts of cache inside `setup-go` action and `golangci-lint` action

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
