### PR TITLE
chore: enable use-any from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,70 @@
-run:
-  timeout: 5m
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:
+    - gofmt
     - govet
     - ineffassign
+    - revive
     - staticcheck
     - typecheck
-    - whitespace
-    - unused
-    - gofmt
     - unconvert
+    - unused
+    - whitespace
+linters-settings:
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+        disabled: true
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+        arguments:
+          - "preserveScope"
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+        disabled: true
+      - name: superfluous-else
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+        disabled: true
+      - name: unexported-return
+        disabled: true
+      - name: unnecessary-stmt
+        disabled: true
+      - name: unreachable-code
+      - name: unused-parameter
+        disabled: true
+        arguments:
+          - allowRegex: "^_"
+      - name: use-any
+      - name: var-declaration
+      - name: var-naming
+        disabled: true
+        arguments:
+          - ["ID"]
+          - ["VM"]
+          - - upperCaseConst: true
+output:
+  sort-results: true
+run:
+  timeout: 5m

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -62,7 +62,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 	s.m.Unlock()
 
 	if s.Tracer() != nil {
-		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp interface{}) bool {
+		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp any) bool {
 			return parentSpanCtx != nil
 		}
 		intercept := otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -89,7 +89,7 @@ func Run() {
 // enabled. If this process is an upgrade, however, and the user
 // might not be there anymore, this just logs to the process
 // log and exits.
-func mustLogFatal(args ...interface{}) {
+func mustLogFatal(args ...any) {
 	if !caddy.IsUpgrade() {
 		log.SetOutput(os.Stderr)
 	}

--- a/plugin/debug/pcap.go
+++ b/plugin/debug/pcap.go
@@ -22,7 +22,7 @@ import (
 // is prefixed with 'debug: ' so the data can be easily extracted.
 //
 // msg will prefix the pcap dump.
-func Hexdump(m *dns.Msg, v ...interface{}) {
+func Hexdump(m *dns.Msg, v ...any) {
 	if !log.D.Value() {
 		return
 	}
@@ -38,7 +38,7 @@ func Hexdump(m *dns.Msg, v ...interface{}) {
 }
 
 // Hexdumpf dumps a DNS message as Hexdump, but allows a format string.
-func Hexdumpf(m *dns.Msg, format string, v ...interface{}) {
+func Hexdumpf(m *dns.Msg, format string, v ...any) {
 	if !log.D.Value() {
 		return
 	}

--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -32,7 +32,7 @@ func periodicClean(c *cache.Cache, stop <-chan struct{}) {
 			// we sign for 8 days, check if a signature in the cache reached 75% of that (i.e. 6), if found delete
 			// the signature
 			is75 := time.Now().UTC().Add(twoDays)
-			c.Walk(func(items map[uint64]interface{}, key uint64) bool {
+			c.Walk(func(items map[uint64]any, key uint64) bool {
 				for _, rr := range items[key].([]dns.RR) {
 					if !rr.(*dns.RRSIG).ValidityPeriod(is75) {
 						delete(items, key)

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -118,7 +118,7 @@ func (d Dnssec) sign(rrs []dns.RR, signerName string, ttl, incep, expir uint32, 
 		return sgs, nil
 	}
 
-	sigs, err := d.inflight.Do(k, func() (interface{}, error) {
+	sigs, err := d.inflight.Do(k, func() (any, error) {
 		var sigs []dns.RR
 		for _, k := range d.keys {
 			if d.splitkeys {

--- a/plugin/errors/errors.go
+++ b/plugin/errors/errors.go
@@ -22,7 +22,7 @@ type pattern struct {
 	count       uint32
 	period      time.Duration
 	pattern     *regexp.Regexp
-	logCallback func(format string, v ...interface{})
+	logCallback func(format string, v ...any)
 }
 
 func (p *pattern) timer() *time.Timer {

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -73,7 +73,7 @@ func TestErrors(t *testing.T) {
 
 func TestLogPattern(t *testing.T) {
 	type args struct {
-		logCallback func(format string, v ...interface{})
+		logCallback func(format string, v ...any)
 	}
 	tests := []struct {
 		name string

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -89,7 +89,7 @@ func parseConsolidate(c *caddy.Controller) (*pattern, error) {
 	return &pattern{period: p, pattern: re, logCallback: lc}, nil
 }
 
-func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...interface{}), error) {
+func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...any), error) {
 	if len(args) != 3 {
 		return log.Errorf, nil
 	}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -182,7 +182,7 @@ func (dns *dnsControl) EndpointSliceLatencyRecorder() *object.EndpointLatencyRec
 	}
 }
 
-func podIPIndexFunc(obj interface{}) ([]string, error) {
+func podIPIndexFunc(obj any) ([]string, error) {
 	p, ok := obj.(*object.Pod)
 	if !ok {
 		return nil, errObj
@@ -190,7 +190,7 @@ func podIPIndexFunc(obj interface{}) ([]string, error) {
 	return []string{p.PodIP}, nil
 }
 
-func svcIPIndexFunc(obj interface{}) ([]string, error) {
+func svcIPIndexFunc(obj any) ([]string, error) {
 	svc, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -200,7 +200,7 @@ func svcIPIndexFunc(obj interface{}) ([]string, error) {
 	return idx, nil
 }
 
-func svcExtIPIndexFunc(obj interface{}) ([]string, error) {
+func svcExtIPIndexFunc(obj any) ([]string, error) {
 	svc, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -210,7 +210,7 @@ func svcExtIPIndexFunc(obj interface{}) ([]string, error) {
 	return idx, nil
 }
 
-func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func svcNameNamespaceIndexFunc(obj any) ([]string, error) {
 	s, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -218,7 +218,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.Index}, nil
 }
 
-func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func epNameNamespaceIndexFunc(obj any) ([]string, error) {
 	s, ok := obj.(*object.Endpoints)
 	if !ok {
 		return nil, errObj
@@ -226,7 +226,7 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.Index}, nil
 }
 
-func epIPIndexFunc(obj interface{}) ([]string, error) {
+func epIPIndexFunc(obj any) ([]string, error) {
 	ep, ok := obj.(*object.Endpoints)
 	if !ok {
 		return nil, errObj
@@ -500,12 +500,12 @@ func (dns *dnsControl) GetNamespaceByName(name string) (*object.Namespace, error
 	return ns, nil
 }
 
-func (dns *dnsControl) Add(obj interface{})               { dns.updateModified() }
-func (dns *dnsControl) Delete(obj interface{})            { dns.updateModified() }
-func (dns *dnsControl) Update(oldObj, newObj interface{}) { dns.detectChanges(oldObj, newObj) }
+func (dns *dnsControl) Add(obj any)               { dns.updateModified() }
+func (dns *dnsControl) Delete(obj any)            { dns.updateModified() }
+func (dns *dnsControl) Update(oldObj, newObj any) { dns.detectChanges(oldObj, newObj) }
 
 // detectChanges detects changes in objects, and updates the modified timestamp
-func (dns *dnsControl) detectChanges(oldObj, newObj interface{}) {
+func (dns *dnsControl) detectChanges(oldObj, newObj any) {
 	// If both objects have the same resource version, they are identical.
 	if newObj != nil && oldObj != nil && (oldObj.(meta.Object).GetResourceVersion() == newObj.(meta.Object).GetResourceVersion()) {
 		return
@@ -599,7 +599,7 @@ func endpointsEquivalent(a, b *object.Endpoints) bool {
 // serviceModified checks the services passed for changes that result in changes
 // to internal and or external records.  It returns two booleans, one for internal
 // record changes, and a second for external record changes
-func serviceModified(oldObj, newObj interface{}) (intSvc, extSvc bool) {
+func serviceModified(oldObj, newObj any) (intSvc, extSvc bool) {
 	if oldObj != nil && newObj == nil {
 		// deleted service only modifies external zone records if it had external ips
 		return true, len(oldObj.(*object.Service).ExternalIPs) > 0

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -239,8 +239,8 @@ func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 
 func TestServiceModified(t *testing.T) {
 	var tests = []struct {
-		oldSvc   interface{}
-		newSvc   interface{}
+		oldSvc   any
+		newSvc   any
 		ichanged bool
 		echanged bool
 	}{

--- a/plugin/kubernetes/logger.go
+++ b/plugin/kubernetes/logger.go
@@ -21,15 +21,15 @@ func (l *loggerAdapter) Enabled(_ int) bool {
 	return true
 }
 
-func (l *loggerAdapter) Info(_ int, msg string, _ ...interface{}) {
+func (l *loggerAdapter) Info(_ int, msg string, _ ...any) {
 	l.P.Info(msg)
 }
 
-func (l *loggerAdapter) Error(_ error, msg string, _ ...interface{}) {
+func (l *loggerAdapter) Error(_ error, msg string, _ ...any) {
 	l.P.Error(msg)
 }
 
-func (l *loggerAdapter) WithValues(_ ...interface{}) logr.LogSink {
+func (l *loggerAdapter) WithValues(_ ...any) logr.LogSink {
 	return l
 }
 

--- a/plugin/kubernetes/metrics_test.backup
+++ b/plugin/kubernetes/metrics_test.backup
@@ -131,7 +131,7 @@ func TestDnsProgrammingLatencyEndpoints(t *testing.T) {
 	}
 }
 
-func buildEndpoints(name string, lastChangeTriggerTime interface{}, subsets []api.EndpointSubset) *api.Endpoints {
+func buildEndpoints(name string, lastChangeTriggerTime any, subsets []api.EndpointSubset) *api.Endpoints {
 	annotations := make(map[string]string)
 	switch v := lastChangeTriggerTime.(type) {
 	case string:
@@ -145,7 +145,7 @@ func buildEndpoints(name string, lastChangeTriggerTime interface{}, subsets []ap
 	}
 }
 
-func buildEndpointSlice(name string, lastChangeTriggerTime interface{}, endpoints []discovery.Endpoint) *discovery.EndpointSlice {
+func buildEndpointSlice(name string, lastChangeTriggerTime any, endpoints []discovery.Endpoint) *discovery.EndpointSlice {
 	annotations := make(map[string]string)
 	switch v := lastChangeTriggerTime.(type) {
 	case string:
@@ -163,28 +163,28 @@ func buildEndpointSlice(name string, lastChangeTriggerTime interface{}, endpoint
 	}
 }
 
-func createEndpoints(t *testing.T, processor cache.ProcessFunc, name string, triggerTime interface{}, subsets []api.EndpointSubset) {
+func createEndpoints(t *testing.T, processor cache.ProcessFunc, name string, triggerTime any, subsets []api.EndpointSubset) {
 	err := processor(cache.Deltas{{Type: cache.Added, Object: buildEndpoints(name, triggerTime, subsets)}})
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func updateEndpoints(t *testing.T, processor cache.ProcessFunc, name string, triggerTime interface{}, subsets []api.EndpointSubset) {
+func updateEndpoints(t *testing.T, processor cache.ProcessFunc, name string, triggerTime any, subsets []api.EndpointSubset) {
 	err := processor(cache.Deltas{{Type: cache.Updated, Object: buildEndpoints(name, triggerTime, subsets)}})
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func createEndpointSlice(t *testing.T, processor cache.ProcessFunc, name string, triggerTime interface{}, endpoints []discovery.Endpoint) {
+func createEndpointSlice(t *testing.T, processor cache.ProcessFunc, name string, triggerTime any, endpoints []discovery.Endpoint) {
 	err := processor(cache.Deltas{{Type: cache.Added, Object: buildEndpointSlice(name, triggerTime, endpoints)}})
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func updateEndpointSlice(t *testing.T, processor cache.ProcessFunc, name string, triggerTime interface{}, endpoints []discovery.Endpoint) {
+func updateEndpointSlice(t *testing.T, processor cache.ProcessFunc, name string, triggerTime any, endpoints []discovery.Endpoint) {
 	err := processor(cache.Deltas{{Type: cache.Updated, Object: buildEndpointSlice(name, triggerTime, endpoints)}})
 	if err != nil {
 		t.Fatal(err)

--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -29,7 +29,7 @@ type RecordLatencyFunc func(meta.Object)
 // DefaultProcessor is based on the Process function from cache.NewIndexerInformer except it does a conversion.
 func DefaultProcessor(convert ToFunc, recordLatency *EndpointLatencyRecorder) ProcessorBuilder {
 	return func(clientState cache.Indexer, h cache.ResourceEventHandler) cache.ProcessFunc {
-		return func(obj interface{}, isInitialList bool) error {
+		return func(obj any, isInitialList bool) error {
 			for _, d := range obj.(cache.Deltas) {
 				if recordLatency != nil {
 					if o, ok := d.Object.(meta.Object); ok {
@@ -57,7 +57,7 @@ func DefaultProcessor(convert ToFunc, recordLatency *EndpointLatencyRecorder) Pr
 						recordLatency.record()
 					}
 				case cache.Deleted:
-					var obj interface{}
+					var obj any
 					obj, ok := d.Object.(cache.DeletedFinalStateUnknown)
 					if !ok {
 						var err error

--- a/plugin/pkg/cache/cache.go
+++ b/plugin/pkg/cache/cache.go
@@ -22,7 +22,7 @@ type Cache struct {
 
 // shard is a cache with random eviction.
 type shard struct {
-	items map[uint64]interface{}
+	items map[uint64]any
 	size  int
 
 	sync.RWMutex
@@ -46,13 +46,13 @@ func New(size int) *Cache {
 
 // Add adds a new element to the cache. If the element already exists it is overwritten.
 // Returns true if an existing element was evicted to make room for this element.
-func (c *Cache) Add(key uint64, el interface{}) bool {
+func (c *Cache) Add(key uint64, el any) bool {
 	shard := key & (shardSize - 1)
 	return c.shards[shard].Add(key, el)
 }
 
 // Get looks up element index under key.
-func (c *Cache) Get(key uint64) (interface{}, bool) {
+func (c *Cache) Get(key uint64) (any, bool) {
 	shard := key & (shardSize - 1)
 	return c.shards[shard].Get(key)
 }
@@ -73,18 +73,18 @@ func (c *Cache) Len() int {
 }
 
 // Walk walks each shard in the cache.
-func (c *Cache) Walk(f func(map[uint64]interface{}, uint64) bool) {
+func (c *Cache) Walk(f func(map[uint64]any, uint64) bool) {
 	for _, s := range &c.shards {
 		s.Walk(f)
 	}
 }
 
 // newShard returns a new shard with size.
-func newShard(size int) *shard { return &shard{items: make(map[uint64]interface{}), size: size} }
+func newShard(size int) *shard { return &shard{items: make(map[uint64]any), size: size} }
 
 // Add adds element indexed by key into the cache. Any existing element is overwritten
 // Returns true if an existing element was evicted to make room for this element.
-func (s *shard) Add(key uint64, el interface{}) bool {
+func (s *shard) Add(key uint64, el any) bool {
 	eviction := false
 	s.Lock()
 	if len(s.items) >= s.size {
@@ -119,7 +119,7 @@ func (s *shard) Evict() {
 }
 
 // Get looks up the element indexed under key.
-func (s *shard) Get(key uint64) (interface{}, bool) {
+func (s *shard) Get(key uint64) (any, bool) {
 	s.RLock()
 	el, found := s.items[key]
 	s.RUnlock()
@@ -135,7 +135,7 @@ func (s *shard) Len() int {
 }
 
 // Walk walks the shard for each element the function f is executed while holding a write lock.
-func (s *shard) Walk(f func(map[uint64]interface{}, uint64) bool) {
+func (s *shard) Walk(f func(map[uint64]any, uint64) bool) {
 	s.RLock()
 	items := make([]uint64, len(s.items))
 	i := 0

--- a/plugin/pkg/cache/cache_test.go
+++ b/plugin/pkg/cache/cache_test.go
@@ -63,7 +63,7 @@ func TestCacheWalk(t *testing.T) {
 		exp[i] = 1
 	}
 	got := make([]int, 10*2)
-	c.Walk(func(items map[uint64]interface{}, key uint64) bool {
+	c.Walk(func(items map[uint64]any, key uint64) bool {
 		got[key] = items[key].(int)
 		return true
 	})

--- a/plugin/pkg/expression/expression.go
+++ b/plugin/pkg/expression/expression.go
@@ -10,8 +10,8 @@ import (
 )
 
 // DefaultEnv returns the default set of custom state variables and functions available to for use in expression evaluation.
-func DefaultEnv(ctx context.Context, state *request.Request) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultEnv(ctx context.Context, state *request.Request) map[string]any {
+	return map[string]any{
 		"incidr": func(ipStr, cidrStr string) (bool, error) {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {

--- a/plugin/pkg/log/listener.go
+++ b/plugin/pkg/log/listener.go
@@ -9,16 +9,16 @@ import (
 // A usage example is, the external plugin k8s_event will replicate log prints to Kubernetes events.
 type Listener interface {
 	Name() string
-	Debug(plugin string, v ...interface{})
-	Debugf(plugin string, format string, v ...interface{})
-	Info(plugin string, v ...interface{})
-	Infof(plugin string, format string, v ...interface{})
-	Warning(plugin string, v ...interface{})
-	Warningf(plugin string, format string, v ...interface{})
-	Error(plugin string, v ...interface{})
-	Errorf(plugin string, format string, v ...interface{})
-	Fatal(plugin string, v ...interface{})
-	Fatalf(plugin string, format string, v ...interface{})
+	Debug(plugin string, v ...any)
+	Debugf(plugin string, format string, v ...any)
+	Info(plugin string, v ...any)
+	Infof(plugin string, format string, v ...any)
+	Warning(plugin string, v ...any)
+	Warningf(plugin string, format string, v ...any)
+	Error(plugin string, v ...any)
+	Errorf(plugin string, format string, v ...any)
+	Fatal(plugin string, v ...any)
+	Fatalf(plugin string, format string, v ...any)
 }
 
 type listeners struct {
@@ -60,7 +60,7 @@ func DeregisterListener(old Listener) error {
 	return nil
 }
 
-func (ls *listeners) debug(plugin string, v ...interface{}) {
+func (ls *listeners) debug(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Debug(plugin, v...)
@@ -68,7 +68,7 @@ func (ls *listeners) debug(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) debugf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) debugf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Debugf(plugin, format, v...)
@@ -76,7 +76,7 @@ func (ls *listeners) debugf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) info(plugin string, v ...interface{}) {
+func (ls *listeners) info(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Info(plugin, v...)
@@ -84,7 +84,7 @@ func (ls *listeners) info(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) infof(plugin string, format string, v ...interface{}) {
+func (ls *listeners) infof(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Infof(plugin, format, v...)
@@ -92,7 +92,7 @@ func (ls *listeners) infof(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) warning(plugin string, v ...interface{}) {
+func (ls *listeners) warning(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Warning(plugin, v...)
@@ -100,7 +100,7 @@ func (ls *listeners) warning(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) warningf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) warningf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Warningf(plugin, format, v...)
@@ -108,7 +108,7 @@ func (ls *listeners) warningf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) error(plugin string, v ...interface{}) {
+func (ls *listeners) error(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Error(plugin, v...)
@@ -116,7 +116,7 @@ func (ls *listeners) error(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) errorf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) errorf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Errorf(plugin, format, v...)
@@ -124,7 +124,7 @@ func (ls *listeners) errorf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) fatal(plugin string, v ...interface{}) {
+func (ls *listeners) fatal(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Fatal(plugin, v...)
@@ -132,7 +132,7 @@ func (ls *listeners) fatal(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) fatalf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) fatalf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Fatalf(plugin, format, v...)

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -79,42 +79,42 @@ func (l *mockListener) Name() string {
 	return l.name
 }
 
-func (l *mockListener) Debug(plugin string, v ...interface{}) {
+func (l *mockListener) Debug(plugin string, v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Debugf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Debugf(plugin string, format string, v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Info(plugin string, v ...interface{}) {
+func (l *mockListener) Info(plugin string, v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Infof(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Infof(plugin string, format string, v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Warning(plugin string, v ...interface{}) {
+func (l *mockListener) Warning(plugin string, v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Warningf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Warningf(plugin string, format string, v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Error(plugin string, v ...interface{}) {
+func (l *mockListener) Error(plugin string, v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Errorf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Errorf(plugin string, format string, v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Fatal(plugin string, v ...interface{}) {
+func (l *mockListener) Fatal(plugin string, v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }
 
-func (l *mockListener) Fatalf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Fatalf(plugin string, format string, v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -40,18 +40,18 @@ func (d *d) Value() bool {
 }
 
 // logf calls log.Printf prefixed with level.
-func logf(level, format string, v ...interface{}) {
+func logf(level, format string, v ...any) {
 	golog.Print(level, fmt.Sprintf(format, v...))
 }
 
 // log calls log.Print prefixed with level.
-func log(level string, v ...interface{}) {
+func log(level string, v ...any) {
 	golog.Print(level, fmt.Sprint(v...))
 }
 
 // Debug is equivalent to log.Print(), but prefixed with "[DEBUG] ". It only outputs something
 // if D is true.
-func Debug(v ...interface{}) {
+func Debug(v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -60,7 +60,7 @@ func Debug(v ...interface{}) {
 
 // Debugf is equivalent to log.Printf(), but prefixed with "[DEBUG] ". It only outputs something
 // if D is true.
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -68,30 +68,30 @@ func Debugf(format string, v ...interface{}) {
 }
 
 // Info is equivalent to log.Print, but prefixed with "[INFO] ".
-func Info(v ...interface{}) { log(info, v...) }
+func Info(v ...any) { log(info, v...) }
 
 // Infof is equivalent to log.Printf, but prefixed with "[INFO] ".
-func Infof(format string, v ...interface{}) { logf(info, format, v...) }
+func Infof(format string, v ...any) { logf(info, format, v...) }
 
 // Warning is equivalent to log.Print, but prefixed with "[WARNING] ".
-func Warning(v ...interface{}) { log(warning, v...) }
+func Warning(v ...any) { log(warning, v...) }
 
 // Warningf is equivalent to log.Printf, but prefixed with "[WARNING] ".
-func Warningf(format string, v ...interface{}) { logf(warning, format, v...) }
+func Warningf(format string, v ...any) { logf(warning, format, v...) }
 
 // Error is equivalent to log.Print, but prefixed with "[ERROR] ".
-func Error(v ...interface{}) { log(err, v...) }
+func Error(v ...any) { log(err, v...) }
 
 // Errorf is equivalent to log.Printf, but prefixed with "[ERROR] ".
-func Errorf(format string, v ...interface{}) { logf(err, format, v...) }
+func Errorf(format string, v ...any) { logf(err, format, v...) }
 
 // Fatal is equivalent to log.Print, but prefixed with "[FATAL] ", and calling
 // os.Exit(1).
-func Fatal(v ...interface{}) { log(fatal, v...); os.Exit(1) }
+func Fatal(v ...any) { log(fatal, v...); os.Exit(1) }
 
 // Fatalf is equivalent to log.Printf, but prefixed with "[FATAL] ", and calling
 // os.Exit(1)
-func Fatalf(format string, v ...interface{}) { logf(fatal, format, v...); os.Exit(1) }
+func Fatalf(format string, v ...any) { logf(fatal, format, v...); os.Exit(1) }
 
 // Discard sets the log output to /dev/null.
 func Discard() { golog.SetOutput(io.Discard) }

--- a/plugin/pkg/log/plugin.go
+++ b/plugin/pkg/log/plugin.go
@@ -14,16 +14,16 @@ type P struct {
 // I.e [INFO] plugin/<name>: message.
 func NewWithPlugin(name string) P { return P{"plugin/" + name + ": "} }
 
-func (p P) logf(level, format string, v ...interface{}) {
+func (p P) logf(level, format string, v ...any) {
 	log(level, p.plugin, fmt.Sprintf(format, v...))
 }
 
-func (p P) log(level string, v ...interface{}) {
+func (p P) log(level string, v ...any) {
 	log(level+p.plugin, v...)
 }
 
 // Debug logs as log.Debug.
-func (p P) Debug(v ...interface{}) {
+func (p P) Debug(v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -32,7 +32,7 @@ func (p P) Debug(v ...interface{}) {
 }
 
 // Debugf logs as log.Debugf.
-func (p P) Debugf(format string, v ...interface{}) {
+func (p P) Debugf(format string, v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -41,50 +41,50 @@ func (p P) Debugf(format string, v ...interface{}) {
 }
 
 // Info logs as log.Info.
-func (p P) Info(v ...interface{}) {
+func (p P) Info(v ...any) {
 	ls.info(p.plugin, v...)
 	p.log(info, v...)
 }
 
 // Infof logs as log.Infof.
-func (p P) Infof(format string, v ...interface{}) {
+func (p P) Infof(format string, v ...any) {
 	ls.infof(p.plugin, format, v...)
 	p.logf(info, format, v...)
 }
 
 // Warning logs as log.Warning.
-func (p P) Warning(v ...interface{}) {
+func (p P) Warning(v ...any) {
 	ls.warning(p.plugin, v...)
 	p.log(warning, v...)
 }
 
 // Warningf logs as log.Warningf.
-func (p P) Warningf(format string, v ...interface{}) {
+func (p P) Warningf(format string, v ...any) {
 	ls.warningf(p.plugin, format, v...)
 	p.logf(warning, format, v...)
 }
 
 // Error logs as log.Error.
-func (p P) Error(v ...interface{}) {
+func (p P) Error(v ...any) {
 	ls.error(p.plugin, v...)
 	p.log(err, v...)
 }
 
 // Errorf logs as log.Errorf.
-func (p P) Errorf(format string, v ...interface{}) {
+func (p P) Errorf(format string, v ...any) {
 	ls.errorf(p.plugin, format, v...)
 	p.logf(err, format, v...)
 }
 
 // Fatal logs as log.Fatal and calls os.Exit(1).
-func (p P) Fatal(v ...interface{}) {
+func (p P) Fatal(v ...any) {
 	ls.fatal(p.plugin, v...)
 	p.log(fatal, v...)
 	os.Exit(1)
 }
 
 // Fatalf logs as log.Fatalf and calls os.Exit(1).
-func (p P) Fatalf(format string, v ...interface{}) {
+func (p P) Fatalf(format string, v ...any) {
 	ls.fatalf(p.plugin, format, v...)
 	p.logf(fatal, format, v...)
 	os.Exit(1)

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -256,7 +256,7 @@ func loadFormat(s string) replacer {
 
 // bufPool stores pointers to scratch buffers.
 var bufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return make([]byte, 0, 256)
 	},
 }

--- a/plugin/pkg/singleflight/singleflight.go
+++ b/plugin/pkg/singleflight/singleflight.go
@@ -23,7 +23,7 @@ import "sync"
 // call is an in-flight or completed Do call
 type call struct {
 	wg  sync.WaitGroup
-	val interface{}
+	val any
 	err error
 }
 
@@ -38,7 +38,7 @@ type Group struct {
 // sure that only one execution is in-flight for a given key at a
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
-func (g *Group) Do(key uint64, fn func() (interface{}, error)) (interface{}, error) {
+func (g *Group) Do(key uint64, fn func() (any, error)) (any, error) {
 	g.mu.Lock()
 	if g.m == nil {
 		g.m = make(map[uint64]*call)

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDo(t *testing.T) {
 	var g Group
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do(1, func() (any, error) {
 		return "bar", nil
 	})
 	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
@@ -41,7 +41,7 @@ func TestDo(t *testing.T) {
 func TestDoErr(t *testing.T) {
 	var g Group
 	someErr := errors.New("some error")
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do(1, func() (any, error) {
 		return nil, someErr
 	})
 	if err != someErr {
@@ -56,7 +56,7 @@ func TestDoDupSuppress(t *testing.T) {
 	var g Group
 	c := make(chan string)
 	var calls int32
-	fn := func() (interface{}, error) {
+	fn := func() (any, error) {
 		atomic.AddInt32(&calls, 1)
 		return <-c, nil
 	}

--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -60,7 +60,7 @@ func parse(corefile caddy.Input) ([]byte, error) {
 	return json.Marshal(serverBlocks)
 }
 
-func hook(event caddy.EventName, info interface{}) error {
+func hook(event caddy.EventName, info any) error {
 	if event != caddy.InstanceStartupEvent {
 		return nil
 	}

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -36,10 +36,10 @@ import (
 type (
 	// MetricFamily holds a prometheus metric.
 	MetricFamily struct {
-		Name    string        `json:"name"`
-		Help    string        `json:"help"`
-		Type    string        `json:"type"`
-		Metrics []interface{} `json:"metrics,omitempty"` // Either metric or summary.
+		Name    string `json:"name"`
+		Help    string `json:"help"`
+		Type    string `json:"type"`
+		Metrics []any  `json:"metrics,omitempty"` // Either metric or summary.
 	}
 
 	// metric is for all "single value" metrics.
@@ -150,7 +150,7 @@ func newMetricFamily(dtoMF *dto.MetricFamily) *MetricFamily {
 		Name:    dtoMF.GetName(),
 		Help:    dtoMF.GetHelp(),
 		Type:    dtoMF.GetType().String(),
-		Metrics: make([]interface{}, len(dtoMF.Metric)),
+		Metrics: make([]any, len(dtoMF.Metric)),
 	}
 	for i, m := range dtoMF.Metric {
 		if dtoMF.GetType() == dto.MetricType_SUMMARY {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use revive rule [use-any](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any) to ensure that 'any' is used instead of 'interface{}'

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No