### PR TITLE
added metric coredns_response_negative_missing_soa to record negative…

### DIFF
--- a/plugin/pkg/response/metrics.go
+++ b/plugin/pkg/response/metrics.go
@@ -1,0 +1,16 @@
+package response
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Variables declared for monitoring.
+var (
+	negativeMissingSoa = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "coredns",
+		Subsystem: "response",
+		Name:      "negative_missing_soa",
+		Help:      "Counter of the number of negative responses that are missing soa",
+	}, []string{})
+)

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -72,7 +72,6 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 	if m.Opcode == dns.OpcodeNotify {
 		return Meta, opt
 	}
-
 	if len(m.Question) > 0 {
 		if m.Question[0].Qtype == dns.TypeAXFR || m.Question[0].Qtype == dns.TypeIXFR {
 			return Meta, opt
@@ -107,6 +106,10 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 	}
 	if soa && m.Rcode == dns.RcodeNameError {
 		return NameError, opt
+	}
+
+	if !soa && m.Rcode == dns.RcodeNameError {
+		negativeMissingSoa.WithLabelValues().Add(1)
 	}
 
 	if m.Rcode == dns.RcodeServerFailure || m.Rcode == dns.RcodeNotImplemented {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
 It adds a metric `coredns_response_negative_missing_soa`.

### 2. Which issues (if any) are related?
Addresses #6683

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No