### PR TITLE
Increase CNAME lookup limit from 7 to 10

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -13,6 +13,8 @@ import (
 	"github.com/miekg/dns"
 )
 
+const maxCnameChainLength = 10
+
 // A returns A records from Backend or an error.
 func A(ctx context.Context, b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, truncated bool, err error) {
 	services, err := checkForApex(ctx, b, zone, state, opt)
@@ -34,7 +36,7 @@ func A(ctx context.Context, b ServiceBackend, zone string, state request.Request
 			}
 
 			newRecord := serv.NewCNAME(state.QName(), serv.Host)
-			if len(previousRecords) > 7 {
+			if len(previousRecords) > maxCnameChainLength {
 				// don't add it, and just continue
 				continue
 			}
@@ -108,7 +110,7 @@ func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Requ
 			}
 
 			newRecord := serv.NewCNAME(state.QName(), serv.Host)
-			if len(previousRecords) > 7 {
+			if len(previousRecords) > maxCnameChainLength {
 				// don't add it, and just continue
 				continue
 			}
@@ -361,7 +363,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			}
 
 			newRecord := serv.NewCNAME(state.QName(), serv.Host)
-			if len(previousRecords) > 7 {
+			if len(previousRecords) > maxCnameChainLength {
 				// don't add it, and just continue
 				continue
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Found a use case where we need to do more than 7 CNAME lookups. For example, hitting an OpenAI endpoint from azure. One example of the endpoint they have on their website is docs-test-001.openai.azure.com, which exceeds 7 lookups, cannot get to the A record.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/discussions/7123
https://github.com/coredns/coredns/issues/7125

### 3. Which documentation changes (if any) need to be made?
This isn't documented anywhere already. Not sure if it needs to be

### 4. Does this introduce a backward incompatible change or deprecation?
No