### PR TITLE
Add configuration knob for max queries per connection

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -54,10 +54,11 @@ type Config struct {
 	// TLSConfig when listening for encrypted connections (gRPC, DNS-over-TLS).
 	TLSConfig *tls.Config
 
-	// Timeouts for TCP, TLS and HTTPS servers.
-	ReadTimeout  time.Duration
-	WriteTimeout time.Duration
-	IdleTimeout  time.Duration
+	// Timeouts and limits for TCP, TLS and HTTPS servers.
+	ReadTimeout          time.Duration
+	WriteTimeout         time.Duration
+	IdleTimeout          time.Duration
+	MaxConnectionQueries int // Max number of queries allowed per connection before it gets reset. Default is 0, meaning no limit.
 
 	// TSIG secrets, [name]key.
 	TsigSecret map[string]string

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -44,6 +44,11 @@ var _ caddy.GracefulServer = &Server{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerTLS) Serve(l net.Listener) error {
+	maxConnectionQueries := defaultMaxConnectionQueries
+	if s.maxConnectionQueries > 0 {
+		maxConnectionQueries = s.maxConnectionQueries
+	}
+
 	s.m.Lock()
 
 	if s.tlsConfig != nil {
@@ -53,7 +58,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 	// Only fill out the TCP server for this one.
 	s.server[tcp] = &dns.Server{Listener: l,
 		Net:           "tcp-tls",
-		MaxTCPQueries: tlsMaxQueries,
+		MaxTCPQueries: maxConnectionQueries,
 		ReadTimeout:   s.readTimeout,
 		WriteTimeout:  s.writeTimeout,
 		IdleTimeout: func() time.Duration {
@@ -97,7 +102,3 @@ func (s *ServerTLS) OnStartupComplete() {
 		fmt.Print(out)
 	}
 }
-
-const (
-	tlsMaxQueries = -1
-)

--- a/plugin/timeouts/README.md
+++ b/plugin/timeouts/README.md
@@ -14,8 +14,11 @@ Additionally some routers hold open connections when using DNS over TLS or DNS
 over HTTPS. Allowing a longer idle timeout helps performance and reduces issues
 with such routers.
 
+Some clients may never reset their connections to CoreDNS. Capping the number of
+queries on a connection can provide better load balancing across CoreDNS servers.
+
 The *timeouts* "plugin" allows you to configure CoreDNS server read, write and
-idle timeouts.
+idle timeouts, alongside a queries cap per connection, after which it gets reset.
 
 ## Syntax
 
@@ -24,12 +27,13 @@ timeouts {
 	read DURATION
 	write DURATION
 	idle DURATION
+	max_queries INTEGER
 }
 ~~~
 
-For any timeouts that are not provided, default values are used which may vary
-depending on the server type. At least one timeout must be specified otherwise
-the entire timeouts block should be omitted.
+For any timeouts or limits that are not provided, default values are used which
+may vary depending on the server type. At least one timeout or limit must be specified
+otherwise the entire timeouts block should be omitted.
 
 ## Examples
 
@@ -64,12 +68,14 @@ https://. {
 ~~~
 
 Start a standard TCP/UDP server on port 1053. A read and write timeout has been
-configured. The timeouts are only applied to the TCP side of the server.
+configured, as well as a maximum number of queries per connection. The timeouts
+and cap are only applied to the TCP side of the server.
 ~~~
 .:1053 {
 	timeouts {
 		read 15s
-                write 30s
+		write 30s
+		max_queries 200
 	}
 	forward . /etc/resolv.conf
 }

--- a/plugin/timeouts/timeouts.go
+++ b/plugin/timeouts/timeouts.go
@@ -1,6 +1,7 @@
 package timeouts
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/coredns/caddy"
@@ -30,30 +31,43 @@ func parseTimeouts(c *caddy.Controller) error {
 
 		b := 0
 		for c.NextBlock() {
-			block := c.Val()
-			timeoutArgs := c.RemainingArgs()
-			if len(timeoutArgs) != 1 {
-				return c.ArgErr()
-			}
-
-			timeout, err := durations.NewDurationFromArg(timeoutArgs[0])
-			if err != nil {
-				return c.Err(err.Error())
-			}
-
-			if timeout < (1*time.Second) || timeout > (24*time.Hour) {
-				return c.Errf("timeout provided '%s' needs to be between 1 second and 24 hours", timeout)
-			}
-
-			switch block {
+			switch block := c.Val(); block {
 			case "read":
+				timeout, err := parseTimeout(c)
+				if err != nil {
+					return err
+				}
 				config.ReadTimeout = timeout
 
 			case "write":
+				timeout, err := parseTimeout(c)
+				if err != nil {
+					return err
+				}
 				config.WriteTimeout = timeout
 
 			case "idle":
+				timeout, err := parseTimeout(c)
+				if err != nil {
+					return err
+				}
 				config.IdleTimeout = timeout
+
+			case "max_queries":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return c.ArgErr()
+				}
+
+				maxQueries, err := strconv.Atoi(args[0])
+				if err != nil {
+					return c.Err(err.Error())
+				}
+
+				if maxQueries < 0 {
+					return c.Err("max_queries must be a positive integer")
+				}
+				config.MaxConnectionQueries = maxQueries
 
 			default:
 				return c.Errf("unknown option: '%s'", block)
@@ -62,8 +76,26 @@ func parseTimeouts(c *caddy.Controller) error {
 		}
 
 		if b == 0 {
-			return plugin.Error("timeouts", c.Err("timeouts block with no timeouts specified"))
+			return plugin.Error("timeouts", c.Err("timeouts block with no timeouts or limits specified"))
 		}
 	}
 	return nil
+}
+
+func parseTimeout(c *caddy.Controller) (time.Duration, error) {
+	timeoutArgs := c.RemainingArgs()
+	if len(timeoutArgs) != 1 {
+		return 0, c.ArgErr()
+	}
+
+	timeout, err := durations.NewDurationFromArg(timeoutArgs[0])
+	if err != nil {
+		return 0, c.Err(err.Error())
+	}
+
+	if timeout < (1*time.Second) || timeout > (24*time.Hour) {
+		return 0, c.Errf("timeout provided '%s' needs to be between 1 second and 24 hours", timeout)
+	}
+
+	return timeout, nil
 }

--- a/plugin/timeouts/timeouts_test.go
+++ b/plugin/timeouts/timeouts_test.go
@@ -30,10 +30,16 @@ func TestTimeouts(t *testing.T) {
 			write 20
 			idle 60
 		}`, false, "", ""},
-		// negative
-		{`timeouts`, true, "", "block with no timeouts specified"},
 		{`timeouts {
-		}`, true, "", "block with no timeouts specified"},
+			read 10
+			write 20
+			idle 60
+			max_queries 100
+		}`, false, "", ""},
+		// negative
+		{`timeouts`, true, "", "block with no timeouts or limits specified"},
+		{`timeouts {
+		}`, true, "", "block with no timeouts or limits specified"},
 		{`timeouts {
 			read 10s
 			giraffe 30s
@@ -51,6 +57,9 @@ func TestTimeouts(t *testing.T) {
 		{`timeouts {
 			read 48h
 		}`, true, "", "needs to be between"},
+		{`timeouts {
+			max_queries -3
+		}`, true, "", "max_queries must be a positive integer"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Coredns underlying DNS library exposes a `MaxTCPQueries` parameter that controls how many queries can be sent on a given connection and defaults to 128 if unset. This previous change to coredns changed the default to `-1` (unlimited). This PR is an attempt at making this value configurable.

This new parameter is added in the `timeouts` plugin because it is the closest plugin I could think of but I might be wrong.

### 2. Which issues (if any) are related?

This is related to the regression mentioned in this issue https://github.com/coredns/coredns/issues/6803

### 3. Which documentation changes (if any) need to be made?

The documentation of the `timeouts` plugin needs to be changed to add the new parameter.

### 4. Does this introduce a backward incompatible change or deprecation?

It doesn't since the new parameter still defaults to "unlimited".