### PR TITLE
fix: order kubernetes plugin before cache plugin

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -45,7 +45,6 @@ any:any
 chaos:chaos
 loadbalance:loadbalance
 tsig:tsig
-cache:cache
 rewrite:rewrite
 header:header
 dnssec:dnssec
@@ -61,8 +60,9 @@ k8s_external:k8s_external
 kubernetes:kubernetes
 file:file
 auto:auto
-secondary:secondary
 etcd:etcd
+cache:cache
+secondary:secondary
 loop:loop
 forward:forward
 grpc:grpc


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
I'm new to this project, and this change has not been tested yet, but it is intended to address issues I've seen in kubernetes which seem involve caching of the zone which kubernetes is authoritative for.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/6937

I have observed delays ~30 seconds to resolve names for slow starting pods (taking more than 30 seconds for IP assignment), also sometimes the old address initially being returned for ~30 seconds with fast starting pods, and an occasional unexpected response (such as NXDOMAIN following NOERROR) around the time resolution seems to start working.

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
Not sure.