### PR TITLE
Use latest commit for softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           cat release.md
           sha256sum release/*.tgz
       - name: Draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           body_path: release.md
           name: v${{ steps.info.outputs.version }}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Per https://github.com/softprops/action-gh-release/issues/411

trying using latest commit to see it it fixes release creation failure

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
