### PR TITLE
fix(kubernetes): multicluster DNS race condition

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -456,11 +456,11 @@ func (dns *dnsControl) HasSynced() bool {
 	d := dns.nsController.HasSynced()
 	e := true
 	if dns.svcImportController != nil {
-		c = dns.svcImportController.HasSynced()
+		e = dns.svcImportController.HasSynced()
 	}
 	f := true
 	if dns.mcEpController != nil {
-		c = dns.mcEpController.HasSynced()
+		f = dns.mcEpController.HasSynced()
 	}
 	return a && b && c && d && e && f
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I was working on #7349 and I noticed this peculiar test failure on a completely unrelated test:

```
--- FAIL: TestMultiClusterHeadless (0.00s)
    controller_test.go:134: Expected SUCCESS, got NXDOMAIN
[coredns.local.]
[coredns.local. clusterset.local.]
```

So I started looking. The `HasSynced` method had incorrect variable assignments for the ServiceImport and MultiCluster Endpoints controllers. Both were incorrectly assigning their sync status to variable `c` instead of their respective variables `e` and `f`.

This caused a race condition where `HasSynced()` would return `true` even when all controllers weren't actually synced, leading to intermittent NXDOMAIN responses.

The fix ensures all controller sync states are properly checked before allowing DNS queries to proceed.

Originally implemented in #7266.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
