### PR TITLE
test: fix cname with proxy test

### DIFF
--- a/test/example_test.go
+++ b/test/example_test.go
@@ -11,6 +11,6 @@ short   1    IN  A      127.0.0.3
 
 *.w     3600 IN  TXT    "Wildcard"
 a.b.c.w      IN  TXT    "Not a wildcard"
-cname        IN  CNAME  www.example.net.
+cname        IN  CNAME  h.gtld-servers.net.
 service      IN  SRV    8080 10 10 @
 `


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
www.example.net is now behind akamai with various IP answered and a chain of CNAME. Let's replace www.example.net by one of the root server which answer a single IP and hopefully should remain this way.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
no documentation changes
### 4. Does this introduce a backward incompatible change or deprecation?
no