### PR TITLE
[bugfix]hosts: add hostsfile as label for coredns_hosts_entries

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -138,7 +138,7 @@ func (h *Hostsfile) readHosts() {
 	h.mtime = stat.ModTime()
 	h.size = stat.Size()
 
-	hostsEntries.WithLabelValues().Set(float64(h.inline.Len() + h.hmap.Len()))
+	hostsEntries.WithLabelValues(h.path).Set(float64(h.inline.Len() + h.hmap.Len()))
 	hostsReloadTime.Set(float64(stat.ModTime().UnixNano()) / 1e9)
 	h.Unlock()
 }

--- a/plugin/hosts/metrics.go
+++ b/plugin/hosts/metrics.go
@@ -14,7 +14,7 @@ var (
 		Subsystem: "hosts",
 		Name:      "entries",
 		Help:      "The combined number of entries in hosts and Corefile.",
-	}, []string{})
+	}, []string{"hostsfile"})
 	// hostsReloadTime is the timestamp of the last reload of hosts file.
 	hostsReloadTime = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
`hosts` plugin: https://coredns.io/plugins/hosts/
But metrics coredns_hosts_entries{} return only the last server block's count.


### 2. Which issues (if any) are related?
Fixes #6791

### 3. Which documentation changes (if any) need to be made?
https://github.com/coredns/coredns/blob/cb0e4e24e11491907b84284b0ec01fc197be21b0/plugin/hosts/README.md#L79-L80
- we may update doc here.

With this change, the metrics is like:
```
# TYPE coredns_hosts_entries gauge
coredns_hosts_entries{hostsfile="/etc/coredns/a.hosts"} 12
coredns_hosts_entries{hostsfile="/etc/hosts"} 10
```

### 4. Does this introduce a backward incompatible change or deprecation?
NA

This metrics was added in https://github.com/coredns/coredns/pull/3277. 