### PR TITLE
fix: plugin/kubernetes: Fix autopath for host network pods

### DIFF
--- a/plugin/kubernetes/autopath.go
+++ b/plugin/kubernetes/autopath.go
@@ -1,6 +1,10 @@
 package kubernetes
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/request"
@@ -27,19 +31,41 @@ func (k *Kubernetes) AutoPath(state request.Request) []string {
 	}
 
 	ip := state.IP()
+	fmt.Println("ip", ip, "zone", zone)
 
-	pod := k.podWithIP(ip)
-	if pod == nil {
+	var namespace string
+	pods := k.podsWithIP(ip)
+	if pods == nil {
 		return nil
+	}
+
+	if len(pods) == 1 {
+		namespace = pods[0].Namespace
+	} else {
+		var expr *regexp.Regexp
+		nsMatcher := namespaceRegex(pods)
+		if zone == "." {
+			expr = regexp.MustCompile(fmt.Sprintf(`.+\.%s\.svc\.`, nsMatcher))
+		} else {
+			regexSafeZone := strings.ReplaceAll(zone, ".", "\\.")
+			expr = regexp.MustCompile(fmt.Sprintf(`.+\.%s\.svc\.%s`, nsMatcher, regexSafeZone))
+		}
+		matches := expr.FindStringSubmatch(state.Name())
+		//We are only matching <base-query>.<pod-namespace>.svc.<zone>
+		//since we only want to trigger autopath on the first query
+		if matches == nil {
+			return nil
+		}
+		namespace = matches[1]
 	}
 
 	search := make([]string, 3)
 	if zone == "." {
-		search[0] = pod.Namespace + ".svc."
+		search[0] = namespace + ".svc."
 		search[1] = "svc."
 		search[2] = "."
 	} else {
-		search[0] = pod.Namespace + ".svc." + zone
+		search[0] = namespace + ".svc." + zone
 		search[1] = "svc." + zone
 		search[2] = zone
 	}
@@ -49,8 +75,21 @@ func (k *Kubernetes) AutoPath(state request.Request) []string {
 	return search
 }
 
-// podWithIP returns the api.Pod for source IP. It returns nil if nothing can be found.
-func (k *Kubernetes) podWithIP(ip string) *object.Pod {
+func namespaceRegex(pods []*object.Pod) string {
+	nsMap := map[string]struct{}{}
+	for _, pod := range pods {
+		nsMap[pod.Namespace] = struct{}{}
+	}
+	var namespaces []string
+	for ns := range nsMap {
+		namespaces = append(namespaces, ns)
+	}
+	return fmt.Sprintf("(%s)", strings.Join(namespaces, "|"))
+}
+
+// podsWithIP returns the list of api.Pod for source IP. It returns nil if nothing can be found.
+// Return a list because there can be multiple host network pods with the same IP (node IP).
+func (k *Kubernetes) podsWithIP(ip string) []*object.Pod {
 	if k.podMode != podModeVerified {
 		return nil
 	}
@@ -58,5 +97,5 @@ func (k *Kubernetes) podWithIP(ip string) *object.Pod {
 	if len(ps) == 0 {
 		return nil
 	}
-	return ps[0]
+	return ps
 }

--- a/plugin/kubernetes/autopath_test.go
+++ b/plugin/kubernetes/autopath_test.go
@@ -1,0 +1,168 @@
+package kubernetes
+
+import (
+	"slices"
+	"testing"
+
+	testhelper "github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+func TestAutoPath(t *testing.T) {
+	// Set up a Kubernetes object for testing
+	defaultZone := "interwebs.test."
+	k := New([]string{defaultZone})
+	k.autoPathSearch = []string{"custom."}
+	k.APIConn = &APIConnServiceTest{}
+	k.podMode = podModeVerified
+	k.opts.initPodCache = true
+
+	type autopathTest struct {
+		qname      string
+		searchpath []string
+		ip         string
+		zone       string
+	}
+	tests := []autopathTest{
+		{
+			// Cluster IP Service FQDN - first query
+			qname: "svc1.testns.svc.interwebs.test.testns.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// Cluster IP Service name only or service inside custom domain - first query
+			qname: "svc1.testns.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// External service - first query
+			qname: "example.com.testns.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// External service matching zone "." - first query
+			qname: "example.com.testns.svc.",
+			zone:  ".",
+			searchpath: []string{
+				"testns.svc.",
+				"svc.",
+				".",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// External service matching zone "." - first query - host pod
+			qname: "example.com.testns.svc.",
+			zone:  ".",
+			ip:    "10.16.0.1",
+			searchpath: []string{
+				"testns.svc.",
+				"svc.",
+				".",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// External service - first query - host pod
+			qname: "example.com.other.svc.interwebs.test.",
+			ip:    "10.16.0.1",
+			searchpath: []string{
+				"other.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// External service - second query
+			qname: "example.com.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// Domain conflicting with other namespace in second query - normal pod
+			qname: "example.other.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// Domain conflicting with testns namespace in second query - normal pod
+			qname: "example.testns.svc.interwebs.test.",
+			searchpath: []string{
+				"testns.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+		{
+			// Domain conflicting with other namespace in second query - host pod
+			qname: "example.other.svc.interwebs.test.",
+			ip:    "10.16.0.1",
+			searchpath: []string{
+				"other.svc.interwebs.test.",
+				"svc.interwebs.test.",
+				"interwebs.test.",
+				"custom.",
+				"",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		writer := &testhelper.ResponseWriter{}
+		if test.ip != "" {
+			writer.RemoteIP = test.ip
+		}
+		zone := "interwebs.test."
+		if test.zone != "" {
+			zone = test.zone
+			k.Zones[0] = test.zone
+		}
+		state := request.Request{
+			Req:  &dns.Msg{Question: []dns.Question{{Name: test.qname, Qtype: dns.TypeA}}},
+			Zone: zone, // must match from k.Zones[0]
+			W:    writer,
+		}
+		searchpath := k.AutoPath(state)
+		if !slices.Equal(searchpath, test.searchpath) {
+			t.Errorf("Expected searchpath %v, but got %v", test.searchpath, searchpath)
+		}
+		if test.zone != "" {
+			k.Zones[0] = defaultZone
+		}
+	}
+}

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -42,11 +42,39 @@ type APIConnServiceTest struct{}
 func (APIConnServiceTest) HasSynced() bool                             { return true }
 func (APIConnServiceTest) Run()                                        {}
 func (APIConnServiceTest) Stop() error                                 { return nil }
-func (APIConnServiceTest) PodIndex(string) []*object.Pod               { return nil }
 func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service    { return nil }
 func (APIConnServiceTest) SvcExtIndexReverse(string) []*object.Service { return nil }
 func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints   { return nil }
 func (APIConnServiceTest) Modified(bool) int64                         { return 0 }
+
+func (APIConnServiceTest) PodIndex(ip string) []*object.Pod {
+	if ip == "10.240.0.1" { //Pod IP
+		return []*object.Pod{
+			{
+				Version:   "10245",
+				PodIP:     "10.240.0.1",
+				Name:      "test",
+				Namespace: "testns",
+			},
+		}
+	} else if ip == "10.16.0.1" { //Node IP
+		return []*object.Pod{
+			{
+				Version:   "12456",
+				PodIP:     "10.16.0.1",
+				Name:      "hostpod",
+				Namespace: "testns",
+			},
+			{
+				Version:   "13245",
+				PodIP:     "10.16.0.1",
+				Name:      "daemon",
+				Namespace: "other",
+			},
+		}
+	}
+	return nil
+}
 
 func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -10,8 +10,9 @@ import (
 
 // Metadata implements the metadata.Provider interface.
 func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) context.Context {
-	pod := k.podWithIP(state.IP())
-	if pod != nil {
+	pods := k.podsWithIP(state.IP())
+	if pods != nil {
+		pod := pods[0]
 		metadata.SetValueFunc(ctx, "kubernetes/client-namespace", func() string {
 			return pod.Namespace
 		})


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR fixes the issue that the autopath plugin isn't working for pods running in the host network.
The reason this is marked as a fix and not a feature is because the current behaviour is causing issues in combination with caching and has inconsistencies.

Currently the AutoPath function fetches the pods by request IP to check where the request is coming from. For pods running in the host network this would be the Node IP. So if you have multiple pods running in host networking it would return multiple pods but only the first one is being used. This means that autopath might work for a pod running on one node because it happens to be the first one in the list, but it doesn't work on another node. For normal pods in the same namespace the same DNS query would also work with autopath.

In itself this is not a big issue, but in combination with caching this can cause lookup failures because A records and AAAA records are cached differently and in our resolvers if one of them returns an answer and the other one doesn't then the whole query fails with NXDOMAIN and it doesn't try the rest of the search path.

This implementation takes all host network pods on the node, matches the query against them and takes the namespace from the pod that matches. Of course any pod could request a DNS name in any namespace, but I don't really see why that is an issue, since the client would have to actively try to break DNS lookup.

The only potential issue I see is if the first query is lost and the second query is matched by accident, it could result in a wrong "base".
Example: If there is a namespace called "other" and a pod in this namespace does a DNS request for "example.other", the first query would be "example.other.other.svc.cluster.local" and the second "example.other.svc.cluster.local". Now if the first query is lost, the second query would use "example" as a base and append the items from the search path, which could result on wrong DNS responses.
But this was already an issue before, this implementation just slightly increases the risk of this happening because it would also apply to other host network pods on the same node as the pod in the "other" namespace.

### 2. Which issues (if any) are related?

This would fix: https://github.com/coredns/coredns/issues/4299

### 3. Which documentation changes (if any) need to be made?

None that I found, currently it's undocumented that host network pods don't work with autopath as far as I can tell.
 
### 4. Does this introduce a backward incompatible change or deprecation?

No, unless clients rely on the inconsistent behaviour of autopath, which would be strange.
