### PR TITLE
Support optional TLS in metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.62.0
+	github.com/prometheus/exporter-toolkit v0.14.0
 	github.com/quic-go/quic-go v0.49.0
 	go.etcd.io/etcd/api/v3 v3.5.18
 	go.etcd.io/etcd/client/v3 v3.5.18
@@ -119,15 +120,19 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mdlayher/socket v0.4.1 // indirect
+	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
 	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/oschwald/maxminddb-golang v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -246,6 +248,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
+github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
+github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
+github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
 github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
@@ -263,6 +269,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
@@ -300,6 +308,8 @@ github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+github.com/prometheus/exporter-toolkit v0.14.0 h1:NMlswfibpcZZ+H0sZBiTjrA3/aBFHkNZqE+iCj5EmRg=
+github.com/prometheus/exporter-toolkit v0.14.0/go.mod h1:Gu5LnVvt7Nr/oqTBUC23WILZepW0nffNo10XdhQcwWA=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/quic-go/quic-go v0.49.0 h1:w5iJHXwHxs1QxyBv1EHKuC50GX5to8mJAxvtnttJp94=

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -2,7 +2,17 @@ package metrics
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -10,6 +20,246 @@ import (
 
 	"github.com/miekg/dns"
 )
+
+func createTestCertFiles(t *testing.T) (certFile, keyFile, caFile string, cleanup func()) {
+	// Generate CA certificate
+	caCert, caKey, err := generateCA()
+	if err != nil {
+		t.Fatalf("Failed to generate CA certificate: %v", err)
+	}
+
+	// Generate server certificate signed by CA
+	cert, key, err := generateCert(caCert, caKey)
+	if err != nil {
+		t.Fatalf("Failed to generate server certificate: %v", err)
+	}
+
+	// Write certificates to temporary files
+	certFile = writeTempFile(t, string(cert))
+	keyFile = writeTempFile(t, string(key))
+	caFile = writeTempFile(t, string(caCert))
+
+	// Return cleanup function to remove files
+	cleanup = func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+		os.Remove(caFile)
+	}
+	return certFile, keyFile, caFile, cleanup
+}
+
+func generateCA() ([]byte, []byte, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	caPrivKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+
+	return caPEM, caPrivKeyPEM, nil
+}
+
+func generateCert(caCertPEM, caKeyPEM []byte) ([]byte, []byte, error) {
+	caCertBlock, _ := pem.Decode(caCertPEM)
+	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caKeyBlock, _ := pem.Decode(caKeyPEM)
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization: []string{"Test Server"},
+		},
+		DNSNames:    []string{"localhost"},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(1, 0, 0),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, caCert, &certPrivKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	certPrivKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	return certPEM, certPrivKeyPEM, nil
+}
+
+func loadTestClientCert(t *testing.T, certFile, keyFile string) tls.Certificate {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("Failed to load client certificate: %v", err)
+	}
+	return cert
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	tmpFile, err := os.CreateTemp("", "testcert")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	return tmpFile.Name()
+}
+
+func TestMetricsTLS(t *testing.T) {
+	certFile, keyFile, caFile, cleanup := createTestCertFiles(t)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		tlsConfig   *tlsConfig
+		expectError bool
+		expectHTTPS bool
+	}{
+		{
+			name:        "No TLS",
+			tlsConfig:   nil,
+			expectError: false,
+			expectHTTPS: false,
+		},
+		{
+			name: "Valid TLS",
+			tlsConfig: &tlsConfig{
+				enabled:    true,
+				certFile:   certFile,
+				keyFile:    keyFile,
+				minVersion: tls.VersionTLS13,
+			},
+			expectError: false,
+			expectHTTPS: true,
+		},
+		{
+			name: "TLS with client auth",
+			tlsConfig: &tlsConfig{
+				enabled:        true,
+				certFile:       certFile,
+				keyFile:        keyFile,
+				clientCAFile:   caFile,
+				clientAuthType: tls.RequireAndVerifyClientCert,
+			},
+			expectError: false,
+			expectHTTPS: true,
+		},
+		{
+			name: "Missing cert file",
+			tlsConfig: &tlsConfig{
+				enabled:  true,
+				certFile: "missing.pem",
+				keyFile:  keyFile,
+			},
+			expectError: true,
+			expectHTTPS: false,
+		},
+		{
+			name: "Missing key file",
+			tlsConfig: &tlsConfig{
+				enabled:  true,
+				certFile: certFile,
+				keyFile:  "missing-key.pem",
+			},
+			expectError: true,
+			expectHTTPS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			met := New("localhost:0")
+			met.tlsConfig = tt.tlsConfig
+
+			err := met.OnStartup()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Failed to start metrics handler: %s", err)
+			}
+			defer met.OnFinalShutdown()
+
+			// Verify server is running with correct protocol
+			client := &http.Client{
+				Timeout: time.Second,
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+						Certificates:       []tls.Certificate{loadTestClientCert(t, certFile, keyFile)},
+					},
+				},
+			}
+
+			url := "http://" + ListenAddr + "/metrics"
+			if tt.expectHTTPS {
+				url = "https://" + ListenAddr + "/metrics"
+			}
+
+			resp, err := client.Get(url)
+			if err != nil {
+				t.Fatalf("Failed to connect to metrics server: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
 
 func TestMetrics(t *testing.T) {
 	met := New("localhost:0")


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
### 1. Why is this pull request needed and what does it do?

This PR adds optional TLS support for the CoreDNS metrics endpoint to enhance security by encrypting metric data communications. Currently, the metrics endpoint operates over unencrypted HTTP, which could expose sensitive operational data in transit. This PR implements:

- A configuration option in Corefile to enable TLS for the metrics endpoint
- Certificate and key configuration for securing metrics traffic
- Backward compatibility by making TLS optional for metrics
- Proper error handling for metrics endpoint TLS-related issues
- Appropriate logging for metrics TLS events

This enhancement is important for environments where secure monitoring is required, especially when metrics might contain sensitive operational data or when compliance regulations mandate encryption for all monitoring traffic.

### 2. Which issues (if any) are related?

#7109 

### 3. Which documentation changes (if any) need to be made?

1. Update to the metrics plugin documentation to describe the new TLS configuration options
2. Addition of configuration examples showing how to enable and configure TLS for the metrics endpoint
3. Updates to monitoring and observability documentation sections
4. Addition of details on:
   - How to configure certificates for the metrics endpoint
   - How to connect monitoring tools to the TLS-enabled metrics endpoint
   - Compatible Prometheus configurations for scraping secure metrics
   - Troubleshooting secure metrics endpoint connectivity

### 4. Does this introduce a backward incompatible change or deprecation?

No, this PR does not introduce any backward incompatible changes or deprecations. The TLS support for the metrics endpoint is implemented as an optional feature that is disabled by default.
