### PR TITLE
replace the mutex locks in logging with atomic bool for the "on" flag

### DIFF
--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	golog "log"
 	"os"
-	"sync"
+	"sync/atomic"
 )
 
 // D controls whether we should output debug logs. If true, we do, once set
@@ -21,30 +21,22 @@ import (
 var D = &d{}
 
 type d struct {
-	on bool
-	sync.RWMutex
+	on atomic.Bool
 }
 
 // Set enables debug logging.
 func (d *d) Set() {
-	d.Lock()
-	d.on = true
-	d.Unlock()
+	d.on.Store(true)
 }
 
 // Clear disables debug logging.
 func (d *d) Clear() {
-	d.Lock()
-	d.on = false
-	d.Unlock()
+	d.on.Store(false)
 }
 
 // Value returns if debug logging is enabled.
 func (d *d) Value() bool {
-	d.RLock()
-	b := d.on
-	d.RUnlock()
-	return b
+	return d.on.Load()
 }
 
 // logf calls log.Printf prefixed with level.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Minor performance improvement for logging.  

### 2. Which issues (if any) are related?
In aggregate when there is logging and with high qps rates / high concurrency this minor tweak can be positively impactful.


### 3. Which documentation changes (if any) need to be made? no

### 4. Does this introduce a backward incompatible change or deprecation? no


---
before:
```
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingOrig ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1615972	       736.9 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.611s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingOrig ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1617918	       761.5 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.170s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingOrig ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1631284	       733.4 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.130s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingOrig ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1627155	       733.0 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.128s
```

—
after:
```
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingNew ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1859108	       645.3 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.383s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingNew ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1858910	       649.2 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.049s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingNew ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1853415	       644.7 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.043s
➜  coredns git:(master) ✗ go test -bench=BenchmarkLoggingNew ./plugin/pkg/log
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/pkg/log
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkLoggingOrig-12    	 1856042	       641.6 ns/op
PASS
ok  	github.com/coredns/coredns/plugin/pkg/log	2.034s
```