### PR TITLE
ci(test-e2e): add Go version setup to workflow

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Setup Go Version
+        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add environment variable setup step for Go version in the e2e tests job of the GitHub workflow. This ensures consistent Go version usage across all test jobs and fixes the warning about missing go-version input.

See [this run](https://github.com/coredns/coredns/actions/runs/15117744950/job/42492590128?pr=7307) for an example, under "Install go" step.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

None.
