### PR TITLE
plugin/kubernetes: Document the kubernetes plugin PTR record behavior

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -121,6 +121,11 @@ The *kubernetes* plugin watches Endpoints via the `discovery.EndpointSlices` API
 This plugin reports readiness to the ready plugin. This will happen after it has synced to the
 Kubernetes API.
 
+## PTR Records
+
+This plugin creates PTR records for every Pod selected by a Service. If a given Pod is selected by more than
+one Service a separate PTR record will exist for each Service selecting it.
+
 ## Examples
 
 Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Also handle all


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Document the kubernetes plugin PTR record behavior specifically in regard to multiple services selecting the same pods.  

### 2. Which issues (if any) are related?

#7177

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
