### PR TITLE
plugin/forward: connection cache performance optimization

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
+    multi_conn_manager [CONN_MANAGER_NUM]
     next RCODE_1 [RCODE_2] [RCODE_3...]
     failfast_all_unhealthy_upstreams
 }
@@ -97,6 +98,7 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `multi_conn_manager` **CONN_MANAGER_NUM** run multiple connection cache managers for each upstream, default value is GOMAXPROCS, enabling this could increase throughput on a multi core machine
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -51,6 +51,7 @@ type Forward struct {
 	expire                     time.Duration
 	maxConcurrent              int64
 	failfastUnhealthyUpstreams bool
+	proxyTransportNum          uint
 
 	opts proxy.Options // also here for testing
 

--- a/plugin/forward/fuzz.go
+++ b/plugin/forward/fuzz.go
@@ -17,8 +17,8 @@ var f *Forward
 func init() {
 	f = New()
 	s := dnstest.NewServer(r{}.reflectHandler)
-	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin1", s.Addr, "tcp"))
-	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin2", s.Addr, "udp"))
+	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin1", s.Addr, "tcp", 1))
+	f.SetProxy(proxy.NewProxy("FuzzForwardPlugin2", s.Addr, "udp", 1))
 }
 
 // Fuzz fuzzes forward.

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
+	"math/rand"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -87,7 +87,8 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		proto = state.Proto()
 	}
 
-	pc, cached, err := p.transport.Dial(proto)
+	index := rand.Intn(len(p.transport))
+	pc, cached, err := p.transport[index].Dial(proto)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 	for {
 		ret, err = pc.c.ReadMsg()
 		if err != nil {
-			if ret != nil && (state.Req.Id == ret.Id) && p.transport.transportTypeFromConn(pc) == typeUDP && shouldTruncateResponse(err) {
+			if ret != nil && (state.Req.Id == ret.Id) && p.transport[index].transportTypeFromConn(pc) == typeUDP && shouldTruncateResponse(err) {
 				// For UDP, if the error is an overflow, we probably have an upstream misbehaving in some way.
 				// (e.g. sending >512 byte responses without an eDNS0 OPT RR).
 				// Instead of returning an error, return an empty response with TC bit set. This will make the
@@ -149,7 +150,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 	// recovery the origin Id after upstream.
 	ret.Id = originId
 
-	p.transport.Yield(pc)
+	p.transport[index].Yield(pc)
 
 	rc, ok := dns.RcodeToString[ret.Rcode]
 	if !ok {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
the single `connManager` goroutine for each upstream can become a performance bottleneck when running on multi core machine,  this PR adds a `multi_conn_manager` directive to allow multiple `connManager`  goroutines for each upstream
### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/7111 might be related
### 3. Which documentation changes (if any) need to be made?
the doc for forward plugin need to be changed
### 4. Does this introduce a backward incompatible change or deprecation?
no