### PR TITLE
chore: enable errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,19 @@
-run:
-  timeout: 5m
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:
+    - errorlint
+    - gofmt
     - govet
     - ineffassign
     - staticcheck
     - typecheck
-    - whitespace
-    - unused
-    - gofmt
     - unconvert
+    - unused
+    - whitespace
+output:
+  sort-results: true
+run:
+  timeout: 5m

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -130,7 +130,7 @@ func (s *ServerQUIC) serveQUICStream(stream quic.Stream, conn quic.Connection) {
 	// io.EOF does not really mean that there's any error, it is just
 	// the STREAM FIN indicating that there will be no data to read
 	// anymore from this stream.
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		s.closeQUICConn(conn, DoQCodeProtocolError)
 
 		return

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -57,7 +57,7 @@ func autoPathParse(c *caddy.Controller) (*AutoPath, string, error) {
 			// assume file on disk
 			rc, err := dns.ClientConfigFromFile(resolv)
 			if err != nil {
-				return ap, "", fmt.Errorf("failed to parse %q: %v", resolv, err)
+				return ap, "", fmt.Errorf("failed to parse %q: %w", resolv, err)
 			}
 			ap.search = rc.Search
 			plugin.Zones(ap.search).Normalize()

--- a/plugin/azure/azure_test.go
+++ b/plugin/azure/azure_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -141,7 +142,7 @@ func TestAzure(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := demoAzure.ServeDNS(context.Background(), rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Fatalf("Test %d: Expected error %v, but got %v", ti, tc.expectedErr, err)
 		}
 

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -18,7 +18,7 @@ func setup(c *caddy.Controller) error {
 	all := []string{}
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		log.Warning(plugin.Error("bind", fmt.Errorf("failed to get interfaces list, cannot bind by interface name: %s", err)))
+		log.Warning(plugin.Error("bind", fmt.Errorf("failed to get interfaces list, cannot bind by interface name: %w", err)))
 	}
 
 	for c.Next() {

--- a/plugin/chaos/chaos_test.go
+++ b/plugin/chaos/chaos_test.go
@@ -2,6 +2,7 @@ package chaos
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
@@ -62,7 +63,7 @@ func TestChaos(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := em.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %v, but got %v", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -165,12 +165,12 @@ func updateZoneFromRRS(rrs *gcp.ResourceRecordSetsListResponse, z *file.Zone) er
 			rfc1035 = fmt.Sprintf("%s %d IN %s %s", dns.Fqdn(rr.Name), rr.Ttl, rr.Type, value)
 			r, err = dns.NewRR(rfc1035)
 			if err != nil {
-				return fmt.Errorf("failed to parse resource record: %v", err)
+				return fmt.Errorf("failed to parse resource record: %w", err)
 			}
 
 			err = z.Insert(r)
 			if err != nil {
-				return fmt.Errorf("failed to insert record: %v", err)
+				return fmt.Errorf("failed to insert record: %w", err)
 			}
 		}
 	}
@@ -197,7 +197,7 @@ func (h *CloudDNS) updateZones(ctx context.Context) error {
 				newZ.Upstream = h.upstream
 				rrListResponse, err = h.client.listRRSets(ctx, hostedZone.projectName, hostedZone.zoneName)
 				if err != nil {
-					err = fmt.Errorf("failed to list resource records for %v:%v:%v from gcp: %v", zName, hostedZone.projectName, hostedZone.zoneName, err)
+					err = fmt.Errorf("failed to list resource records for %v:%v:%v from gcp: %w", zName, hostedZone.projectName, hostedZone.zoneName, err)
 					return
 				}
 				updateZoneFromRRS(rrListResponse, newZ)

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -289,7 +289,7 @@ func TestCloudDNS(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := r.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Fatalf("Test %d: Expected error %v, but got %v", ti, tc.expectedErr, err)
 		}
 		if code != tc.wantRetCode {

--- a/plugin/erratic/erratic_test.go
+++ b/plugin/erratic/erratic_test.go
@@ -2,6 +2,7 @@ package erratic
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -34,7 +35,7 @@ func TestErraticDrop(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := e.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %q, but got %q", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {
@@ -68,7 +69,7 @@ func TestErraticTruncate(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := e.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %q, but got %q", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -56,7 +56,7 @@ func TestErrors(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := em.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %v, but got %v",
 				i, tc.expectedErr, err)
 		}

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -63,7 +63,7 @@ func (e *Etcd) Lookup(ctx context.Context, state request.Request, name string, t
 
 // IsNameError implements the ServiceBackend interface.
 func (e *Etcd) IsNameError(err error) bool {
-	return err == errKeyNotFound
+	return errors.Is(err, errKeyNotFound)
 }
 
 // Records looks up records in etcd. If exact is true, it will lookup just this

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -156,7 +156,7 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
 	}
 	if zp.Err() != nil {
-		return nil, fmt.Errorf("failed to parse file %q for origin %s with error %v", fileName, origin, zp.Err())
+		return nil, fmt.Errorf("failed to parse file %q for origin %s with error %w", fileName, origin, zp.Err())
 	}
 
 	if err := zp.Err(); err != nil {

--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,7 +31,8 @@ func (z *Zone) Reload(t *transfer.Transfer) error {
 				zone, err := Parse(reader, z.origin, zFile, serial)
 				reader.Close()
 				if err != nil {
-					if _, ok := err.(*serialErr); !ok {
+					var e *serialErr
+					if !errors.As(err, &e) {
 						log.Errorf("Parsing zone %q: %v", z.origin, err)
 					}
 					continue

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -153,7 +153,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		for {
 			ret, err = proxy.Connect(ctx, state, opts)
 
-			if err == ErrCachedClosed { // Remote side closed conn, can only happen with TCP.
+			if errors.Is(err, ErrCachedClosed) { // Remote side closed conn, can only happen with TCP.
 				continue
 			}
 			// Retry with TCP if truncated and prefer_udp configured.

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -54,7 +54,7 @@ func parse(c *caddy.Controller) (string, time.Duration, error) {
 				}
 				l, err := time.ParseDuration(args[0])
 				if err != nil {
-					return "", 0, fmt.Errorf("unable to parse lameduck duration value: '%v' : %v", args[0], err)
+					return "", 0, fmt.Errorf("unable to parse lameduck duration value: '%v' : %w", args[0], err)
 				}
 				dur = l
 			default:

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/kubernetes"
@@ -30,7 +31,7 @@ func TestApex(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := e.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/kubernetes"
@@ -33,7 +34,7 @@ func TestExternal(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := e.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_case_test.go
+++ b/plugin/kubernetes/handler_case_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -60,7 +61,7 @@ func TestPreserveCase(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_ignore_emptyservice_test.go
+++ b/plugin/kubernetes/handler_ignore_emptyservice_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -42,7 +43,7 @@ func TestServeDNSEmptyService(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_pod_disabled_test.go
+++ b/plugin/kubernetes/handler_pod_disabled_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -40,7 +41,7 @@ func TestServeDNSModeDisabled(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d got unexpected error %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/plugin/kubernetes/handler_pod_insecure_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -75,7 +76,7 @@ func TestServeDNSModeInsecure(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_pod_verified_test.go
+++ b/plugin/kubernetes/handler_pod_verified_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -61,7 +62,7 @@ func TestServeDNSModeVerified(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -433,7 +434,7 @@ func TestServeDNS(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}
@@ -494,7 +495,7 @@ func TestServeNamespaceDNS(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}
@@ -540,7 +541,7 @@ func TestNotSyncedServeDNS(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -175,7 +175,7 @@ func (k *Kubernetes) Lookup(ctx context.Context, state request.Request, name str
 
 // IsNameError implements the ServiceBackend interface.
 func (k *Kubernetes) IsNameError(err error) bool {
-	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest
+	return errors.Is(err, errNoItems) || errors.Is(err, errNsNotExposed) || errors.Is(err, errInvalidRequest)
 }
 
 func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
@@ -234,14 +234,14 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create kubernetes notification controller: %q", err)
+		return nil, nil, fmt.Errorf("failed to create kubernetes notification controller: %w", err)
 	}
 
 	if k.opts.labelSelector != nil {
 		var selector labels.Selector
 		selector, err = meta.LabelSelectorAsSelector(k.opts.labelSelector)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.labelSelector, err)
+			return nil, nil, fmt.Errorf("unable to create Selector for LabelSelector '%s': %w", k.opts.labelSelector, err)
 		}
 		k.opts.selector = selector
 	}
@@ -250,7 +250,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 		var selector labels.Selector
 		selector, err = meta.LabelSelectorAsSelector(k.opts.namespaceLabelSelector)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to create Selector for LabelSelector '%s': %q", k.opts.namespaceLabelSelector, err)
+			return nil, nil, fmt.Errorf("unable to create Selector for LabelSelector '%s': %w", k.opts.namespaceLabelSelector, err)
 		}
 		k.opts.namespaceSelector = selector
 	}

--- a/plugin/kubernetes/kubernetes_apex_test.go
+++ b/plugin/kubernetes/kubernetes_apex_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestServeDNSApex(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d, expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +67,7 @@ func DefaultProcessor(convert ToFunc, recordLatency *EndpointLatencyRecorder) Pr
 							return fmt.Errorf("unexpected object %v", d.Object)
 						}
 						obj, err = convert(metaObj)
-						if err != nil && err != errPodTerminating {
+						if err != nil && !errors.Is(err, errPodTerminating) {
 							return err
 						}
 					}

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/kubernetes/object"
@@ -241,7 +242,7 @@ func TestReverse(t *testing.T) {
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
-		if err != tc.Error {
+		if !errors.Is(err, tc.Error) {
 			t.Errorf("Test %d: expected no error, got %v", i, err)
 			return
 		}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -166,7 +166,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				labelSelectorString := strings.Join(args, " ")
 				ls, err := meta.ParseToLabelSelector(labelSelectorString)
 				if err != nil {
-					return nil, fmt.Errorf("unable to parse label selector value: '%v': %v", labelSelectorString, err)
+					return nil, fmt.Errorf("unable to parse label selector value: '%v': %w", labelSelectorString, err)
 				}
 				k8s.opts.labelSelector = ls
 				continue
@@ -178,7 +178,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				namespaceLabelSelectorString := strings.Join(args, " ")
 				nls, err := meta.ParseToLabelSelector(namespaceLabelSelectorString)
 				if err != nil {
-					return nil, fmt.Errorf("unable to parse namespace_label selector value: '%v': %v", namespaceLabelSelectorString, err)
+					return nil, fmt.Errorf("unable to parse namespace_label selector value: '%v': %w", namespaceLabelSelectorString, err)
 				}
 				k8s.opts.namespaceLabelSelector = nls
 				continue

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ func TestKubernetesTransferNonAuthZone(t *testing.T) {
 	dnsmsg.SetAxfr("example.com")
 
 	_, err := k.Transfer("example.com", 0)
-	if err != transfer.ErrNotAuthoritative {
+	if !errors.Is(err, transfer.ErrNotAuthoritative) {
 		t.Error(err)
 	}
 }

--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -322,7 +322,7 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) (map[string]weights, e
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Weight file %s parsing error:%s", w.fileName, err)
+		return nil, fmt.Errorf("Weight file %s parsing error:%w", w.fileName, err)
 	}
 
 	return domains, nil

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"sync"
@@ -53,7 +54,8 @@ func (m *Metrics) MustRegister(c prometheus.Collector) {
 	err := m.Reg.Register(c)
 	if err != nil {
 		// ignore any duplicate error, but fatal on any other kind of error
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+		var e prometheus.AlreadyRegisteredError
+		if !errors.As(err, &e) {
 			log.Fatalf("Cannot register metrics collector: %s", err)
 		}
 	}

--- a/plugin/nsid/nsid_test.go
+++ b/plugin/nsid/nsid_test.go
@@ -3,6 +3,7 @@ package nsid
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
@@ -54,7 +55,7 @@ func TestNsid(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := em.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %v, but got %v", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {
@@ -116,7 +117,7 @@ func TestNsidCache(t *testing.T) {
 		c.Next = em
 		code, err := c.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %v, but got %v", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -91,8 +91,8 @@ func HostPortOrFile(s ...string) ([]string, error) {
 // Try to open this is a file first.
 func tryFile(s string) ([]string, error) {
 	c, err := dns.ClientConfigFromFile(s)
-	if err == os.ErrNotExist {
-		return nil, fmt.Errorf("failed to open file %q: %q", s, err)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to open file %q: %w", s, err)
 	} else if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -44,7 +44,7 @@ func TestDoErr(t *testing.T) {
 	v, err := g.Do(1, func() (interface{}, error) {
 		return nil, someErr
 	})
-	if err != someErr {
+	if !errors.Is(err, someErr) {
 		t.Errorf("Do error = %v; want someErr", err)
 	}
 	if v != nil {

--- a/plugin/pkg/tls/tls.go
+++ b/plugin/pkg/tls/tls.go
@@ -87,7 +87,7 @@ func NewTLSConfigFromArgs(args ...string) (*tls.Config, error) {
 func NewTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not load TLS cert: %s", err)
+		return nil, fmt.Errorf("could not load TLS cert: %w", err)
 	}
 
 	roots, err := loadRoots(caPath)
@@ -123,11 +123,11 @@ func loadRoots(caPath string) (*x509.CertPool, error) {
 	roots := x509.NewCertPool()
 	pem, err := os.ReadFile(filepath.Clean(caPath))
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", caPath, err)
+		return nil, fmt.Errorf("error reading %s: %w", caPath, err)
 	}
 	ok := roots.AppendCertsFromPEM(pem)
 	if !ok {
-		return nil, fmt.Errorf("could not read root certs: %s", err)
+		return nil, fmt.Errorf("could not read root certs: %w", err)
 	}
 	return roots, nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -67,7 +67,7 @@ func (f HandlerFunc) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 func (f HandlerFunc) Name() string { return "handlerfunc" }
 
 // Error returns err with 'plugin/name: ' prefixed to it.
-func Error(name string, err error) error { return fmt.Errorf("%s/%s: %s", "plugin", name, err) }
+func Error(name string, err error) error { return fmt.Errorf("%s/%s: %w", "plugin", name, err) }
 
 // NextOrFailure calls next.ServeDNS when next is not nil, otherwise it will return, a ServerFailure and a `no next plugin found` error.
 func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) { // nolint: golint

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -391,7 +391,7 @@ func parseAnswerRules(name string, args []string) (auto bool, rules ResponseRule
 			rewriteAnswerFromPattern, err := isValidRegexPattern(rewriteAnswerFrom, rewriteAnswerTo)
 			rewriteAnswerTo = plugin.Name(rewriteAnswerTo).Normalize()
 			if err != nil {
-				return false, nil, fmt.Errorf("%s answer rule for %s rule: %s", last, name, err)
+				return false, nil, fmt.Errorf("%s answer rule for %s rule: %w", last, name, err)
 			}
 			rules = append(rules, &nameRewriterResponseRule{newStringRewriter(rewriteAnswerFromPattern, rewriteAnswerTo)})
 			arg += 2
@@ -405,7 +405,7 @@ func parseAnswerRules(name string, args []string) (auto bool, rules ResponseRule
 			rewriteAnswerFromPattern, err := isValidRegexPattern(rewriteAnswerFrom, rewriteAnswerTo)
 			rewriteAnswerTo = plugin.Name(rewriteAnswerTo).Normalize()
 			if err != nil {
-				return false, nil, fmt.Errorf("%s answer rule for %s rule: %s", last, name, err)
+				return false, nil, fmt.Errorf("%s answer rule for %s rule: %w", last, name, err)
 			}
 			rules = append(rules, &valueRewriterResponseRule{newStringRewriter(rewriteAnswerFromPattern, rewriteAnswerTo)})
 			arg += 2

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -215,18 +215,18 @@ func updateZoneFromRRS(rrs *route53.ResourceRecordSet, z *file.Zone) error {
 	for _, rr := range rrs.ResourceRecords {
 		n, err := maybeUnescape(aws.StringValue(rrs.Name))
 		if err != nil {
-			return fmt.Errorf("failed to unescape `%s' name: %v", aws.StringValue(rrs.Name), err)
+			return fmt.Errorf("failed to unescape `%s' name: %w", aws.StringValue(rrs.Name), err)
 		}
 		v, err := maybeUnescape(aws.StringValue(rr.Value))
 		if err != nil {
-			return fmt.Errorf("failed to unescape `%s' value: %v", aws.StringValue(rr.Value), err)
+			return fmt.Errorf("failed to unescape `%s' value: %w", aws.StringValue(rr.Value), err)
 		}
 
 		// Assemble RFC 1035 conforming record to pass into dns scanner.
 		rfc1035 := fmt.Sprintf("%s %d IN %s %s", n, aws.Int64Value(rrs.TTL), aws.StringValue(rrs.Type), v)
 		r, err := dns.NewRR(rfc1035)
 		if err != nil {
-			return fmt.Errorf("failed to parse resource record: %v", err)
+			return fmt.Errorf("failed to parse resource record: %w", err)
 		}
 
 		z.Insert(r)
@@ -266,7 +266,7 @@ func (h *Route53) updateZones(ctx context.Context) error {
 						return true
 					})
 				if err != nil {
-					err = fmt.Errorf("failed to list resource records for %v:%v from route53: %v", zName, hostedZone.id, err)
+					err = fmt.Errorf("failed to list resource records for %v:%v from route53: %w", zName, hostedZone.id, err)
 					return
 				}
 				h.zMu.Lock()

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -228,7 +228,7 @@ func TestRoute53(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := r.ServeDNS(ctx, rec, req)
 
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Fatalf("Test %d: Expected error %v, but got %v", ti, tc.expectedErr, err)
 		}
 		if code != tc.wantRetCode {
@@ -288,7 +288,7 @@ func TestMaybeUnescape(t *testing.T) {
 		{escaped: `example.com\0`, wantErr: errors.New(`invalid escape sequence: '\0'`)},
 	} {
 		got, gotErr := maybeUnescape(tc.escaped)
-		if tc.wantErr != gotErr && !reflect.DeepEqual(tc.wantErr, gotErr) {
+		if !errors.Is(gotErr, tc.wantErr) && !reflect.DeepEqual(tc.wantErr, gotErr) {
 			t.Fatalf("Test %d: Expected error: `%v', but got: `%v'", ti, tc.wantErr, gotErr)
 		}
 		if tc.want != got {

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -22,6 +22,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -237,7 +238,7 @@ func fetchMetricFamilies(url string, ch chan<- *dto.MetricFamily) {
 		for {
 			mf := &dto.MetricFamily{}
 			if _, err = pbutil.ReadDelimited(resp.Body, mf); err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				return

--- a/plugin/transfer/notify.go
+++ b/plugin/transfer/notify.go
@@ -52,7 +52,7 @@ func sendNotify(c *dns.Client, m *dns.Msg, s string) error {
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("notify for zone %q was not accepted by %q: %q", m.Question[0].Name, s, err)
+		return fmt.Errorf("notify for zone %q was not accepted by %q: %w", m.Question[0].Name, s, err)
 	}
 	return fmt.Errorf("notify for zone %q was not accepted by %q: rcode was %q", m.Question[0].Name, s, rcode.ToString(code))
 }

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -94,7 +94,7 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	var err error
 	for _, p := range t.Transferers {
 		pchan, err = p.Transfer(state.QName(), serial)
-		if err == ErrNotAuthoritative {
+		if errors.Is(err, ErrNotAuthoritative) {
 			// plugin was not authoritative for the zone, try next plugin
 			continue
 		}

--- a/plugin/tsig/tsig.go
+++ b/plugin/tsig/tsig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -53,10 +54,10 @@ func (t *TSIGServer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	if tsigStatus != nil {
 		log.Debugf("TSIG validation failed: %v %v", dns.TypeToString[state.QType()], tsigStatus)
 		rcode = dns.RcodeNotAuth
-		switch tsigStatus {
-		case dns.ErrSecret:
+		switch {
+		case errors.Is(tsigStatus, dns.ErrSecret):
 			tsigRR.Error = dns.RcodeBadKey
-		case dns.ErrTime:
+		case errors.Is(tsigStatus, dns.ErrTime):
 			tsigRR.Error = dns.RcodeBadTime
 		default:
 			tsigRR.Error = dns.RcodeBadSig

--- a/plugin/whoami/whoami_test.go
+++ b/plugin/whoami/whoami_test.go
@@ -2,6 +2,7 @@ package whoami
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -63,7 +64,7 @@ func TestWhoami(t *testing.T) {
 		req.SetQuestion(dns.Fqdn(tc.qname), tc.qtype)
 		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: tc.remote})
 		code, err := wh.ServeDNS(ctx, rec, req)
-		if err != tc.expectedErr {
+		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("Test %d: Expected error %v, but got %v", i, tc.expectedErr, err)
 		}
 		if code != tc.expectedCode {

--- a/test/tsig_test.go
+++ b/test/tsig_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -62,7 +63,7 @@ func TestTsigBadKey(t *testing.T) {
 	client := dns.Client{Net: "udp", TsigSecret: map[string]string{"bad.key.": tsigSecret}}
 	r, _, err := client.Exchange(m, udp)
 
-	if err != dns.ErrAuth {
+	if !errors.Is(err, dns.ErrAuth) {
 		t.Fatalf("Expected \"dns: bad authentication\" error, got: %s", err)
 	}
 	if r.Rcode != dns.RcodeNotAuth {
@@ -101,7 +102,7 @@ func TestTsigBadSig(t *testing.T) {
 	client := dns.Client{Net: "udp", TsigSecret: map[string]string{tsigKey: "BADSIG00ECfVZG2qCjr4mPpaGim/Bq+IWMiNrLjUO4Y="}}
 	r, _, err := client.Exchange(m, udp)
 
-	if err != dns.ErrAuth {
+	if !errors.Is(err, dns.ErrAuth) {
 		t.Fatalf("Expected \"dns: bad authentication\" error, got: %s", err)
 	}
 	if r.Rcode != dns.RcodeNotAuth {
@@ -141,7 +142,7 @@ func TestTsigBadTime(t *testing.T) {
 	client := dns.Client{Net: "udp", TsigSecret: map[string]string{tsigKey: tsigSecret}}
 	r, _, err := client.Exchange(m, udp)
 
-	if err != dns.ErrAuth {
+	if !errors.Is(err, dns.ErrAuth) {
 		t.Fatalf("Expected \"dns: bad authentication\" error, got: %s", err)
 	}
 	if r.Rcode != dns.RcodeNotAuth {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

[Errorlint](https://golangci-lint.run/usage/linters/#errorlint) is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.

### 2. Which issues (if any) are related? 

None

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No
