### PR TITLE
feat: allow forward plugin read domain list as from field from file

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -40,7 +40,7 @@ type Forward struct {
 	p          Policy
 	hcInterval time.Duration
 
-	from    string
+	from    []string
 	ignored []string
 
 	nextAlternateRcodes []int
@@ -64,7 +64,7 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: proxy.Options{ForceTCP: false, PreferUDP: false, HCRecursionDesired: true, HCDomain: "."}}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: []string{"."}, hcInterval: hcInterval, opts: proxy.Options{ForceTCP: false, PreferUDP: false, HCRecursionDesired: true, HCDomain: "."}}
 	return f
 }
 
@@ -217,15 +217,17 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 }
 
 func (f *Forward) match(state request.Request) bool {
-	if !plugin.Name(f.from).Matches(state.Name()) || !f.isAllowedDomain(state.Name()) {
-		return false
+	for _, from := range f.from {
+		if plugin.Name(from).Matches(state.Name()) && f.isAllowedDomain(from, state.Name()) {
+			return true
+		}
 	}
 
-	return true
+	return false
 }
 
-func (f *Forward) isAllowedDomain(name string) bool {
-	if dns.Name(name) == dns.Name(f.from) {
+func (f *Forward) isAllowedDomain(from, name string) bool {
+	if dns.Name(name) == dns.Name(from) {
 		return true
 	}
 

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -191,7 +191,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 // github.com
 // ```
 //
-// If line start with `#`, this line will be treated as a comment and ignored. Every line is a domain
+// Every line is a domain unless it starts with `#`, then it will be treated as a comment and ignored it.
 func parseFile(path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -17,34 +17,34 @@ func TestSetup(t *testing.T) {
 	tests := []struct {
 		input           string
 		shouldErr       bool
-		expectedFrom    string
+		expectedFrom    []string
 		expectedIgnored []string
 		expectedFails   uint32
 		expectedOpts    proxy.Options
 		expectedErr     string
 	}{
 		// positive
-		{"forward . 127.0.0.1", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example.org\n}\n", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "example.org."}, ""},
-		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, proxy.Options{ForceTCP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, proxy.Options{PreferUDP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, proxy.Options{PreferUDP: true, ForceTCP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1:53", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1:8080", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . [::1]:53", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . [2003::1]:53", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward . 127.0.0.1 \n", false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
-		{"forward 10.9.3.0/18 127.0.0.1", false, "0.9.10.in-addr.arpa.", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain example.org\n}\n", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "example.org."}, ""},
+		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, []string{"."}, nil, 3, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, []string{"."}, nil, 2, proxy.Options{ForceTCP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, []string{"."}, nil, 2, proxy.Options{PreferUDP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, []string{"."}, nil, 2, proxy.Options{PreferUDP: true, ForceTCP: true, HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1:53", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1:8080", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . [::1]:53", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . [2003::1]:53", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward . 127.0.0.1 \n", false, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
+		{"forward 10.9.3.0/18 127.0.0.1", false, []string{"0.9.10.in-addr.arpa."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, ""},
 		{`forward . ::1
-		forward com ::2`, false, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "plugin"},
+		forward com ::2`, false, []string{"0.9.10.in-addr.arpa."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "plugin"},
 		// negative
-		{"forward . a27.0.0.1", true, "", nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "not an IP"},
-		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "unknown property"},
-		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain\n}\n", true, "", nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "Wrong argument count or unexpected line ending after 'domain'"},
-		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
-		{"forward xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 127.0.0.1 \n", true, ".", nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "unable to normalize 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
+		{"forward . a27.0.0.1", true, []string{""}, nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "not an IP"},
+		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, []string{""}, nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "unknown property"},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s domain\n}\n", true, []string{""}, nil, 0, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "Wrong argument count or unexpected line ending after 'domain'"},
+		{"forward . https://127.0.0.1 \n", true, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
+		{"forward xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 127.0.0.1 \n", true, []string{"."}, nil, 2, proxy.Options{HCRecursionDesired: true, HCDomain: "."}, "unable to normalize 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
 	}
 
 	for i, test := range tests {
@@ -67,7 +67,7 @@ func TestSetup(t *testing.T) {
 
 		if !test.shouldErr {
 			f := fs[0]
-			if f.from != test.expectedFrom {
+			if !reflect.DeepEqual(f.from, test.expectedFrom) {
 				t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedFrom, f.from)
 			}
 			if test.expectedIgnored != nil {
@@ -313,7 +313,7 @@ func TestMultiForward(t *testing.T) {
 		t.Fatalf("expected first plugin to be Forward, got %v", reflect.TypeOf(f1.Next))
 	}
 
-	if f1.from != "1st.example.org." {
+	if f1.from[0] != "1st.example.org." {
 		t.Errorf("expected first forward from \"1st.example.org.\", got %q", f1.from)
 	}
 	if f1.Next == nil {
@@ -324,7 +324,7 @@ func TestMultiForward(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected second plugin to be Forward, got %v", reflect.TypeOf(f1.Next))
 	}
-	if f2.from != "2nd.example.org." {
+	if f2.from[0] != "2nd.example.org." {
 		t.Errorf("expected second forward from \"2nd.example.org.\", got %q", f2.from)
 	}
 	if f2.Next == nil {
@@ -335,7 +335,7 @@ func TestMultiForward(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected third plugin to be Forward, got %v", reflect.TypeOf(f2.Next))
 	}
-	if f3.from != "3rd.example.org." {
+	if f3.from[0] != "3rd.example.org." {
 		t.Errorf("expected third forward from \"3rd.example.org.\", got %q", f3.from)
 	}
 	if f3.Next != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Currently `forward` plugin only support one domain at the `from` field, if we want to set multi domains which are not end with same postfix, such as `example.com` and `github.io`, we have to write multi `forward` block

This PR allow `forward` plugin read the domains list from a file so we can reduce the `forward` blocks

### 2. Which issues (if any) are related?

I searched issue but it seems no one say "I want this feature" but I want it, so I try to modify the `forward` plugin and found it easy :)

### 3. Which documentation changes (if any) need to be made?

The `forward` plugin `from` field doc should be updated

### 4. Does this introduce a backward incompatible change or deprecation?

No, this PR introduce a new prefix `file://` at the `from` field to distinguish this feature, so we can make sure any exist config files won't be break
