### PR TITLE
plugin/forward: added option `failfast_all_unhealthy_upstreams` to return servfail if all upstreams are down

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -48,9 +48,10 @@ forward FROM TO... {
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
-    health_check DURATION [no_rec] [domain FQDN] [on_fail ONFAIL]
+    health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
     next RCODE_1 [RCODE_2] [RCODE_3...]
+    failfast_all_unhealthy_upstreams
 }
 ~~~
 
@@ -91,13 +92,13 @@ forward FROM TO... {
     The flag is default `true`.
   * `domain FQDN` - set the domain name used for health checks to **FQDN**.
     If not configured, the domain name used for health checks is `.`.
-  * `on_fail ONFAIL` - controls how requests are handled when _all_ upstream servers are unhealthy and unresponsive to health checks. Allowed values for **ONFAIL** are `servfail` and `spray`.  `servfail` will immediately return SERVFAIL responses for all requests. `spray` will instead send requests to a random upstream.  The default behavior is `spray`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
+* `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls_servername` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -48,7 +48,7 @@ forward FROM TO... {
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
-    health_check DURATION [no_rec] [domain FQDN]
+    health_check DURATION [no_rec] [domain FQDN] [on_fail ONFAIL]
     max_concurrent MAX
     next RCODE_1 [RCODE_2] [RCODE_3...]
 }
@@ -91,6 +91,7 @@ forward FROM TO... {
     The flag is default `true`.
   * `domain FQDN` - set the domain name used for health checks to **FQDN**.
     If not configured, the domain name used for health checks is `.`.
+  * `on_fail ONFAIL` - Allowed values for ONFAIL are **servfail** or **spray**. If healthcheck is broken for an upstream the setting servfail would return servfail response to clients and would not contact the upstreams whereas spray would keep health checking the upstreams even if upstreams are failing. It defaults to **spray**.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -91,7 +91,7 @@ forward FROM TO... {
     The flag is default `true`.
   * `domain FQDN` - set the domain name used for health checks to **FQDN**.
     If not configured, the domain name used for health checks is `.`.
-  * `on_fail ONFAIL` - Allowed values for ONFAIL are **servfail** or **spray**. If healthcheck is broken for an upstream the setting servfail would return servfail response to clients and would not contact the upstreams whereas spray would keep health checking the upstreams even if upstreams are failing. It defaults to **spray**.
+  * `on_fail ONFAIL` - controls how requests are handled when _all_ upstream servers are unhealthy and unresponsive to health checks. Allowed values for **ONFAIL** are `servfail` and `spray`.  `servfail` will immediately return SERVFAIL responses for all requests. `spray` will instead send requests to a random upstream.  The default behavior is `spray`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -46,12 +46,12 @@ type Forward struct {
 
 	nextAlternateRcodes []int
 
-	tlsConfig       *tls.Config
-	tlsServerName   string
-	maxfails        uint32
-	expire          time.Duration
-	maxConcurrent   int64
-	hcFailureAction string
+	tlsConfig      *tls.Config
+	tlsServerName  string
+	maxfails       uint32
+	expire         time.Duration
+	maxConcurrent  int64
+	hcOnFailAction string
 
 	opts proxy.Options // also here for testing
 
@@ -131,7 +131,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 			healthcheckBrokenCount.Add(1)
 			// All upstreams are dead, return servfail if all upstreams are down
-			if f.hcFailureAction == "servfail" {
+			if f.hcOnFailAction == "servfail" {
 				upstreamErr = fmt.Errorf("all upstreams down: %s", proxy.Addr())
 				break
 			} else {

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -279,12 +279,15 @@ func TestHealthDomain(t *testing.T) {
 }
 
 func TestHealthAllUpstreamsDownServeFail(t *testing.T) {
-
+	defaultTimeout = 20 * time.Second
 	// Setting bad address for healthcheck to fail
-	p := proxy.NewProxy("TestHealthAllUpstreamsDown", "test-serv-fail.coredns.local", transport.DNS)
+	p := proxy.NewProxy("TestHealthAllUpstreamsDown", "8.8.8.8:5003", transport.DNS)
+	p1 := proxy.NewProxy("TestHealthAllUpstreamsDown", "8.8.8.8:5004", transport.DNS)
 	f := New()
-	f.hcOnFailAction = "servfail"
 	f.SetProxy(p)
+	f.SetProxy(p1)
+	f.hcOnFailAction = "servfail"
+
 	defer f.OnShutdown()
 
 	req := new(dns.Msg)

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -283,7 +283,7 @@ func TestHealthAllUpstreamsDownServeFail(t *testing.T) {
 	// Setting bad address for healthcheck to fail
 	p := proxy.NewProxy("TestHealthAllUpstreamsDown", "test-serv-fail.coredns.local", transport.DNS)
 	f := New()
-	f.hcFailureAction = "servfail"
+	f.hcOnFailAction = "servfail"
 	f.SetProxy(p)
 	defer f.OnShutdown()
 

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -277,3 +277,21 @@ func TestHealthDomain(t *testing.T) {
 		t.Errorf("Expected number of health checks with Domain==%s to be %d, got %d", hcDomain, 1, i1)
 	}
 }
+
+func TestHealthAllUpstreamsDownServeFail(t *testing.T) {
+
+	// Setting bad address for healthcheck to fail
+	p := proxy.NewProxy("TestHealthAllUpstreamsDown", "test-serv-fail.coredns.local", transport.DNS)
+	f := New()
+	f.hcFailureAction = "servfail"
+	f.SetProxy(p)
+	defer f.OnShutdown()
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	resp, _ := f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+	if resp != dns.RcodeServerFailure {
+		t.Errorf("Expected Response code: %d, Got: %d", dns.RcodeServerFailure, resp)
+	}
+}

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -278,23 +278,78 @@ func TestHealthDomain(t *testing.T) {
 	}
 }
 
-func TestHealthAllUpstreamsDownServeFail(t *testing.T) {
-	defaultTimeout = 20 * time.Second
-	// Setting bad address for healthcheck to fail
-	p := proxy.NewProxy("TestHealthAllUpstreamsDown", "8.8.8.8:5003", transport.DNS)
-	p1 := proxy.NewProxy("TestHealthAllUpstreamsDown", "8.8.8.8:5004", transport.DNS)
+func TestAllUpstreamsDown(t *testing.T) {
+	qs := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// count non-healthcheck queries
+		if r.Question[0].Name != "." {
+			atomic.AddUint32(&qs, 1)
+		}
+		// timeout
+	})
+	defer s.Close()
+
+	s1 := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// count non-healthcheck queries
+		if r.Question[0].Name != "." {
+			atomic.AddUint32(&qs, 1)
+		}
+		// timeout
+	})
+	defer s1.Close()
+
+	p := proxy.NewProxy("TestHealthAllUpstreamsDown", s.Addr, transport.DNS)
+	p1 := proxy.NewProxy("TestHealthAllUpstreamsDown2", s1.Addr, transport.DNS)
+	p.GetHealthchecker().SetReadTimeout(10 * time.Millisecond)
+	p1.GetHealthchecker().SetReadTimeout(10 * time.Millisecond)
+
 	f := New()
 	f.SetProxy(p)
 	f.SetProxy(p1)
-	f.hcOnFailAction = "servfail"
+	f.failfastUnhealthyUpstreams = true
+	f.maxfails = 1
+	// Make proxys fail by checking health twice
+	// i.e, fails > maxfails
+	for range f.maxfails + 1 {
+		p.GetHealthchecker().Check(p)
+		p1.GetHealthchecker().Check(p1)
+	}
 
 	defer f.OnShutdown()
 
+	// Check if all proxies are down
+	if !p.Down(f.maxfails) || !p1.Down(f.maxfails) {
+		t.Fatalf("Expected all proxies to be down")
+	}
 	req := new(dns.Msg)
 	req.SetQuestion("example.org.", dns.TypeA)
+	resp, err := f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
 
-	resp, _ := f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
 	if resp != dns.RcodeServerFailure {
 		t.Errorf("Expected Response code: %d, Got: %d", dns.RcodeServerFailure, resp)
+	}
+
+	if err != ErrNoHealthy {
+		t.Errorf("Expected error message: no healthy proxies, Got: %s", err.Error())
+	}
+
+	q1 := atomic.LoadUint32(&qs)
+	if q1 != 0 {
+		t.Errorf("Expected queries to the upstream: 0, Got: %d", q1)
+	}
+
+	// set failfast to false to check if queries get answered
+	f.failfastUnhealthyUpstreams = false
+
+	req = new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	_, err = f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+	if err == ErrNoHealthy {
+		t.Error("Unexpected error message: no healthy proxies")
+	}
+
+	q1 = atomic.LoadUint32(&qs)
+	if q1 != 1 {
+		t.Errorf("Expected queries to the upstream: 1, Got: %d", q1)
 	}
 }

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -215,15 +215,15 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 					return fmt.Errorf("health_check: invalid domain name %s", hcDomain)
 				}
 				f.opts.HCDomain = plugin.Name(hcDomain).Normalize()
-			case "onfailure":
+			case "on_fail":
 				if !c.NextArg() {
 					return c.ArgErr()
 				}
 				failAction := c.Val()
-				if failAction != "retry" && failAction != "servfail" {
-					return fmt.Errorf("invalid value for healthcheck onfailure: %s", failAction)
+				if failAction != "spray" && failAction != "servfail" {
+					return fmt.Errorf("invalid value for healthcheck on_fail: %s", failAction)
 				}
-				f.hcFailureAction = failAction
+				f.hcOnFailAction = failAction
 			default:
 				return fmt.Errorf("health_check: unknown option %s", hcOpts)
 			}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -215,6 +215,15 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 					return fmt.Errorf("health_check: invalid domain name %s", hcDomain)
 				}
 				f.opts.HCDomain = plugin.Name(hcDomain).Normalize()
+			case "onfailure":
+				if !c.NextArg() {
+					return c.ArgErr()
+				}
+				failAction := c.Val()
+				if failAction != "retry" && failAction != "servfail" {
+					return fmt.Errorf("invalid value for healthcheck onfailure: %s", failAction)
+				}
+				f.hcFailureAction = failAction
 			default:
 				return fmt.Errorf("health_check: unknown option %s", hcOpts)
 			}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -215,15 +215,6 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 					return fmt.Errorf("health_check: invalid domain name %s", hcDomain)
 				}
 				f.opts.HCDomain = plugin.Name(hcDomain).Normalize()
-			case "on_fail":
-				if !c.NextArg() {
-					return c.ArgErr()
-				}
-				failAction := c.Val()
-				if failAction != "spray" && failAction != "servfail" {
-					return fmt.Errorf("invalid value for healthcheck on_fail: %s", failAction)
-				}
-				f.hcOnFailAction = failAction
 			default:
 				return fmt.Errorf("health_check: unknown option %s", hcOpts)
 			}
@@ -315,6 +306,12 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 
 			f.nextAlternateRcodes = append(f.nextAlternateRcodes, rc)
 		}
+	case "failfast_all_unhealthy_upstreams":
+		args := c.RemainingArgs()
+		if len(args) != 0 {
+			return c.ArgErr()
+		}
+		f.failfastUnhealthyUpstreams = true
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -259,12 +259,16 @@ func TestSetupHealthCheck(t *testing.T) {
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example.org\n}\n", false, true, "example.org.", ""},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain .\n}\n", false, true, ".", ""},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example.org.\n}\n", false, true, "example.org.", ""},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s on_fail servfail\n}\n", false, true, ".", ""},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example.org. on_fail spray\n}\n", false, true, "example.org.", ""},
 		// negative
 		{"forward . 127.0.0.1 {\nhealth_check no_rec\n}\n", true, true, ".", "time: invalid duration"},
 		{"forward . 127.0.0.1 {\nhealth_check domain example.org\n}\n", true, true, "example.org", "time: invalid duration"},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s rec\n}\n", true, true, ".", "health_check: unknown option rec"},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain\n}\n", true, true, ".", "Wrong argument count or unexpected line ending after 'domain'"},
 		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example..org\n}\n", true, true, ".", "health_check: invalid domain name"},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s on_fail invalidaction\n}\n", true, true, ".", "invalid value for healthcheck on_fail:"},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s on_fail\n}\n", true, true, ".", "unexpected line ending after 'on_fail'"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

If all upstream proxies are unavailable, coredns forward plugin returns a servfail to the client and does not call the upstream unless proxies are back to being healthy.

### 2. Issue link?
It addresses #6991 

### 3. Which documentation changes (if any) need to be made?

Forward plugin documentation: 

<pre><code>
forward FROM TO... {
    except IGNORED_NAMES...
    force_tcp
    prefer_udp
    expire DURATION
    max_fails INTEGER
    tls CERT KEY CA
    tls_servername NAME
    policy random|round_robin|sequential
    health_check DURATION [no_rec] [domain FQDN]
    max_concurrent MAX
    next RCODE_1 [RCODE_2] [RCODE_3...]
    <b>failfast_all_unhealthy_upstreams</b>  <i>(THIS IS A NEW OPTION ADDED BY THIS PR)</i> 
}
</code>
</pre>

```
failfast_all_unhealthy_upstreams - determines the handling of requests when all upstream servers are 
unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL
 responses for all requests. By default, requests are sent to a random upstream.
```

### 4. Does this introduce a backward incompatible change or deprecation?
No, it is backward compatible.
