### PR TITLE
Fix outdated test

### DIFF
--- a/test/corefile_test.go
+++ b/test/corefile_test.go
@@ -5,13 +5,16 @@ import (
 )
 
 func TestCorefile1(t *testing.T) {
-	corefile := `ȶ
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Expected no panic, but got %v", r)
+		}
+	}()
+
+	// this used to crash
+	corefile := `\\\\ȶ.
 acl
 `
-	// this crashed, now it should return an error.
-	i, _, _, err := CoreDNSServerAndPorts(corefile)
-	if err == nil {
-		defer i.Stop()
-		t.Fatalf("Expected an error got none")
-	}
+	i, _, _, _ := CoreDNSServerAndPorts(corefile)
+	defer i.Stop()
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR fixes an outdated test that was introduced in this [PR](https://github.com/coredns/coredns/pull/4637). This was caused by a bug in normalization in the [DNS library](https://github.com/miekg/dns). It has since been partially fixed by this [commit](https://github.com/miekg/dns/commit/4bdf30257457cd291de58a569e56920d51763492) causing this test to fail.

The following [playground](https://go.dev/play/p/RfhvX8dsXM7) show the difference in behavior between old and new behaviors. But introducing escape characters into the domain name triggers the same bug again. The original goal of the test was to check that even if the parsing fails, the application doesn't crash so the test was changed to reflect this.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No