### PR TITLE
Fixup grpc test

### DIFF
--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -22,7 +22,7 @@ func TestGrpc(t *testing.T) {
 	}
 	defer g.Stop()
 
-	conn, err := grpc.NewClient(tcp, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	conn, err := grpc.NewClient(tcp, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Remove deprecated `grpc.WithBlock()`. This option is a noop with `grpc.NewClient()`.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
