### PR TITLE
[Forward plugin] Improve load balancing in connection pool

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -66,11 +66,11 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 	if proto == "tcp-tls" {
 		conn, err := dns.DialTimeoutWithTLS("tcp", t.addr, t.tlsConfig, timeout)
 		t.updateDialTimeout(time.Since(reqTime))
-		return &persistConn{c: conn}, false, err
+		return &persistConn{c: conn, dialed: reqTime}, false, err
 	}
 	conn, err := dns.DialTimeout(proto, t.addr, timeout)
 	t.updateDialTimeout(time.Since(reqTime))
-	return &persistConn{c: conn}, false, err
+	return &persistConn{c: conn, dialed: reqTime}, false, err
 }
 
 // Connect selects an upstream, sends the request and waits for a response.

--- a/plugin/pkg/proxy/proxy.go
+++ b/plugin/pkg/proxy/proxy.go
@@ -49,8 +49,13 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 	p.health.SetTLSConfig(cfg)
 }
 
-// SetExpire sets the expire duration in the lower p.transport.
-func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
+// SetIdleTimeout sets the connection idle timeout in the lower p.transport.
+func (p *Proxy) SetIdleTimeout(idleTimeout time.Duration) { p.transport.SetIdleTimeout(idleTimeout) }
+
+// SetMaxConnectionAge sets the connection max age in the lower p.transport.
+func (p *Proxy) SetMaxConnectionAge(maxConnectionAge time.Duration) {
+	p.transport.SetMaxConnectionAge(maxConnectionAge)
+}
 
 func (p *Proxy) GetHealthchecker() HealthChecker {
 	return p.health


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

More details are available in the issue. In a nutshell, when multiple servers back a single destination endpoint (through a Kubernetes clusterIP, for example) in the forward plugin, the traffic is very unbalanced. The connection pool favors slow servers when returning cached connections.

This PR proposes the following changes:
- Change from LIFO to FIFO behavior when returning a cached connection from the pool.
- Add two explicit parameters: `idle_timeout` and `max_connection_age`. `expire` is deprecated in favor of `idle_timeout`, hence, `idle_timeout` takes precedence if both are defined but `expire` can still be used. For backward compatibility, `max_connection_age` defaults to infinite if not defined.

This PR is only meant as a suggestion to gather feedback.

### 2. Which issues (if any) are related?

This PR is a suggestion for this [issue](https://github.com/coredns/coredns/issues/6803).

### 3. Which documentation changes (if any) need to be made?

Document the new parameters `idle_timeout` and `max_connection_age` and the "deprecation" of `expire`

### 4. Does this introduce a backward incompatible change or deprecation?

This PR doesn't introduce a breaking change because an existing configuration would still work after applying this change.