### PR TITLE
Set IP_TRANSPARENT on the sockets

### DIFF
--- a/plugin/pkg/reuseport/listen_reuseport.go
+++ b/plugin/pkg/reuseport/listen_reuseport.go
@@ -17,6 +17,9 @@ func control(network, address string, c syscall.RawConn) error {
 		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
 			log.Warningf("Failed to set SO_REUSEPORT on socket: %s", err)
 		}
+		if err := unix.SetsockoptInt(int(fd), unix.SOL_IP, unix.IP_TRANSPARENT, 1); err != nil {
+			log.Warningf("Failed to set IP_TRANSPARENT on socket: %s", err)
+		}
 	})
 	return nil
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
It enables coreDNS to work as a transparent DNS proxy. You can capture DNS requests going to IP A and redirect them to coreDNS IP B. A classic example setup is to use `TPROXY` in the `mangle` table in the `PREROUTING` chain to redirect the packets to coreDNS

### 2. Which issues (if any) are related?
Not related to any Open issue. Needed in our setup to have coreDNS as transparent DNS Proxy and at the moment we have to patch coreDNS.

### 3. Which documentation changes (if any) need to be made?
In places that it is mentioned that coreDNS supports/sets `SO_REUSEPORT` it can be mentioned that it also supports/sets `IP_TRANSPARENT`

### 4. Does this introduce a backward incompatible change or deprecation?
`IP_TRANSPARENT` is supported since Linux 2.6.24