### PR TITLE
docs: fix "GitHub" capitalization

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -24,7 +24,7 @@ The initial Product Security Team will consist of the set of maintainers that vo
 ### Private Disclosure Processes
 
 If you find a security vulnerability or any security related issues,
-please DO NOT file a public issue. Do not create a Github issue.
+please DO NOT file a public issue. Do not create a GitHub issue.
 Instead, send your report privately to security@coredns.io.
 Security reports are greatly appreciated and we will publicly thank you for it.
 
@@ -94,7 +94,7 @@ so that a realistic timeline can be communicated to users.
 
 **Disclosure of Forthcoming Fix to Users** (Completed within 1-7 days of Disclosure)
 
-- The Fix Lead will create a github issue in CoreDNS project to inform users that a security vulnerability
+- The Fix Lead will create a GitHub issue in CoreDNS project to inform users that a security vulnerability
 has been disclosed and that a fix will be made available, with an estimation of the Release Date.
 It will include any mitigating steps users can take until a fix is available.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,7 +36,7 @@ maintainers.
 
 Every Maintainer is listed in the
 [CODEOWNERS](https://github.com/coredns/coredns/blob/master/CODEOWNERS)
-file, with their Github handle.
+file, with their GitHub handle.
 
 A Maintainer should be a member of `maintainers@coredns.io`, although this is not a hard requirement.
 
@@ -107,7 +107,7 @@ The decision-making process should be transparent to adhere to the CoreDNS Code 
 All proposals, ideas, and decisions by maintainers or the steering committee
 should either be part of a GitHub issue or PR, or be sent to `maintainers@coredns.io`.
 
-## Github Project Administration
+## GitHub Project Administration
 
 The __coredns__ GitHub project maintainers team reflects the list of Maintainers.
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -68,7 +68,7 @@ endif
 	@mkdir -p build/docker
 	@# 1. Copy appropriate coredns binary to build/docker/<arch>
 	@# 2. Copy Dockerfile into the correct dir as well.
-	@# 3. Unpack the tgz from github into 'coredns' binary.
+	@# 3. Unpack the tgz from GitHub into 'coredns' binary.
 	for arch in $(LINUX_ARCH); do \
 		mkdir build/docker/$${arch}; \
 		curl -L $(GITHUB)/v$(VERSION)/coredns_$(VERSION)_linux_$${arch}.tgz > build/docker/$${arch}/coredns.tgz && \

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ When no transport protocol is specified the default `dns://` is assumed.
 
 ## Community
 
-We're most active on Github (and Slack):
+We're most active on GitHub (and Slack):
 
-- Github: <https://github.com/coredns/coredns>
+- GitHub: <https://github.com/coredns/coredns>
 - Slack: #coredns on <https://slack.cncf.io>
 
 More resources can be found:

--- a/man/coredns-dnstap.7
+++ b/man/coredns-dnstap.7
@@ -71,7 +71,7 @@ dnstap tcp://127.0.0.1:6000 full
 .SH "COMMAND LINE TOOL"
 .PP
 Dnstap has a command line tool that can be used to inspect the logging. The tool can be found
-at Github: https://github.com/dnstap/golang-dnstap
+at GitHub: https://github.com/dnstap/golang-dnstap
 \[la]https://github.com/dnstap/golang-dnstap\[ra]. It's written in Go.
 
 .PP

--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -95,7 +95,7 @@ dnstap tcp://example.com:6000
 ## Command Line Tool
 
 Dnstap has a command line tool that can be used to inspect the logging. The tool can be found
-at Github: <https://github.com/dnstap/golang-dnstap>. It's written in Go.
+at GitHub: <https://github.com/dnstap/golang-dnstap>. It's written in Go.
 
 The following command listens on the given socket and decodes messages to stdout.
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Hello, this is just a small issue but the spelling of the word "Github" is not canonical. This PR replaces the "Github" and "github" with the correct "GitHub".

### 2. Which issues (if any) are related?
N/A (I skipped creating an extra issue as this is not related to the core feature but just a small docs-related change)

### 3. Which documentation changes (if any) need to be made?
No additional fix is required as no feature changed.

### 4. Does this introduce a backward incompatible change or deprecation?
No.