### PR TITLE
Try to parse X-Real-IP header in DoH server

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -160,9 +160,16 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Create a DoHWriter with the correct addresses in it.
 	h, p, _ := net.SplitHostPort(r.RemoteAddr)
 	port, _ := strconv.Atoi(p)
+	realIp := r.Header.Get("X-Real-IP") // Since we might be placed behind a reverse proxy
+	ip := net.ParseIP(realIp)
+
+	if ip == nil {
+		ip = net.ParseIP(h)
+	}
+
 	dw := &DoHWriter{
 		laddr:   s.listenAddr,
-		raddr:   &net.TCPAddr{IP: net.ParseIP(h), Port: port},
+		raddr:   &net.TCPAddr{IP: ip, Port: port},
 		request: r,
 	}
 


### PR DESCRIPTION
to determine the requesting IP address when behind a reverse proxy

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Currently coredns cannot correctly determine the origin IP address when used behind a reverse proxy
such as nginx. This can lead to issues for plugins that depends on origin IP addresses
such as ends0 rewrite (which will set the the subnet IP to be set to 127.0.0.1 when used in a typical configuration and
cause issues).

### 2. Which issues (if any) are related?
AFAIK none.

### 3. Which documentation changes (if any) need to be made?
I don't think this the behavior was documented so I guess none.

### 4. Does this introduce a backward incompatible change or deprecation?
I'm not very familiar with the coredns codebase but I would assume no.
