### PR TITLE
chore: enable more rules from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,6 @@ linters:
           disabled: true
 
         - name: unnecessary-stmt
-          disabled: true
 
         - name: unreachable-code
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,7 +88,6 @@ linters:
             - allowRegex: "^_"
 
         - name: use-any
-          disabled: true
 
         - name: var-declaration
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,7 +84,6 @@ linters:
         - name: unreachable-code
 
         - name: unused-parameter
-          disabled: true
           arguments:
             - allowRegex: "^_"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters:
         - name: blank-imports
 
         - name: context-as-argument
-          disabled: true
           arguments:
             - allowTypesBefore: "*testing.T"
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use revive rules

* [context-as-argument](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument) : By [convention](https://go.dev/wiki/CodeReviewComments#contexts), context.Context should be the first parameter of a function. This rule spots function declarations that do not follow the convention.
* [unnecessary-stmt](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt): This rule suggests to remove redundant statements like a break at the end of a case block, for improving the code's readability.
* [unused-parameter](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter): This rule warns on unused parameters. Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
* [use-any](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any): Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No
