### PR TITLE
lint: enable wastedassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - unconvert
     - unused
     - usetesting
+    - wastedassign
     - whitespace
   exclusions:
     generated: lax

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -34,14 +34,13 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	// in which upstream doesn't support DNSSEC, the two cache items will effectively be the same. Regardless, any
 	// DNSSEC RRs in the response are written to cache with the response.
 
-	ttl := 0
 	i := c.getIgnoreTTL(now, state, server)
 	if i == nil {
 		crr := &ResponseWriter{ResponseWriter: w, Cache: c, state: state, server: server, do: do, ad: ad, cd: cd,
 			nexcept: c.nexcept, pexcept: c.pexcept, wildcardFunc: wildcardFunc(ctx)}
 		return c.doRefresh(ctx, state, crr)
 	}
-	ttl = i.ttl(now)
+	ttl := i.ttl(now)
 	if ttl < 0 {
 		// serve stale behavior
 		if c.verifyStale {

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -25,7 +25,7 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 			MultipleTcpWriteBuf: 1,
 			MultipleQueue:       1,
 		}
-		endpoint := ""
+
 		d.repl = replacer.New()
 
 		args := c.RemainingArgs()
@@ -34,7 +34,7 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 			return nil, c.ArgErr()
 		}
 
-		endpoint = args[0]
+		endpoint := args[0]
 
 		if len(args) >= 3 {
 			d.MultipleTcpWriteBuf, _ = strconv.Atoi(args[2])

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -171,7 +171,7 @@ func (h *Hostsfile) parse(r io.Reader) *Map {
 			continue
 		}
 
-		family := 0
+		var family int
 		if addr.To4() != nil {
 			family = 1
 		} else {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -379,7 +379,8 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	zonePath := msg.Path(zone, coredns)
-	ip := ""
+
+	var ip string
 	if strings.Count(podname, "-") == 3 && !strings.Contains(podname, "--") {
 		ip = strings.ReplaceAll(podname, "-", ".")
 	} else {

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -11,10 +11,8 @@ import (
 // 54.119.58.176.in-addr.arpa. becomes 176.58.119.54. If the conversion
 // fails the empty string is returned.
 func ExtractAddressFromReverse(reverseName string) string {
-	search := ""
-
 	f := reverse
-
+	var search string
 	switch {
 	case strings.HasSuffix(reverseName, IP4arpa):
 		search = strings.TrimSuffix(reverseName, IP4arpa)

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -107,7 +107,7 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options) (*dns.Msg, error) {
 	start := time.Now()
 
-	proto := ""
+	var proto string
 	switch {
 	case opts.ForceTCP: // TCP flag has precedence over UDP flag
 		proto = "tcp"


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable wastedassign linter to catch unnecessary variable initializations. Fix assignments where variables were declared with zero values and immediately reassigned, instead declaring them at the point of first meaningful assignment.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.