### PR TITLE
fix(rewrite): truncated upstream response

### DIFF
--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -100,6 +100,9 @@ func (r *cnameTargetRuleWithReqState) RewriteResponse(res *dns.Msg, rr dns.RR) {
 					}
 				}
 				res.Answer = newAnswer
+				// if not propagated, the truncated response might get cached,
+				// and it will be impossible to resolve the full response
+				res.Truncated = upRes.Truncated
 			}
 		}
 	}


### PR DESCRIPTION
Forward information that a upstream response is truncated when rewriting
a CNAME. Otherwise, the cache plugin stores the truncated resonse,
making it impossible to receive the full response as a client via TCP.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fixes [#7276 rewrite cname: Incorrect handling of truncated upstream response when cache is enabled](https://github.com/coredns/coredns/issues/7276).

### 2. Which issues (if any) are related?

[#7276 rewrite cname: Incorrect handling of truncated upstream response when cache is enabled](https://github.com/coredns/coredns/issues/7276).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
