### PR TITLE
Fix zone parser error handling

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -136,10 +136,6 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 	z := NewZone(origin, fileName)
 	seenSOA := false
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
-		if err := zp.Err(); err != nil {
-			return nil, err
-		}
-
 		if !seenSOA {
 			if s, ok := rr.(*dns.SOA); ok {
 				seenSOA = true
@@ -158,6 +154,10 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 	}
 	if !seenSOA {
 		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
+	}
+
+	if err := zp.Err(); err != nil {
+		return nil, err
 	}
 
 	return z, nil

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -29,3 +29,31 @@ www          IN  A      192.168.0.14
 mail         IN  A      192.168.0.15
 imap         IN  CNAME  mail
 `
+
+func TestParseSyntaxError(t *testing.T) {
+	_, err := Parse(strings.NewReader(dbSyntaxError), "example.org.", "stdin", 0)
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+	if !strings.Contains(err.Error(), "\"invalid\"") {
+		t.Fatalf("Zone %q should have failed with syntax error: %s", "example.org.", err)
+	}
+}
+
+const dbSyntaxError = `
+$TTL         1M
+$ORIGIN      example.org.
+
+@            IN  SOA    ns1.example.com. admin.example.com.  (
+                               2005011437 ; Serial
+                               1200       ; Refresh
+                               144        ; Retry
+                               1814400    ; Expire
+                               2h )       ; Minimum
+@            IN  NS     ns1.example.com.
+
+# invalid comment
+www          IN  A      192.168.0.14
+mail         IN  A      192.168.0.15
+imap         IN  CNAME  mail
+`

--- a/plugin/sign/file.go
+++ b/plugin/sign/file.go
@@ -66,10 +66,6 @@ func Parse(f io.Reader, origin, fileName string) (*file.Zone, error) {
 	seenSOA := false
 
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
-		if err := zp.Err(); err != nil {
-			return nil, err
-		}
-
 		switch rr.(type) {
 		case *dns.DNSKEY, *dns.RRSIG, *dns.CDNSKEY, *dns.CDS:
 			continue
@@ -86,6 +82,10 @@ func Parse(f io.Reader, origin, fileName string) (*file.Zone, error) {
 	}
 	if !seenSOA {
 		return nil, fmt.Errorf("file %q has no SOA record", fileName)
+	}
+
+	if err := zp.Err(); err != nil {
+		return nil, err
 	}
 
 	return z, nil

--- a/plugin/sign/signer.go
+++ b/plugin/sign/signer.go
@@ -133,10 +133,6 @@ func resign(rd io.Reader, now time.Time) (why error) {
 	i := 0
 
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
-		if err := zp.Err(); err != nil {
-			return err
-		}
-
 		switch x := rr.(type) {
 		case *dns.RRSIG:
 			if x.TypeCovered != dns.TypeSOA {
@@ -166,7 +162,7 @@ func resign(rd io.Reader, now time.Time) (why error) {
 		}
 	}
 
-	return nil
+	return zp.Err()
 }
 
 func signAndLog(s *Signer, why error) {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Error handling for the zone parser does not follow the guidance of the [dns library](https://pkg.go.dev/github.com/miekg/dns#ZoneParser.Next).

> After Next returns (nil, false), the Err method will return any error that occurred during parsing.

`zp.Err()` will only return nil while inside the loop.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
May cause an error where previously the parser would have silently stopped parsing the file.
