### PR TITLE
Multi sub support

### DIFF
--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -56,7 +56,7 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 	var zoneName string
 
 	for c.Next() {
-        resourceGroupMapping := map[string][]string{}
+		resourceGroupMapping := map[string][]string{}
 		args := c.RemainingArgs()
 
 		for i := 0; i < len(args); i++ {
@@ -122,9 +122,9 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 				return env, resourceGroupMapping, accessMap, fall, c.Errf("unknown property: %q", c.Val())
 			}
 		}
-        for k,v := range resourceGroupMapping {
-            subResourceGroupMapping[env.Values[auth.SubscriptionID]+"/"+k] = v
-        }
+		for k, v := range resourceGroupMapping {
+			subResourceGroupMapping[env.Values[auth.SubscriptionID]+"/"+k] = v
+		}
 	}
 
 	env.Values[auth.Resource] = azureEnv.ResourceManagerEndpoint


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

In current form, the Azure plugin will parse subscriptions across many zones and apply the last zone's subscription ID to all plugin definitions. When used across multiple subscriptions with distinct resource group names (which most subscriptions in a large tenant will have), this causes 404s when interacting with the Azure API. DNS Clients must be created within the context of a subscription; this PR moves to a client per zone.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

None - this corrects behavior to match expectations / existing documentation.

### 4. Does this introduce a backward incompatible change or deprecation?

I don't believe so - multi-subscription support appears to be non-existent as is.
