### PR TITLE
 plugin/loadbalance: add limit_answers option

### DIFF
--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -18,6 +18,7 @@ implementations (like glibc) are particular about that.
 ~~~
 loadbalance [round_robin | weighted WEIGHTFILE] {
 			reload DURATION
+			limit_answers NUM_ANSWERS
 }
 ~~~
 * `round_robin` policy randomizes the order of  A, AAAA, and MX records applying a uniform probability distribution. This is the default load balancing policy.
@@ -30,6 +31,7 @@ returned in the answer.
 
  * **DURATION** interval to reload `WEIGHTFILE` and update weight assignments if there are changes in the file. The default value is `30s`. A value of `0s` means to not scan for changes and reload.
 
+ * **NUM_ANSWERS** limits the number of RRs in the Answer section of a DNS response, by returning only the first **NUM_ANSWERS** after `round_robin` shuffling or `weighted` adjustment has happened.
 
 ## Weightfile
 
@@ -88,3 +90,13 @@ www.example.com
 100.64.1.3 2
 ~~~
 
+Limit the number of RRs in the Answer section of the response by using `limit_answers`:
+
+~~~ corefile
+example.com {
+        file ./db.example.com
+        loadbalance round_robin {
+                limit_answers 5
+        }
+}
+~~~


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR proposes an addition to the `loadbalance` plugin enabling it to limit the number of RRs in the Answers section of a DNS response after it has been shuffled / weighted by the plugin.

### 2. Which issues (if any) are related?
A similar capability is discussed in #6337 with the proposed `oneaddr` plugin. I commented there about the possibility of expanding that capability from 1 to N. This is the first step in that direction.

### 3. Which documentation changes (if any) need to be made?
Changes to the README.md (as outlined in this first commit) for the `loadbalance` plugin, also probably plugin docs on coredns.io.

### 4. Does this introduce a backward incompatible change or deprecation?
No.

Assuming the syntax / format of this addition are approved, I plan to push additional commits to this PR to implement this proposed change.
