### PR TITLE
fix: fix slice init length

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -43,7 +43,7 @@ type Azure struct {
 // New validates the input DNS zones and initializes the Azure struct.
 func New(ctx context.Context, publicClient publicdns.RecordSetsClient, privateClient privatedns.RecordSetsClient, keys map[string][]string, accessMap map[string]string) (*Azure, error) {
 	zones := make(map[string][]*zone, len(keys))
-	names := make([]string, len(keys))
+	names := make([]string, 0, len(keys))
 	var private bool
 
 	for resourceGroup, znames := range keys {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The intention here should be to initialize a slice with a capacity of len(keys) rather than initializing the length of this slice.



### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
