### PR TITLE
plugin/cache: Add option to handle 0 ttl, when responding from cache

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -142,3 +142,13 @@ example.org {
     }
 }
 ~~~
+
+Enable zerottl for `example.org`, set 30seconds when the cache is served from the stale record:
+
+~~~ corefile
+example.org {
+    cache {
+        zerottl 30s
+    }
+}
+~~~

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -51,6 +51,10 @@ type Cache struct {
 	// Keep ttl option
 	keepttl bool
 
+        // Zero ttl option
+        zerottl time.Duration
+        zerottlflag bool
+
 	// Testing.
 	now func() time.Time
 }
@@ -73,6 +77,8 @@ func New() *Cache {
 		duration:   1 * time.Minute,
 		percentage: 10,
 		now:        time.Now,
+                zerottl:    minNTTL,
+                zerottlflag: false,
 	}
 }
 

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -77,7 +77,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		// one so that we always get the original TTL
 		now = i.stored
 	}
-	resp := i.toMsg(r, now, do, ad)
+        resp := i.toMsg(r, now, do, ad, c.zerottlflag, c.zerottl.Seconds())
 	w.WriteMsg(resp)
 	return dns.RcodeSuccess, nil
 }

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -65,7 +65,7 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 // So we're forced to always set this to 1; regardless if the answer came from the cache or not.
 // On newer systems(e.g. ubuntu 16.04 with glib version 2.23), this issue is resolved.
 // So we may set this bit back to 0 in the future ?
-func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool) *dns.Msg {
+func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool, zeroflag bool, zerottl float64) *dns.Msg {
 	m1 := new(dns.Msg)
 	m1.SetReply(m)
 
@@ -87,6 +87,12 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool) *dns.Msg {
 	m1.Extra = make([]dns.RR, len(i.Extra))
 
 	ttl := uint32(i.ttl(now))
+        // Zerottl handling, when flag is set and ttl is zero.
+        // Update the ttl with the defined value.
+        if zeroflag && ttl <= 0 {
+                ttl = uint32(zerottl)
+        }
+
 	m1.Answer = filterRRSlice(i.Answer, ttl, true)
 	m1.Ns = filterRRSlice(i.Ns, ttl, true)
 	m1.Extra = filterRRSlice(i.Extra, ttl, true)

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -211,6 +211,20 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 					return nil, errors.New("caching SERVFAIL responses over 5 minutes is not permitted")
 				}
 				ca.failttl = d
+			case "zerottl":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				d, err := time.ParseDuration(args[0])
+				if err != nil {
+					return nil, err
+				}
+				if d < 0 {
+					return nil, errors.New("invalid negative ttl for zerottl")
+				}
+				ca.zerottl = d
+				ca.zerottlflag = true
 			case "disable":
 				// disable [success|denial] [zones]...
 				args := c.RemainingArgs()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

We need to avoid having 0ttl in the DNS responses. because some legacy devices/PC uses this 0 ttl as infinite wait. 

When serving from the cache, There is a background cache update taking place which would need some buffer time to complete. So by setting non 0 ttl value we can avoid more requests during this update transition. 

### 2. Which issues (if any) are related?

Not related to any issue. 

### 3. Which documentation changes (if any) need to be made?

plugin/cache readme has been updated for this. 

### 4. Does this introduce a backward incompatible change or deprecation?

Without the new option the functionality remains the same. So no backward compatibility issues. 