### PR TITLE
test: add t.Helper() calls to test helper functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - nolintlint
     - protogetter
     - staticcheck
+    - thelper
     - unconvert
     - unused
     - usetesting

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -17,6 +17,7 @@ var (
 )
 
 func testServerHTTPS(t *testing.T, path string, validator func(*http.Request) bool) *http.Response {
+	t.Helper()
 	c := Config{
 		Zone:                    "example.com.",
 		Transport:               "https",

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -62,6 +62,7 @@ func TestWalkNonExistent(t *testing.T) {
 }
 
 func createFiles(t *testing.T) (string, error) {
+	t.Helper()
 	dir := t.TempDir()
 
 	for _, name := range dbFiles {

--- a/plugin/cache/freq/freq_test.go
+++ b/plugin/cache/freq/freq_test.go
@@ -30,6 +30,7 @@ func TestReset(t *testing.T) {
 }
 
 func hitsCheck(t *testing.T, f *Freq, expected int) {
+	t.Helper()
 	if x := f.Hits(); x != expected {
 		t.Fatalf("Expected hits to be %d, got %d", expected, x)
 	}

--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -248,6 +248,7 @@ func testEmptyMsg() *dns.Msg {
 }
 
 func newDnssec(t *testing.T, zones []string) (Dnssec, func(), func()) {
+	t.Helper()
 	k, rm1, rm2 := newKey(t)
 	c := cache.New(defaultCap)
 	d := New(zones, []*DNSKEY{k}, false, nil, c)
@@ -255,6 +256,7 @@ func newDnssec(t *testing.T, zones []string) (Dnssec, func(), func()) {
 }
 
 func newKey(t *testing.T) (*DNSKEY, func(), func()) {
+	t.Helper()
 	fPriv, rmPriv, _ := test.TempFile(".", privKey)
 	fPub, rmPub, _ := test.TempFile(".", pubKey)
 

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func testCase(t *testing.T, tapq, tapr *tap.Dnstap, q, r *dns.Msg, extraFormat string) {
+	t.Helper()
 	w := writer{t: t}
 	w.queue = append(w.queue, tapq, tapr)
 	h := Dnstap{

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -18,6 +18,7 @@ var (
 )
 
 func accept(t *testing.T, l net.Listener, count int) {
+	t.Helper()
 	server, err := l.Accept()
 	if err != nil {
 		t.Fatalf("Server accepted: %s", err)

--- a/plugin/file/delegation_test.go
+++ b/plugin/file/delegation_test.go
@@ -170,6 +170,7 @@ func TestLookupSecureDelegation(t *testing.T) {
 }
 
 func testDelegation(t *testing.T, z, origin string, testcases []test.Case) {
+	t.Helper()
 	zone, err := Parse(strings.NewReader(z), origin, "stdin", 0)
 	if err != nil {
 		t.Fatalf("Expect no error when reading zone, got %q", err)

--- a/plugin/geoip/geoip_test.go
+++ b/plugin/geoip/geoip_test.go
@@ -71,6 +71,7 @@ func TestMetadata(t *testing.T) {
 }
 
 func testMetadata(t *testing.T, state request.Request, geoIP *GeoIP, label, expectedValue string) {
+	t.Helper()
 	ctx := metadata.ContextWithMetadata(context.Background())
 	rCtx := geoIP.Metadata(ctx, state)
 	if fmt.Sprintf("%p", ctx) != fmt.Sprintf("%p", rCtx) {

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -120,6 +120,7 @@ func TestLookupStaticHost(t *testing.T) {
 }
 
 func testStaticHost(t *testing.T, ent staticHostEntry, h *Hostsfile) {
+	t.Helper()
 	ins := []string{ent.in, plugin.Name(ent.in).Normalize(), strings.ToLower(ent.in), strings.ToUpper(ent.in)}
 	for k, in := range ins {
 		addrsV4 := h.LookupStaticHostV4(in)
@@ -206,6 +207,7 @@ func TestLookupStaticAddr(t *testing.T) {
 }
 
 func testStaticAddr(t *testing.T, ent staticIPEntry, h *Hostsfile) {
+	t.Helper()
 	hosts := h.LookupStaticAddr(ent.in)
 	for i := range ent.out {
 		ent.out[i] = plugin.Name(ent.out[i]).Normalize()

--- a/plugin/kubernetes/informer_test.go
+++ b/plugin/kubernetes/informer_test.go
@@ -21,6 +21,7 @@ func TestDefaultProcessor(t *testing.T) {
 }
 
 func testProcessor(t *testing.T, processor cache.ProcessFunc, idx cache.Indexer) {
+	t.Helper()
 	obj := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "service1", Namespace: "test1"},
 		Spec: api.ServiceSpec{
@@ -129,6 +130,7 @@ func TestDefaultProcessorWithPod(t *testing.T) {
 }
 
 func testProcessorWithPod(t *testing.T, processor cache.ProcessFunc, idx cache.Indexer) {
+	t.Helper()
 	container := api.Container{}
 	obj := &api.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test1"},

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -105,6 +105,7 @@ func TestKubernetesIXFRCurrent(t *testing.T) {
 }
 
 func validateAXFR(t *testing.T, ch <-chan []dns.RR, multicluster bool) {
+	t.Helper()
 	xfr := []dns.RR{}
 	for rrs := range ch {
 		xfr = append(xfr, rrs...)

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -136,6 +136,7 @@ func TestWeightFileUpdate(t *testing.T) {
 }
 
 func checkDomainsWRR(t *testing.T, testIndex int, expectedDomains, domains map[string]weights) error {
+	t.Helper()
 	var ret error
 	retError := errors.New("Check domains failed")
 	for dname, expectedWeights := range expectedDomains {
@@ -410,6 +411,7 @@ func TestLoadBalanceWRR(t *testing.T) {
 }
 
 func checkTopIP(t *testing.T, i, j int, result []dns.RR, expectedTopIP string) {
+	t.Helper()
 	expected := net.ParseIP(expectedTopIP)
 	for _, r := range result {
 		switch r.Header().Rrtype {

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -43,6 +43,7 @@ func TestMultipleListenerMock(t *testing.T) {
 }
 
 func testListenersCalled(t *testing.T, listenerNames []string, outputs []string) {
+	t.Helper()
 	for _, name := range listenerNames {
 		err := RegisterListener(NewMockListener(name))
 		if err != nil {

--- a/plugin/pkg/tls/tls_test.go
+++ b/plugin/pkg/tls/tls_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func getPEMFiles(t *testing.T) (cert, key, ca string) {
+	t.Helper()
 	tempDir, err := test.WritePEMFiles(t)
 	if err != nil {
 		t.Fatalf("Could not write PEM files: %s", err)

--- a/plugin/quic/setup_test.go
+++ b/plugin/quic/setup_test.go
@@ -196,6 +196,7 @@ func TestQuicSetup(t *testing.T) {
 
 // assertMaxStreamsValue compares the actual MaxQUICStreams value with the expected one
 func assertMaxStreamsValue(t *testing.T, testIndex int, testInput string, actual, expected *int) {
+	t.Helper()
 	if actual == nil && expected == nil {
 		return
 	}
@@ -214,6 +215,7 @@ func assertMaxStreamsValue(t *testing.T, testIndex int, testInput string, actual
 
 // assertWorkerPoolSizeValue compares the actual MaxQUICWorkerPoolSize value with the expected one
 func assertWorkerPoolSizeValue(t *testing.T, testIndex int, testInput string, actual, expected *int) {
+	t.Helper()
 	if actual == nil && expected == nil {
 		return
 	}

--- a/plugin/rewrite/cname_target_test.go
+++ b/plugin/rewrite/cname_target_test.go
@@ -88,10 +88,11 @@ func TestCNameTargetRewrite(t *testing.T) {
 		cnameTargetRule.Upstream = &MockedUpstream{}
 		rules = append(rules, rule)
 	}
-	doTestCNameTargetTests(rules, t)
+	doTestCNameTargetTests(t, rules)
 }
 
-func doTestCNameTargetTests(rules []Rule, t *testing.T) {
+func doTestCNameTargetTests(t *testing.T, rules []Rule) {
+	t.Helper()
 	tests := []struct {
 		from              string
 		fromType          uint16

--- a/plugin/rewrite/reverter_test.go
+++ b/plugin/rewrite/reverter_test.go
@@ -35,16 +35,17 @@ func TestResponseReverter(t *testing.T) {
 	r, _ := newNameRule("stop", "regex", `(core)\.(dns)\.(rocks)`, "{2}.{1}.{3}", "answer", "name", `(dns)\.(core)\.(rocks)`, "{2}.{1}.{3}")
 	rules = append(rules, r)
 
-	doReverterTests(rules, t)
+	doReverterTests(t, rules)
 
 	rules = []Rule{}
 	r, _ = newNameRule("continue", "regex", `(core)\.(dns)\.(rocks)`, "{2}.{1}.{3}", "answer", "name", `(dns)\.(core)\.(rocks)`, "{2}.{1}.{3}")
 	rules = append(rules, r)
 
-	doReverterTests(rules, t)
+	doReverterTests(t, rules)
 }
 
-func doReverterTests(rules []Rule, t *testing.T) {
+func doReverterTests(t *testing.T, rules []Rule) {
+	t.Helper()
 	ctx := context.TODO()
 	for i, tc := range tests {
 		m := new(dns.Msg)
@@ -105,7 +106,7 @@ func TestValueResponseReverter(t *testing.T) {
 	}
 	rules = append(rules, r)
 
-	doValueReverterTests("stop", rules, t)
+	doValueReverterTests(t, "stop", rules)
 
 	rules = []Rule{}
 	r, err = newNameRule("continue", "regex", `(.*)\.domain\.uk`, "{1}.cluster.local", "answer", "name", `(.*)\.cluster\.local`, "{1}.domain.uk", "answer", "value", `(.*)\.cluster\.local`, "{1}.domain.uk")
@@ -115,7 +116,7 @@ func TestValueResponseReverter(t *testing.T) {
 	}
 	rules = append(rules, r)
 
-	doValueReverterTests("continue", rules, t)
+	doValueReverterTests(t, "continue", rules)
 
 	rules = []Rule{}
 	r, err = newNameRule("stop", "suffix", `.domain.uk`, ".cluster.local", "answer", "auto", "answer", "value", `(.*)\.cluster\.local`, "{1}.domain.uk")
@@ -125,7 +126,7 @@ func TestValueResponseReverter(t *testing.T) {
 	}
 	rules = append(rules, r)
 
-	doValueReverterTests("suffix", rules, t)
+	doValueReverterTests(t, "suffix", rules)
 
 	// multiple rules
 	rules = []Rule{}
@@ -143,10 +144,11 @@ func TestValueResponseReverter(t *testing.T) {
 	}
 	rules = append(rules, r)
 
-	doValueReverterTests("suffix_multiple", rules, t)
+	doValueReverterTests(t, "suffix_multiple", rules)
 }
 
-func doValueReverterTests(name string, rules []Rule, t *testing.T) {
+func doValueReverterTests(t *testing.T, name string, rules []Rule) {
+	t.Helper()
 	ctx := context.TODO()
 	for i, tc := range valueTests {
 		m := new(dns.Msg)

--- a/plugin/rewrite/ttl_test.go
+++ b/plugin/rewrite/ttl_test.go
@@ -99,10 +99,11 @@ func TestTtlRewrite(t *testing.T) {
 		}
 		rules = append(rules, rule)
 	}
-	doTTLTests(rules, t)
+	doTTLTests(t, rules)
 }
 
-func doTTLTests(rules []Rule, t *testing.T) {
+func doTTLTests(t *testing.T, rules []Rule) {
+	t.Helper()
 	tests := []struct {
 		from      string
 		fromType  uint16

--- a/plugin/test/file.go
+++ b/plugin/test/file.go
@@ -21,6 +21,7 @@ func TempFile(dir, content string) (string, func(), error) {
 
 // WritePEMFiles creates a tmp dir with ca.pem, cert.pem, and key.pem
 func WritePEMFiles(t *testing.T) (string, error) {
+	t.Helper()
 	tempDir := t.TempDir()
 
 	data := `-----BEGIN CERTIFICATE-----

--- a/plugin/test/file_test.go
+++ b/plugin/test/file_test.go
@@ -1,6 +1,8 @@
 package test
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTempFile(t *testing.T) {
 	_, f, e := TempFile(".", "test")

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -218,6 +218,7 @@ func TestTransferIXFRFallback(t *testing.T) {
 }
 
 func validateAXFRResponse(t *testing.T, w *dnstest.MultiRecorder) {
+	t.Helper()
 	if len(w.Msgs) == 0 {
 		t.Fatal("Did not get back a zone response")
 	}

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -56,6 +56,7 @@ func TestLookupCache(t *testing.T) {
 }
 
 func testCase(t *testing.T, name, addr string, expectAnsLen int, expectTTL uint32) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.SetQuestion(name, dns.TypeA)
 	resp, err := dns.Exchange(m, addr)
@@ -74,6 +75,7 @@ func testCase(t *testing.T, name, addr string, expectAnsLen int, expectTTL uint3
 }
 
 func testCaseDNSSEC(t *testing.T, name, addr string, bufsize int) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.SetQuestion(name, dns.TypeA)
 

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
+	t.Helper()
 	tmpdir := t.TempDir()
 
 	content := `

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -117,6 +117,7 @@ func getBucketCount(mf *test.MetricFamily, bucketLabel string) (int, error) {
 
 // extractRequestSizeBucketCounts extracts bucket counts from DNS request size metrics
 func extractRequestSizeBucketCounts(t *testing.T, metrics []*test.MetricFamily, label string) (int, int, error) {
+	t.Helper()
 	var countBelow100, countAbove100 int
 	var err error
 

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -55,6 +55,7 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 }
 
 func createKeyFile(t *testing.T) func() {
+	t.Helper()
 	os.WriteFile(base+".key",
 		[]byte(`example.org. IN DNSKEY 256 3 13 tDyI0uEIDO4SjhTJh1AVTFBLpKhY3He5BdAlKztewiZ7GecWj94DOodg ovpN73+oJs+UfZ+p9zOSN5usGAlHrw==`),
 		0644)

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -44,6 +44,7 @@ func TestReload(t *testing.T) {
 }
 
 func send(t *testing.T, server string) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.SetQuestion("whoami.example.org.", dns.TypeSRV)
 

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -57,6 +57,7 @@ func TestRewrite(t *testing.T) {
 }
 
 func testMX(t *testing.T, server string) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeMX)
 
@@ -78,6 +79,7 @@ func testMX(t *testing.T, server string) {
 }
 
 func testEdns0(t *testing.T, server string) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
 

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -45,6 +45,7 @@ func TestProxyToChaosServer(t *testing.T) {
 }
 
 func chaosTest(t *testing.T, server string) {
+	t.Helper()
 	m := new(dns.Msg)
 	m.Question = make([]dns.Question, 1)
 	m.Question[0] = dns.Question{Qclass: dns.ClassCHAOS, Name: "version.bind.", Qtype: dns.TypeTXT}

--- a/test/view_test.go
+++ b/test/view_test.go
@@ -140,6 +140,7 @@ func TestView(t *testing.T) {
 }
 
 func viewTest(t *testing.T, testName, addr, qname string, qtype uint16, expectRcode int, expectAnswers []dns.RR) {
+	t.Helper()
 	t.Run(testName, func(t *testing.T) {
 		m := new(dns.Msg)
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable the `thelper` linter and fix all violations by adding `t.Helper()` calls to test helper functions throughout the codebase. This improves test error reporting by ensuring failures point to the calling test function rather than the helper function itself.

Also reorder parameters in some helper functions to place `*testing.T` first, as required by the linter.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
