### PR TITLE
fix: Ensure DNS query name reset in plugin.NS error path

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -427,20 +427,20 @@ func PTR(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 	return records, nil
 }
 
-// NS returns NS records from  the backend
+// NS returns NS records from the backend
 func NS(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
-	// NS record for this zone live in a special place, ns.dns.<zone>. Fake our lookup.
-	// only a tad bit fishy...
+	// NS record for this zone lives in a special place, ns.dns.<zone>. Fake our lookup.
+	// Only a tad bit fishy...
 	old := state.QName()
 
 	state.Clear()
 	state.Req.Question[0].Name = dnsutil.Join("ns.dns.", zone)
 	services, err := b.Services(ctx, state, false, opt)
+	// reset the query name to the original
+	state.Req.Question[0].Name = old
 	if err != nil {
 		return nil, nil, err
 	}
-	// ... and reset
-	state.Req.Question[0].Name = old
 
 	seen := map[string]bool{}
 

--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -1,0 +1,86 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// mockBackend implements ServiceBackend interface for testing
+var _ ServiceBackend = &mockBackend{}
+
+type mockBackend struct {
+	mockServices func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error)
+}
+
+func (m *mockBackend) Serial(state request.Request) uint32 {
+	return uint32(time.Now().Unix())
+}
+
+func (m *mockBackend) MinTTL(state request.Request) uint32 {
+	return 30
+}
+
+func (m *mockBackend) Services(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+	return m.mockServices(ctx, state, exact, opt)
+}
+
+func (m *mockBackend) Reverse(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+	return nil, nil
+}
+
+func (m *mockBackend) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return nil, nil
+}
+
+func (m *mockBackend) IsNameError(err error) bool {
+	return false
+}
+
+func (m *mockBackend) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
+	return nil, nil
+}
+
+func TestNSStateReset(t *testing.T) {
+	// Create a mock backend that always returns error
+	mock := &mockBackend{
+		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+			return nil, fmt.Errorf("mock error")
+		},
+	}
+	// Create a test request
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeNS)
+	state := request.Request{
+		Req: req,
+		W:   &test.ResponseWriter{},
+	}
+
+	originalName := state.QName()
+	ctx := context.TODO()
+
+	// Call NS function which should fail due to mock error
+	records, extra, err := NS(ctx, mock, "example.org.", state, Options{})
+
+	// Verify error is returned
+	if err == nil {
+		t.Error("Expected error from mock backend, got nil")
+	}
+
+	// Verify query name is reset even when an error occurs
+	if state.QName() != originalName {
+		t.Errorf("Query name not properly reset after error. Expected %s, got %s", originalName, state.QName())
+	}
+
+	// Verify no records are returned
+	if len(records) != 0 || len(extra) != 0 {
+		t.Error("Expected no records returned on error")
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Currently, the implementation of the NS function in `plugin/backend_lookup.go` of CoreDNS is as follows:

```go
func NS(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
    // NS record for this zone live in a special place, ns.dns.<zone>. Fake our lookup.
    // only a tad bit fishy...
    old := state.QName()

    state.Clear()
    state.Req.Question[0].Name = dnsutil.Join("ns.dns.", zone)
    services, err := b.Services(ctx, state, false, opt)
    if err != nil {
        return nil, nil, err
    }
    // ... and reset
    state.Req.Question[0].Name = old

    seen := map[string]bool{}

    for _, serv := range services {
        what, ip := serv.HostType()
        switch what {
        case dns.TypeCNAME:
            return nil, nil, fmt.Errorf("NS record must be an IP address: %s", serv.Host)

        case dns.TypeA, dns.TypeAAAA:
            serv.Host = msg.Domain(serv.Key)
            ns := serv.NewNS(state.QName())
            extra = append(extra, newAddress(serv, ns.Ns, ip, what))
            if _, ok := seen[ns.Ns]; ok {
                continue
            }
            seen[ns.Ns] = true
            records = append(records, ns)
        }
    }
    return records, extra, nil
}
```

In `plugin.NS`, when `Services()` returns an error, the function returns directly without resetting the query name back to original. This leaves the query name set to the internal lookup value ("ns.dns.<zone>") in error cases.

So, in this case, the DNS domain name has actually been changed, not the original value. And when the caller of `plugin.NS` (possibly a plugin) needs to pass the request to the next plugin for processing, the domain name processed by the next plugin is not actually the origin domain name.

This PR ensures the query name is always reset to original value before error handling, making the error path consistent with the success path.

Before:

```go
if err != nil {
    return nil, nil, err  // Query name remains as "ns.dns.<zone>"
}
// ... and reset
state.Req.Question[0].Name = old
```

After:

```go
// Always reset the query name to original first
state.Req.Question[0].Name = old
if err != nil {
    return nil, nil, err  // Query name is properly reset
}
```

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

No

### 4. Does this introduce a backward incompatible change or deprecation?

No
