### PR TITLE
forward: respect context

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -110,7 +110,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	list := f.List()
 	deadline := time.Now().Add(defaultTimeout)
 	start := time.Now()
-	for time.Now().Before(deadline) {
+	for time.Now().Before(deadline) && ctx.Err() == nil {
 		if i >= len(list) {
 			// reached the end of list, reset to begin
 			i = 0


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

1. Stop useless query attempts when context is already expired.
2. Allows to control effective forward timeout with `cancel` plugin.

### 2. Which issues (if any) are related?

Related #4493 

### 3. Which documentation changes (if any) need to be made?

None, it's close to correct behaviour we would naturally expect.

### 4. Does this introduce a backward incompatible change or deprecation?

No, there is no way one could successfully query some server relying on canceled context as base context for their queries.