### PR TITLE
lint: enable canonicalheader linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - canonicalheader
     - copyloopvar
     - govet
     - ineffassign

--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -45,8 +45,8 @@ func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 			return req, err
 		}
 
-		req.Header.Set("content-type", MimeType)
-		req.Header.Set("accept", MimeType)
+		req.Header.Set("Content-Type", MimeType)
+		req.Header.Set("Accept", MimeType)
 		return req, nil
 
 	case http.MethodPost:
@@ -59,8 +59,8 @@ func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 			return req, err
 		}
 
-		req.Header.Set("content-type", MimeType)
-		req.Header.Set("accept", MimeType)
+		req.Header.Set("Content-Type", MimeType)
+		req.Header.Set("Accept", MimeType)
 		return req, nil
 
 	default:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable canonicalheader linter to enforce proper HTTP header casing. This ensures headers use Go's canonical format (e.g., "Content-Type" instead of "content-type") for consistency.

Fixes header casing in DoH implementation.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.