### PR TITLE
docs: timeouts plugin documentation include DNS over QUIC (DoQ)

### DIFF
--- a/plugin/timeouts/README.md
+++ b/plugin/timeouts/README.md
@@ -2,7 +2,7 @@
 
 ## Name
 
-*timeouts* - allows you to configure the server read, write and idle timeouts for the TCP, TLS and DoH servers.
+*timeouts* - allows you to configure the server read, write and idle timeouts for the TCP, TLS, DoH and DoQ (idle only) servers.
 
 ## Description
 
@@ -63,13 +63,26 @@ https://. {
 }
 ~~~
 
+Start a DNS-over-QUIC server that has the idle timeout set to two minutes.
+
+~~~
+quic://.:853 {
+	tls cert.pem key.pem ca.pem
+	timeouts {
+		idle 2m
+	}
+	forward . /etc/resolv.conf
+}
+~~~
+
 Start a standard TCP/UDP server on port 1053. A read and write timeout has been
 configured. The timeouts are only applied to the TCP side of the server.
+
 ~~~
 .:1053 {
 	timeouts {
 		read 15s
-                write 30s
+		write 30s
 	}
 	forward . /etc/resolv.conf
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This is just a small documentation change to include DNS over QUIC details for the `timeouts` plug-in.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

`timeouts` plugin

### 4. Does this introduce a backward incompatible change or deprecation?

N/A


I was just seeing what new servers had been added and if the `timeouts` plugin that got merged a while ago supported them. It looks like QUIC support has been added and whoever added it did set the idle timeout (thanks very much!). This documentation change just makes it clear that QUIC is supported by `timeouts` but ONLY the `idle` value.