### PR TITLE
Add the CoreDNS maintained alternate plugin to the build by default.

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -55,6 +55,7 @@ var Directives = []string{
 	"secondary",
 	"etcd",
 	"loop",
+	"alternate",
 	"forward",
 	"grpc",
 	"erratic",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -4,6 +4,7 @@ package plugin
 
 import (
 	// Include all plugins.
+	_ "github.com/coredns/alternate"
 	_ "github.com/coredns/caddy/onevent"
 	_ "github.com/coredns/coredns/plugin/acl"
 	_ "github.com/coredns/coredns/plugin/any"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/antonmedv/expr v1.15.5
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.50.10
+	github.com/coredns/alternate v0.2.9
 	github.com/coredns/caddy v1.1.1
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/farsightsec/golang-framestream v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coredns/alternate v0.2.9 h1:Ue3JJHAQffmzfg5ikNhsLmRd2vdXrcJV3NXc+8FlHbo=
+github.com/coredns/alternate v0.2.9/go.mod h1:9coOPaZg7xxH695ReMdERlBVuU1sBAhhBg/djxp++bU=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -64,6 +64,7 @@ auto:auto
 secondary:secondary
 etcd:etcd
 loop:loop
+alternate:github.com/coredns/alternate
 forward:forward
 grpc:grpc
 erratic:erratic


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR compiles the CoreDNS alternate package as part of the standard binary and Docker image that ship with various distributions or CoreDNS. This is especially useful for Kubernetes cluster operators that provide internal DNS servers which resolve specific domains locally to make sure requests stay inside a specific network or cluster unless the host resolving the address is outside the cluster for both fault tolerance and other purposes, but also leverage something like cert-manager which requires external TXT records to be generated and resolved for the DNS-01 resolution mechanism to function. Using the alternate plugin provides a mechanism to resolve entries that are only available on public DNS servers to allow these mechanisms to appropriately function without maintaining self-compiled and hosted versions of CoreDNS.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
Any relevant documentation about included plugins should be updated to include information indicating the alternate plugin has been included and should link to the repo.

### 4. Does this introduce a backward incompatible change or deprecation?
No.
