### PR TITLE
dynamicforward: the new plugin implementation

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -63,4 +63,5 @@ var Directives = []string{
 	"on",
 	"sign",
 	"view",
+	"dynamicforward",
 }

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/dns64"
 	_ "github.com/coredns/coredns/plugin/dnssec"
 	_ "github.com/coredns/coredns/plugin/dnstap"
+	_ "github.com/coredns/coredns/plugin/dynamicforward"
 	_ "github.com/coredns/coredns/plugin/erratic"
 	_ "github.com/coredns/coredns/plugin/errors"
 	_ "github.com/coredns/coredns/plugin/etcd"

--- a/man/coredns-dynamicforward.7
+++ b/man/coredns-dynamicforward.7
@@ -20,8 +20,8 @@ dynamicforward {
     port_name <portname>
     expire <duration>
     health_check <duration>
-    force_tcp <bool>
-    prefer_udp <bool>
+    force_tcp
+    prefer_udp
 }
 .Ed
 
@@ -70,8 +70,8 @@ To use the plugin, include it in the Corefile configuration for your CoreDNS ser
         port_name dns
         expire 10m
         health_check 5s
-        prefer_udp true
-        force_tcp false
+        prefer_udp
+        force_tcp
     }
 }
 .Ed

--- a/man/coredns-dynamicforward.7
+++ b/man/coredns-dynamicforward.7
@@ -20,6 +20,8 @@ dynamicforward {
     port_name <portname>
     expire <duration>
     health_check <duration>
+    force_tcp <bool>
+    prefer_udp <bool>
 }
 .Ed
 
@@ -68,6 +70,8 @@ To use the plugin, include it in the Corefile configuration for your CoreDNS ser
         port_name dns
         expire 10m
         health_check 5s
+        prefer_udp true
+        force_tcp false
     }
 }
 .Ed

--- a/man/coredns-dynamicforward.7
+++ b/man/coredns-dynamicforward.7
@@ -1,0 +1,87 @@
+.Dd January 25, 2025
+.Dt DYNAMICFORWARD 8
+.Os
+.Sh NAME
+.Nm dynamicforward
+.Nd CoreDNS plugin for dynamically updating forwarders using Kubernetes Service
+.Sh SYNOPSIS
+.Nm dynamicforward
+.Op Fl options
+.Sh DESCRIPTION
+The
+.Nm dynamicforward
+plugin allows CoreDNS to dynamically update its list of DNS forwarders based on changes to Kubernetes Service of upstream DNS server. This is useful in environments where DNS servers are ephemeral or their configuration is managed dynamically.
+
+The plugin can be configured in the CoreDNS Corefile with the following syntax:
+.Bd -literal -offset indent
+dynamicforward {
+    namespace <namespace>
+    service_name <servicename>
+    port_name <portname>
+    expire <duration>
+    health_check <duration>
+}
+.Ed
+
+.Sh OPTIONS
+.Bl -tag -width indent
+.It Xo
+.Cm namespace
+.Ar <namespace>
+.Xc
+Specifies the Kubernetes namespace where the upstream DNS Service is. This parameter is required.
+
+.It Xo
+.Cm service_name
+.Ar <servicename>
+.Xc
+Defines the upstream DNS Service name.
+
+.It Xo
+.Cm portname
+.Ar <portname>
+.Xc
+Specifies the port name responsible for DNS serving in Service resource.
+
+.It Xo
+.Cm expire
+.Ar <duration>
+.Xc
+Expire (cached) connections after this time, the default is 10s.
+
+.It Xo
+.Cm health_check
+.Ar <duration>
+.Xc
+Configure the behaviour of health checking of the upstream servers. use a different duration for health checking, the default duration is 0.5s.
+.El
+
+.Sh USAGE
+To use the plugin, include it in the Corefile configuration for your CoreDNS server. An example configuration is shown below:
+.Bd -literal -offset indent
+.:53 {
+    errors
+    log
+    dynamicforward {
+        namespace kube-system
+        service_name kube-dns
+        port_name dns
+        expire 10m
+        health_check 5s
+    }
+}
+.Ed
+
+The plugin will automatically watch related to specified Service's EndpointSlices. Whenever an EndpointSlice is added, updated, or deleted, the list of forward servers will be updated dynamically.
+
+.Sh LOGGING
+The plugin logs important events such as updates to the forwarder list and errors encountered during operation.
+
+.Sh FILES
+None.
+
+.Sh BUGS
+No known bugs. If you encounter issues, please report them to the project's issue tracker.
+
+.Sh SEE ALSO
+.Xr coredns 8 ,

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -72,3 +72,4 @@ whoami:whoami
 on:github.com/coredns/caddy/onevent
 sign:sign
 view:view
+dynamicforward:dynamicforward

--- a/plugin/dynamicforward/dynamicforward.go
+++ b/plugin/dynamicforward/dynamicforward.go
@@ -43,7 +43,14 @@ func (df *DynamicForward) UpdateForwardServers(newServers []string, config Dynam
 	df.cond.L.Lock()
 
 	// Clear proxy list `Forwarder`
+	if df.forwarder != nil {
+		for _, oldProxy := range df.forwarder.List() {
+			oldProxy.Stop()
+		}
+	}
+
 	df.forwarder = forward.New()
+
 	// Fill up list servers
 	df.forwardTo = newServers
 

--- a/plugin/dynamicforward/dynamicforward.go
+++ b/plugin/dynamicforward/dynamicforward.go
@@ -1,0 +1,67 @@
+package dynamicforward
+
+import (
+	"context"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/forward"
+	"github.com/coredns/coredns/plugin/pkg/proxy"
+	"github.com/coredns/coredns/plugin/pkg/transport"
+	"github.com/miekg/dns"
+	"log"
+	"sync"
+)
+
+// DynamicForward main struct of plugin
+type DynamicForward struct {
+	Next        plugin.Handler
+	Namespace   string
+	ServiceName string
+	forwardTo   []string
+	mu          sync.RWMutex
+	forwarder   *forward.Forward
+	options     *forward.Options
+	cond        *sync.Cond
+}
+
+func (df *DynamicForward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	//wait forwarder
+	df.cond.L.Lock()
+
+	if df.forwarder == nil {
+		df.cond.Wait()
+	}
+
+	df.cond.L.Unlock()
+
+	return df.forwarder.ServeDNS(ctx, w, r)
+}
+
+// UpdateForwardServers update list servers for forward requests
+func (df *DynamicForward) UpdateForwardServers(newServers []string, config DynamicForwardConfig) {
+	//df.mu.Lock()
+	//defer df.mu.Unlock()
+	df.cond.L.Lock()
+
+	// Clear proxy list `Forwarder`
+	df.forwarder = forward.New()
+	// Fill up list servers
+	df.forwardTo = newServers
+
+	// Create new list proxy
+	for _, server := range newServers {
+		// Create proxy
+		proxyInstance := proxy.NewProxy(server, server, transport.DNS)
+		proxyInstance.SetExpire(config.Expire)
+		proxyInstance.SetReadTimeout(config.HealthCheck)
+
+		df.forwarder.SetProxy(proxyInstance)
+	}
+
+	df.cond.Broadcast()
+	df.cond.L.Unlock()
+
+	log.Printf("[dynamicforward] Forward servers updated: %v", newServers)
+}
+
+// Name return plugin name
+func (df *DynamicForward) Name() string { return "dynamicforward" }

--- a/plugin/dynamicforward/dynamicforward.go
+++ b/plugin/dynamicforward/dynamicforward.go
@@ -19,7 +19,7 @@ type DynamicForward struct {
 	forwardTo   []string
 	mu          sync.RWMutex
 	forwarder   *forward.Forward
-	options     *forward.Options
+	options     proxy.Options
 	cond        *sync.Cond
 }
 
@@ -47,6 +47,7 @@ func (df *DynamicForward) UpdateForwardServers(newServers []string, config Dynam
 		proxyInstance.SetExpire(config.Expire)
 		proxyInstance.SetReadTimeout(config.HealthCheck)
 		newForwarder.SetProxy(proxyInstance)
+		newForwarder.SetProxyOptions(df.options)
 	}
 
 	oldForwarder := df.forwarder

--- a/plugin/dynamicforward/setup.go
+++ b/plugin/dynamicforward/setup.go
@@ -1,0 +1,76 @@
+package dynamicforward
+
+import (
+	"context"
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/forward"
+	"log"
+	"sync"
+)
+
+func init() { plugin.Register("dynamicforward", setup) }
+
+func setup(c *caddy.Controller) error {
+
+	version := "0.2.9"
+
+	log.Printf("\033[34m[dynamicforward] version: %s\033[0m\n", version)
+
+	// While unused, need add func SetOptions in plugin forward.
+	options := forward.Options{
+		ForceTCP:           false,
+		PreferUDP:          true,
+		HCRecursionDesired: false,
+		HCDomain:           "",
+	}
+
+	// parse config
+	config, err := ParseConfig(c)
+	if err != nil {
+		return err
+	}
+
+	dynamicForwardPlugin := &DynamicForward{
+		Namespace:   config.Namespace,
+		ServiceName: config.ServiceName, //kubernetes.io/service-name=d8-kube-dns
+		forwarder:   nil,
+		options:     &options,
+		cond:        sync.NewCond(&sync.Mutex{}),
+	}
+
+	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		dynamicForwardPlugin.Next = next
+		return dynamicForwardPlugin
+	})
+
+	// Context for properly shutdown goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c.OnStartup(func() error {
+		log.Printf("[dynamicforward] Starting with namespace=%s, service_name=%s\n", config.Namespace, config.ServiceName)
+		// Start go routine for watch EndpointSlice
+		go func() {
+			err := startEndpointSliceWatcher(ctx, config.Namespace, config.ServiceName, config.PortName, func(newServers []string) {
+				dynamicForwardPlugin.UpdateForwardServers(newServers, *config)
+				log.Printf("[dynamicforward] Updated servers namespace%s, service_name=%s\n: %v", config.Namespace, config.ServiceName, newServers)
+			})
+
+			if err != nil {
+				log.Printf("[dynamicforward] Error starting EndpointSlice watcher with label kubernetes.io/service-name=%s: %v", config.ServiceName, err)
+			}
+		}()
+
+		return nil
+	})
+
+	c.OnShutdown(func() error {
+		log.Printf("[dynamicforward] Shutting down with namespace=%s\n", config.Namespace)
+		cancel()
+		return nil
+	})
+
+	return nil
+}

--- a/plugin/dynamicforward/setup.go
+++ b/plugin/dynamicforward/setup.go
@@ -5,7 +5,6 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/forward"
 	"log"
 	"sync"
 )
@@ -14,17 +13,9 @@ func init() { plugin.Register("dynamicforward", setup) }
 
 func setup(c *caddy.Controller) error {
 
-	version := "0.2.9"
+	version := "0.3.5"
 
 	log.Printf("\033[34m[dynamicforward] version: %s\033[0m\n", version)
-
-	// While unused, need add func SetOptions in plugin forward.
-	options := forward.Options{
-		ForceTCP:           false,
-		PreferUDP:          true,
-		HCRecursionDesired: false,
-		HCDomain:           "",
-	}
 
 	// parse config
 	config, err := ParseConfig(c)
@@ -36,7 +27,7 @@ func setup(c *caddy.Controller) error {
 		Namespace:   config.Namespace,
 		ServiceName: config.ServiceName, //kubernetes.io/service-name=d8-kube-dns
 		forwarder:   nil,
-		options:     &options,
+		options:     config.opts,
 		cond:        sync.NewCond(&sync.Mutex{}),
 	}
 

--- a/plugin/dynamicforward/utils.go
+++ b/plugin/dynamicforward/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin/pkg/proxy"
-	"strconv"
 	"time"
 )
 
@@ -68,23 +67,9 @@ func ParseConfig(c *caddy.Controller) (*DynamicForwardConfig, error) {
 			}
 			config.HealthCheck = duration
 		case "force_tcp":
-			if !c.NextArg() {
-				return nil, c.ArgErr()
-			}
-			forceTCP, err := strconv.ParseBool(c.Val())
-			if err != nil {
-				return nil, fmt.Errorf("invalid force_tcp: %v", err)
-			}
-			config.opts.ForceTCP = forceTCP
+			config.opts.ForceTCP = true
 		case "prefer_udp":
-			if !c.NextArg() {
-				return nil, c.ArgErr()
-			}
-			preferUDP, err := strconv.ParseBool(c.Val())
-			if err != nil {
-				return nil, fmt.Errorf("invalid prefer_udp: %v", err)
-			}
-			config.opts.PreferUDP = preferUDP
+			config.opts.PreferUDP = true
 
 		default:
 			return nil, c.Errf("unknown parameter: %s", c.Val())

--- a/plugin/dynamicforward/utils.go
+++ b/plugin/dynamicforward/utils.go
@@ -1,0 +1,74 @@
+package dynamicforward
+
+import (
+	"fmt"
+	"github.com/coredns/caddy"
+	"time"
+)
+
+// DynamicForwardConfig хранит параметры блока
+type DynamicForwardConfig struct {
+	Namespace   string
+	ServiceName string
+	PortName    string
+	Expire      time.Duration
+	HealthCheck time.Duration
+}
+
+// ParseConfig parse conf CoreFile
+func ParseConfig(c *caddy.Controller) (*DynamicForwardConfig, error) {
+	config := &DynamicForwardConfig{
+		Expire:      30 * time.Minute, // Default value
+		HealthCheck: 10 * time.Second, // Default value
+	}
+
+	c.RemainingArgs()
+	// Checking the presence of a parameter block
+	for c.NextBlock() {
+		switch c.Val() {
+		case "namespace":
+			if !c.NextArg() {
+				return nil, c.ArgErr() // Отсутствует значение
+			}
+			config.Namespace = c.Val()
+		case "service_name":
+			if !c.NextArg() {
+				return nil, c.ArgErr() // Отсутствует значение
+			}
+			config.ServiceName = c.Val()
+		case "port_name":
+			if !c.NextArg() {
+				return nil, c.ArgErr() // Отсутствует значение
+			}
+			config.PortName = c.Val()
+		case "expire":
+			if !c.NextArg() {
+				return nil, c.ArgErr() // Отсутствует значение
+			}
+			duration, err := time.ParseDuration(c.Val())
+			if err != nil {
+				return nil, fmt.Errorf("invalid expire duration: %v", err)
+			}
+			config.Expire = duration
+		case "health_check":
+			if !c.NextArg() {
+				return nil, c.ArgErr() // Отсутствует значение
+			}
+			duration, err := time.ParseDuration(c.Val())
+			if err != nil {
+				return nil, fmt.Errorf("invalid health_check duration: %v", err)
+			}
+			config.HealthCheck = duration
+
+		default:
+			return nil, c.Errf("unknown parameter: %s", c.Val())
+		}
+	}
+
+	// Checking the required parameters
+	if config.Namespace == "" || config.ServiceName == "" || config.PortName == "" {
+		return nil, fmt.Errorf("namespace, servicename, and portname are required parameters")
+	}
+
+	return config, nil
+}

--- a/plugin/dynamicforward/utils_test.go
+++ b/plugin/dynamicforward/utils_test.go
@@ -1,0 +1,132 @@
+package dynamicforward
+
+import (
+	"github.com/coredns/caddy"
+	"testing"
+	"time"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      DynamicForwardConfig
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid config with all parameters",
+			input: `dynamicforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+				expire 10m
+				health_check 5s
+			}`,
+			expected: DynamicForwardConfig{
+				Namespace:   "kube-system",
+				ServiceName: "d8-kube-dns",
+				PortName:    "dns",
+				Expire:      10 * time.Minute,
+				HealthCheck: 5 * time.Second,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Config missing namespace",
+			input: `dynamicforward {
+				service_name d8-kube-dns
+				port_name dns
+				expire 10m
+				health_check 5s
+			}`,
+			expectErr:     true,
+			expectedError: "namespace, servicename, and portname are required parameters",
+		},
+		{
+			name: "Config with invalid expire value",
+			input: `dynamicforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+				expire not-a-duration
+			}`,
+			expectErr:     true,
+			expectedError: "invalid expire duration",
+		},
+		{
+			name: "Config with missing health_check value",
+			input: `dynamicforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+				health_check 
+			}`,
+			expectErr:     true,
+			expectedError: "wrong argument count or unexpected line ending",
+		},
+		{
+			name: "Minimal valid config",
+			input: `dynamicforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+			}`,
+			expected: DynamicForwardConfig{
+				Namespace:   "kube-system",
+				ServiceName: "d8-kube-dns",
+				PortName:    "dns",
+				Expire:      30 * time.Minute,
+				HealthCheck: 10 * time.Second,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Parsing controller
+			controller := caddy.NewTestController("dns", test.input)
+
+			// Parse config
+			config, err := ParseConfig(controller)
+
+			// Check err
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !containsError(err.Error(), test.expectedError) {
+					t.Fatalf("expected error containing %q, got %q", test.expectedError, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Compare results
+			if config.Namespace != test.expected.Namespace {
+				t.Errorf("expected namespace %q, got %q", test.expected.Namespace, config.Namespace)
+			}
+			if config.ServiceName != test.expected.ServiceName {
+				t.Errorf("expected label %q, got %q", test.expected.ServiceName, config.ServiceName)
+			}
+			if config.PortName != test.expected.PortName {
+				t.Errorf("expected portname %q, got %q", test.expected.PortName, config.PortName)
+			}
+			if config.Expire != test.expected.Expire {
+				t.Errorf("expected expire %v, got %v", test.expected.Expire, config.Expire)
+			}
+			if config.HealthCheck != test.expected.HealthCheck {
+				t.Errorf("expected health_check %v, got %v", test.expected.HealthCheck, config.HealthCheck)
+			}
+		})
+	}
+}
+
+// containsError
+func containsError(actual, expected string) bool {
+	return len(actual) >= len(expected) && actual[:len(expected)] == expected
+}

--- a/plugin/dynamicforward/watchslice.go
+++ b/plugin/dynamicforward/watchslice.go
@@ -1,0 +1,149 @@
+package dynamicforward
+
+import (
+	"context"
+	_ "context"
+	"fmt"
+	v1 "k8s.io/api/discovery/v1"
+	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"log"
+)
+
+// startEndpointSliceWatcher tracks changes to the EndpointSlicesList for the specified service.
+func startEndpointSliceWatcher(ctx context.Context, namespace, serviceName string, portName string, onUpdate func(newServers []string)) error {
+	// Create config for Kubernetes-client
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("[dynamicforward] failed to create in-cluster config in namespace=%s, service-name %s: %w\n", namespace, serviceName, err)
+	}
+
+	// Create client Kubernetes
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("[dynamicforward] failed to create Kubernetes client in namespace=%s, service-name %s: %w\n", namespace, serviceName, err)
+	}
+
+	// Create list/watch with filter by label
+	listWatch := cache.NewFilteredListWatchFromClient(
+		clientset.DiscoveryV1().RESTClient(),
+		"endpointslices",
+		namespace,
+		func(options *metav1.ListOptions) {
+			options.LabelSelector = fmt.Sprintf("kubernetes.io/service-name=%s", serviceName)
+		},
+	)
+
+	//store all  slices
+	esStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			endpointSlice, ok := obj.(*v1.EndpointSlice)
+			if !ok {
+				log.Printf("[dynamicforward] error hadling addition EndpointSlice for service=%s: Unexpected type %T\n", serviceName, obj)
+				return
+			}
+			esStore.Add(endpointSlice)
+			handleUpdate(esStore, portName, serviceName, namespace, onUpdate)
+			log.Printf("[dynamicforward] succusfuly added EndpointSlices for service=%s: %s\n", serviceName, endpointSlice.Name)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldEndpointSlice, ok1 := old.(*v1.EndpointSlice)
+			newEndpointSlice, ok2 := new.(*v1.EndpointSlice)
+			if !ok1 || !ok2 {
+				log.Printf("[dynamicforward] error hadling update EndpointSlice for service=%s: Unexpected types: %T, %T\n", serviceName, old, new)
+				return
+			}
+			esStore.Update(newEndpointSlice)
+			handleUpdate(esStore, portName, serviceName, namespace, onUpdate)
+			log.Printf("[dynamicforward] succusfuly updated EndpointSlices for service=%s: EndpointSlice updated: %s -> %s\n", serviceName, oldEndpointSlice.Name, newEndpointSlice.Name)
+		},
+		DeleteFunc: func(obj interface{}) {
+			endpointSlice, ok := obj.(*v1.EndpointSlice)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					log.Printf("[dynamicforward] error delete EndpointSlice for service=%s: Unexpected type %T\n", serviceName, obj)
+					return
+				}
+				endpointSlice, ok = tombstone.Obj.(*v1.EndpointSlice)
+				if !ok {
+					log.Printf("[dynamicforward] error delete EndpointSlice for service=%s: Tombstone contained object of unexpected type %T\n", serviceName, tombstone.Obj)
+					return
+				}
+			}
+			esStore.Delete(endpointSlice)
+			handleUpdate(esStore, portName, serviceName, namespace, onUpdate)
+			log.Printf("[dynamicforward] succusfuly seleted EndpointSlice for service=%s: EndpointSlice: %s\n", serviceName, endpointSlice.Name)
+		},
+	}
+
+	// Create controller for EndpointSlice
+	informerOptions := cache.InformerOptions{
+		ListerWatcher:   listWatch,
+		ObjectType:      &v1.EndpointSlice{},
+		Handler:         handler,
+		ResyncPeriod:    0,
+		MinWatchTimeout: 0,
+		Indexers:        nil,
+		Transform:       nil,
+	}
+
+	_, controller := cache.NewInformerWithOptions(informerOptions)
+
+	// Start informer
+	go controller.Run(ctx.Done())
+
+	// Wait while informer end sync
+	if !cache.WaitForCacheSync(ctx.Done(), controller.HasSynced) {
+		return fmt.Errorf("[dynamicforward] failed to sync EndpointSlices informer")
+	}
+
+	log.Printf("[dynamicforward] EndpointSlice watcher for service %s in namespace %s: is running...", serviceName, namespace)
+
+	return nil
+}
+
+// updateServers handle update EndpointSlice and callback
+func handleUpdate(store cache.Store, portName string, serviceName string, namespace string, onUpdate func(newServers []string)) {
+
+	// Show all pslices in cache
+	items := store.List()
+	log.Printf("[dynamicforward] Number of EndpointSlices in cache for service %s in namespace %s: %d", serviceName, namespace, len(items))
+
+	// Collecting a list of addresses and ports
+	servers := make(map[string]struct{})
+	for _, item := range items {
+		endpointSlice, ok := item.(*v1.EndpointSlice)
+		if !ok {
+			log.Printf("[dynamicforward] Failed to cast object to EndpointSlice for service %s in namespace %s: %v", serviceName, namespace, item)
+			continue
+		}
+
+		// We process all addresses and ports
+		for _, endpoint := range endpointSlice.Endpoints {
+			for _, address := range endpoint.Addresses {
+				for _, port := range endpointSlice.Ports {
+					if port.Port != nil && port.Name != nil && *port.Name == portName {
+						server := fmt.Sprintf("%s:%d", address, *port.Port)
+						servers[server] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	// convert map in slice
+	serverList := make([]string, 0, len(servers)) // в противном случае вызовет ненужные ресайзы слайса
+	for server := range servers {
+		serverList = append(serverList, server)
+	}
+
+	// callback onUpdate
+	onUpdate(serverList)
+}

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -74,6 +74,11 @@ func (f *Forward) SetProxy(p *proxy.Proxy) {
 	p.Start(f.hcInterval)
 }
 
+// SetProxyOptions setup proxy options
+func (f *Forward) SetProxyOptions(opts proxy.Options) {
+	f.opts = opts
+}
+
 // SetTapPlugin appends one or more dnstap plugins to the tap plugin list.
 func (f *Forward) SetTapPlugin(tapPlugin *dnstap.Dnstap) {
 	f.tapPlugins = append(f.tapPlugins, tapPlugin)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull request introduces a new CoreDNS plugin, dynamicforward, designed for dynamic tracking of Kubernetes Services and seamless updates to the forward server list. The plugin monitors EndpointSlices associated with a specified Service, dynamically adjusting the DNS forwarding configuration as endpoints are added, removed, or updated.

The dynamicforward plugin  is particularly useful for organizing node-local-dns caching mechanism. In [standard scheme](https://github.com/kubernetes/kubernetes/blob/8294abc599696e0d1b5aa734afa7ae1e4f5059a0/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L100)  we use ClusterIP as upstream, so we are delegating responsibility for load balancing to CNI. In case of apiserver failure, CNI don't know which upstream endpoints are alive or not.
But coredns itself can handle upstream healthchecks and in case of apiserver failure it will still keep the endpoints list and will load balance the requests. 

There are some design imperfections:
* The plugin don't support the full list of  classic forward options. It uses the forward plugin for serving DNS under the hood, but it don't have public interface for configuring options.
* Controversial name of the plugin.


### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Added man.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
