### PR TITLE
fix(cache): data race when refreshing cached messages

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -199,6 +199,18 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		duration = computeTTL(msgTTL, w.minpttl, w.pttl)
 	}
 
+	// Apply capped TTL to this reply to avoid jarring TTL experience 1799 -> 8 (e.g.)
+	ttl := uint32(duration.Seconds())
+	res.Answer = filterRRSlice(res.Answer, ttl, false)
+	res.Ns = filterRRSlice(res.Ns, ttl, false)
+	res.Extra = filterRRSlice(res.Extra, ttl, false)
+
+	if !w.do && !w.ad {
+		// unset AD bit if requester is not OK with DNSSEC
+		// But retain AD bit if requester set the AD bit in the request, per RFC6840 5.7-5.8
+		res.AuthenticatedData = false
+	}
+
 	if hasKey && duration > 0 {
 		if w.state.Match(res) {
 			w.set(res, key, mt, duration)
@@ -212,18 +224,6 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 
 	if w.prefetch {
 		return nil
-	}
-
-	// Apply capped TTL to this reply to avoid jarring TTL experience 1799 -> 8 (e.g.)
-	ttl := uint32(duration.Seconds())
-	res.Answer = filterRRSlice(res.Answer, ttl, false)
-	res.Ns = filterRRSlice(res.Ns, ttl, false)
-	res.Extra = filterRRSlice(res.Extra, ttl, false)
-
-	if !w.do && !w.ad {
-		// unset AD bit if requester is not OK with DNSSEC
-		// But retain AD bit if requester set the AD bit in the request, per RFC6840 5.7-5.8
-		res.AuthenticatedData = false
 	}
 
 	return w.ResponseWriter.WriteMsg(res)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This fixes a data race where one goroutine refreshes a cached message while another one serves the same message from the cache. Since the refreshed message is modified after insertion into the cache, this leads to the following data race:

```
WARNING: DATA RACE
Write at 0x00c000ba7d14 by goroutine 1894:
  github.com/coredns/coredns/plugin/cache.filterRRSlice()
      coredns/plugin/cache/dnssec.go:20 +0x264
  github.com/coredns/coredns/plugin/cache.(*ResponseWriter).WriteMsg()
      coredns/plugin/cache/cache.go:219 +0x938
  github.com/coredns/coredns/plugin/forward.(*Forward).ServeDNS()
      coredns/plugin/forward/forward.go:218 +0x1879
  github.com/coredns/coredns/plugin.NextOrFailure()
      coredns/plugin/plugin.go:80 +0x2dd
  github.com/coredns/coredns/plugin/cache.(*Cache).doRefresh()
      coredns/plugin/cache/handler.go:107 +0x158e
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      coredns/plugin/cache/handler.go:41 +0x1503
  github.com/coredns/coredns/plugin.NextOrFailure()
      coredns/plugin/plugin.go:80 +0x2dd
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      coredns/plugin/log/log.go:36 +0x3b3
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x104
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      coredns/core/dnsserver/server.go:364 +0xcf5
  ...

Previous read at 0x00c000ba7d10 by goroutine 1896:
  github.com/miekg/dns.(*A).copy()
      pkg/mod/github.com/miekg/dns@v1.1.66/ztypes.go:833 +0xe4
  github.com/miekg/dns.Copy()
      pkg/mod/github.com/miekg/dns@v1.1.66/msg.go:1065 +0x194
  github.com/coredns/coredns/plugin/cache.filterRRSlice()
      coredns/plugin/cache/dnssec.go:16 +0x7e
  github.com/coredns/coredns/plugin/cache.(*item).toMsg()
      coredns/plugin/cache/item.go:90 +0x668
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      coredns/plugin/cache/handler.go:79 +0x1064
  github.com/coredns/coredns/plugin.NextOrFailure()
      coredns/plugin/plugin.go:80 +0x2dd
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      coredns/plugin/log/log.go:36 +0x3b3
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x104
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      coredns/core/dnsserver/server.go:364 +0xcf5
  ...
```

It's pretty trivial to fix by mutating the refreshed message before insertion into the cache.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
