### PR TITLE
fix: loop variable capture and linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,13 +2,14 @@ version: "2"
 linters:
   default: none
   enable:
+    - copyloopvar
     - govet
     - ineffassign
     - staticcheck
     - unconvert
     - unused
-    - whitespace
     - usetesting
+    - whitespace
   exclusions:
     generated: lax
     presets:

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -21,7 +21,6 @@ func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) contex
 		})
 
 		for k, v := range pod.Labels {
-			v := v
 			metadata.SetValueFunc(ctx, "kubernetes/client-label/"+k, func() string {
 				return v
 			})


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable copyloopvar linter and remove redundant variable shadowing in Kubernetes plugin metadata handling. This pattern is no longer needed in Go 1.22+ where loop variables are automatically captured correctly in closures.

Also changed the order of the linters to alphabetical order. Missed this in #7322.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.