### PR TITLE
Drop RetryOnError from cache.Config

### DIFF
--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -17,7 +17,6 @@ func NewIndexerInformer(lw cache.ListerWatcher, objType runtime.Object, h cache.
 		ListerWatcher:    lw,
 		ObjectType:       objType,
 		FullResyncPeriod: defaultResyncPeriod,
-		RetryOnError:     false,
 		Process:          builder(clientState, h),
 	}
 	return clientState, cache.New(cfg)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This allows CoreDNS to build with Kubernetes 1.33 without requiring it. RetryOnError was removed in
https://github.com/kubernetes/kubernetes/pull/129568/commits/8e77ac000131019d5aa49c19aa1f477f6dac4d59 and defaults to false anyway.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.