### PR TITLE
lint: enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - unconvert
     - unused
     - whitespace
+    - usetesting
   exclusions:
     generated: lax
     presets:

--- a/plugin/file/tree/print_test.go
+++ b/plugin/file/tree/print_test.go
@@ -70,7 +70,7 @@ func TestPrint(t *testing.T) {
 
 	*/
 
-	f, err := os.CreateTemp("", "print_test_tmp")
+	f, err := os.CreateTemp(t.TempDir(), "print_test_tmp")
 	if err != nil {
 		t.Error(err)
 	}

--- a/plugin/pkg/tls/tls_test.go
+++ b/plugin/pkg/tls/tls_test.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -79,15 +78,8 @@ func TestNewTLSConfigFromArgs(t *testing.T) {
 
 func TestNewTLSConfigFromArgsWithRoot(t *testing.T) {
 	cert, key, ca := getPEMFiles(t)
-	tempDir, err := os.MkdirTemp("", "go-test-pemfiles")
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Error("failed to clean up temporary directory", err)
-		}
-	}()
-	if err != nil {
-		t.Error("failed to create temporary directory", err)
-	}
+	tempDir := t.TempDir()
+
 	root := tempDir
 	args := []string{cert, key, ca}
 	for i := range args {

--- a/plugin/root/root_test.go
+++ b/plugin/root/root_test.go
@@ -23,7 +23,7 @@ func TestRoot(t *testing.T) {
 
 	nonExistingDir := filepath.Join(existingDirPath, "highly_unlikely_to_exist_dir")
 
-	existingFile, err := os.CreateTemp("", "root_test")
+	existingFile, err := os.CreateTemp(t.TempDir(), "root_test")
 	if err != nil {
 		t.Fatalf("BeforeTest: Failed to create temp file for testing! Error was: %v", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable the usetesting linter in golangci.yml configuration to enforce proper testing practices. Replace manual temporary directory and file creation with t.TempDir() in test files.

This improves test reliability by ensuring proper cleanup and follows Go testing best practices.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

No.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
