### PR TITLE
Replace k8s.io/utils/strings/slices by Go stdlib slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 )
 
 require (
@@ -138,6 +137,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -4,13 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/log"
-
-	"k8s.io/utils/strings/slices"
 )
 
 func setup(c *caddy.Controller) error {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use the functionality provided by the Go standard library `slices` package since Go 1.21 instead of the deprecated functions in the `k8s.io/utils/strings/slices` package.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No