### PR TITLE
Remove `?bla=foo:443` for `POST` DoH

### DIFF
--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -52,7 +52,7 @@ func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 	case http.MethodPost:
 		req, err := http.NewRequest(
 			http.MethodPost,
-			fmt.Sprintf("%s%s?bla=foo:443", url, Path),
+			fmt.Sprintf("%s%s", url, Path),
 			bytes.NewReader(buf),
 		)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Removes an unnecessary query parameter included in POST DoH requests.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

I do not think DoH servers will rely on this field to identify the query source as CoreDNS, so removing this query parameter should be acceptable.