### PR TITLE
Do not interrupt querying readiness probes for plugins

### DIFF
--- a/plugin/ready/README.md
+++ b/plugin/ready/README.md
@@ -19,7 +19,7 @@ their readiness reported as the union of their respective readinesses.
 
 ~~~
 ready [ADDRESS] {
-    monitor [until-ready | continuously]
+    monitor until-ready|continuously
 }
 ~~~
 

--- a/plugin/ready/README.md
+++ b/plugin/ready/README.md
@@ -8,8 +8,7 @@
 
 By enabling *ready* an HTTP endpoint on port 8181 will return 200 OK, when all plugins that are able
 to signal readiness have done so. If some are not ready yet the endpoint will return a 503 with the
-body containing the list of plugins that are not ready. Once a plugin has signaled it is ready it
-will not be queried again.
+body containing the list of plugins that are not ready.
 
 Each Server Block that enables the *ready* plugin will have the plugins *in that server block*
 report readiness into the /ready endpoint that runs on the same port. This also means that the

--- a/plugin/ready/README.md
+++ b/plugin/ready/README.md
@@ -18,12 +18,19 @@ their readiness reported as the union of their respective readinesses.
 ## Syntax
 
 ~~~
-ready [ADDRESS]
+ready [ADDRESS] {
+    monitor [until-ready | continuously]
+}
 ~~~
 
 *ready* optionally takes an address; the default is `:8181`. The path is fixed to `/ready`. The
 readiness endpoint returns a 200 response code and the word "OK" when this server is ready. It
 returns a 503 otherwise *and* the list of plugins that are not ready.
+
+The *ready* directive can include an optional `monitor` parameter, defaulting to `until-ready`. The following values are supported:
+
+* `until-ready` - once a plugin signals it is ready, it will not be checked again. This mode assumes stability after the initial readiness confirmation.
+* `continuously` - in this mode, plugins are continuously monitored for readiness. This means a plugin may transition between ready and not ready states, providing real-time status updates.
 
 ## Plugins
 

--- a/plugin/ready/README.md
+++ b/plugin/ready/README.md
@@ -25,7 +25,8 @@ ready [ADDRESS] {
 
 *ready* optionally takes an address; the default is `:8181`. The path is fixed to `/ready`. The
 readiness endpoint returns a 200 response code and the word "OK" when this server is ready. It
-returns a 503 otherwise *and* the list of plugins that are not ready.
+returns a 503 otherwise *and* the list of plugins that are not ready. 
+By default, once a plugin has signaled it is ready it will not be queried again.
 
 The *ready* directive can include an optional `monitor` parameter, defaulting to `until-ready`. The following values are supported:
 

--- a/plugin/ready/list.go
+++ b/plugin/ready/list.go
@@ -11,6 +11,12 @@ type list struct {
 	sync.RWMutex
 	rs    []Readiness
 	names []string
+
+	// keepReadiness indicates whether the readiness status of plugins should be retained
+	// after they have been confirmed as ready. When set to false, the plugin readiness
+	// status will be reset to nil to conserve resources, assuming ready plugins don't
+	// need continuous monitoring.
+	keepReadiness bool
 }
 
 // Reset resets l
@@ -41,6 +47,9 @@ func (l *list) Ready() (bool, string) {
 			continue
 		}
 		if r.Ready() {
+			if !l.keepReadiness {
+				l.rs[i] = nil
+			}
 			continue
 		}
 		ok = false

--- a/plugin/ready/list.go
+++ b/plugin/ready/list.go
@@ -40,13 +40,11 @@ func (l *list) Ready() (bool, string) {
 		if r == nil {
 			continue
 		}
-		if !r.Ready() {
-			ok = false
-			s = append(s, l.names[i])
-		} else {
-			// if ok, this plugin is ready and will not be queried anymore.
-			l.rs[i] = nil
+		if r.Ready() {
+			continue
 		}
+		ok = false
+		s = append(s, l.names[i])
 	}
 	if ok {
 		return true, ""

--- a/plugin/ready/ready.go
+++ b/plugin/ready/ready.go
@@ -50,15 +50,15 @@ func (rd *ready) onStartup() error {
 			io.WriteString(w, "Shutting down")
 			return
 		}
-		ok, todo := plugins.Ready()
-		if ok {
+		ready, notReadyPlugins := plugins.Ready()
+		if ready {
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, http.StatusText(http.StatusOK))
 			return
 		}
-		log.Infof("Still waiting on: %q", todo)
+		log.Infof("Plugins not ready: %q", notReadyPlugins)
 		w.WriteHeader(http.StatusServiceUnavailable)
-		io.WriteString(w, todo)
+		io.WriteString(w, notReadyPlugins)
 	})
 
 	go func() { http.Serve(rd.ln, rd.mux) }()

--- a/plugin/ready/setup_test.go
+++ b/plugin/ready/setup_test.go
@@ -8,18 +8,82 @@ import (
 
 func TestSetupReady(t *testing.T) {
 	tests := []struct {
-		input     string
+		input string
+
+		expectedAddr        string
+		expectedMonitorType monitorType
+
 		shouldErr bool
 	}{
-		{`ready`, false},
-		{`ready localhost:1234`, false},
-		{`ready localhost:1234 b`, true},
-		{`ready bla`, true},
-		{`ready bla bla`, true},
+		{
+			input:               `ready`,
+			expectedAddr:        ":8181",
+			expectedMonitorType: monitorTypeUntilReady,
+			shouldErr:           false,
+		},
+		{
+			input:               `ready localhost:1234`,
+			expectedAddr:        "localhost:1234",
+			expectedMonitorType: monitorTypeUntilReady,
+			shouldErr:           false,
+		},
+		{
+			input: `
+ready { 
+	monitor until-ready
+}`,
+			expectedAddr:        ":8181",
+			expectedMonitorType: monitorTypeUntilReady,
+			shouldErr:           false,
+		},
+		{
+			input: `
+ready { 
+	monitor continuously 
+}`,
+			expectedAddr:        ":8181",
+			expectedMonitorType: monitorTypeContinuously,
+			shouldErr:           false,
+		},
+		{
+			input: `
+ready localhost:1234 { 
+	monitor continuously 
+}`,
+			expectedAddr:        "localhost:1234",
+			expectedMonitorType: monitorTypeContinuously,
+			shouldErr:           false,
+		},
+		{
+			input: `
+ready localhost:1234 { 
+	monitor 404 
+}`,
+			shouldErr: true,
+		},
+		{
+			input:     `ready localhost:1234 b`,
+			shouldErr: true,
+		},
+		{
+			input:     `ready bla`,
+			shouldErr: true,
+		},
+		{
+			input:     `ready bla bla`,
+			shouldErr: true,
+		},
 	}
 
 	for i, test := range tests {
-		_, err := parse(caddy.NewTestController("dns", test.input))
+		actualAddress, actualMonitorType, err := parse(caddy.NewTestController("dns", test.input))
+
+		if actualAddress != test.expectedAddr {
+			t.Errorf("Test %d: Expected address %s but found %s for input %s", i, test.expectedAddr, actualAddress, test.input)
+		}
+		if actualMonitorType != test.expectedMonitorType {
+			t.Errorf("Test %d: Expected monitor type %s but found %s for input %s", i, test.expectedMonitorType, actualMonitorType, test.input)
+		}
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error but found none for input %s", i, test.input)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Kubernetes constantly polls the readiness of the applications running in cluster. Getting the OK status does not guarantee that the application will continue to be ready to serve traffic. For example, our DNS server can use an external application as a source for DNS records. At some point, it may stop responding, we might want to signal this to k8s and stop receiving traffic until the connection is restored.

### 2. Which issues (if any) are related?
No issues

### 3. Which documentation changes (if any) need to be made?
I've already updated documentation for `ready` plugin

### 4. Does this introduce a backward incompatible change or deprecation?
It's backwards compatible as I introduced new functionality via additional configuration param.