### PR TITLE
Canonicalize IPv4 addresses in acl

### DIFF
--- a/plugin/acl/setup.go
+++ b/plugin/acl/setup.go
@@ -20,6 +20,7 @@ func newDefaultFilter() *iptree.Tree {
 	defaultFilter := iptree.NewTree()
 	_, IPv4All, _ := net.ParseCIDR("0.0.0.0/0")
 	_, IPv6All, _ := net.ParseCIDR("::/0")
+	IPv4All.IP = IPv4All.IP.To4()
 	defaultFilter.InplaceInsertNet(IPv4All, struct{}{})
 	defaultFilter.InplaceInsertNet(IPv6All, struct{}{})
 	return defaultFilter
@@ -111,6 +112,9 @@ func parse(c *caddy.Controller) (ACL, error) {
 						_, source, err := net.ParseCIDR(token)
 						if err != nil {
 							return a, c.Errf("illegal CIDR notation %q", token)
+						}
+						if temp := source.IP.To4(); temp != nil {
+							source.IP = temp
 						}
 						p.filter.InplaceInsertNet(source, struct{}{})
 					}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull requests canonicalizes IPv4 addresses (turning them into a 4-byte slice) before using them in the iptree, due to a bug in the `iptree` library which ignores IPv4 addresses if they're in a 16-byte slice (see https://github.com/infobloxopen/go-trees/pull/27 for more info). 
