### PR TITLE
fix: plugin/file: return error when parsing the file fails

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -159,6 +159,9 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 	if !seenSOA {
 		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
 	}
+	if zp.Err() != nil {
+		return nil, fmt.Errorf("failed to parse file %q for origin %s with error %v", fileName, origin, zp.Err())
+	}
 
 	return z, nil
 }


### PR DESCRIPTION
Close by mistake