### PR TITLE
Prepare for the k8s api update

### DIFF
--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -17,7 +17,6 @@ func NewIndexerInformer(lw cache.ListerWatcher, objType runtime.Object, h cache.
 		ListerWatcher:    lw,
 		ObjectType:       objType,
 		FullResyncPeriod: defaultResyncPeriod,
-		RetryOnError:     false,
 		Process:          builder(clientState, h),
 	}
 	return clientState, cache.New(cfg)


### PR DESCRIPTION
Don't explicitly set `RetryOnError` to `false`.  It won't exist in the next version of the k8s api and it won't make a difference in this code since the struct would default to that. It also means that projects including codedns can build with Go 1.24.x.

### 1. Why is this pull request needed and what does it do?

This field is removed in the next release of the k8s client libraries. Currently we're not seeing them because this is built with go 1.23.x.

### 2. Which issues (if any) are related?

None - this is the default value of this field while it exists.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.