### PR TITLE
enabled query name and type as part of the metrics optionally

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -61,6 +61,8 @@ type Forward struct {
 	tapPlugins []*dnstap.Dnstap // when dnstap plugins are loaded, we use to this to send messages out.
 
 	Next plugin.Handler
+
+	qTypeForMetrics []string
 }
 
 // New returns a new Forward.

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -312,6 +312,15 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return c.ArgErr()
 		}
 		f.failfastUnhealthyUpstreams = true
+	case "qtype_for_metrics":
+		args := c.RemainingArgs()
+		if len(args) < 1 {
+			return c.ArgErr()
+		}
+		f.qTypeForMetrics = args
+		for _, p := range f.proxies {
+			p.SetQTypeForMetrics(args)
+		}
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -156,6 +156,9 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		rc = strconv.Itoa(ret.Rcode)
 	}
 
+	if _, ok := p.qTypeForMetrics[state.Type()]; ok {
+		requestDurationWithName.WithLabelValues(p.proxyName, p.addr, rc, state.Name(), state.Type()).Observe(float64(time.Since(start).Seconds()))
+	}
 	requestDuration.WithLabelValues(p.proxyName, p.addr, rc).Observe(time.Since(start).Seconds())
 
 	return ret, nil

--- a/plugin/pkg/proxy/metrics.go
+++ b/plugin/pkg/proxy/metrics.go
@@ -18,6 +18,15 @@ var (
 		Help:                        "Histogram of the time each request took.",
 	}, []string{"proxy_name", "to", "rcode"})
 
+	requestDurationWithName = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                   plugin.Namespace,
+		Subsystem:                   "proxy",
+		Name:                        "request_duration_seconds_with_name",
+		Buckets:                     plugin.TimeBuckets,
+		NativeHistogramBucketFactor: plugin.NativeHistogramBucketFactor,
+		Help:                        "Histogram of the time each request took.",
+	}, []string{"proxy_name", "to", "rcode", "name", "type"})
+
 	healthcheckFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "proxy",

--- a/plugin/pkg/proxy/proxy.go
+++ b/plugin/pkg/proxy/proxy.go
@@ -23,22 +23,31 @@ type Proxy struct {
 	// health checking
 	probe  *up.Probe
 	health HealthChecker
+
+	qTypeForMetrics map[string]bool
 }
 
 // NewProxy returns a new proxy.
 func NewProxy(proxyName, addr, trans string) *Proxy {
 	p := &Proxy{
-		addr:        addr,
-		fails:       0,
-		probe:       up.New(),
-		readTimeout: 2 * time.Second,
-		transport:   newTransport(proxyName, addr),
-		health:      NewHealthChecker(proxyName, trans, true, "."),
-		proxyName:   proxyName,
+		addr:            addr,
+		fails:           0,
+		probe:           up.New(),
+		readTimeout:     2 * time.Second,
+		transport:       newTransport(proxyName, addr),
+		health:          NewHealthChecker(proxyName, trans, true, "."),
+		proxyName:       proxyName,
+		qTypeForMetrics: make(map[string]bool),
 	}
 
 	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
+}
+
+func (p *Proxy) SetQTypeForMetrics(qTypes []string) {
+	for _, q := range qTypes {
+		p.qTypeForMetrics[q] = true
+	}
 }
 
 func (p *Proxy) Addr() string { return p.addr }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
As part of this change, we are introducing a new configuration for the `forward` plugin named `qtype_for_metrics` that can be used to configure the query types that needs to be generated into metrics which contains the additional information of `name` and `type`.

The new metrics will be `request_duration_seconds_with_name` and will contain `"proxy_name", "to", "rcode", "name", "type"` as the labels/tags in the metrics.


### 2. Which issues (if any) are related?
#7196 

### 3. Which documentation changes (if any) need to be made?
1. Document on the `forward` plugin needs to be updated to contain the additional details. https://github.com/coredns/coredns.io/blob/master/content/plugins/forward.md

### 4. Does this introduce a backward incompatible change or deprecation?
No