### PR TITLE
Added `SetProxyOptions` function for `forward` plugin

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -75,6 +75,11 @@ func (f *Forward) SetProxy(p *proxy.Proxy) {
 	p.Start(f.hcInterval)
 }
 
+// SetProxyOptions setup proxy options
+func (f *Forward) SetProxyOptions(opts proxy.Options) {
+	f.opts = opts
+}
+
 // SetTapPlugin appends one or more dnstap plugins to the tap plugin list.
 func (f *Forward) SetTapPlugin(tapPlugin *dnstap.Dnstap) {
 	f.tapPlugins = append(f.tapPlugins, tapPlugin)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR adds a SetProxyOptions function for the forward plugin. During the discussion of the previous Pull Request #7105 we came to the conclusion that the dynamicforward plugin should be moved to external plugins under a different name kubeforward, which we did [https://github.com/deckhouse/coredns-kubeforward], we also submitted a [PR](https://github.com/coredns/coredns.io/pull/323) to add this plugin to external plugins.
But to fully realize the functionality of our plugin, we need an interface to pass proxy parameters to the forward plugin.

### 2. Which issues (if any) are related?

No.
### 3. Which documentation changes (if any) need to be made?
No.
### 4. Does this introduce a backward incompatible change or deprecation?
No.