### PR TITLE
chore: enable unused-parameter from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,70 @@
-run:
-  timeout: 5m
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:
+    - gofmt
     - govet
     - ineffassign
+    - revive
     - staticcheck
     - typecheck
-    - whitespace
-    - unused
-    - gofmt
     - unconvert
+    - unused
+    - whitespace
+linters-settings:
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+        disabled: true
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+        arguments:
+          - "preserveScope"
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+        disabled: true
+      - name: superfluous-else
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+        disabled: true
+      - name: unexported-return
+        disabled: true
+      - name: unnecessary-stmt
+        disabled: true
+      - name: unreachable-code
+      - name: unused-parameter
+        arguments:
+          - allowRegex: "^_"
+      - name: use-any
+        disabled: true
+      - name: var-declaration
+      - name: var-naming
+        disabled: true
+        arguments:
+          - ["ID"]
+          - ["VM"]
+          - - upperCaseConst: true
+output:
+  sort-results: true
+run:
+  timeout: 5m

--- a/core/dnsserver/quic.go
+++ b/core/dnsserver/quic.go
@@ -54,7 +54,7 @@ func AddPrefix(b []byte) (m []byte) {
 
 // These methods implement the dns.ResponseWriter interface from Go DNS.
 func (w *DoQWriter) TsigStatus() error     { return nil }
-func (w *DoQWriter) TsigTimersOnly(b bool) {}
+func (w *DoQWriter) TsigTimersOnly(_ bool) {}
 func (w *DoQWriter) Hijack()               {}
 func (w *DoQWriter) LocalAddr() net.Addr   { return w.localAddr }
 func (w *DoQWriter) RemoteAddr() net.Addr  { return w.remoteAddr }

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-func newContext(i *caddy.Instance) caddy.Context {
+func newContext(_ *caddy.Instance) caddy.Context {
 	return &dnsContext{keysToConfigs: make(map[string]*Config)}
 }
 
@@ -52,7 +52,7 @@ var _ caddy.Context = &dnsContext{}
 // InspectServerBlocks make sure that everything checks out before
 // executing directives and otherwise prepares the directives to
 // be parsed and executed.
-func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddyfile.ServerBlock) ([]caddyfile.ServerBlock, error) {
+func (h *dnsContext) InspectServerBlocks(_ string, serverBlocks []caddyfile.ServerBlock) ([]caddyfile.ServerBlock, error) {
 	// Normalize and check all the zone names and check for duplicates
 	for ib, s := range serverBlocks {
 		// Walk the s.Keys and expand any reverse address in their proper DNS in-addr zones. If the expansions leads for

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -407,7 +407,7 @@ func (s *Server) Tracer() ot.Tracer {
 }
 
 // errorFunc responds to an DNS request with an error.
-func errorFunc(server string, w dns.ResponseWriter, r *dns.Msg, rc int) {
+func errorFunc(_ string, w dns.ResponseWriter, r *dns.Msg, rc int) {
 	state := request.Request{W: w, Req: r}
 
 	answer := new(dns.Msg)

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -62,7 +62,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 	s.m.Unlock()
 
 	if s.Tracer() != nil {
-		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp interface{}) bool {
+		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, _ string, _, _ interface{}) bool {
 			return parentSpanCtx != nil
 		}
 		intercept := otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))
@@ -80,7 +80,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServergRPC) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServergRPC) ServePacket(_ net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServergRPC) Listen() (net.Listener, error) {
@@ -177,7 +177,7 @@ func (r *gRPCresponse) Write(b []byte) (int, error) {
 // These methods implement the dns.ResponseWriter interface from Go DNS.
 func (r *gRPCresponse) Close() error              { return nil }
 func (r *gRPCresponse) TsigStatus() error         { return nil }
-func (r *gRPCresponse) TsigTimersOnly(b bool)     {}
+func (r *gRPCresponse) TsigTimersOnly(_ bool)     {}
 func (r *gRPCresponse) Hijack()                   {}
 func (r *gRPCresponse) LocalAddr() net.Addr       { return r.localAddr }
 func (r *gRPCresponse) RemoteAddr() net.Addr      { return r.remoteAddr }

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -104,7 +104,7 @@ func (s *ServerHTTPS) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServerHTTPS) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServerHTTPS) ServePacket(_ net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Listen() (net.Listener, error) {

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -76,7 +76,7 @@ func NewServerQUIC(addr string, group []*Config) (*ServerQUIC, error) {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServerQUIC) ServePacket(p net.PacketConn) error {
+func (s *ServerQUIC) ServePacket(_ net.PacketConn) error {
 	s.m.Lock()
 	s.listenAddr = s.quicListener.Addr()
 	s.m.Unlock()
@@ -213,7 +213,7 @@ func (s *ServerQUIC) Stop() error {
 }
 
 // Serve implements caddy.TCPServer interface.
-func (s *ServerQUIC) Serve(l net.Listener) error { return nil }
+func (s *ServerQUIC) Serve(_ net.Listener) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerQUIC) Listen() (net.Listener, error) { return nil, nil }

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -13,7 +13,7 @@ import (
 
 type testPlugin struct{}
 
-func (tp testPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (tp testPlugin) ServeDNS(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 	return 0, nil
 }
 
@@ -29,7 +29,7 @@ func testConfig(transport string, p plugin.Handler) *Config {
 		Stacktrace:  false,
 	}
 
-	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
+	c.AddPlugin(func(_ plugin.Handler) plugin.Handler { return p })
 	return c
 }
 

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -71,7 +71,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServerTLS) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServerTLS) ServePacket(_ net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerTLS) Listen() (net.Listener, error) {

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -44,7 +44,7 @@ func TestWalk(t *testing.T) {
 	}
 }
 
-func TestWalkNonExistent(t *testing.T) {
+func TestWalkNonExistent(_ *testing.T) {
 	nonExistingDir := "highly_unlikely_to_exist_dir"
 
 	ldr := loader{

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -109,7 +109,7 @@ func TestAutoPathNoAnswer(t *testing.T) {
 // nextHandler returns a Handler that returns an answer for the question in the
 // request per the domain->answer map. On success an RR will be returned: "qname 3600 IN A 127.0.0.53"
 func nextHandler(mm map[string]int) test.Handler {
-	return test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		rcode, ok := mm[r.Question[0].Name]
 		if !ok {
 			return dns.RcodeServerFailure, nil

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -41,7 +41,7 @@ type Azure struct {
 }
 
 // New validates the input DNS zones and initializes the Azure struct.
-func New(ctx context.Context, publicClient publicdns.RecordSetsClient, privateClient privatedns.RecordSetsClient, keys map[string][]string, accessMap map[string]string) (*Azure, error) {
+func New(_ context.Context, publicClient publicdns.RecordSetsClient, privateClient privatedns.RecordSetsClient, keys map[string][]string, accessMap map[string]string) (*Azure, error) {
 	zones := make(map[string][]*zone, len(keys))
 	names := make([]string, len(keys))
 	var private bool

--- a/plugin/azure/azure_test.go
+++ b/plugin/azure/azure_test.go
@@ -48,7 +48,7 @@ func testZones() zones {
 }
 
 func testHandler() test.HandlerFunc {
-	return func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -325,7 +325,7 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 }
 
 // CNAME returns CNAME records from the backend or an error.
-func CNAME(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+func CNAME(ctx context.Context, b ServiceBackend, _ string, state request.Request, opt Options) (records []dns.RR, err error) {
 	services, err := b.Services(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
@@ -408,7 +408,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 }
 
 // PTR returns the PTR records from the backend, only services that have a domain name as host are included.
-func PTR(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+func PTR(ctx context.Context, b ServiceBackend, _ string, state request.Request, opt Options) (records []dns.RR, err error) {
 	services, err := b.Reverse(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
@@ -465,7 +465,7 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 }
 
 // SOA returns a SOA record from the backend.
-func SOA(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) ([]dns.RR, error) {
+func SOA(_ context.Context, b ServiceBackend, zone string, state request.Request, _ Options) ([]dns.RR, error) {
 	minTTL := b.MinTTL(state)
 	ttl := uint32(300)
 	if minTTL < ttl {

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -609,7 +609,7 @@ func BenchmarkCacheResponse(b *testing.B) {
 }
 
 func BackendHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response = true
@@ -624,7 +624,7 @@ func BackendHandler() plugin.Handler {
 }
 
 func nxDomainBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true
@@ -638,7 +638,7 @@ func nxDomainBackend(ttl int) plugin.Handler {
 }
 
 func ttlBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true
@@ -650,7 +650,7 @@ func ttlBackend(ttl int) plugin.Handler {
 }
 
 func servFailBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true

--- a/plugin/cache/dnssec_test.go
+++ b/plugin/cache/dnssec_test.go
@@ -65,7 +65,7 @@ func TestResponseWithDNSSEC(t *testing.T) {
 }
 
 func dnssecHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)
 		state := request.Request{W: &test.ResponseWriter{}, Req: r}

--- a/plugin/cache/error_test.go
+++ b/plugin/cache/error_test.go
@@ -28,7 +28,7 @@ func TestFormErr(t *testing.T) {
 
 // formErrHandler is a fake plugin implementation which returns a FORMERR for a reply.
 func formErrHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.net.", dns.TypeA)
 		m.Rcode = dns.RcodeFormatError

--- a/plugin/cache/prefetch_test.go
+++ b/plugin/cache/prefetch_test.go
@@ -214,7 +214,7 @@ type verification struct {
 // 127.0.0.1 and is incremented on every request.
 func prefetchHandler(qname string, ttl int, fetchc chan struct{}) plugin.Handler {
 	i := 0
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		i++
 		m := new(dns.Msg)
 		m.SetQuestion(qname, dns.TypeA)

--- a/plugin/cache/spoof_test.go
+++ b/plugin/cache/spoof_test.go
@@ -58,7 +58,7 @@ func TestResponse(t *testing.T) {
 // spoofHandler is a fake plugin implementation which returns a single A records for example.org. The qname in the
 // question section is set to example.NET (i.e. they *don't* match).
 func spoofHandler(response bool) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.net.", dns.TypeA)
 		m.Response = response
@@ -71,7 +71,7 @@ func spoofHandler(response bool) plugin.Handler {
 // spoofHandlerType is a fake plugin implementation which returns a single MX records for example.org. The qtype in the
 // question section is set to A.
 func spoofHandlerType() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)
 		m.Response = true

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -47,7 +47,7 @@ type zones map[string][]*zone
 // that each domain name/zone id pair does exist, and returns a new *CloudDNS.
 // In addition to this, upstream is passed for doing recursive queries against CNAMEs.
 // Returns error if it cannot verify any given domain name/zone id pair.
-func New(ctx context.Context, c gcpDNS, keys map[string][]string, up *upstream.Upstream) (*CloudDNS, error) {
+func New(_ context.Context, c gcpDNS, keys map[string][]string, up *upstream.Upstream) (*CloudDNS, error) {
 	zones := make(map[string][]*zone, len(keys))
 	zoneNames := make([]string, 0, len(keys))
 	for dnsName, hostedZoneDetails := range keys {

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -20,11 +20,11 @@ type fakeGCPClient struct {
 	*gcp.Service
 }
 
-func (c fakeGCPClient) zoneExists(projectName, hostedZoneName string) error {
+func (c fakeGCPClient) zoneExists(_, _ string) error {
 	return nil
 }
 
-func (c fakeGCPClient) listRRSets(ctx context.Context, projectName, hostedZoneName string) (*gcp.ResourceRecordSetsListResponse, error) {
+func (c fakeGCPClient) listRRSets(_ context.Context, projectName, hostedZoneName string) (*gcp.ResourceRecordSetsListResponse, error) {
 	if projectName == "bad-project" || hostedZoneName == "bad-zone" {
 		return nil, errors.New("the 'parameters.managedZone' resource named 'bad-zone' does not exist")
 	}
@@ -146,7 +146,7 @@ func TestCloudDNS(t *testing.T) {
 	}
 	r.Fall = fall.Zero
 	r.Fall.SetZonesFromArgs([]string{"gov."})
-	r.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	r.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/clouddns/setup_test.go
+++ b/plugin/clouddns/setup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSetupCloudDNS(t *testing.T) {
-	f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
+	f = func(_ context.Context, _ option.ClientOption) (gcpDNS, error) {
 		return fakeGCPClient{}, nil
 	}
 

--- a/plugin/erratic/autopath.go
+++ b/plugin/erratic/autopath.go
@@ -3,6 +3,6 @@ package erratic
 import "github.com/coredns/coredns/request"
 
 // AutoPath implements the AutoPathFunc call from the autopath plugin.
-func (e *Erratic) AutoPath(state request.Request) []string {
+func (e *Erratic) AutoPath(_ request.Request) []string {
 	return []string{"a.example.org.", "b.example.org.", ""}
 }

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -23,7 +23,7 @@ type Erratic struct {
 }
 
 // ServeDNS implements the plugin.Handler interface.
-func (e *Erratic) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (e *Erratic) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 	drop := false
 	delay := false

--- a/plugin/erratic/setup.go
+++ b/plugin/erratic/setup.go
@@ -18,7 +18,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("erratic", err)
 	}
 
-	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+	dnsserver.GetConfig(c).AddPlugin(func(_ plugin.Handler) plugin.Handler {
 		return e
 	})
 

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -231,7 +231,7 @@ func TestStop(t *testing.T) {
 }
 
 func genErrorHandler(rcode int, err error) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		return rcode, err
 	})
 }

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -41,7 +41,7 @@ type Etcd struct {
 }
 
 // Services implements the ServiceBackend interface.
-func (e *Etcd) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
+func (e *Etcd) Services(ctx context.Context, state request.Request, exact bool, _ plugin.Options) (services []msg.Service, err error) {
 	services, err = e.Records(ctx, state, exact)
 	if err != nil {
 		return

--- a/plugin/etcd/xfr.go
+++ b/plugin/etcd/xfr.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Serial returns the serial number to use.
-func (e *Etcd) Serial(state request.Request) uint32 {
+func (e *Etcd) Serial(_ request.Request) uint32 {
 	return uint32(time.Now().Unix())
 }
 
 // MinTTL returns the minimal TTL.
-func (e *Etcd) MinTTL(state request.Request) uint32 {
+func (e *Etcd) MinTTL(_ request.Request) uint32 {
 	return 30
 }

--- a/plugin/file/delete_test.go
+++ b/plugin/file/delete_test.go
@@ -29,7 +29,7 @@ type treebuf struct {
 	*bytes.Buffer
 }
 
-func (t *treebuf) printFunc(e *tree.Elem, rrs map[uint16][]dns.RR) error {
+func (t *treebuf) printFunc(_ *tree.Elem, rrs map[uint16][]dns.RR) error {
 	fmt.Fprintf(t.Buffer, "%v\n", rrs) // should be fixed order in new go versions.
 	return nil
 }

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -180,7 +180,7 @@ func TestLookup(t *testing.T) {
 	}
 }
 
-func TestLookupNil(t *testing.T) {
+func TestLookupNil(_ *testing.T) {
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: nil}, Names: []string{testzone}}}
 	ctx := context.TODO()
 

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -138,7 +138,7 @@ func TestIsNotify(t *testing.T) {
 	}
 }
 
-func newRequest(zone string, qtype uint16) request.Request {
+func newRequest(_ string, _ uint16) request.Request {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4097, true)

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -177,7 +177,7 @@ func TestHealthMaxFails(t *testing.T) {
 	defaultTimeout = 10 * time.Millisecond
 	//,hcInterval = 10 * time.Millisecond
 
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s := dnstest.NewServer(func(_ dns.ResponseWriter, _ *dns.Msg) {
 		// timeout
 	})
 	defer s.Close()

--- a/plugin/grpc/proxy_test.go
+++ b/plugin/grpc/proxy_test.go
@@ -66,7 +66,7 @@ type testServiceClient struct {
 	err       error
 }
 
-func (m testServiceClient) Query(ctx context.Context, in *pb.DnsPacket, opts ...grpc.CallOption) (*pb.DnsPacket, error) {
+func (m testServiceClient) Query(_ context.Context, _ *pb.DnsPacket, _ ...grpc.CallOption) (*pb.DnsPacket, error) {
 	return m.dnsPacket, m.err
 }
 
@@ -109,7 +109,7 @@ type grpcDnsServiceServer struct {
 	pb.UnimplementedDnsServiceServer
 }
 
-func (*grpcDnsServiceServer) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket, error) {
+func (*grpcDnsServiceServer) Query(_ context.Context, in *pb.DnsPacket) (*pb.DnsPacket, error) {
 	msg := &dns.Msg{}
 	msg.Unpack(in.GetMsg())
 	answer := new(dns.Msg)

--- a/plugin/header/header_test.go
+++ b/plugin/header/header_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHeaderResponseRules(t *testing.T) {
 	wr := dnstest.NewRecorder(&test.ResponseWriter{})
-	next := plugin.HandlerFunc(func(ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
+	next := plugin.HandlerFunc(func(_ context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
 		writer.WriteMsg(msg)
 		return dns.RcodeSuccess, nil
 	})
@@ -83,7 +83,7 @@ func TestHeaderResponseRules(t *testing.T) {
 
 func TestHeaderQueryRules(t *testing.T) {
 	wr := dnstest.NewRecorder(&test.ResponseWriter{})
-	next := plugin.HandlerFunc(func(ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
+	next := plugin.HandlerFunc(func(_ context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
 		writer.WriteMsg(msg)
 		return dns.RcodeSuccess, nil
 	})

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -54,7 +54,7 @@ func (h *health) OnStartup() error {
 	h.mux = http.NewServeMux()
 	h.nlSetup = true
 
-	h.mux.HandleFunc(h.healthURI.Path, func(w http.ResponseWriter, r *http.Request) {
+	h.mux.HandleFunc(h.healthURI.Path, func(w http.ResponseWriter, _ *http.Request) {
 		// We're always healthy.
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, http.StatusText(http.StatusOK))

--- a/plugin/health/overloaded_test.go
+++ b/plugin/health/overloaded_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_health_overloaded_cancellation(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(1 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -297,9 +297,9 @@ func (external) EndpointsList() []*object.Endpoints {
 	}
 	return eps
 }
-func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
-func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
-func (external) PodIndex(string) []*object.Pod                                     { return nil }
+func (external) GetNodeByName(_ context.Context, _ string) (*api.Node, error) { return nil, nil }
+func (external) SvcIndex(s string) []*object.Service                          { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                { return nil }
 
 func (external) SvcExtIndexReverse(ip string) (result []*object.Service) {
 	for _, svcs := range svcIndexExternal {
@@ -416,7 +416,7 @@ func (external) ServiceList() []*object.Service {
 	return svcs
 }
 
-func externalAddress(state request.Request, headless bool) []dns.RR {
+func externalAddress(_ request.Request, _ bool) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
 }

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -500,8 +500,8 @@ func (dns *dnsControl) GetNamespaceByName(name string) (*object.Namespace, error
 	return ns, nil
 }
 
-func (dns *dnsControl) Add(obj interface{})               { dns.updateModified() }
-func (dns *dnsControl) Delete(obj interface{})            { dns.updateModified() }
+func (dns *dnsControl) Add(_ interface{})                 { dns.updateModified() }
+func (dns *dnsControl) Delete(_ interface{})              { dns.updateModified() }
 func (dns *dnsControl) Update(oldObj, newObj interface{}) { dns.detectChanges(oldObj, newObj) }
 
 // detectChanges detects changes in objects, and updates the modified timestamp

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -205,7 +205,7 @@ func createClusterIPSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 	}, meta.CreateOptions{})
 }
 
-func createHeadlessSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+func createHeadlessSvc(suffix int, client kubernetes.Interface, _ net.IP) {
 	ctx := context.TODO()
 	client.CoreV1().Services("testns").Create(ctx, &api.Service{
 		ObjectMeta: meta.ObjectMeta{
@@ -218,7 +218,7 @@ func createHeadlessSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 	}, meta.CreateOptions{})
 }
 
-func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+func createExternalSvc(suffix int, client kubernetes.Interface, _ net.IP) {
 	ctx := context.TODO()
 	client.CoreV1().Services("testns").Create(ctx, &api.Service{
 		ObjectMeta: meta.ObjectMeta{

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -107,9 +107,9 @@ func (external) EndpointsList() []*object.Endpoints {
 	}
 	return eps
 }
-func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
-func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
-func (external) PodIndex(string) []*object.Pod                                     { return nil }
+func (external) GetNodeByName(_ context.Context, _ string) (*api.Node, error) { return nil, nil }
+func (external) SvcIndex(s string) []*object.Service                          { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                { return nil }
 
 func (external) GetNamespaceByName(name string) (*object.Namespace, error) {
 	return &object.Namespace{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -798,7 +798,7 @@ func (APIConnServeTest) EndpointsList() []*object.Endpoints {
 	return eps
 }
 
-func (APIConnServeTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnServeTest) GetNodeByName(_ context.Context, _ string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",
@@ -826,7 +826,7 @@ type Upstub struct {
 }
 
 // Lookup returns a set response
-func (t *Upstub) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (t *Upstub) Lookup(_ context.Context, _ request.Request, _ string, _ uint16) (*dns.Msg, error) {
 	var answer []dns.RR
 	// if query type is not CNAME, remove any CNAME with same name as qname from the answer
 	if t.Qtype != dns.TypeCNAME {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -91,7 +91,7 @@ var (
 )
 
 // Services implements the ServiceBackend interface.
-func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (svcs []msg.Service, err error) {
+func (k *Kubernetes) Services(ctx context.Context, state request.Request, _ bool, _ plugin.Options) (svcs []msg.Service, err error) {
 	// We're looking again at types, which we've already done in ServeDNS, but there are some types k8s just can't answer.
 	switch state.QType() {
 	case dns.TypeTXT:
@@ -298,7 +298,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 }
 
 // Records looks up services in kubernetes.
-func (k *Kubernetes) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
+func (k *Kubernetes) Records(_ context.Context, state request.Request, _ bool) ([]msg.Service, error) {
 	r, e := parseRequest(state.Name(), state.Zone)
 	if e != nil {
 		return nil, e
@@ -519,10 +519,10 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 }
 
 // Serial return the SOA serial.
-func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIConn.Modified(false)) }
+func (k *Kubernetes) Serial(_ request.Request) uint32 { return uint32(k.APIConn.Modified(false)) }
 
 // MinTTL returns the minimal TTL.
-func (k *Kubernetes) MinTTL(state request.Request) uint32 { return k.ttl }
+func (k *Kubernetes) MinTTL(_ request.Request) uint32 { return k.ttl }
 
 // match checks if a and b are equal.
 func match(a, b string) bool {

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -225,7 +225,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 	return eps
 }
 
-func (APIConnServiceTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnServiceTest) GetNodeByName(_ context.Context, _ string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -91,10 +91,10 @@ func (APIConnTest) EpIndexReverse(ip string) []*object.Endpoints {
 	return eps
 }
 
-func (APIConnTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnTest) GetNodeByName(_ context.Context, _ string) (*api.Node, error) {
 	return &api.Node{}, nil
 }
-func (APIConnTest) GetNamespaceByName(name string) (*object.Namespace, error) {
+func (APIConnTest) GetNamespaceByName(_ string) (*object.Namespace, error) {
 	return nil, fmt.Errorf("namespace not found")
 }
 

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -167,16 +167,16 @@ func (e *Endpoints) DeepCopyObject() runtime.Object {
 func (e *Endpoints) GetNamespace() string { return e.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (e *Endpoints) SetNamespace(namespace string) {}
+func (e *Endpoints) SetNamespace(_ string) {}
 
 // GetName implements the metav1.Object interface.
 func (e *Endpoints) GetName() string { return e.Name }
 
 // SetName implements the metav1.Object interface.
-func (e *Endpoints) SetName(name string) {}
+func (e *Endpoints) SetName(_ string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (e *Endpoints) GetResourceVersion() string { return e.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (e *Endpoints) SetResourceVersion(version string) {}
+func (e *Endpoints) SetResourceVersion(_ string) {}

--- a/plugin/kubernetes/object/namespace.go
+++ b/plugin/kubernetes/object/namespace.go
@@ -46,16 +46,16 @@ func (n *Namespace) DeepCopyObject() runtime.Object {
 func (n *Namespace) GetNamespace() string { return "" }
 
 // SetNamespace implements the metav1.Object interface.
-func (n *Namespace) SetNamespace(namespace string) {}
+func (n *Namespace) SetNamespace(_ string) {}
 
 // GetName implements the metav1.Object interface.
 func (n *Namespace) GetName() string { return n.Name }
 
 // SetName implements the metav1.Object interface.
-func (n *Namespace) SetName(name string) {}
+func (n *Namespace) SetName(_ string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (n *Namespace) GetResourceVersion() string { return n.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (n *Namespace) SetResourceVersion(version string) {}
+func (n *Namespace) SetResourceVersion(_ string) {}

--- a/plugin/kubernetes/object/object.go
+++ b/plugin/kubernetes/object/object.go
@@ -38,37 +38,37 @@ func (e *Empty) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKin
 func (e *Empty) GetGenerateName() string { return "" }
 
 // SetGenerateName implements the metav1.Object interface.
-func (e *Empty) SetGenerateName(name string) {}
+func (e *Empty) SetGenerateName(_ string) {}
 
 // GetUID implements the metav1.Object interface.
 func (e *Empty) GetUID() types.UID { return "" }
 
 // SetUID implements the metav1.Object interface.
-func (e *Empty) SetUID(uid types.UID) {}
+func (e *Empty) SetUID(_ types.UID) {}
 
 // GetGeneration implements the metav1.Object interface.
 func (e *Empty) GetGeneration() int64 { return 0 }
 
 // SetGeneration implements the metav1.Object interface.
-func (e *Empty) SetGeneration(generation int64) {}
+func (e *Empty) SetGeneration(_ int64) {}
 
 // GetSelfLink implements the metav1.Object interface.
 func (e *Empty) GetSelfLink() string { return "" }
 
 // SetSelfLink implements the metav1.Object interface.
-func (e *Empty) SetSelfLink(selfLink string) {}
+func (e *Empty) SetSelfLink(_ string) {}
 
 // GetCreationTimestamp implements the metav1.Object interface.
 func (e *Empty) GetCreationTimestamp() v1.Time { return v1.Time{} }
 
 // SetCreationTimestamp implements the metav1.Object interface.
-func (e *Empty) SetCreationTimestamp(timestamp v1.Time) {}
+func (e *Empty) SetCreationTimestamp(_ v1.Time) {}
 
 // GetDeletionTimestamp implements the metav1.Object interface.
 func (e *Empty) GetDeletionTimestamp() *v1.Time { return &v1.Time{} }
 
 // SetDeletionTimestamp implements the metav1.Object interface.
-func (e *Empty) SetDeletionTimestamp(timestamp *v1.Time) {}
+func (e *Empty) SetDeletionTimestamp(_ *v1.Time) {}
 
 // GetDeletionGracePeriodSeconds implements the metav1.Object interface.
 func (e *Empty) GetDeletionGracePeriodSeconds() *int64 { return nil }
@@ -80,19 +80,19 @@ func (e *Empty) SetDeletionGracePeriodSeconds(*int64) {}
 func (e *Empty) GetLabels() map[string]string { return nil }
 
 // SetLabels implements the metav1.Object interface.
-func (e *Empty) SetLabels(labels map[string]string) {}
+func (e *Empty) SetLabels(_ map[string]string) {}
 
 // GetAnnotations implements the metav1.Object interface.
 func (e *Empty) GetAnnotations() map[string]string { return nil }
 
 // SetAnnotations implements the metav1.Object interface.
-func (e *Empty) SetAnnotations(annotations map[string]string) {}
+func (e *Empty) SetAnnotations(_ map[string]string) {}
 
 // GetFinalizers implements the metav1.Object interface.
 func (e *Empty) GetFinalizers() []string { return nil }
 
 // SetFinalizers implements the metav1.Object interface.
-func (e *Empty) SetFinalizers(finalizers []string) {}
+func (e *Empty) SetFinalizers(_ []string) {}
 
 // GetOwnerReferences implements the metav1.Object interface.
 func (e *Empty) GetOwnerReferences() []v1.OwnerReference { return nil }
@@ -104,10 +104,10 @@ func (e *Empty) SetOwnerReferences([]v1.OwnerReference) {}
 func (e *Empty) GetZZZ_DeprecatedClusterName() string { return "" }
 
 // SetZZZ_DeprecatedClusterName implements the metav1.Object interface.
-func (e *Empty) SetZZZ_DeprecatedClusterName(clusterName string) {}
+func (e *Empty) SetZZZ_DeprecatedClusterName(_ string) {}
 
 // GetManagedFields implements the metav1.Object interface.
 func (e *Empty) GetManagedFields() []v1.ManagedFieldsEntry { return nil }
 
 // SetManagedFields implements the metav1.Object interface.
-func (e *Empty) SetManagedFields(managedFields []v1.ManagedFieldsEntry) {}
+func (e *Empty) SetManagedFields(_ []v1.ManagedFieldsEntry) {}

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -65,16 +65,16 @@ func (p *Pod) DeepCopyObject() runtime.Object {
 func (p *Pod) GetNamespace() string { return p.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (p *Pod) SetNamespace(namespace string) {}
+func (p *Pod) SetNamespace(_ string) {}
 
 // GetName implements the metav1.Object interface.
 func (p *Pod) GetName() string { return p.Name }
 
 // SetName implements the metav1.Object interface.
-func (p *Pod) SetName(name string) {}
+func (p *Pod) SetName(_ string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (p *Pod) GetResourceVersion() string { return p.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (p *Pod) SetResourceVersion(version string) {}
+func (p *Pod) SetResourceVersion(_ string) {}

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -105,16 +105,16 @@ func (s *Service) DeepCopyObject() runtime.Object {
 func (s *Service) GetNamespace() string { return s.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (s *Service) SetNamespace(namespace string) {}
+func (s *Service) SetNamespace(_ string) {}
 
 // GetName implements the metav1.Object interface.
 func (s *Service) GetName() string { return s.Name }
 
 // SetName implements the metav1.Object interface.
-func (s *Service) SetName(name string) {}
+func (s *Service) SetName(_ string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (s *Service) GetResourceVersion() string { return s.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (s *Service) SetResourceVersion(version string) {}
+func (s *Service) SetResourceVersion(_ string) {}

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Reverse implements the ServiceBackend interface.
-func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
+func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, _ plugin.Options) ([]msg.Service, error) {
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
 		_, e := k.Records(ctx, state, exact)
@@ -27,7 +27,7 @@ func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact b
 
 // serviceRecordForIP gets a service record with a cluster ip matching the ip argument
 // If a service cluster ip does not match, it checks all endpoints
-func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
+func (k *Kubernetes) serviceRecordForIP(ip, _ string) []msg.Service {
 	// First check services with cluster ips
 	for _, service := range k.APIConn.SvcIndexReverse(ip) {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -136,7 +136,7 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
 	return nil
 }
 
-func (APIConnReverseTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnReverseTest) GetNodeByName(_ context.Context, _ string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -196,7 +196,7 @@ func countRecords(result []dns.RR) (cname int, address int, mx int, sorted bool)
 }
 
 func handler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		w.WriteMsg(r)
 		return dns.RcodeSuccess, nil
 	})

--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -12,7 +12,7 @@ import (
 
 type testProvider map[string]Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _ request.Request) context.Context {
 	for k, v := range tp {
 		SetValueFunc(ctx, k, v)
 	}
@@ -23,7 +23,7 @@ type testHandler struct{ ctx context.Context }
 
 func (m *testHandler) Name() string { return "test" }
 
-func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *testHandler) ServeDNS(ctx context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 	m.ctx = ctx
 	return 0, nil
 }

--- a/plugin/minimal/minimal_test.go
+++ b/plugin/minimal/minimal_test.go
@@ -19,7 +19,7 @@ type testHandler struct {
 
 func (t *testHandler) Name() string { return "test-handler" }
 
-func (t *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (t *testHandler) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	d := new(dns.Msg)
 	d.SetReply(r)
 	if t.Response != nil {

--- a/plugin/pkg/dnstest/recorder_test.go
+++ b/plugin/pkg/dnstest/recorder_test.go
@@ -8,7 +8,7 @@ import (
 
 type responseWriter struct{ dns.ResponseWriter }
 
-func (r *responseWriter) WriteMsg(m *dns.Msg) error     { return nil }
+func (r *responseWriter) WriteMsg(_ *dns.Msg) error     { return nil }
 func (r *responseWriter) Write(buf []byte) (int, error) { return len(buf), nil }
 
 func TestNewRecorder(t *testing.T) {

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -79,42 +79,42 @@ func (l *mockListener) Name() string {
 	return l.name
 }
 
-func (l *mockListener) Debug(plugin string, v ...interface{}) {
+func (l *mockListener) Debug(_ string, _ ...interface{}) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Debugf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Debugf(_ string, _ string, _ ...interface{}) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Info(plugin string, v ...interface{}) {
+func (l *mockListener) Info(_ string, _ ...interface{}) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Infof(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Infof(_ string, _ string, _ ...interface{}) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Warning(plugin string, v ...interface{}) {
+func (l *mockListener) Warning(_ string, _ ...interface{}) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Warningf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Warningf(_ string, _ string, _ ...interface{}) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Error(plugin string, v ...interface{}) {
+func (l *mockListener) Error(_ string, _ ...interface{}) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Errorf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Errorf(_ string, _ string, _ ...interface{}) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Fatal(plugin string, v ...interface{}) {
+func (l *mockListener) Fatal(_ string, _ ...interface{}) {
 	log(fatal, l.name+" mocked fatal")
 }
 
-func (l *mockListener) Fatalf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Fatalf(_ string, _ string, _ ...interface{}) {
 	log(fatal, l.name+" mocked fatal")
 }

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -74,7 +74,7 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 }
 
 // Connect selects an upstream, sends the request and waits for a response.
-func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options) (*dns.Msg, error) {
+func (p *Proxy) Connect(_ context.Context, state request.Request, opts Options) (*dns.Msg, error) {
 	start := time.Now()
 
 	proto := ""

--- a/plugin/pkg/proxy/health_test.go
+++ b/plugin/pkg/proxy/health_test.go
@@ -103,7 +103,7 @@ func TestHealthNoRecursion(t *testing.T) {
 }
 
 func TestHealthTimeout(t *testing.T) {
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s := dnstest.NewServer(func(_ dns.ResponseWriter, _ *dns.Msg) {
 		// timeout
 	})
 	defer s.Close()

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -310,7 +310,7 @@ func BenchmarkParseFormat(b *testing.B) {
 
 type testProvider map[string]metadata.Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _ request.Request) context.Context {
 	for k, v := range tp {
 		metadata.SetValueFunc(ctx, k, v)
 	}
@@ -321,7 +321,7 @@ type testHandler struct{ ctx context.Context }
 
 func (m *testHandler) Name() string { return "test" }
 
-func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *testHandler) ServeDNS(ctx context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 	m.ctx = ctx
 	return 0, nil
 }

--- a/plugin/pkg/reuseport/listen_reuseport.go
+++ b/plugin/pkg/reuseport/listen_reuseport.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func control(network, address string, c syscall.RawConn) error {
+func control(_, _ string, c syscall.RawConn) error {
 	c.Control(func(fd uintptr) {
 		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
 			log.Warningf("Failed to set SO_REUSEPORT on socket: %s", err)

--- a/plugin/rewrite/class.go
+++ b/plugin/rewrite/class.go
@@ -30,7 +30,7 @@ func newClassRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the current request.
-func (rule *classRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *classRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.fromClass > 0 && rule.toClass > 0 {
 		if state.Req.Question[0].Qclass == rule.fromClass {
 			state.Req.Question[0].Qclass = rule.toClass

--- a/plugin/rewrite/cname_target_test.go
+++ b/plugin/rewrite/cname_target_test.go
@@ -15,7 +15,7 @@ import (
 
 type MockedUpstream struct{}
 
-func (u *MockedUpstream) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (u *MockedUpstream) Lookup(_ context.Context, state request.Request, _ string, _ uint16) (*dns.Msg, error) {
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
 	m.Authoritative = true

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -81,7 +81,7 @@ func setupEdns0Opt(r *dns.Msg) *dns.OPT {
 }
 
 // Rewrite will alter the request EDNS0 NSID option
-func (rule *edns0NsidRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0NsidRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	var resp ResponseRules
@@ -115,7 +115,7 @@ func (rule *edns0NsidRule) Rewrite(ctx context.Context, state request.Request) (
 func (rule *edns0NsidRule) Mode() string { return rule.mode }
 
 // Rewrite will alter the request EDNS0 local options.
-func (rule *edns0LocalRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0LocalRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	var resp ResponseRules
@@ -390,7 +390,7 @@ func (rule *edns0SubnetRule) fillEcsData(state request.Request, ecs *dns.EDNS0_S
 }
 
 // Rewrite will alter the request EDNS0 subnet option.
-func (rule *edns0SubnetRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0SubnetRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	var resp ResponseRules

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -92,7 +92,7 @@ type nameRewriterResponseRule struct {
 	stringRewriter
 }
 
-func (r *nameRewriterResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *nameRewriterResponseRule) RewriteResponse(_ *dns.Msg, rr dns.RR) {
 	rr.Header().Name = r.rewriteString(rr.Header().Name)
 }
 
@@ -101,7 +101,7 @@ type valueRewriterResponseRule struct {
 	stringRewriter
 }
 
-func (r *valueRewriterResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *valueRewriterResponseRule) RewriteResponse(_ *dns.Msg, rr dns.RR) {
 	value := getRecordValueForRewrite(rr)
 	if value != "" {
 		new := r.rewriteString(value)
@@ -181,7 +181,7 @@ func newExactNameRule(nextAction string, orig, replacement string, answers Respo
 	}
 }
 
-func (rule *exactNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactNameRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.from == state.Name() {
 		state.Req.Question[0].Name = rule.replacement
 		return rule.responseRuleFor(state)
@@ -202,7 +202,7 @@ func newPrefixNameRule(nextAction string, auto bool, prefix, replacement string,
 	}
 }
 
-func (rule *prefixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixNameRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if strings.HasPrefix(state.Name(), rule.prefix) {
 		state.Req.Question[0].Name = rule.replacement + strings.TrimPrefix(state.Name(), rule.prefix)
 		return rule.responseRuleFor(state)
@@ -233,7 +233,7 @@ func newSuffixNameRule(nextAction string, auto bool, suffix, replacement string,
 	}
 }
 
-func (rule *suffixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixNameRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if strings.HasSuffix(state.Name(), rule.suffix) {
 		state.Req.Question[0].Name = strings.TrimSuffix(state.Name(), rule.suffix) + rule.replacement
 		return rule.responseRuleFor(state)
@@ -255,7 +255,7 @@ func newSubstringNameRule(nextAction string, auto bool, substring, replacement s
 	}
 }
 
-func (rule *substringNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringNameRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if strings.Contains(state.Name(), rule.substring) {
 		state.Req.Question[0].Name = strings.Replace(state.Name(), rule.substring, rule.replacement, -1)
 		return rule.responseRuleFor(state)
@@ -277,7 +277,7 @@ func newRegexNameRule(nextAction string, auto bool, pattern *regexp.Regexp, repl
 	}
 }
 
-func (rule *regexNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexNameRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	regexGroups := rule.pattern.FindStringSubmatch(state.Name())
 	if len(regexGroups) == 0 {
 		return nil, RewriteIgnored

--- a/plugin/rewrite/rcode.go
+++ b/plugin/rewrite/rcode.go
@@ -18,7 +18,7 @@ type rcodeResponseRule struct {
 	new int
 }
 
-func (r *rcodeResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *rcodeResponseRule) RewriteResponse(res *dns.Msg, _ dns.RR) {
 	if r.old == res.MsgHdr.Rcode {
 		res.MsgHdr.Rcode = r.new
 	}
@@ -73,29 +73,29 @@ type regexRCodeRule struct {
 
 // Rewrite rewrites the current request based upon exact match of the name
 // in the question section of the request.
-func (rule *exactRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactRCodeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(rule.From == state.Name())
 }
 
 // Rewrite rewrites the current request when the name begins with the matching string.
-func (rule *prefixRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixRCodeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasPrefix(state.Name(), rule.Prefix))
 }
 
 // Rewrite rewrites the current request when the name ends with the matching string.
-func (rule *suffixRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixRCodeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasSuffix(state.Name(), rule.Suffix))
 }
 
 // Rewrite rewrites the current request based upon partial match of the
 // name in the question section of the request.
-func (rule *substringRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringRCodeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.Contains(state.Name(), rule.Substring))
 }
 
 // Rewrite rewrites the current request when the name in the question
 // section of the request matches a regular expression.
-func (rule *regexRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexRCodeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(len(rule.Pattern.FindStringSubmatch(state.Name())) != 0)
 }
 

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func msgPrinter(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func msgPrinter(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if len(r.Answer) == 0 {
 		r.Answer = []dns.RR{
 			test.A(fmt.Sprintf("%s  5   IN  A  10.0.0.1", r.Question[0].Name)),
@@ -700,7 +700,7 @@ func optsEqual(a, b []dns.EDNS0) bool {
 
 type testProvider map[string]metadata.Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _ request.Request) context.Context {
 	for k, v := range tp {
 		metadata.SetValueFunc(ctx, k, v)
 	}

--- a/plugin/rewrite/ttl.go
+++ b/plugin/rewrite/ttl.go
@@ -18,7 +18,7 @@ type ttlResponseRule struct {
 	maxTTL uint32
 }
 
-func (r *ttlResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *ttlResponseRule) RewriteResponse(_ *dns.Msg, rr dns.RR) {
 	if rr.Header().Ttl < r.minTTL {
 		rr.Header().Ttl = r.minTTL
 	} else if rr.Header().Ttl > r.maxTTL {
@@ -75,29 +75,29 @@ type regexTTLRule struct {
 
 // Rewrite rewrites the current request based upon exact match of the name
 // in the question section of the request.
-func (rule *exactTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactTTLRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(rule.From == state.Name())
 }
 
 // Rewrite rewrites the current request when the name begins with the matching string.
-func (rule *prefixTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixTTLRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasPrefix(state.Name(), rule.Prefix))
 }
 
 // Rewrite rewrites the current request when the name ends with the matching string.
-func (rule *suffixTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixTTLRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasSuffix(state.Name(), rule.Suffix))
 }
 
 // Rewrite rewrites the current request based upon partial match of the
 // name in the question section of the request.
-func (rule *substringTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringTTLRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.Contains(state.Name(), rule.Substring))
 }
 
 // Rewrite rewrites the current request when the name in the question
 // section of the request matches a regular expression.
-func (rule *regexTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexTTLRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(len(rule.Pattern.FindStringSubmatch(state.Name())) != 0)
 }
 

--- a/plugin/rewrite/type.go
+++ b/plugin/rewrite/type.go
@@ -31,7 +31,7 @@ func newTypeRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the current request.
-func (rule *typeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *typeRule) Rewrite(_ context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.fromType > 0 && rule.toType > 0 {
 		if state.QType() == rule.fromType {
 			state.Req.Question[0].Qtype = rule.toType

--- a/plugin/root/root_test.go
+++ b/plugin/root/root_test.go
@@ -97,6 +97,6 @@ func getTempDirPath() (string, error) {
 	return tempDir, nil
 }
 
-func getInaccessiblePath(file string) string {
+func getInaccessiblePath(_ string) string {
 	return filepath.Join("C:", "file\x00name") // null byte in filename is not allowed on Windows AND unix
 }

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -256,7 +256,7 @@ func (h *Route53) updateZones(ctx context.Context) error {
 					MaxItems:     aws.String("1000"),
 				}
 				err = h.client.ListResourceRecordSetsPagesWithContext(ctx, in,
-					func(out *route53.ListResourceRecordSetsOutput, last bool) bool {
+					func(out *route53.ListResourceRecordSetsOutput, _ bool) bool {
 						for _, rrs := range out.ResourceRecordSets {
 							if err := updateZoneFromRRS(rrs, newZ); err != nil {
 								// Maybe unsupported record type. Log and carry on.

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -23,7 +23,7 @@ type fakeRoute53 struct {
 	route53iface.Route53API
 }
 
-func (fakeRoute53) ListHostedZonesByNameWithContext(_ aws.Context, input *route53.ListHostedZonesByNameInput, _ ...request.Option) (*route53.ListHostedZonesByNameOutput, error) {
+func (fakeRoute53) ListHostedZonesByNameWithContext(_ aws.Context, _ *route53.ListHostedZonesByNameInput, _ ...request.Option) (*route53.ListHostedZonesByNameOutput, error) {
 	return nil, nil
 }
 
@@ -94,7 +94,7 @@ func TestRoute53(t *testing.T) {
 	}
 	r.Fall = fall.Zero
 	r.Fall.SetZonesFromArgs([]string{"gov."})
-	r.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	r.Next = test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := crequest.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSetupRoute53(t *testing.T) {
-	f = func(opts session.Options) route53iface.Route53API {
+	f = func(_ session.Options) route53iface.Route53API {
 		return fakeRoute53{}
 	}
 

--- a/plugin/sign/nsec.go
+++ b/plugin/sign/nsec.go
@@ -10,7 +10,7 @@ import (
 )
 
 // names returns the elements of the zone in nsec order.
-func names(origin string, z *file.Zone) []string {
+func names(_ string, z *file.Zone) []string {
 	// There will also be apex records other than NS and SOA (who are kept separate), as we
 	// are adding DNSKEY and CDS/CDNSKEY records in the apex *before* we sign.
 	n := []string{}

--- a/plugin/template/cname_test.go
+++ b/plugin/template/cname_test.go
@@ -68,7 +68,7 @@ type Upstub struct {
 }
 
 // Lookup returns a set response
-func (t *Upstub) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (t *Upstub) Lookup(_ context.Context, _ request.Request, _ string, _ uint16) (*dns.Msg, error) {
 	var answer []dns.RR
 	// if query type is not CNAME, remove any CNAME with same name as qname from the answer
 	if t.Qtype != dns.TypeCNAME {

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -170,7 +170,7 @@ func TestHandler(t *testing.T) {
 			tmpl:         rcodeServfailTemplate,
 			qname:        "test.invalid.",
 			expectedCode: dns.RcodeServerFailure,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},
@@ -190,7 +190,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `template: answer:1:26: executing "answer" at <index .Match 2>: error calling index: index out of range: 2`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},
@@ -202,7 +202,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},
@@ -214,7 +214,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},
@@ -226,7 +226,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},
@@ -295,7 +295,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  "template: answer:1:26: executing \"answer\" at <parseInt \"gg\" 16 8>: error calling parseInt: strconv.ParseUint: parsing \"gg\": invalid syntax",
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_ *dns.Msg) error {
 				return nil
 			},
 		},

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -295,7 +295,7 @@ func SortAndCheck(resp *dns.Msg, tc Case) error {
 
 // ErrorHandler returns a Handler that returns ServerFailure error when called.
 func ErrorHandler() Handler {
-	return HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeServerFailure)
 		w.WriteMsg(m)
@@ -305,7 +305,7 @@ func ErrorHandler() Handler {
 
 // NextHandler returns a Handler that returns rcode and err.
 func NextHandler(rcode int, err error) Handler {
-	return HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 		return rcode, err
 	})
 }

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -40,7 +40,7 @@ func (t *ResponseWriter) RemoteAddr() net.Addr {
 }
 
 // WriteMsg implements dns.ResponseWriter interface.
-func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { return nil }
+func (t *ResponseWriter) WriteMsg(_ *dns.Msg) error { return nil }
 
 // Write implements dns.ResponseWriter interface.
 func (t *ResponseWriter) Write(buf []byte) (int, error) { return len(buf), nil }

--- a/plugin/transfer/select_test.go
+++ b/plugin/transfer/select_test.go
@@ -16,14 +16,14 @@ type (
 	t2 struct{}
 )
 
-func (t t1) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+func (t t1) Transfer(zone string, _ uint32) (<-chan []dns.RR, error) {
 	const z = "example.org."
 	if zone != z {
 		return nil, ErrNotAuthoritative
 	}
 	return nil, errors.New(z)
 }
-func (t t2) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+func (t t2) Transfer(zone string, _ uint32) (<-chan []dns.RR, error) {
 	const z = "sub.example.org."
 	if zone != z {
 		return nil, ErrNotAuthoritative

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -56,7 +56,7 @@ type terminatingPlugin struct{}
 func (*terminatingPlugin) Name() string { return "testplugin" }
 
 // ServeDNS implements plugin.Handler that returns NXDOMAIN for all requests.
-func (*terminatingPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (*terminatingPlugin) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	m := new(dns.Msg)
 	m.SetRcode(r, dns.RcodeNameError)
 	w.WriteMsg(m)

--- a/plugin/tsig/tsig_test.go
+++ b/plugin/tsig/tsig_test.go
@@ -227,7 +227,7 @@ func TestServeDNSTsigErrors(t *testing.T) {
 }
 
 func testHandler() test.HandlerFunc {
-	return func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/view/metadata.go
+++ b/plugin/view/metadata.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Metadata implements the metadata.Provider interface.
-func (v *View) Metadata(ctx context.Context, state request.Request) context.Context {
+func (v *View) Metadata(ctx context.Context, _ request.Request) context.Context {
 	metadata.SetValueFunc(ctx, "view/name", func() string {
 		return v.viewName
 	})

--- a/plugin/whoami/setup.go
+++ b/plugin/whoami/setup.go
@@ -14,7 +14,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("whoami", c.ArgErr())
 	}
 
-	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+	dnsserver.GetConfig(c).AddPlugin(func(_ plugin.Handler) plugin.Handler {
 		return Whoami{}
 	})
 

--- a/plugin/whoami/whoami.go
+++ b/plugin/whoami/whoami.go
@@ -19,7 +19,7 @@ const name = "whoami"
 type Whoami struct{}
 
 // ServeDNS implements the plugin.Handler interface.
-func (wh Whoami) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (wh Whoami) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 
 	a := new(dns.Msg)

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -54,7 +54,7 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 	}
 }
 
-func createKeyFile(t *testing.T) func() {
+func createKeyFile(_ *testing.T) func() {
 	os.WriteFile(base+".key",
 		[]byte(`example.org. IN DNSKEY 256 3 13 tDyI0uEIDO4SjhTJh1AVTFBLpKhY3He5BdAlKztewiZ7GecWj94DOodg ovpN73+oJs+UfZ+p9zOSN5usGAlHrw==`),
 		0644)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use revive rule [unused-parameter](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter) which warns on unused parameters. Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No