### PR TITLE
Upgrade antonmedv/expr to expr-lang/expr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ initWorkingDir: &initWorkingDir
 
 integrationDefaults: &integrationDefaults
   machine:
-    image: ubuntu-2004:2022.04.2
+    image: default
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
     - K8S_VERSION: v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.13
-	github.com/antonmedv/expr v1.15.5
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.54.11
 	github.com/coredns/caddy v1.1.1
 	github.com/dnstap/golang-dnstap v0.4.0
+	github.com/expr-lang/expr v1.16.9
 	github.com/farsightsec/golang-framestream v0.3.0
 	github.com/go-logr/logr v1.4.1
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
+github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
 github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/man/coredns-view.7
+++ b/man/coredns-view.7
@@ -120,8 +120,8 @@ Note that the regex pattern is enclosed in single quotes, and backslashes are es
 
 .SH "EXPRESSIONS"
 .PP
-To evaluate expressions, \fIview\fP uses the antonmedv/expr package (https://github.com/antonmedv/expr
-\[la]https://github.com/antonmedv/expr\[ra]).
+To evaluate expressions, \fIview\fP uses the expr-lang/expr package (https://github.com/expr-lang/expr
+\[la]https://github.com/expr-lang/expr\[ra]).
 For example, an expression could look like:
 \fB\fC(type() == 'A' && name() == 'example.com') || client_ip() == '1.2.3.4'\fR.
 
@@ -129,8 +129,8 @@ For example, an expression could look like:
 All expressions should be written to evaluate to a boolean value.
 
 .PP
-See https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md
-\[la]https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md\[ra] as a detailed reference for valid syntax.
+See https://github.com/expr-lang/expr/blob/master/docs/Language-Definition.md
+\[la]https://github.com/expr-lang/expr/blob/master/docs/Language-Definition.md\[ra] as a detailed reference for valid syntax.
 
 .SS "AVAILABLE EXPRESSION FUNCTIONS"
 .PP

--- a/plugin/view/README.md
+++ b/plugin/view/README.md
@@ -93,13 +93,13 @@ Note that the regex pattern is enclosed in single quotes, and backslashes are es
 
 ## Expressions
 
-To evaluate expressions, *view* uses the antonmedv/expr package ( https://github.com/antonmedv/expr ).
+To evaluate expressions, *view* uses the expr-lang/expr package ( https://github.com/expr-lang/expr ).
 For example, an expression could look like:
 `(type() == 'A' && name() == 'example.com.') || client_ip() == '1.2.3.4'`.
 
 All expressions should be written to evaluate to a boolean value.
 
-See https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md as a detailed reference for valid syntax.
+See https://github.com/expr-lang/expr/blob/master/docs/Language-Definition.md as a detailed reference for valid syntax.
 
 ### Available Expression Functions
 

--- a/plugin/view/setup.go
+++ b/plugin/view/setup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/expression"
 
-	"github.com/antonmedv/expr"
+	"github.com/expr-lang/expr"
 )
 
 func init() { plugin.Register("view", setup) }

--- a/plugin/view/view.go
+++ b/plugin/view/view.go
@@ -7,8 +7,8 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/expression"
 	"github.com/coredns/coredns/request"
 
-	"github.com/antonmedv/expr"
-	"github.com/antonmedv/expr/vm"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
 	"github.com/miekg/dns"
 )
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The expr project has moved.  This also upgrades from 1.15.5 to 1.16.9. The expr project lacks a changelog but tests pass and the changes don't seem to change it much - but there were a lot of changes.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

It shouldn't.