### PR TITLE
fix: plugin/auto: call OnShutdown() for each zone at its own OnShutdo…

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -71,6 +71,11 @@ func setup(c *caddy.Controller) error {
 
 	c.OnShutdown(func() error {
 		close(walkChan)
+		for _, z := range a.Zones.Z {
+			z.Lock()
+			z.OnShutdown()
+			z.Unlock()
+		}
 		return nil
 	})
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
try to fix #6703
### 2. Which issues (if any) are related?
#6703
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
no

### After the changes
```
API server listening at: 127.0.0.1:38999
[INFO] plugin/auto: Inserting zone `example.com.' from: zonefile/db.example.com
example.com.:8853
[INFO] plugin/reload: Running configuration SHA512 = 5f6fe......
CoreDNS-1.11.2
linux/amd64, go1.21.8, 
2024-05-27 15:40:37.837486874 +0800 CST m=+60.029481310: reload called by 0xc0001908c0
2024-05-27 15:41:37.838566942 +0800 CST m=+120.030561380: reload called by 0xc0001908c0
2024-05-27 15:42:37.838851891 +0800 CST m=+180.030846329: reload called by 0xc0001908c0
[INFO] Reloading
[INFO] plugin/auto: Inserting zone `example.com.' from: zonefile/db.example.com
[INFO] plugin/reload: Running configuration SHA512 = a5f02......
[INFO] Reloading complete
2024-05-27 15:42:51.081971917 +0800 CST m=+193.273966351: reloadShutdown called by 0xc0001908c0
2024-05-27 15:43:51.083877975 +0800 CST m=+253.275872413: reload called by 0xc000190000
2024-05-27 15:44:51.083605362 +0800 CST m=+313.275599800: reload called by 0xc000190000
[INFO] Reloading
[INFO] plugin/auto: Inserting zone `example.com.' from: zonefile/db.example.com
[INFO] plugin/reload: Running configuration SHA512 = e459......
[INFO] Reloading complete
2024-05-27 15:45:13.540742543 +0800 CST m=+335.732736977: reloadShutdown called by 0xc000190000
2024-05-27 15:46:13.542792686 +0800 CST m=+395.734787124: reload called by 0xc000190700
2024-05-27 15:47:13.54286623 +0800 CST m=+455.734860668: reload called by 0xc000190700
```
