### PR TITLE
test: skip certain network-specific tests on non-Linux

### DIFF
--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -1,6 +1,7 @@
 package bind
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -8,6 +9,12 @@ import (
 )
 
 func TestSetup(t *testing.T) {
+	// Skip on non-Linux systems as some tests refer to for e.g. loopback interfaces which
+	// are not present on all systems.
+	if runtime.GOOS != "linux" {
+		t.Skipf("Skipping bind test on %s", runtime.GOOS)
+	}
+
 	for i, test := range []struct {
 		config   string
 		expected []string

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -45,6 +46,12 @@ PrivateKey: f03VplaIEA+KHI9uizlemUSbUJH86hPBPjmcUninPoM=
 // While we're at it - we also check the README.md itself. It should at least have the sections:
 // Name, Description, Syntax and Examples. See plugin.md for more details.
 func TestReadme(t *testing.T) {
+	// Skip on non-Linux systems as some tests refer to for e.g. loopback interfaces which
+	// are not present on all systems.
+	if runtime.GOOS != "linux" {
+		t.Skipf("Skipping readme test on %s", runtime.GOOS)
+	}
+
 	port := 30053
 	caddy.Quiet = true
 	dnsserver.Quiet = true


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add conditional test skipping for bind and readme tests that rely on Linux-specific loopback interface behavior. These tests reference network configurations that may not exist on for e.g. macOS or other platforms, causing spurious test failures.

For example on macOS when testing `plugin/bind`:

```
$ go test -v ./plugin/bind
=== RUN   TestSetup
    setup_test.go:29: Test 6, expected no errors, but got: plugin/bind: not a valid IP address or interface name: "lo"
--- FAIL: TestSetup (0.00s)
FAIL
FAIL    github.com/coredns/coredns/plugin/bind  0.240s
FAIL
```

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
