### PR TITLE
plugin/kubernetes: Add useragent

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -31,7 +31,7 @@ func init() {
 	flag.StringVar(&dnsserver.Port, serverType+".port", dnsserver.DefaultPort, "Default port")
 	flag.StringVar(&dnsserver.Port, "p", dnsserver.DefaultPort, "Default port")
 
-	caddy.AppName = coreName
+	caddy.AppName = CoreName
 	caddy.AppVersion = CoreVersion
 }
 

--- a/coremain/version.go
+++ b/coremain/version.go
@@ -3,6 +3,6 @@ package coremain
 // Various CoreDNS constants.
 const (
 	CoreVersion = "1.11.3"
-	coreName    = "CoreDNS"
+	CoreName    = "CoreDNS"
 	serverType  = "dns"
 )

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 
+	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/kubernetes/object"
@@ -192,6 +194,7 @@ func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
 			return nil, err
 		}
 		cc.ContentType = "application/vnd.kubernetes.protobuf"
+		cc.UserAgent = fmt.Sprintf("%s/%s git_commit:%s (%s/%s/%s)", coremain.CoreName, coremain.CoreVersion, coremain.GitCommit, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		return cc, err
 	}
 
@@ -218,6 +221,7 @@ func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
 		return nil, err
 	}
 	cc.ContentType = "application/vnd.kubernetes.protobuf"
+	cc.UserAgent = fmt.Sprintf("%s/%s git_commit:%s (%s/%s/%s)", coremain.CoreName, coremain.CoreVersion, coremain.GitCommit, runtime.GOOS, runtime.GOARCH, runtime.Version())
 	return cc, err
 }
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
CoreDNS doesn't set a UserAgent and client-go will fallback to the default one https://github.com/kubernetes/client-go/blob/master/rest/config.go#L498

In kubernetes' audit logs you'll see:
```
"userAgent":"coredns/v0.0.0 (linux/amd64) kubernetes/$Format"
```

This change adds a userAgent to the requests made by CoreDNS against the kubernetes API:

```
"userAgent":"CoreDNS/v1.11.1+ae2bbc29be1aaae0b3ded5d188968a6c97bb3144 (linux/amd64)"
```


### 2. Which issues (if any) are related?
-
### 3. Which documentation changes (if any) need to be made?
-
### 4. Does this introduce a backward incompatible change or deprecation?
-