### PR TITLE
[plugin/cache] create a copy of a response to ensure original res.Msg is never modified

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -182,6 +182,7 @@ func (w *ResponseWriter) RemoteAddr() net.Addr {
 
 // WriteMsg implements the dns.ResponseWriter interface.
 func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
+	res = res.Copy()
 	mt, _ := response.Typify(res, w.now().UTC())
 
 	// key returns empty string for anything we don't want to cache.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
`cache` plugin mutates responses of other plugins:
https://github.com/coredns/coredns/blob/master/plugin/cache/cache.go#L216-L228
The behavior seems to be against the [plugin guideline](https://github.com/coredns/coredns/blob/master/plugin.md?#mutating-a-response):
>Using a custom ResponseWriter, a plugin can mutate a response when another plugin further down the chain writes the response to the client. If a plugin mutates a response it MUST make a copy of the entire response before doing so. A response is a pointer to a dns.Msg and as such you will be manipulating the original response, which could have been generated from a data store. 

### 2. Which issues (if any) are related?
Fixes https://github.com/coredns/coredns/issues/7335

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No