### PR TITLE
fix(auto/file): return REFUSED when no next plugin is available

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -51,6 +51,10 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	// Now the real zone.
 	zone = plugin.Zones(a.Zones.Names()).Matches(qname)
 	if zone == "" {
+		// If no next plugin is configured, it's more correct to return REFUSED as auto acts as an authoritative server
+		if a.Next == nil {
+			return dns.RcodeRefused, nil
+		}
 		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)
 	}
 

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -42,6 +42,10 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	// TODO(miek): match the qname better in the map
 	zone := plugin.Zones(f.Zones.Names).Matches(qname)
 	if zone == "" {
+		// If no next plugin is configured, it's more correct to return REFUSED as file acts as an authoritative server
+		if f.Next == nil {
+			return dns.RcodeRefused, nil
+		}
 		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
 	}
 

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -32,8 +32,8 @@ func TestAuto(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")
 	}
-	if resp.Rcode != dns.RcodeServerFailure {
-		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	if resp.Rcode != dns.RcodeRefused {
+		t.Fatalf("Expected reply to be REFUSED, got %d", resp.Rcode)
 	}
 
 	// Write db.example.org to get example.org.
@@ -59,8 +59,8 @@ func TestAuto(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")
 	}
-	if resp.Rcode != dns.RcodeServerFailure {
-		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	if resp.Rcode != dns.RcodeRefused {
+		t.Fatalf("Expected reply to be REFUSED, got %d", resp.Rcode)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestAutoNonExistentZone(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")
 	}
-	if resp.Rcode != dns.RcodeServerFailure {
-		t.Fatalf("Expected reply to be a SERVFAIL, got %d", resp.Rcode)
+	if resp.Rcode != dns.RcodeRefused {
+		t.Fatalf("Expected reply to be REFUSED, got %d", resp.Rcode)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It is standard behaviour of authoritative DNS servers to return REFUSED when responding to a request they are not authoritative for. CoreDNS correctly follows this when responding to queries that don't match any server blocks, however when broader server blocks are present (such as a catch-all), queries not responded to by any plugin are typically responded to with SERVFAIL, as this is defined in `plugin.NextOrFailure()`.

By itself, this is not really an issue, however as described in #7346, this causes CoreDNS to return SERVFAIL when resolving out-of-bailiwick CNAME targets, which breaks these CNAMEs.

While it is difficult to map the traditional authoritative/resolver framework onto CoreDNS, for the case of the `auto` and `file` plugins, they fall more on the authoritative side, particularly when they are the last plugin in the chain.

Therefore, this PR adds logic to the `auto` and `file` plugins that, when they are the last plugin, they return REFUSED for unrecognised names, instead of SERVFAIL.

### 2. Which issues (if any) are related?
fixes #7346 

### 3. Which documentation changes (if any) need to be made?
None, this corrects the behaviour of the examples already in the `auto` documentation

### 4. Does this introduce a backward incompatible change or deprecation?
No
