### PR TITLE
fix(cwd): Restored backwards compatibility of Current Workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ FROM --platform=$TARGETPLATFORM ${BASE}
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /coredns /coredns
 USER nonroot:nonroot
+WORKDIR /
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This merge requests restores the default working directory for the coredns container that now runs nonroot.

### 2. Which issues (if any) are related?
An issue has not been opened yet, after implementation of https://github.com/coredns/coredns/commit/d21537f93197f82f9abd66569ea78f0fe629061f the base-image of the container has changed, resulting in the Working Directory being changed from `/` to `/home/nonroot`. This causes the container to, by default, no longer use `/Corefile` as a default conf, but instead use `/home/nonroot/Corefile`

### 3. Which documentation changes (if any) need to be made?
None, the documentation already suggests is runs from /Corefile

### 4. Does this introduce a backward incompatible change or deprecation?
It fixes backwards incompatibility.[ In the PR of the commit](https://github.com/coredns/coredns/pull/5969), it was suggested that there would be no backwards compatibility breaking, however this change was breaking the default config file location.
