### PR TITLE
plugin/ready: fix Reset list of readiness plugins

### DIFF
--- a/plugin/ready/setup.go
+++ b/plugin/ready/setup.go
@@ -11,6 +11,7 @@ import (
 func init() { plugin.Register("ready", setup) }
 
 func setup(c *caddy.Controller) error {
+	plugins.Reset()
 	addr, err := parse(c)
 	if err != nil {
 		return plugin.Error("ready", err)
@@ -25,7 +26,6 @@ func setup(c *caddy.Controller) error {
 	c.OnRestartFailed(func() error { return uniqAddr.ForEach() })
 
 	c.OnStartup(func() error {
-		plugins.Reset()
 		for _, p := range dnsserver.GetConfig(c).Handlers() {
 			if r, ok := p.(Readiness); ok {
 				plugins.Append(r, p.Name())


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When ready starts, it adds all implementors of readiness to its list of plugins to check for readiness. 
We need to clears out the list,  on every reload (such as kubernetes).

However, the current method of clears out the list is placed in the c.OnStartup function, which causes each plug-in to be cleared  out, and there will be only one plug-in in the final list.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
