### PR TITLE
[plugin/forward] Strip local zone from IPV6 nameservers

### DIFF
--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -143,6 +143,13 @@ nameserver 10.10.255.253`), 0666); err != nil {
 	}
 	defer os.Remove(resolv)
 
+	const resolvIPV6 = "resolv-ipv6.conf"
+	if err := os.WriteFile(resolvIPV6,
+		[]byte(`nameserver 0388:d254:7aec:6892:9f7f:e93b:5806:1b0f%en0`), 0666); err != nil {
+		t.Fatalf("Failed to write %v file: %s", resolvIPV6, err)
+	}
+	defer os.Remove(resolvIPV6)
+
 	tests := []struct {
 		input         string
 		shouldErr     bool
@@ -153,6 +160,8 @@ nameserver 10.10.255.253`), 0666); err != nil {
 		{`forward . ` + resolv, false, "", []string{"10.10.255.252:53", "10.10.255.253:53"}},
 		// fail
 		{`forward . /dev/null`, true, "no nameservers", nil},
+		// IPV6 with local zone
+		{`forward . ` + resolvIPV6, false, "", []string{"[0388:d254:7aec:6892:9f7f:e93b:5806:1b0f]:53"}},
 	}
 
 	for i, test := range tests {

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -99,7 +99,7 @@ func tryFile(s string) ([]string, error) {
 
 	servers := []string{}
 	for _, s := range c.Servers {
-		servers = append(servers, net.JoinHostPort(s, c.Port))
+		servers = append(servers, net.JoinHostPort(stripZone(s), c.Port))
 	}
 	return servers, nil
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

In some scenarios, the forward plugin can be configured to read the /etc/resolv.conf file containing only one nameserver with an IPV6 address containing the suffix `%en0`.

### 2. Which issues (if any) are related?

Right now CoreDNS returns an error 
`[ERROR] plugin/errors: 2 mcr.microsoft.com. A: dial udp [0388:d254:7aec:6892:9f7f:e93b:5806:1b0f%en0]:53: connect: invalid argument`

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.