### PR TITLE
fix: multiarch builds and multiple repos using buildx

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   docker-release:
@@ -21,14 +22,18 @@ jobs:
       RELEASE: ${{ github.event.inputs.release || github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v4
-      - name: Build Docker Images
-        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker release
-      - name: Show Docker Images
-        run: docker images
-      - name: Docker login
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: DockerHub login
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446  # v3.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Publish Docker Images
-        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker docker-push
+      - name: Docker login ghcr.io
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446  # v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Publish Docker Images
+        run: make VERSION=${RELEASE:1} -f Makefile.docker docker-build

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Install dependencies
         run: sudo apt-get install make curl
 
@@ -86,4 +89,4 @@ jobs:
         run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
 
       - name: Test Makefile.docker
-        run: make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker
+        run: make VERSION=x DOCKER=coredns -n DRY_RUN=1 release -f Makefile.docker

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -8,9 +8,8 @@
 #    Where VERSION is the version of the release.
 # 3. (to test as release /docker -t VERSION can be used.
 #
-# To release we run, these target from the this Makefile.docker ordered like:
+# To release we run one target from the this Makefile.docker ordered like:
 # * make release
-# * make docker-push
 #
 # Testing docker is done e.g. via:
 #
@@ -29,15 +28,34 @@ endif
 VERSION:=
 # DOCKER is the docker image repo we need to push to.
 DOCKER:=
-NAME:=coredns
 GITHUB:=https://github.com/coredns/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64
-DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~mips64le ~~g" | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
+LINUX_BASE_ARCH:=amd64 arm arm64 ppc64le s390x
+LINUX_RISV_ARCH:=riscv64
+LINUX_ARCH:=$(LINUX_RISV_ARCH) $(LINUX_BASE_ARCH)
+
+# docker platform args are formated on the cli like `--platform linux/arm,linux/amd64` etc
+space := $(subst ,, )
+comma := ,
+DOCKER_ARCH_PLATFORM := linux/$(subst $(space),$(comma)linux/,$(LINUX_BASE_ARCH))
+
+# path to find the built binaries
+DOCKER_BIN_ARCH_BASE:=build/docker/linux
+# image tag names to be pushed, this is done so we can build/tag all in one command
+DOCKER_IMAGE_NAMES:=ghcr.io/coredns/coredns,coredns/coredns
+DOCKER_IMAGE_NAMES_LIST:=$(subst $(comma),$(space),$(DOCKER_IMAGE_NAMES))
+DOCKER_IMAGE_OPTS:=$(foreach image,$(DOCKER_IMAGE_NAMES_LIST),-t $(image))
+DOCKER_IMAGE_W_VERSION_OPTS:=$(foreach image,$(DOCKER_IMAGE_NAMES_LIST),-t $(image):$(VERSION))
+# this is disabled so we can run in E2E tests
+DOCKER_BUILDX_EXTRA_ARGS:=--push
+RISCV_DOCKER_ID_FILE:=$(shell mktemp)
+ifeq ($(DRY_RUN),1)
+DOCKER_BUILDX_EXTRA_ARGS:=
+endif
+
 
 all:
-	@echo Use the 'release' target to download released binaries and build containers per arch, 'docker-push' to build and push a multi arch manifest.
+	@echo Use the 'release' target to download released binaries and build containers per arch, 'docker-build' to build and push a multi arch manifest.
 	echo $(DOCKER_IMAGE_LIST_VERSIONED)
 	echo $(DOCKER_IMAGE_LIST_LATEST)
 
@@ -48,8 +66,6 @@ image-download:
 ifeq ($(VERSION),)
 	$(error "Please specify a version use. Use VERSION=<version>")
 endif
-
-	@# 0. Check until all asset are alive, up to 10 min (asset may not be alive immediately after upload)
 	try_max=20; try_sleep=30; \
 	for arch in $(LINUX_ARCH); do \
 		asset=coredns_$(VERSION)_linux_$${arch}.tgz; \
@@ -64,54 +80,43 @@ endif
 			echo "$$asset is not live after $$try_max tries" ; exit 1; \
 		fi ; \
 	done
-	@rm -rf build/docker
-	@mkdir -p build/docker
-	@# 1. Copy appropriate coredns binary to build/docker/<arch>
-	@# 2. Copy Dockerfile into the correct dir as well.
-	@# 3. Unpack the tgz from github into 'coredns' binary.
+	@rm -rf $(DOCKER_BIN_ARCH_BASE)
+	@mkdir -p $(DOCKER_BIN_ARCH_BASE)
+	@# 1. Copy appropriate coredns binary to $(DOCKER_BIN_ARCH_BASE)/<arch>
+	@# 2. Unpack the tgz from github into 'coredns' binary.
 	for arch in $(LINUX_ARCH); do \
-		mkdir build/docker/$${arch}; \
-		curl -L $(GITHUB)/v$(VERSION)/coredns_$(VERSION)_linux_$${arch}.tgz > build/docker/$${arch}/coredns.tgz && \
-			( cd build/docker/$${arch}; tar xf coredns.tgz && rm coredns.tgz ); \
+		outpath=$${arch} ; \
+		[ "$${arch}" = "arm" ] && outpath="arm/v7" ; \
+		mkdir -p $(DOCKER_BIN_ARCH_BASE)/$${outpath}; \
+		curl -sL $(GITHUB)/v$(VERSION)/coredns_$(VERSION)_linux_$${arch}.tgz > $(DOCKER_BIN_ARCH_BASE)/$${outpath}/coredns.tgz && \
+			( cd $(DOCKER_BIN_ARCH_BASE)/$${outpath}; tar xf coredns.tgz && rm coredns.tgz ); \
 	done
+
 
 .PHONY: docker-build
 docker-build:
-ifeq ($(DOCKER),)
+ifeq ($(DOCKER_IMAGE_NAMES),)
 	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
 else
-	docker version
-	for arch in $(LINUX_ARCH); do \
-	    cp Dockerfile build/docker/$${arch} ; \
-	    DOCKER_ARGS=""; \
-	    if [ "$${arch}" = "riscv64" ]; then \
-	        DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=debian:unstable-slim --build-arg=BASE=ghcr.io/go-riscv/distroless/static-unstable:nonroot"; \
-	    fi; \
-	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) $${DOCKER_ARGS} build/docker/$${arch} ;\
-	done
-endif
+	@# Build risvc image, save the sha to a file so we can update the rest of our release with this image
+	docker buildx build \
+		--build-context=corednsbins=build \
+		--platform linux/$(LINUX_RISV_ARCH) \
+		--build-arg=DEBIAN_IMAGE=debian:unstable-slim \
+		--iidfile $(RISCV_DOCKER_ID_FILE) \
+		--build-arg=BASE=ghcr.io/go-riscv/distroless/static-unstable:nonroot \
+		$(DOCKER_BUILDX_EXTRA_ARGS) $(DOCKER_IMAGE_OPTS) .
+	@# Build and push all but riscv images
+	docker buildx build \
+		--build-context=corednsbins=build \
+		--platform $(DOCKER_ARCH_PLATFORM) \
+		$(DOCKER_BUILDX_EXTRA_ARGS) $(DOCKER_IMAGE_W_VERSION_OPTS) .
+	ls $(RISCV_DOCKER_ID_FILE)
+	@# Append the risvc image to the release if we have pushed images to a registry
+	if [ "$(DOCKER_BUILDX_EXTRA_ARGS)" != "$${DOCKER_BUILDX_EXTRA_ARGS%"--push"*}" ]; then \
+		docker buildx imagetools create \
+			--append $(firstword $(DOCKER_IMAGE_NAMES_LIST))@$$(cat ${RISCV_DOCKER_ID_FILE}) \
+			$(DOCKER_IMAGE_W_VERSION_OPTS); \
+	fi
 
-.PHONY: docker-push
-docker-push:
-ifeq ($(VERSION),)
-	$(error "Please specify a version use. Use VERSION=<version>")
-endif
-ifeq ($(DOCKER),)
-	$(error "Please specify Docker registry to use. Use DOCKER=coredns for releases")
-else
-	@# Pushes coredns/coredns-$arch:$version images
-	@# Creates manifest for multi-arch image
-	@# Pushes multi-arch image to coredns/coredns:$version
-	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
-	for arch in $(LINUX_ARCH); do \
-		docker push $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) ;\
-	done
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_LIST_VERSIONED)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_LIST_VERSIONED)
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
-	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
-	TOKEN=$$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\":\"$${DOCKER_LOGIN}\",\"password\":\"$${DOCKER_PASSWORD}\"}" "https://hub.docker.com/v2/users/login/" | jq -r .token) ; \
-	for arch in $(LINUX_ARCH); do \
-		curl -X DELETE -H "Authorization: JWT $${TOKEN}" "https://hub.docker.com/v2/repositories/$(DOCKER_IMAGE_NAME)/tags/$${arch}-$(VERSION)/" ;\
-	done
 endif


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This should help finally getting v1.11.3 images built and released. Once the setup of ghcr.io packages and fixing the docker hub token is resolved.

This PR fixes code and reliability issues of getting images built and pushed for multi-arch support. It also adds support for ghcr.io. However it *will not fix the token for the Docker Hub registry*. Additionally there's repo configuration steps required to get ghcr.io to work as well.

Refactors `Makefile.docker` to use buildx and to support multiple repos.

`docker buildx build` removes the need to push multiple tags, use `docker manifest create` and delete tags so that all arches appear on a single tag. This was not feasible to complete when adding ghcr.io hosted images.

Updates to Dockerfile to use TARGETPLATFORM to pickup the correct binary.

Updates to E2E tests for new target and test mode.

Example Images
- [ghcr.io images](https://github.com/grumps/coredns/pkgs/container/coredns)
- [hub.docker.com](https://hub.docker.com/repository/docker/grumps/coredns/general)

Example Job:
- [Docker release (action)](https://github.com/grumps/coredns/actions/runs/9851072955/job/27197308346)

### 2. Which issues (if any) are related?

ref: #6661

### 3. Which documentation changes (if any) need to be made?

Maybe update the image can now be pulled from ghcr.io once this is merged.

### 4. Does this introduce a backward incompatible change or deprecation?

No.

One can't simply merge this PR and resolve #6661.
1. An admin for coredns needs to get a new token form [hub.docker.com](https://hub.docker.com/) then add it to the coredns secrets. e.g. 
![2024-07-08_22-50](https://github.com/coredns/coredns/assets/1273422/c82e1691-7485-4a1b-afa5-8f245582529a)
2. Make sure that actions have read/write permissions
![write-workflow](https://github.com/coredns/coredns/assets/1273422/a4921858-3812-4576-af1c-93a9394b3848)
3. Allow actions to write to packages. This is the part L'm not 100% sure the exact steps here. I found that I had to manually push a container so that I could link it to the coredns fork on the `grumps` [packages page.](https://github.com/grumps?tab=packages). You will also need to make sure that it's public (the default to private). i expect this to cause the docker release action/job to fail a few times since this would be the coredns orgs first github package and I found the docs lacking how to do this the first time.
![2024-07-08_21-35](https://github.com/coredns/coredns/assets/1273422/71f43605-be53-422b-b789-74bd282111ff)

Also there's an test failing but it's been failing on master prior to my commit.