### PR TITLE
return PTR record if pod hostname is not set

### DIFF
--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -37,24 +37,37 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 		return []msg.Service{{Host: domain, TTL: k.ttl}}
 	}
 	// If no cluster ips match, search endpoints
-	var svcs []msg.Service
+	// Keep a discrete accounting of services with Hostnames set and those without
+	// So that we don't return a mixed set of service records with and without Hostnames set
+	var svcsHostname, svcsIPs []msg.Service
 	for _, ep := range k.APIConn.EpIndexReverse(ip) {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.Namespace) {
 			continue
 		}
 		for _, eps := range ep.Subsets {
 			for _, addr := range eps.Addresses {
-				// The endpoint's Hostname will be set if this endpoint is supposed to generate a PTR.
-				// So only return reverse records that match the IP AND have a non-empty hostname.
-				// Kubernetes more or less keeps this to one canonical service/endpoint per IP, but in the odd event there
-				// are multiple endpoints for the same IP with hostname set, return them all rather than selecting one
-				// arbitrarily.
-				if addr.IP == ip && addr.Hostname != "" {
-					domain := strings.Join([]string{addr.Hostname, ep.Index, Svc, k.primaryZone()}, ".")
-					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
+				var domain string
+				if addr.IP == ip {
+					if addr.Hostname != "" {
+						// If the endpoint's Hostname is set, compose a compliant PTR record composed from that hostname
+						// Kubernetes more or less keeps this to one canonical service/endpoint per IP, but in the odd event there
+						// are multiple endpoints for the same IP with hostname set, return them all rather than selecting one
+						// arbitrarily.
+						domain = strings.Join([]string{addr.Hostname, ep.Index, Svc, k.primaryZone()}, ".")
+						svcsHostname = append(svcsHostname, msg.Service{Host: domain, TTL: k.ttl})
+					} else {
+						// If the endpoint's Hostname is not set, generate a hostname from the IP address compose compliant PTR record
+						domain = strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Index, Svc, k.primaryZone()}, ".")
+						svcsIPs = append(svcsIPs, msg.Service{Host: domain, TTL: k.ttl})
+					}
 				}
 			}
 		}
 	}
-	return svcs
+	// If our service list with Hostnames set is not empty, return it
+	if len(svcsHostname) > 0 {
+		return svcsHostname
+	}
+	// Otherwise return the service list with IPs
+	return svcsIPs
 }

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -121,6 +121,21 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
 		Namespace: "testns",
 		Index:     object.EndpointsKey("svc2", "testns"),
 	}
+	ep3 := object.Endpoints{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{
+					{IP: "10.0.0.98", Hostname: ""}, // This endpoint has no hostname
+				},
+				Ports: []object.EndpointPort{
+					{Port: 80, Protocol: "tcp", Name: "http"},
+				},
+			},
+		},
+		Name:      "svc3-slice1",
+		Namespace: "testns",
+		Index:     object.EndpointsKey("svc3", "testns"),
+	}
 	switch ip {
 	case "1234:abcd::1":
 		fallthrough
@@ -132,6 +147,8 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
 		return []*object.Endpoints{&ep1s1, &ep1s3}
 	case "10.0.0.99": // two different Services select this IP
 		return []*object.Endpoints{&ep1s1, &ep2}
+	case "10.0.0.98": // EndPointSlice with no hostname
+		return []*object.Endpoints{&ep3}
 	}
 	return nil
 }
@@ -230,6 +247,13 @@ func TestReverse(t *testing.T) {
 			Rcode: dns.RcodeNameError,
 			Ns: []dns.RR{
 				test.SOA("cluster.local.       5     IN      SOA     ns.dns.cluster.local. hostmaster.cluster.local. 1502989566 7200 1800 86400 5"),
+			},
+		},
+		{
+			Qname: "98.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("98.0.0.10.in-addr.arpa.      5    IN      PTR       10-0-0-98.svc3.testns.svc.cluster.local."),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR restores the previous behavior of returning a well-formed PTR record for DNS records that correlate with pods without a hostname. It is compatible with the changes in #6898 whose intention (among other things) was to improve the deterministic response of PTR records for pod IPs sharing a common hostname.

### 2. Which issues (if any) are related?

Fixes #7177

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
