### PR TITLE
fix(cache): data race when updating the TTL of cached messages

### DIFF
--- a/plugin/cache/dnssec.go
+++ b/plugin/cache/dnssec.go
@@ -3,8 +3,8 @@ package cache
 import "github.com/miekg/dns"
 
 // filterRRSlice filters out OPT RRs, and sets all RR TTLs to ttl.
-// If dup is true the RRs in rrs are _copied_ into the slice that is
-// returned.
+// If dup is true the RRs in rrs are _copied_ before adjusting their
+// TTL and the slice of copied RRs is returned.
 func filterRRSlice(rrs []dns.RR, ttl uint32, dup bool) []dns.RR {
 	j := 0
 	rs := make([]dns.RR, len(rrs))
@@ -12,12 +12,12 @@ func filterRRSlice(rrs []dns.RR, ttl uint32, dup bool) []dns.RR {
 		if r.Header().Rrtype == dns.TypeOPT {
 			continue
 		}
-		r.Header().Ttl = ttl
 		if dup {
 			rs[j] = dns.Copy(r)
 		} else {
 			rs[j] = r
 		}
+		rs[j].Header().Ttl = ttl
 		j++
 	}
 	return rs[:j]


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR fixes a data race that occurs when a cached DNS message is served by multiple goroutines. In this case the TTL of resource records is accessed and modified concurrently and go's race detector reports the following:

```
WARNING: DATA RACE
Write at 0x00c000a7e344 by goroutine 1264:
  github.com/coredns/coredns/plugin/cache.filterRRSlice()
      coredns/plugin/cache/dnssec.go:15 +0x118
  github.com/coredns/coredns/plugin/cache.(*item).toMsg()
      coredns/plugin/cache/item.go:90 +0x668
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      coredns/plugin/cache/handler.go:79 +0x1064
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      coredns/core/dnsserver/server.go:364 +0xcf5
...

Previous read at 0x00c000a7e340 by goroutine 1265:
  github.com/miekg/dns.(*CNAME).copy()
      pkg/mod/github.com/miekg/dns@v1.1.66/ztypes.go:898 +0x46
  github.com/miekg/dns.Copy()
      pkg/mod/github.com/miekg/dns@v1.1.66/msg.go:1065 +0x1b8
  github.com/coredns/coredns/plugin/cache.filterRRSlice()
      coredns/plugin/cache/dnssec.go:17 +0x79
  github.com/coredns/coredns/plugin/cache.(*item).toMsg()
      coredns/plugin/cache/item.go:90 +0x668
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      coredns/plugin/cache/handler.go:79 +0x1064
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      coredns/core/dnsserver/server.go:364 +0xcf5
  ...
```


### 2. Which issues (if any) are related?

Fixes #6718, pretty much as suggested by @DmitriyMV.

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No