### PR TITLE
Add Windows Service support

### DIFF
--- a/coredns.go
+++ b/coredns.go
@@ -1,13 +1,18 @@
+//go:build !windows
+
 package main
 
 //go:generate go run directives_generate.go
 //go:generate go run owners_generate.go
 
 import (
+	"flag"
+
 	_ "github.com/coredns/coredns/core/plugin" // Plug in CoreDNS.
 	"github.com/coredns/coredns/coremain"
 )
 
 func main() {
-	coremain.Run()
+	flag.Parse()
+	coremain.RunForever()
 }

--- a/coredns_windows.go
+++ b/coredns_windows.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package main
+
+//go:generate go run directives_generate.go
+//go:generate go run owners_generate.go
+
+import (
+	"flag"
+	"log"
+
+	_ "github.com/coredns/coredns/core/plugin" // Plug in CoreDNS.
+	"github.com/coredns/coredns/coremain"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/debug"
+)
+
+type coreDnsService struct{}
+
+func (m *coreDnsService) Execute(args []string, r <-chan svc.ChangeRequest, status chan<- svc.Status) (bool, uint32) {
+
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+
+	status <- svc.Status{State: svc.StartPending}
+
+	instance := coremain.Run()
+
+	status <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+
+loop:
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				status <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				status <- svc.Status{State: svc.StopPending}
+				log.Print("Shutting down DNS service...")
+				instance.ShutdownCallbacks()
+				instance.Stop()
+				break loop
+			default:
+				log.Printf("Unexpected service control request #%d", c)
+			}
+		}
+	}
+
+	status <- svc.Status{State: svc.Stopped}
+	return false, 0
+}
+
+func runService(name string, isDebug bool) {
+	if isDebug {
+		err := debug.Run(name, &coreDnsService{})
+		if err != nil {
+			log.Fatalf("Error running service in debug mode: %s\n", err.Error())
+		}
+	} else {
+		err := svc.Run(name, &coreDnsService{})
+		if err != nil {
+			log.Fatalf("Error running service in Service Control mode: %s\n", err.Error())
+		}
+	}
+}
+
+var svcMode = flag.Bool("service", false, "Run as a Windows service")
+
+func main() {
+	flag.Parse()
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		log.Fatalf("Could not determine service status: %s", err.Error())
+		return
+	}
+
+	if isService || *svcMode {
+		log.Printf("Running CoreDNS in service mode")
+		runService("CoreDNS", !isService)
+	} else {
+		coremain.RunForever()
+	}
+}

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -37,10 +37,8 @@ func init() {
 	caddy.AppVersion = CoreVersion
 }
 
-// Run is CoreDNS's main() function.
-func Run() {
+func Run() *caddy.Instance {
 	caddy.TrapSignals()
-	flag.Parse()
 
 	if len(flag.Args()) > 0 {
 		mustLogFatal(fmt.Errorf("extra command line arguments: %s", flag.Args()))
@@ -78,6 +76,13 @@ func Run() {
 	if !dnsserver.Quiet {
 		showVersion()
 	}
+
+	return instance
+}
+
+// Run is CoreDNS's main() function.
+func RunForever() {
+	instance := Run()
 
 	// Twiddle your thumbs
 	instance.Wait()


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

This PR adds support to run CoreDNS as a Windows service.

1. It splits Run into two functions: `Run` which contains most of the old function except it returns the instance object instead of waiting for it, and `RunForever` which creates and instance and waits for it (i.e. exactly the same behaviour as Run used to have).
2. It moves the flag.Parse call earlier on the execution
3. It adds a Windows-specific entrypoint which can run the program just like before or in service mode
4. If executed in service mode, it starts the Windows Service event loop, starts the server instance and maintains it until the service exits.

In short, there are no changes in behaviour except when launched as a service on Windows or when launched with the `-service` flag on Windows which will start the service debug mode.

### 2. Which issues (if any) are related?

There is no issue for this

### 3. Which documentation changes (if any) need to be made?

A note could be added that CoreDNS can be run as a Windows service. The new `-service` flag on Windows allows to run the service in debug mode (i.e. in a terminal but using the service interface).

### 4. Does this introduce a backward incompatible change or deprecation?

If someone was previously calling `.Run()` from other code they would now have to call `.RunForever`. If this is unacceptable, it's easy to change so that the the functions are called for example `.CreateInstance` and `.Run` so that `.Run` maintains it function.
