### PR TITLE
Dockerfile: Switch to debian 12 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_IMAGE=debian:stable-slim
-ARG BASE=gcr.io/distroless/static-debian11:nonroot
+ARG BASE=gcr.io/distroless/static-debian12:nonroot
 FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
 SHELL [ "/bin/sh", "-ec" ]
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
debian 11 is EOL https://endoflife.date/debian

### 2. Which issues (if any) are related?
would be good to consider this for the next release @chrisohaver https://github.com/coredns/coredns/pull/6967
### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
