### PR TITLE
add client labels to k8s plugin metadata

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -207,9 +207,11 @@ plugin is also enabled:
  * `kubernetes/service`: the service name in the query
  * `kubernetes/client-namespace`: the client pod's namespace (see requirements below)
  * `kubernetes/client-pod-name`: the client pod's name (see requirements below)
+ * `kubernetes/client-label/<label key>`: a label on the client pod (see requirements below)
 
-The `kubernetes/client-namespace` and `kubernetes/client-pod-name` metadata work by reconciling the
-client IP address in the DNS request packet to a known pod IP address. Therefore the following is required:
+The `kubernetes/client-namespace`, `kubernetes/client-pod-name`, and `kubernetes/client-label/<label key>`
+metadata work by reconciling the client IP address in the DNS request packet to a known pod IP address.
+Therefore the following is required:
  * `pods verified` mode must be enabled
  * the remote IP address in the DNS packet received by CoreDNS must be the IP address
    of the Pod that sent the request.

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -580,7 +580,13 @@ func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 		return []*object.Pod{}
 	}
 	a := []*object.Pod{
-		{Namespace: "podns", Name: "foo", PodIP: "10.240.0.1"}, // Remote IP set in test.ResponseWriter
+		{
+			Namespace: "podns", Name: "foo", PodIP: "10.240.0.1",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "foo",
+				"bar":                    "baz",
+			},
+		}, // Remote IP set in test.ResponseWriter
 	}
 	return a
 }

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -19,6 +19,13 @@ func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) contex
 		metadata.SetValueFunc(ctx, "kubernetes/client-pod-name", func() string {
 			return pod.Name
 		})
+
+		for k, v := range pod.Labels {
+			v := v
+			metadata.SetValueFunc(ctx, "kubernetes/client-label/"+k, func() string {
+				return v
+			})
+		}
 	}
 
 	zone := plugin.Zones(k.Zones).Matches(state.Name())

--- a/plugin/kubernetes/metadata_test.go
+++ b/plugin/kubernetes/metadata_test.go
@@ -141,8 +141,10 @@ func TestMetadataPodsVerified(t *testing.T) {
 	k.Metadata(ctx, state)
 
 	expect := map[string]string{
-		"kubernetes/client-namespace": "podns",
-		"kubernetes/client-pod-name":  "foo",
+		"kubernetes/client-namespace":                    "podns",
+		"kubernetes/client-pod-name":                     "foo",
+		"kubernetes/client-label/app.kubernetes.io/name": "foo",
+		"kubernetes/client-label/bar":                    "baz",
 	}
 
 	md := make(map[string]string)

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -16,6 +16,7 @@ type Pod struct {
 	PodIP     string
 	Name      string
 	Namespace string
+	Labels    map[string]string
 
 	*Empty
 }
@@ -33,6 +34,7 @@ func ToPod(obj meta.Object) (meta.Object, error) {
 		PodIP:     apiPod.Status.PodIP,
 		Namespace: apiPod.GetNamespace(),
 		Name:      apiPod.GetName(),
+		Labels:    apiPod.GetLabels(),
 	}
 	t := apiPod.ObjectMeta.DeletionTimestamp
 	if t != nil && !(*t).Time.IsZero() {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull request is needed to implement split DNS on the basis of a client pod's labels, allowing kubernetes cluster administrators to have fine-grained control over how different pods' DNS requests are routed. Additionally, as the cluster grows the same label can be used for new pods without requiring an update to the Corefile. Without this change, using namespaces as a discriminator requires an update to the Corefile as new namespaces are added.

Example usage (modified from [a view plugin example](https://coredns.io/plugins/view/#examples)):
```
. {
  view example {
    expr metadata('kubernetes/client-label/forward') == 'alternate'
  }
  forward . 10.0.0.6
}

. {
  forward . 10.0.0.1
}
```

This PR updates the `object.Pod` struct to include the labels as a map. Each of the labels is set as metadata, where the metadata key is of the form `kubernetes/client-label/<label key>` and the metadata value is the label's value.
Currently, the kubernetes plugin publishes the namespace and name of the client pod making the DNS request when pods verified mode is enabled. This enhancement request is for publishing the client pod's labels as metadata as well.

### 2. Which issues (if any) are related?

#6344 

### 3. Which documentation changes (if any) need to be made?

I added a brief update to `plugin/kubernetes/README.md`. I can add a sentence or two further explaining the syntax if necessary.

### 4. Does this introduce a backward incompatible change or deprecation?

No
