### PR TITLE
plugin/bind: add zone for link-local IPv6 instead of skipping

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -13,7 +13,7 @@ If several addresses are provided, a listener will be open on each of the IP pro
 
 Each address has to be an IP or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
 
-If the given argument is an interface name, and that interface has several IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for IPv6 link-local addresses on that interface.
+If the given argument is an interface name, and that interface has several IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6).
 
 ## Syntax
 

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -99,8 +99,7 @@ func listIP(args []string, ifaces []net.Interface) ([]string, error) {
 			}
 		}
 		if !isIface {
-			_, err := net.ResolveIPAddr("ip", a)
-			if err != nil {
+			if net.ParseIP(a) == nil {
 				return nil, fmt.Errorf("not a valid IP address or interface name: %q", a)
 			}
 			all = append(all, a)


### PR DESCRIPTION
This rewrites #4531 to actually not skip link-local IPs.  See #6536.