### PR TITLE
lint: enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - govet
     - ineffassign
     - intrange
+    - nolintlint
     - staticcheck
     - unconvert
     - unused

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -183,7 +183,6 @@ var (
 
 // Build information obtained with the help of -ldflags
 var (
-	// nolint
 	appVersion = "(untracked dev build)" // inferred at startup
 	devBuild   = true                    // inferred at startup
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -70,7 +70,7 @@ func (f HandlerFunc) Name() string { return "handlerfunc" }
 func Error(name string, err error) error { return fmt.Errorf("%s/%s: %s", "plugin", name, err) }
 
 // NextOrFailure calls next.ServeDNS when next is not nil, otherwise it will return, a ServerFailure and a `no next plugin found` error.
-func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) { // nolint: golint
+func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if next != nil {
 		if span := ot.SpanFromContext(ctx); span != nil {
 			child := span.Tracer().StartSpan(next.Name(), ot.ChildOf(span.Context()))


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable nolintlint to enforce proper formatting and usage of //nolint directives. Ensures linter suppressions are correctly formatted, have explanations where needed, and target specific linters rather than using blanket disables.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
