### PR TITLE
dnstap: adds message_types option for filtering

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -20,6 +20,7 @@ dnstap SOCKET [full] {
   [version VERSION]
   [extra EXTRA]
   [skipverify]
+  [message_types MESSAGE_TYPES]
 }
 ~~~
 
@@ -29,6 +30,12 @@ dnstap SOCKET [full] {
 * **VERSION** to override the version field. Defaults to the CoreDNS version.
 * **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
 * `skipverify` to skip tls verification during connection. Default to be secure
+* **MESSAGE_TYPES** is a space-separated list of [dnstap message types](https://github.com/dnstap/dnstap.pb/blob/1061e3ed4430f68a0adb87eecadbb9208e7b51dd/dnstap.proto#L156-L229) to be tapped.
+Defaults to tapping all message types. Currently, this plugin only supports the following message types: 
+  * `CLIENT_QUERY`
+  * `CLIENT_RESPONSE`
+  * `FORWARDER_QUERY`: only available when the forward plugin is used.
+  * `FORWARDER_RESPONSE`: only available when the forward plugin is used.
 
 ## Examples
 
@@ -80,6 +87,14 @@ Log to a remote TLS endpoint.
 ~~~ txt
 dnstap tls://127.0.0.1:6000 full {
   skipverify
+}
+~~~
+
+Log only `CLIENT_QUERY` and `CLIENT_RESPONSE` messages to a remote endpoint.
+
+~~~ txt
+dnstap tcp://example.com:6000 full {
+  message_types CLIENT_QUERY CLIENT_RESPONSE
 }
 ~~~
 

--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -31,11 +31,12 @@ dnstap SOCKET [full] {
 * **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
 * `skipverify` to skip tls verification during connection. Default to be secure
 * **MESSAGE_TYPES** is a space-separated list of [dnstap message types](https://github.com/dnstap/dnstap.pb/blob/1061e3ed4430f68a0adb87eecadbb9208e7b51dd/dnstap.proto#L156-L229) to be tapped.
-Defaults to tapping all message types. Currently, this plugin only supports the following message types: 
+Defaults to tapping all message types. Currently, this plugin only supports the following message types by default:
   * `CLIENT_QUERY`
   * `CLIENT_RESPONSE`
   * `FORWARDER_QUERY`: only available when the forward plugin is used.
   * `FORWARDER_RESPONSE`: only available when the forward plugin is used.
+  * Other message types might be tapped by the custom plugins that use the dnstap as described in the [Using Dnstap in your plugin](#using-dnstap-in-your-plugin) section.
 
 ## Examples
 

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -71,8 +71,8 @@ func (h *Dnstap) tapClientQuery(ctx context.Context, w dns.ResponseWriter, query
 
 // ServeDNS logs the client query and response to dnstap and passes the dnstap Context.
 func (h *Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	qt := time.Now()
 	if h.MessageTypeEnabled(tap.Message_CLIENT_RESPONSE) {
+		qt := time.Now()
 		// Custom ResponseWriter is only used to tap CLIENT_RESPONSE messages, so we only create it if needed.
 		w = &ResponseWriter{
 			ResponseWriter: w,
@@ -86,6 +86,7 @@ func (h *Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	// The query tap message should be sent before sending the query to the
 	// forwarder. Otherwise, the tap messages will come out out of order.
 	if h.MessageTypeEnabled(tap.Message_CLIENT_QUERY) {
+		qt := time.Now()
 		h.tapClientQuery(ctx, w, r, qt)
 	}
 	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -24,7 +24,7 @@ type Dnstap struct {
 	Identity          []byte
 	Version           []byte
 	ExtraFormat       string
-	// enabledMessageTypes is a bitfield of enabled tap.Message_Types.
+	// enabledMessageTypes is a bitmap of enabled tap.Message_Types.
 	// There's 14 message types in total, so uint64 is enough to store all of them.
 	// https://github.com/dnstap/golang-dnstap/blob/ebb538e7d351a58861a8f348491828214a1d8db2/dnstap.pb.go#L216-L275
 	enabledMessageTypes uint64

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -72,22 +72,20 @@ func (h *Dnstap) tapClientQuery(ctx context.Context, w dns.ResponseWriter, query
 // ServeDNS logs the client query and response to dnstap and passes the dnstap Context.
 func (h *Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if h.MessageTypeEnabled(tap.Message_CLIENT_RESPONSE) {
-		qt := time.Now()
 		// Custom ResponseWriter is only used to tap CLIENT_RESPONSE messages, so we only create it if needed.
 		w = &ResponseWriter{
 			ResponseWriter: w,
 			Dnstap:         h,
 			query:          r,
 			ctx:            ctx,
-			queryTime:      qt,
+			queryTime:      time.Now(),
 		}
 	}
 
 	// The query tap message should be sent before sending the query to the
 	// forwarder. Otherwise, the tap messages will come out out of order.
 	if h.MessageTypeEnabled(tap.Message_CLIENT_QUERY) {
-		qt := time.Now()
-		h.tapClientQuery(ctx, w, r, qt)
+		h.tapClientQuery(ctx, w, r, time.Now())
 	}
 	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 }

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -21,8 +21,9 @@ func testCase(t *testing.T, tapq, tapr *tap.Dnstap, q, r *dns.Msg, extraFormat s
 			w dns.ResponseWriter, _ *dns.Msg) (int, error) {
 			return 0, w.WriteMsg(r)
 		}),
-		io:          &w,
-		ExtraFormat: extraFormat,
+		io:                  &w,
+		ExtraFormat:         extraFormat,
+		enabledMessageTypes: defaultEnabledMessageTypes,
 	}
 	ctx := metadata.ContextWithMetadata(context.TODO())
 	ok := metadata.SetValueFunc(ctx, "metadata/test", func() string {

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -134,3 +134,20 @@ func TestTapMessage(t *testing.T) {
 	}
 	h.TapMessage(tapq.Message)
 }
+
+func TestDnstap_MessageTypeEnabled(t *testing.T) {
+	// Ensures that the default enables all message types.
+	h := Dnstap{enabledMessageTypes: defaultEnabledMessageTypes}
+	for tyy, name := range tap.Message_Type_name {
+		if !h.MessageTypeEnabled(tap.Message_Type(tyy)) {
+			t.Errorf("Expected %s to be enabled", name)
+		}
+	}
+	h.enabledMessageTypes = parseMessageTypes("CLIENT_QUERY CLIENT_RESPONSE")
+	if !h.MessageTypeEnabled(tap.Message_CLIENT_QUERY) {
+		t.Error("Expected CLIENT_QUERY to be enabled")
+	}
+	if !h.MessageTypeEnabled(tap.Message_CLIENT_RESPONSE) {
+		t.Error("Expected CLIENT_RESPONSE to be enabled")
+	}
+}

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -151,4 +151,7 @@ func TestDnstap_MessageTypeEnabled(t *testing.T) {
 	if !h.MessageTypeEnabled(tap.Message_CLIENT_RESPONSE) {
 		t.Error("Expected CLIENT_RESPONSE to be enabled")
 	}
+	if h.MessageTypeEnabled(tap.Message_AUTH_RESPONSE) {
+		t.Error("Expected AUTH_RESPONSE to be disabled")
+	}
 }

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -144,7 +144,7 @@ func TestDnstap_MessageTypeEnabled(t *testing.T) {
 			t.Errorf("Expected %s to be enabled", name)
 		}
 	}
-	h.enabledMessageTypes = parseMessageTypes("CLIENT_QUERY CLIENT_RESPONSE")
+	h.enabledMessageTypes = messageTypesMap([]string{"CLIENT_QUERY", "CLIENT_RESPONSE"})
 	if !h.MessageTypeEnabled(tap.Message_CLIENT_QUERY) {
 		t.Error("Expected CLIENT_QUERY to be enabled")
 	}

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -96,10 +96,11 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 				}
 			case "message_types":
 				{
-					if !c.NextArg() {
+					types := c.RemainingArgs()
+					if len(types) == 0 {
 						return nil, c.ArgErr()
 					}
-					d.enabledMessageTypes = messageTypesMap(c.RemainingArgs())
+					d.enabledMessageTypes = messageTypesMap(types)
 				}
 			}
 		}

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -99,7 +99,7 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 					if !c.NextArg() {
 						return nil, c.ArgErr()
 					}
-					d.enabledMessageTypes = parseMessageTypes(c.Val())
+					d.enabledMessageTypes = messageTypesMap(c.RemainingArgs())
 				}
 			}
 		}
@@ -152,10 +152,10 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-// parseMessageTypes parses a space-separated list of message types and returns a bitmap of the tap.Message_Type values.
-func parseMessageTypes(raw string) uint64 {
+// messageTypesMap returns a bitmap of enabled message types from a list of message type strings.
+func messageTypesMap(types []string) uint64 {
 	var bitmap uint64
-	for _, str := range strings.Split(raw, " ") {
+	for _, str := range types {
 		typ, ok := tap.Message_Type_value[str]
 		if !ok {
 			log.Warningf("Unknown message type: %s", str)

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -18,7 +18,7 @@ var log = clog.NewWithPlugin("dnstap")
 
 func init() { plugin.Register("dnstap", setup) }
 
-// defaultEnabledMessageTypes is a bitfield of all message types enabled by default.
+// defaultEnabledMessageTypes is a bitmap of all message types enabled by default.
 const defaultEnabledMessageTypes = ^uint64(0)
 
 func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/replacer"
+
 	tap "github.com/dnstap/golang-dnstap"
 )
 

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -56,6 +56,7 @@ func TestConfig(t *testing.T) {
 		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
 		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
 		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
+		{"dnstap dnstap.sock {\nmessage_types\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
-
-	tap "github.com/dnstap/golang-dnstap"
 )
 
 type results struct {
@@ -50,7 +48,7 @@ func TestConfig(t *testing.T) {
 				message_types CLIENT_RESPONSE CLIENT_QUERY
               }`, false, []results{
 			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), "EXTRA", defaultEnabledMessageTypes},
-			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), "EXTRA2", 1<<tap.Message_CLIENT_RESPONSE | 1<<tap.Message_CLIENT_QUERY},
+			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), "EXTRA2", 0b1100000},
 		}},
 		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
 		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -1,13 +1,14 @@
 package dnstap
 
 import (
-	tap "github.com/dnstap/golang-dnstap"
 	"os"
 	"reflect"
 	"testing"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
+
+	tap "github.com/dnstap/golang-dnstap"
 )
 
 type results struct {

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -141,24 +141,24 @@ func TestMultiDnstap(t *testing.T) {
 	}
 }
 
-func Test_parseMessageTypes(t *testing.T) {
+func Test_initMessageTypesMap(t *testing.T) {
 	tests := []struct {
-		in     string
+		in     []string
 		expect uint64
 	}{
-		{in: "", expect: ^uint64(0)},
-		{in: "CLIENT_QUERY", expect: 1 << tap.Message_CLIENT_QUERY},
+		{in: nil, expect: ^uint64(0)},
+		{in: []string{"CLIENT_QUERY"}, expect: 1 << tap.Message_CLIENT_QUERY},
 		{
-			in:     "CLIENT_QUERY CLIENT_RESPONSE",
+			in:     []string{"CLIENT_QUERY", "CLIENT_RESPONSE"},
 			expect: (1 << tap.Message_CLIENT_QUERY) | (1 << tap.Message_CLIENT_RESPONSE),
 		},
 		{
-			in:     "CLIENT_QUERY FORWARDER_QUERY FORWARDER_RESPONSE",
+			in:     []string{"CLIENT_QUERY", "FORWARDER_QUERY", "FORWARDER_RESPONSE"},
 			expect: (1 << tap.Message_CLIENT_QUERY) | (1 << tap.Message_FORWARDER_QUERY) | (1 << tap.Message_FORWARDER_RESPONSE),
 		},
 	}
 	for i, tc := range tests {
-		x := parseMessageTypes(tc.in)
+		x := messageTypesMap(tc.in)
 		if x != tc.expect {
 			t.Errorf("Test %d: expected %d, got %d", i, tc.expect, x)
 		}

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -141,21 +141,15 @@ func TestMultiDnstap(t *testing.T) {
 	}
 }
 
-func Test_initMessageTypesMap(t *testing.T) {
+func Test_messageTypesMap(t *testing.T) {
 	tests := []struct {
 		in     []string
 		expect uint64
 	}{
 		{in: nil, expect: ^uint64(0)},
-		{in: []string{"CLIENT_QUERY"}, expect: 1 << tap.Message_CLIENT_QUERY},
-		{
-			in:     []string{"CLIENT_QUERY", "CLIENT_RESPONSE"},
-			expect: (1 << tap.Message_CLIENT_QUERY) | (1 << tap.Message_CLIENT_RESPONSE),
-		},
-		{
-			in:     []string{"CLIENT_QUERY", "FORWARDER_QUERY", "FORWARDER_RESPONSE"},
-			expect: (1 << tap.Message_CLIENT_QUERY) | (1 << tap.Message_FORWARDER_QUERY) | (1 << tap.Message_FORWARDER_RESPONSE),
-		},
+		{in: []string{"CLIENT_QUERY"}, expect: 0b100000},
+		{in: []string{"CLIENT_QUERY", "CLIENT_RESPONSE"}, expect: 0b1100000},
+		{in: []string{"CLIENT_QUERY", "UPDATE_RESPONSE", "FORWARDER_RESPONSE"}, expect: 0b100000100100000},
 	}
 	for i, tc := range tests {
 		x := messageTypesMap(tc.in)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -48,7 +48,9 @@ func TestConfig(t *testing.T) {
 				message_types CLIENT_RESPONSE CLIENT_QUERY
               }`, false, []results{
 			{"dnstap.sock", true, "unix", []byte("NAME"), []byte("VER"), "EXTRA", defaultEnabledMessageTypes},
-			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), "EXTRA2", 0b1100000},
+			{"127.0.0.1:6000", false, "tcp", []byte("NAME2"), []byte("VER2"), "EXTRA2",
+				// CLIENT_QUERY (6-th bit) and CLIENT_RESPONSE (7-th bit) are enabled.
+				0b1100000},
 		}},
 		{"dnstap tls://127.0.0.1:6000", false, []results{{"127.0.0.1:6000", false, "tls", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},
 		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", defaultEnabledMessageTypes}}},

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -165,7 +165,7 @@ dnstap tcp://example.com:6000 {
 					return
 				}
 				if actualTaps[0] != next.Next {
-					t.Error("Unexpected order of dnstap plugins")
+					t.Error("Unexpected dnstap plugins")
 				}
 			},
 		},

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -48,7 +48,8 @@ func TestSetTapPlugin(t *testing.T) {
 			tapConfig: `dnstap tcp://example.com:6000`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 1 {
-					t.Fatalf("Expected: 1 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 1 results, got: %v", len(actualTaps))
+					return
 				}
 				if actualTaps[0] != src {
 					t.Error("Unexpected dnstap plugin")
@@ -62,7 +63,8 @@ func TestSetTapPlugin(t *testing.T) {
 }`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 1 {
-					t.Fatalf("Expected: 1 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 1 results, got: %v", len(actualTaps))
+					return
 				}
 				if actualTaps[0] != src {
 					t.Error("Unexpected dnstap plugin")
@@ -76,7 +78,7 @@ func TestSetTapPlugin(t *testing.T) {
 }`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 0 {
-					t.Fatalf("Expected: 0 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 0 results, got: %v", len(actualTaps))
 				}
 			},
 		},
@@ -86,7 +88,8 @@ func TestSetTapPlugin(t *testing.T) {
 	dnstap tcp://example.com:6000`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 2 {
-					t.Fatalf("Expected: 2 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 2 results, got: %v", len(actualTaps))
+					return
 				}
 				if actualTaps[0] != src || src.Next != actualTaps[1] {
 					t.Error("Unexpected order of dnstap plugins")
@@ -101,7 +104,8 @@ dnstap tcp://example.com:6000 {
 }`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 2 {
-					t.Fatalf("Expected: 2 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 2 results, got: %v", len(actualTaps))
+					return
 				}
 				if actualTaps[0] != src || src.Next != actualTaps[1] {
 					t.Error("Unexpected order of dnstap plugins")
@@ -116,15 +120,16 @@ dnstap tcp://example.com:6000 {
 dnstap /tmp/dnstap.sock full`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 1 {
-					t.Fatalf("Expected: 2 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 1 results, got: %v", len(actualTaps))
+					return
 				}
 				if actualTaps[0] != src.Next {
-					t.Error("Unexpected order of dnstap plugins")
+					t.Error("Unexpected dnstap plugins")
 				}
 			},
 		},
 		{
-			name: "three dnstaps with only non-forward message types",
+			name: "two dnstaps with only non-forward message types",
 			tapConfig: `dnstap tcp://example.com:6000 {
 	message_types CLIENT_RESPONSE
 }
@@ -133,7 +138,7 @@ dnstap /tmp/dnstap.sock full {
 }`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 0 {
-					t.Fatalf("Expected: 0 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 0 results, got: %v", len(actualTaps))
 				}
 			},
 		},
@@ -150,12 +155,14 @@ dnstap tcp://example.com:6000 {
 }`,
 			assert: func(t *testing.T, src *dnstap.Dnstap, actualTaps []*dnstap.Dnstap) {
 				if len(actualTaps) != 1 {
-					t.Fatalf("Expected: 1 results, got: %v", len(actualTaps))
+					t.Errorf("Expected: 1 results, got: %v", len(actualTaps))
+					return
 				}
 
 				next, ok := src.Next.(*dnstap.Dnstap)
 				if !ok {
-					t.Fatal("Expected a dnstap plugin")
+					t.Errorf("Expected a dnstap plugin")
+					return
 				}
 				if actualTaps[0] != next.Next {
 					t.Error("Unexpected order of dnstap plugins")


### PR DESCRIPTION
Note: I am completely open to discuss the naming of the option

### 1. Why is this pull request needed and what does it do?

This resolves #4198 and #6640 by introducing `message_types` configuration in the `dnstap` plugin.

### 2. Which issues (if any) are related?

#4198 and #6640 

### 3. Which documentation changes (if any) need to be made?

dnstap/README.md

### 4. Does this introduce a backward incompatible change or deprecation?

No.

---


~I left this as draft until we agreed on the naming of the option. I would appreciate it if you folks can take a look @rdrozhdzh  @miekg (pinging the people in the original issue #4198)~

