### PR TITLE
feat: enable plugins via environment during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $ cd coredns
 $ make
 ~~~
 
+> **_NOTE:_**  extra plugins may be enabled when building by setting the `COREDNS_PLUGINS` environment variable with comma separate list of plugins in the same format as plugin.cfg
+
 This should yield a `coredns` binary.
 
 ## Compilation with Docker


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This change will make it easier to automate builds using external plugins. For example, if I'm building my own image using `coredns-abc` and `coredns-def` plugins, I can just set `COREDNS_PLUGINS=abs:github.com/whatever/coredns-abc,def:github.com/something/coredns-def` when I initiate my build.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
Docs changes are not strictly necessary, but I've added a note to the README on how to use this feature.

### 4. Does this introduce a backward incompatible change or deprecation?
Nope!