### PR TITLE
dnstap: uses pointer receiver for small response writer

### DIFF
--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -27,7 +27,7 @@ type Dnstap struct {
 }
 
 // TapMessage sends the message m to the dnstap interface, without populating "Extra" field.
-func (h Dnstap) TapMessage(m *tap.Message) {
+func (h *Dnstap) TapMessage(m *tap.Message) {
 	if h.ExtraFormat == "" {
 		h.tapWithExtra(m, nil)
 	} else {
@@ -36,7 +36,7 @@ func (h Dnstap) TapMessage(m *tap.Message) {
 }
 
 // TapMessageWithMetadata sends the message m to the dnstap interface, with "Extra" field being populated.
-func (h Dnstap) TapMessageWithMetadata(ctx context.Context, m *tap.Message, state request.Request) {
+func (h *Dnstap) TapMessageWithMetadata(ctx context.Context, m *tap.Message, state request.Request) {
 	if h.ExtraFormat == "" {
 		h.tapWithExtra(m, nil)
 		return
@@ -45,12 +45,12 @@ func (h Dnstap) TapMessageWithMetadata(ctx context.Context, m *tap.Message, stat
 	h.tapWithExtra(m, []byte(extraStr))
 }
 
-func (h Dnstap) tapWithExtra(m *tap.Message, extra []byte) {
+func (h *Dnstap) tapWithExtra(m *tap.Message, extra []byte) {
 	t := tap.Dnstap_MESSAGE
 	h.io.Dnstap(&tap.Dnstap{Type: &t, Message: m, Identity: h.Identity, Version: h.Version, Extra: extra})
 }
 
-func (h Dnstap) tapQuery(ctx context.Context, w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {
+func (h *Dnstap) tapQuery(ctx context.Context, w dns.ResponseWriter, query *dns.Msg, queryTime time.Time) {
 	q := new(tap.Message)
 	msg.SetQueryTime(q, queryTime)
 	msg.SetQueryAddress(q, w.RemoteAddr())
@@ -65,7 +65,7 @@ func (h Dnstap) tapQuery(ctx context.Context, w dns.ResponseWriter, query *dns.M
 }
 
 // ServeDNS logs the client query and response to dnstap and passes the dnstap Context.
-func (h Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (h *Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	rw := &ResponseWriter{
 		ResponseWriter: w,
 		Dnstap:         h,
@@ -82,4 +82,4 @@ func (h Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 }
 
 // Name implements the plugin.Plugin interface.
-func (h Dnstap) Name() string { return "dnstap" }
+func (h *Dnstap) Name() string { return "dnstap" }

--- a/plugin/dnstap/writer.go
+++ b/plugin/dnstap/writer.go
@@ -17,7 +17,7 @@ type ResponseWriter struct {
 	query     *dns.Msg
 	ctx       context.Context
 	dns.ResponseWriter
-	Dnstap
+	*Dnstap
 }
 
 // WriteMsg writes back the response to the client and THEN works on logging the request and response to dnstap.


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

Previously, dnstap plugin's handler has methods defined with a value receiver even though the struct itself is relatively large and there's no reason for extra copies (the fields are static). Further more, it embeds the handler struct in `ResponseWriter`, which is allocated per query, hence it's putting the unnecessary memory pressures on the critical path. 

This fixes it by changing methods to pointer receiver and takes the pointer in ResponseWriter struct.


### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

No.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
