### PR TITLE
Add dependabot groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+      go.etcd.io:
+        patterns:
+          - "go.etcd.io/etcd/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Add groupings for Go modules updates in dependabot. This will reduce the number of PRs when projects update.
* `k8s.io/*`
* `go.etcd.io/etcd/*`

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
