### PR TITLE
fix(proxy): flaky dial tests

### DIFF
--- a/plugin/pkg/proxy/connect_test.go
+++ b/plugin/pkg/proxy/connect_test.go
@@ -92,7 +92,7 @@ func TestDial_TransportStoppedDuringRetWait(t *testing.T) {
 	select {
 	case protoFromDial = <-tr.dial:
 		t.Logf("Test: Simulated connManager read '%s' from Dial via test-controlled tr.dial", protoFromDial)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Test: Timeout waiting for Dial to send on test-controlled tr.dial")
 	}
 
@@ -154,7 +154,7 @@ func TestDial_Returns_ErrTransportStoppedRetClosed(t *testing.T) {
 			t.Fatalf("Test: Dial sent wrong proto on testDialChan: got %s, want udp", proto)
 		}
 		t.Logf("Test: Simulated connManager received '%s' from Dial via testDialChan.", proto)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		// If Dial didn't send, the test is flawed or Dial is stuck before sending.
 		wg.Done()
 		t.Fatal("Test: Timeout waiting for Dial to send on testDialChan.")
@@ -228,7 +228,7 @@ func TestDial_ConnManagerClosesRetOnStop(t *testing.T) {
 		} else {
 			t.Logf("Interaction Dial completed without error.")
 		}
-	case <-time.After(100 * time.Millisecond): // Timeout for safety if Dial hangs
+	case <-time.After(500 * time.Millisecond): // Timeout for safety if Dial hangs
 		t.Logf("Timeout waiting for interaction Dial to complete.")
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Increase timeout from 100ms to 500ms in Dial related tests, to fix test timeouts in CI environments.

Tests were refactored recently in #7321. Seems to fail not too often but still.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
