### PR TITLE
Return RcodeServerFailure when DNS64 has no next plugin

### DIFF
--- a/plugin/dns64/dns64.go
+++ b/plugin/dns64/dns64.go
@@ -36,7 +36,7 @@ type DNS64 struct {
 func (d *DNS64) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	// Don't proxy if we don't need to.
 	if !d.requestShouldIntercept(&request.Request{W: w, Req: r}) {
-		return d.Next.ServeDNS(ctx, w, r)
+		return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 	}
 
 	// Pass the request to the next plugin in the chain, but intercept the response.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

If using a coredns config with only the dns64 plugin specified, the `Next` plugin that dns64 will attempt to call will be nil, resulting in a nil pointer dereference. We should return an error instead of crashing.

```
server # [   42.192968] coredns[836]: panic: runtime error: invalid memory address or nil pointer dereference
server # [   42.195715] coredns[836]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc30dc7]
server # [   42.198407] coredns[836]: goroutine 70 [running]:
server # [   42.200304] coredns[836]: github.com/coredns/coredns/plugin/dns64.(*DNS64).ServeDNS(0xc0001d4720, {0x2943198, 0xc0001d4ed0}, {0x294c3f8, 0xc000013ed8}, 0xc0004bbd40)
server # [   42.202514] coredns[836]:   github.com/coredns/coredns/plugin/dns64/dns64.go:47 +0x287
server # [   42.206366] coredns[836]: github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS(0xc000751480, {0x2943198, 0xc0001d4ed0}, {0x294c3f8, 0xc000013ed8}, 0xc0004bbd40)
server # [   42.208629] coredns[836]:   github.com/coredns/coredns/core/dnsserver/server.go:364 +0x826
server # [   42.209917] coredns[836]: github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1({0x294d9f8, 0xc000751680}, 0xc0004bbd40)
server # [   42.211190] coredns[836]:   github.com/coredns/coredns/core/dnsserver/server.go:178 +0x8e
server # [   42.212123] coredns[836]: github.com/miekg/dns.HandlerFunc.ServeDNS(0xc000145c00?, {0x294d9f8?, 0xc000751680?}, 0xc0004bbd40?)
server # [   42.213307] coredns[836]:   github.com/miekg/dns@v1.1.55/server.go:37 +0x29
server # [   42.214177] coredns[836]: github.com/miekg/dns.(*Server).serveDNS(0xc0000fb200, {0xc000145c00, 0x36, 0x200}, 0xc000751680)
server # [   42.215303] coredns[836]:   github.com/miekg/dns@v1.1.55/server.go:659 +0x42a
server # [   42.216110] coredns[836]: github.com/miekg/dns.(*Server).serveUDPPacket(0xc0000fb200, 0xc000643fd0, {0xc000145c00, 0x36, 0x200}, {0x294a0c0, 0xc00076ddd0}, 0xc0007a7040, {0x0, 0x0})
server # [   42.217697] coredns[836]:   github.com/miekg/dns@v1.1.55/server.go:603 +0x1a5
server # [   42.218505] coredns[836]: created by github.com/miekg/dns.(*Server).serveUDP in goroutine 65
server # [   42.219385] coredns[836]:   github.com/miekg/dns@v1.1.55/server.go:533 +0x405
```

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No