### PR TITLE
Actually invoke make release -f Makefile.release during test

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -85,8 +85,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install make curl
 
-      - name: Test Makefile.release
+      - name: Test Makefile.release release
+        run: make GITHUB_ACCESS_TOKEN=x release -f Makefile.release
+
+      - name: Test Makefile.release release/github-push (dry-run)
         run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
 
-      - name: Test Makefile.docker
+      - name: Test Makefile.docker release/github-push (dry-run)
         run: make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

In previous setup, we do release test but only with dry-run:

This caused problems and we couldn't detect the 1.24.3's build issue (See #7337)

This PR actually test the release with make release -f Makefile.release.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A