### PR TITLE
Update grpc library use

### DIFF
--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -37,7 +37,7 @@ func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.Dial(p.addr, p.dialOpts...)
+	conn, err := grpc.NewClient(p.addr, p.dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/pb"
 
@@ -23,9 +22,7 @@ func TestGrpc(t *testing.T) {
 	}
 	defer g.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, tcp, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	conn, err := grpc.NewClient(tcp, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Replace deprecated grpc Dial/DialContext with grpc.NewClient.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
