### PR TITLE
plugin/bind: remove macOS bug mention in docs

### DIFF
--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -108,6 +108,3 @@ bad.example.com {
     forward . 5.6.7.8
 }
 ```
-
-Also on MacOS there is an (open) bug where this doesn't work properly. See
-<https://github.com/miekg/dns/issues/724> for details, but no solution.


### PR DESCRIPTION
fixed by updating to miekg/dns@v1.1.65 in #7240

upstream bug was fixed by miekg/dns#1643

### 1. Why is this pull request needed and what does it do?
removes the mention of the bind bug on macOS since it's fixed now

### 2. Which issues (if any) are related?
- PR #7240 which bumped miekg/dns to v1.1.65
- PR miekg/dns#1643 which fixed (workarund'ed) the bug
- PR #4995 which added this notice into docs

### 3. Which documentation changes (if any) need to be made?
n/a, this is the documentation change

### 4. Does this introduce a backward incompatible change or deprecation?
n/a, it's just a documentation change
