### PR TITLE
Only create PTR records for endpoints with hostname defined

### DIFF
--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -44,8 +44,13 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 		}
 		for _, eps := range ep.Subsets {
 			for _, addr := range eps.Addresses {
-				if addr.IP == ip {
-					domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Index, Svc, k.primaryZone()}, ".")
+				// The endpoint's Hostname will be set if this endpoint is supposed to generate a PTR.
+				// So only return reverse records that match the IP AND have a non-empty hostname.
+				// Kubernetes more or less keeps this to one canonical service/endpoint per IP, but in the odd event there
+				// are multiple endpoints for the same IP with hostname set, return them all rather than selecting one
+				// arbitrarily.
+				if addr.IP == ip && addr.Hostname != "" {
+					domain := strings.Join([]string{addr.Hostname, ep.Index, Svc, k.primaryZone()}, ".")
 					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
 				}
 			}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Per discussion in https://kubernetes.slack.com/archives/C09QYUH5W/p1713088975540039,

We should only be creating PTR records for Endpoints that have a hostname defined in the endpoint address object.
This should normally result in producing one PTR record for each IP, even if multiple Services select the same Pod.  K8s enforces that only one endpoints has a hostname defined at any time.  If for some reason more than one have hostname defined, we will return both rather than select one arbitrarily - but IIUC, this would only happen if something is awry in k8s.

### 2. Which issues (if any) are related?

https://kubernetes.slack.com/archives/C09QYUH5W/p1713088975540039

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
