### PR TITLE
test(plugin): add tests for any

### DIFF
--- a/plugin/any/any_test.go
+++ b/plugin/any/any_test.go
@@ -26,3 +26,42 @@ func TestAny(t *testing.T) {
 		t.Errorf("Expected HINFO, but got %q", rec.Msg.Answer[0].(*dns.HINFO).Cpu)
 	}
 }
+
+func TestAnyNonANYQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		qtype uint16
+	}{
+		{"A query", dns.TypeA},
+		{"AAAA query", dns.TypeAAAA},
+		{"MX query", dns.TypeMX},
+		{"TXT query", dns.TypeTXT},
+		{"CNAME query", dns.TypeCNAME},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := new(dns.Msg)
+			req.SetQuestion("example.org.", tt.qtype)
+
+			nextCalled := false
+			a := &Any{
+				Next: test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+					nextCalled = true
+					return 0, nil
+				}),
+			}
+
+			rec := dnstest.NewRecorder(&test.ResponseWriter{})
+			_, err := a.ServeDNS(context.TODO(), rec, req)
+
+			if err != nil {
+				t.Errorf("Expected no error, but got %q", err)
+			}
+
+			if !nextCalled {
+				t.Error("Expected Next handler to be called for non-ANY query")
+			}
+		})
+	}
+}

--- a/plugin/any/setup_test.go
+++ b/plugin/any/setup_test.go
@@ -1,0 +1,21 @@
+package any
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+)
+
+func TestSetup(t *testing.T) {
+	c := caddy.NewTestController("dns", `any`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
+	// Check that the plugin was added to the config
+	cfg := dnsserver.GetConfig(c)
+	if len(cfg.Plugin) == 0 {
+		t.Error("Expected plugin to be added to config")
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add comprehensive test cases for non-ANY query types (A, AAAA, MX, TXT, CNAME) to verify that the any plugin correctly passes these queries to the next handler in the chain.

Add tests for setup.

Improves code coverage for the plugin from 53% to 87%.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.