### PR TITLE
plugin/bind: allow binding particularly link-local addresses (using a scope/zone)

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -11,7 +11,7 @@ another IP instead.
 
 If several addresses are provided, a listener will be open on each of the IP provided.
 
-Each address has to be an IP or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
+Each address has to be an IP, a host name (not recommended as it resolves to at most one IP) or name of one of the interfaces of the host. Bind by interface name, binds to the IPs on that interface at the time of startup or reload (reload will happen with a SIGHUP or if the config file changes).
 
 If the given argument is an interface name, and that interface has several IP addresses, CoreDNS will listen on all of the interface IP addresses (including IPv4 and IPv6), except for IPv6 link-local addresses on that interface.
 

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -92,7 +92,8 @@ func listIP(args []string, ifaces []net.Interface) ([]string, error) {
 			}
 		}
 		if !isIface {
-			if net.ParseIP(a) == nil {
+			_, err := net.ResolveIPAddr("ip", a)
+			if err != nil {
 				return nil, fmt.Errorf("not a valid IP address or interface name: %q", a)
 			}
 			all = append(all, a)

--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -21,6 +21,7 @@ func TestSetup(t *testing.T) {
 		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, true},
 		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, false},
 		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, false},
+		{"bind localhost", []string{"127.0.0.1"}, false},
 	} {
 		c := caddy.NewTestController("dns", test.config)
 		err := setup(c)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
I split off this PR as part of  #6547  as it introduces new behaviour. It particularly allows binding link local addresses where a scope/zone is needed (typically the interface name). As it uses [ResolveIPAddr](https://pkg.go.dev/net#ResolveIPAddr) hostnames are also passed through. It seems that the downstream bind code will accept this as well

### 2. Which issues (if any) are related?

This started of as #6536


### 3. Which documentation changes (if any) need to be made?

I tried to change the documentation

### 4. Does this introduce a backward incompatible change or deprecation?

This widens the acceptable input. I would doubt that workflows relied on the error behavior, but it is not impossible.