### PR TITLE
fix(plugin/bind): remove zone for link-local IPv4

### DIFF
--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -85,7 +85,7 @@ func listIP(args []string, ifaces []net.Interface) ([]string, error) {
 					if ipnet, ok := addr.(*net.IPNet); ok {
 						ipa, err := net.ResolveIPAddr("ip", ipnet.IP.String())
 						if err == nil {
-							if len(ipnet.IP) == net.IPv6len &&
+							if ipnet.IP.To4() == nil &&
 								(ipnet.IP.IsLinkLocalMulticast() || ipnet.IP.IsLinkLocalUnicast()) {
 								if ipa.Zone == "" {
 									ipa.Zone = iface.Name


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

On a host with an IPv4 link-local address assigned to an interface that CoreDNS is configured to bind to, this happens:

```
$ ./coredns -conf=/etc/coredns/Corefile
maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined
lookup 169.254.1.1%dummy0: no such host
```

This PR fixes an incorrect test for an IPv6 address so it only adds the zone to IPv6 addresses, never to IPv4.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/pull/6547 introduced the bug.

### 3. Which documentation changes (if any) need to be made?

None, this makes it work the way the documentation already says it works. 😃 

### 4. Does this introduce a backward incompatible change or deprecation?

No.