### PR TITLE
core: set cache-control max-age as integer, not float

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -188,7 +188,7 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	age := dnsutil.MinimalTTL(dw.Msg, mt)
 
 	w.Header().Set("Content-Type", doh.MimeType)
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%f", age.Seconds()))
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", uint32(age.Seconds())))
 	w.Header().Set("Content-Length", strconv.Itoa(len(buf)))
 	w.WriteHeader(http.StatusOK)
 	s.countResponse(http.StatusOK)


### PR DESCRIPTION
## What

When CoreDNS is used as a dns-over-https server, it sets cache control headers.
However, the max-age is set as a float, instead of an integer as specified in RFC 2616.

## How

This PR truncates the float into an integer, using `uint32` which is also what the dnsutil is using.

## Why

Setting the max-age as a float can make the value get ignored in some cases, such as when fronted by a caching CDN.
