### PR TITLE
Update README.md to up golang version to 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ setup a Go environment, you could build CoreDNS easily:
 ```
 docker run --rm -i -t \
     -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns \
-        golang:1.21 sh -c 'GOFLAGS="-buildvcs=false" make gen && GOFLAGS="-buildvcs=false" make'
+        golang:1.22 sh -c 'GOFLAGS="-buildvcs=false" make gen && GOFLAGS="-buildvcs=false" make'
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
1.21 no longer supported. go.mod requires `1.22`

Per https://github.com/coredns/coredns/blob/f4f0d55dcec3b0b555a603348013177c46c063d2/go.mod#L3C2-L3C10



```
❯ docker run --rm -i -t \
    -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns \
        golang:1.21 sh -c 'GOFLAGS="-buildvcs=false" make gen && GOFLAGS="-buildvcs=false" make'
Unable to find image 'golang:1.21' locally
1.21: Pulling from library/golang
7b24851aa36d: Already exists
1593650c7572: Already exists
275677961327: Already exists
22ed394a57fd: Already exists
2a6022646f09: Already exists
33391554cd4c: Already exists
4f4fb700ef54: Already exists
Digest: sha256:4746d26432a9117a5f58e95cb9f954ddf0de128e9d5816886514199316e4a2fb
Status: Downloaded newer image for golang:1.21
go generate coredns.go
go: go.mod requires go >= 1.22.0 (running go 1.21.13; GOTOOLCHAIN=go1.21.13)
make: *** [Makefile:31: gen] Error 1
```

### 2. Which issues (if any) are related?

Related to #6836 

### 3. Which documentation changes (if any) need to be made?

README.md

### 4. Does this introduce a backward incompatible change or deprecation?

I don't think so