### PR TITLE
Change the log flags to be a variable that can be set 

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -45,7 +45,7 @@ func Run() {
 	}
 
 	log.SetOutput(os.Stdout)
-	log.SetFlags(0) // Set to 0 because we're doing our own time, with timezone
+	log.SetFlags(LogFlags)
 
 	if version {
 		showVersion()
@@ -169,6 +169,9 @@ var (
 	conf    string
 	version bool
 	plugins bool
+
+	// LogFlags are initially set to 0 for no extra output
+	LogFlags int
 )
 
 // Build information obtained with the help of -ldflags


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

There is currently no easy way to set the the log flags for the package.  For example CoreDNS is used within another application and that application wishes to set the log format to use dates, then currently there is no way. At least in change provided one could set the LogFlags prior to calling Run().  

If there is a better way I'm open to making those changes.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/3892 

In my change I'm making it accessible, not creating an option. 

### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
not that I am aware.
