### PR TITLE
[UT] fix TestCorefile1 panic for nil handling

### DIFF
--- a/test/corefile_test.go
+++ b/test/corefile_test.go
@@ -16,5 +16,9 @@ func TestCorefile1(t *testing.T) {
 acl
 `
 	i, _, _, _ := CoreDNSServerAndPorts(corefile)
-	defer i.Stop()
+	defer func() {
+		if i != nil {
+			i.Stop()
+		}
+	}()
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This test failed in my other PR like https://github.com/coredns/coredns/actions/runs/10156554953/job/28085154891?pr=6800
```
--- FAIL: TestCorefile1 (0.00s)
    corefile_test.go:10: Expected no panic, but got runtime error: invalid memory address or nil pointer dereference
FAIL
coverage: 92.0% of statements
```

### 2. Which issues (if any) are related?

NA

### 3. Which documentation changes (if any) need to be made?
NA
### 4. Does this introduce a backward incompatible change or deprecation?
NA


https://github.com/coredns/coredns/blob/72a91d99aa7de2849a25400c467bd12a3de00d70/test/corefile_test.go#L9-L11

This only print the panic error message without the trace.

To print the trace, you can edit it like below
```
		if r := recover(); r != nil {
			//t.Fatalf("Expected no panic, but got %v", r)
	        panic(r)
		}
```

Then you can get the  trace below:
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestCorefile1$ github.com/coredns/coredns/test

--- FAIL: TestCorefile1 (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xdc41262]

goroutine 124 [running]:
testing.tRunner.func1.2({0xfb77960, 0x111bb700})
	/usr/local/go/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1635 +0x35e
panic({0xfb77960?, 0x111bb700?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
github.com/coredns/coredns/test.TestCorefile1.func1()
	/Users/pacoxu/git/gopath/src/github.com/coredns/coredns/test/corefile_test.go:11 +0x28
panic({0xfb77960?, 0x111bb700?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
github.com/coredns/caddy.(*Instance).Stop(0x0)
	/Users/pacoxu/go/pkg/mod/github.com/coredns/caddy@v1.1.1/caddy.go:138 +0x22
github.com/coredns/coredns/test.TestCorefile1.func2()
	/Users/pacoxu/git/gopath/src/github.com/coredns/coredns/test/corefile_test.go:21 +0x17
github.com/coredns/coredns/test.TestCorefile1(0xc000507040?)
	/Users/pacoxu/git/gopath/src/github.com/coredns/coredns/test/corefile_test.go:23 +0x65
testing.tRunner(0xc000507040, 0xfef3db0)
	/usr/local/go/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1743 +0x390
FAIL	github.com/coredns/coredns/test	1.392s
FAIL
```
