### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,12 +29,12 @@ go.mod                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /plugin/clouddns/       @miekg @yongtang
 /plugin/dns64           @superq
 /plugin/dnssec/         @isolus @miekg
-/plugin/dnstap/         @varyoo @yongtang
+/plugin/dnstap/         @yongtang
 /plugin/erratic/        @miekg
 /plugin/errors/         @miekg @Tantalor93
 /plugin/etcd/           @miekg @nitisht
 /plugin/file/           @miekg @yongtang @stp-ip
-/plugin/forward/        @johnbelamaric @miekg @rdrozhdzh @Tantalor93 @chrisohaver
+/plugin/forward/        @johnbelamaric @miekg @Tantalor93 @chrisohaver
 /plugin/geoip/          @miekg @snebel29
 /plugin/grpc/           @inigohu @miekg @zouyee
 /plugin/health/         @jameshartig @miekg @zouyee
@@ -45,7 +45,7 @@ go.mod                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /plugin/loadbalance/    @miekg
 /plugin/log/            @miekg @nchrisdk @Tantalor93
 /plugin/loop/           @miekg @chrisohaver
-/plugin/metadata/       @ekleiner @miekg @Tantalor93
+/plugin/metadata/       @miekg @Tantalor93
 /plugin/metrics/        @jameshartig @miekg @superq @greenpau @Tantalor93
 /plugin/nsid/           @yongtang
 /plugin/pprof/          @miekg @zouyee


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

GitHub UI shows an error in the [current CODEOWNERS file](https://github.com/coredns/coredns/blob/master/CODEOWNERS) about users who no longer have write access to the repository. This PR removes those users from the file.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

None.
