### PR TITLE
`root`: explicit mark `dnssec` support

### DIFF
--- a/plugin/root/README.md
+++ b/plugin/root/README.md
@@ -11,8 +11,9 @@ this. A relative root path is relative to the current working directory.
 **NOTE: The *root* directory is NOT currently supported by all plugins.** 
 Currently the following plugins respect the *root* plugin configuration:
 
-* file
-* tls
+* *file*
+* *tls*
+* *dnssec*
 
 This plugin can only be used once per Server Block. 
 
@@ -50,5 +51,6 @@ tls://example.com:853 {
 **NOTE: The *root* directory is NOT currently supported by all plugins.** 
 Currently the following plugins respect the *root* plugin configuration:
 
-* file
-* tls
+* *file*
+* *tls*
+* *dnssec*


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Improve documentation. DNSSEC keys can be specified relative to `root`: https://github.com/coredns/coredns/blob/master/plugin/dnssec/setup.go#L135

### 2. Which issues (if any) are related?

Didn't open issue for this

### 3. Which documentation changes (if any) need to be made?

Aligns docs with code

### 4. Does this introduce a backward incompatible change or deprecation?

Nope