### PR TITLE
fuzzing: fix broken oss-fuzz build

### DIFF
--- a/plugin/forward/fuzz.go
+++ b/plugin/forward/fuzz.go
@@ -17,8 +17,8 @@ var f *Forward
 func init() {
 	f = New()
 	s := dnstest.NewServer(r{}.reflectHandler)
-	f.SetProxy(proxy.NewProxy(s.Addr, "tcp"))
-	f.SetProxy(proxy.NewProxy(s.Addr, "udp"))
+	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin1", s.Addr, "tcp"))
+	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin2", s.Addr, "udp"))
 }
 
 // Fuzz fuzzes forward.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Currently, the OSS-Fuzz build is broken because a fuzzer has a bug. This PR fixes that bug and allows OSS-Fuzz to build all the fuzzers.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
