### PR TITLE
Added OpenSSF Scorecard Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/coredns/coredns.svg)](https://hub.docker.com/r/coredns/coredns)
 [![Go Report Card](https://goreportcard.com/badge/github.com/coredns/coredns)](https://goreportcard.com/report/coredns/coredns)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1250/badge)](https://bestpractices.coreinfrastructure.org/projects/1250)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/coredns/coredns/badge)](https://api.securityscorecards.dev/projects/github.com/coredns/coredns)
 
 CoreDNS is a DNS server/forwarder, written in Go, that chains [plugins](https://coredns.io/plugins).
 Each plugin performs a (DNS) function.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/coredns/coredns.svg)](https://hub.docker.com/r/coredns/coredns)
 [![Go Report Card](https://goreportcard.com/badge/github.com/coredns/coredns)](https://goreportcard.com/report/coredns/coredns)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1250/badge)](https://bestpractices.coreinfrastructure.org/projects/1250)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/coredns/coredns/badge)](https://api.securityscorecards.dev/projects/github.com/coredns/coredns)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/coredns/coredns/badge)](https://scorecard.dev/viewer/?uri=github.com/coredns/coredns)
 
 CoreDNS is a DNS server/forwarder, written in Go, that chains [plugins](https://coredns.io/plugins).
 Each plugin performs a (DNS) function.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR adds OpenSSF Scorecard Badge in the README file.

Hi, I'm Harshita. I’m working with [CNCF and the Google Open Source Security Team for the GSoC 2024 term](https://github.com/cncf/mentoring/issues/1196). We are collaborating to enhance security practices across various CNCF projects. The goal is to improve security for all CNCF projects by both using OpenSSF Scorecards and implementing its security improvements.

The project already has the Scorecard GitHub Action running, so adding the scorecard badge would be quite handy. So that the results can be shown as a badge in the repository's README. This badge serves as a quick indicator of the project's security posture, helping users and contributors evaluate the project's security practices quickly.

### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A