### PR TITLE
Use Docker username/password variables safely

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -111,7 +111,7 @@ else
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_VERSIONED)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
-	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"$(DOCKER_LOGIN)\",\"password\":\"$(DOCKER_PASSWORD)\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \
+	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"${{DOCKER_LOGIN}}\",\"password\":\"${{DOCKER_PASSWORD}} "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \
 	for arch in $(LINUX_ARCH); do \
 		curl -X DELETE -H "Authorization: JWT $${TOKEN}" "https://hub.docker.com/v2/repositories/$(DOCKER_IMAGE_NAME)/tags/$${arch}-$(VERSION)/" ;\
 	done

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -102,7 +102,7 @@ else
 	@# Pushes coredns/coredns-$arch:$version images
 	@# Creates manifest for multi-arch image
 	@# Pushes multi-arch image to coredns/coredns:$version
-	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
+	@echo $${DOCKER_PASSWORD} | docker login -u $${DOCKER_LOGIN} --password-stdin
 	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
 	for arch in $(LINUX_ARCH); do \
 		docker push $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
@chrisohaver 's suspicion the docker creds are causing the docker push to fail. This change replaces the Makefile variables  with shell variables (which will be used literally as they are in shell).

Make will expand any `$` in a variable value as an embedded variable. So a string like `foo$bar` will end up as `fooar` - because variable `b` is unset. Using `$${VAR}` takes VAR's value direct from the shell environment without any further processing.

Of course I can't really test this fixes the problem without making a release. But using  `$(VAR)` definitely experiences the problem described above with `$` in the value, and this change fixes that. So this seems like a sensible change to make regardless and is quicker/easier than moving everyone/everything over to ghcr.io. 

### 2. Which issues (if any) are related?
[#6454
](https://github.com/coredns/coredns/issues/6454)

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No