### PR TITLE
chore: enable early-return and superfluous-else from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,9 @@
 version: "2"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   default: none
   enable:
@@ -23,16 +28,82 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  settings:
+    revive:
+      rules:
+        - name: blank-imports
+
+        - name: context-as-argument
+          disabled: true
+          arguments:
+            - allowTypesBefore: "*testing.T"
+
+        - name: context-keys-type
+
+        - name: dot-imports
+
+        - name: early-return
+          arguments:
+            - "preserveScope"
+
+        - name: empty-block
+          disabled: true
+
+        - name: error-naming
+
+        - name: error-return
+
+        - name: error-strings
+
+        - name: errorf
+
+        - name: increment-decrement
+
+        - name: indent-error-flow
+          arguments:
+            - "preserveScope"
+
+        - name: range
+
+        - name: receiver-naming
+
+        - name: redefines-builtin-id
+          disabled: true
+
+        - name: superfluous-else
+          arguments:
+            - "preserveScope"
+
+        - name: time-naming
+          disabled: true
+
+        - name: unexported-return
+          disabled: true
+
+        - name: unnecessary-stmt
+          disabled: true
+
+        - name: unreachable-code
+
+        - name: unused-parameter
+          disabled: true
+          arguments:
+            - allowRegex: "^_"
+
+        - name: use-any
+          disabled: true
+
+        - name: var-declaration
+
+        - name: var-naming
+          disabled: true
+          arguments:
+            - ["ID"]
+            - ["VM"]
+            - - upperCaseConst: true
+
 formatters:
   enable:
     - gofmt
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -118,11 +118,10 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 				}
 				_, err := os.Stat(a.directory)
 				if err != nil {
-					if os.IsNotExist(err) {
-						log.Warningf("Directory does not exist: %s", a.directory)
-					} else {
+					if !os.IsNotExist(err) {
 						return a, c.Errf("Unable to access root path '%s': %v", a.directory, err)
 					}
+					log.Warningf("Directory does not exist: %s", a.directory)
 				}
 
 				// regexp template

--- a/plugin/etcd/msg/service.go
+++ b/plugin/etcd/msg/service.go
@@ -149,12 +149,11 @@ func split255(s string) []string {
 	sx := []string{}
 	p, i := 0, 255
 	for {
-		if i <= len(s) {
-			sx = append(sx, s[p:i])
-		} else {
+		if i > len(s) {
 			sx = append(sx, s[p:])
 			break
 		}
+		sx = append(sx, s[p:i])
 		p, i = p+255, i+255
 	}
 

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -96,11 +96,10 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			}
 			s, err := os.Stat(h.path)
 			if err != nil {
-				if os.IsNotExist(err) {
-					log.Warningf("File does not exist: %s", h.path)
-				} else {
+				if !os.IsNotExist(err) {
 					return h, c.Errf("unable to access hosts file '%s': %v", h.path, err)
 				}
+				log.Warningf("File does not exist: %s", h.path)
 			}
 			if s != nil && s.IsDir() {
 				log.Warningf("Hosts file %q is a directory", h.path)

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -127,18 +127,17 @@ func (k *Kubernetes) External(state request.Request, headless bool) ([]msg.Servi
 				}
 			}
 			continue
-		} else {
-			for _, ip := range svc.ExternalIPs {
-				for _, p := range svc.Ports {
-					if !(matchPortAndProtocol(port, p.Name, protocol, string(p.Protocol))) {
-						continue
-					}
-					rcode = dns.RcodeSuccess
-					s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
-					s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
-
-					services = append(services, s)
+		}
+		for _, ip := range svc.ExternalIPs {
+			for _, p := range svc.Ports {
+				if !(matchPortAndProtocol(port, p.Name, protocol, string(p.Protocol))) {
+					continue
 				}
+				rcode = dns.RcodeSuccess
+				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+
+				services = append(services, s)
 			}
 		}
 	}
@@ -195,16 +194,15 @@ func (k *Kubernetes) ExternalServices(zone string, headless bool) (services []ms
 				}
 			}
 			continue
-		} else {
-			for _, ip := range svc.ExternalIPs {
-				for _, p := range svc.Ports {
-					s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
-					s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
-					services = append(services, s)
-					s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+p.Name)), "/")
-					s.TargetStrip = 2
-					services = append(services, s)
-				}
+		}
+		for _, ip := range svc.ExternalIPs {
+			for _, p := range svc.Ports {
+				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+				services = append(services, s)
+				s.Key = strings.Join(append([]string{zonePath, svc.Namespace, svc.Name}, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+p.Name)), "/")
+				s.TargetStrip = 2
+				services = append(services, s)
 			}
 		}
 	}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -212,9 +212,8 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				if ignore == "empty_service" {
 					k8s.opts.ignoreEmptyService = true
 					continue
-				} else {
-					return nil, fmt.Errorf("unable to parse ignore value: '%v'", ignore)
 				}
+				return nil, fmt.Errorf("unable to parse ignore value: '%v'", ignore)
 			}
 		case "kubeconfig":
 			args := c.RemainingArgs()

--- a/plugin/pkg/parse/parse.go
+++ b/plugin/pkg/parse/parse.go
@@ -23,15 +23,14 @@ func TransferIn(c *caddy.Controller) (froms []string, err error) {
 			return nil, c.ArgErr()
 		}
 		for i := range froms {
-			if froms[i] != "*" {
-				normalized, err := HostPort(froms[i], transport.Port)
-				if err != nil {
-					return nil, err
-				}
-				froms[i] = normalized
-			} else {
+			if froms[i] == "*" {
 				return nil, fmt.Errorf("can't use '*' in transfer from")
 			}
+			normalized, err := HostPort(froms[i], transport.Port)
+			if err != nil {
+				return nil, err
+			}
+			froms[i] = normalized
 		}
 	}
 	return froms, nil

--- a/plugin/root/root.go
+++ b/plugin/root/root.go
@@ -26,13 +26,12 @@ func setup(c *caddy.Controller) error {
 	// Check if root path exists
 	_, err := os.Stat(config.Root)
 	if err != nil {
-		if os.IsNotExist(err) {
-			// Allow this, because the folder might appear later.
-			// But make sure the user knows!
-			log.Warningf("Root path does not exist: %s", config.Root)
-		} else {
+		if !os.IsNotExist(err) {
 			return plugin.Error("root", c.Errf("unable to access root path '%s': %v", config.Root, err))
 		}
+		// Allow this, because the folder might appear later.
+		// But make sure the user knows!
+		log.Warningf("Root path does not exist: %s", config.Root)
 	}
 
 	return nil


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use revive rules
* [early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return) : In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions.
* [superfluous-else](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else): To improve the readability of code, it is recommended to reduce the indentation as much as possible. This rule highlights redundant else-blocks that can be eliminated from the code.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No