### PR TITLE
plugin/file: preserve case in SRV record names and targets per RFC 6763

### DIFF
--- a/plugin/file/tree/less.go
+++ b/plugin/file/tree/less.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -27,8 +28,8 @@ func less(a, b string) int {
 
 		// sadly this []byte will allocate... TODO(miek): check if this is needed
 		// for a name, otherwise compare the strings.
-		ab := []byte(a[ai:aj])
-		bb := []byte(b[bi:bj])
+		ab := []byte(strings.ToLower(a[ai:aj]))
+		bb := []byte(strings.ToLower(b[bi:bj]))
 		doDDD(ab)
 		doDDD(bb)
 

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -73,7 +73,10 @@ func (z *Zone) CopyWithoutApex() *Zone {
 
 // Insert inserts r into z.
 func (z *Zone) Insert(r dns.RR) error {
-	r.Header().Name = strings.ToLower(r.Header().Name)
+	// r.Header().Name = strings.ToLower(r.Header().Name)
+	if r.Header().Rrtype != dns.TypeSRV {
+		r.Header().Name = strings.ToLower(r.Header().Name)
+	}
 
 	switch h := r.Header().Rrtype; h {
 	case dns.TypeNS:
@@ -108,7 +111,7 @@ func (z *Zone) Insert(r dns.RR) error {
 	case dns.TypeMX:
 		r.(*dns.MX).Mx = strings.ToLower(r.(*dns.MX).Mx)
 	case dns.TypeSRV:
-		r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
+		// r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
 	}
 
 	z.Tree.Insert(r)

--- a/plugin/file/zone_test.go
+++ b/plugin/file/zone_test.go
@@ -1,6 +1,12 @@
 package file
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/file/tree"
+
+	"github.com/miekg/dns"
+)
 
 func TestNameFromRight(t *testing.T) {
 	z := NewZone("example.org.", "stdin")
@@ -26,5 +32,43 @@ func TestNameFromRight(t *testing.T) {
 		if shot != tc.shot {
 			t.Errorf("Test %d: expected shot to be %t, got %t", i, tc.shot, shot)
 		}
+	}
+}
+
+func TestInsertPreservesSRVCase(t *testing.T) {
+	z := NewZone("home.arpa.", "stdin")
+
+	// SRV with mixed case and space-escaped instance name
+	srv, err := dns.NewRR(`Home\032Media._smb._tcp.home.arpa. 5 IN SRV 0 0 445 samba.home.arpa.`)
+	if err != nil {
+		t.Fatalf("Failed to parse SRV RR: %v", err)
+	}
+
+	if err := z.Insert(srv); err != nil {
+		t.Fatalf("Insert failed: %v", err)
+	}
+
+	found := false
+	err = z.Walk(func(elem *tree.Elem, rrsets map[uint16][]dns.RR) error {
+		for _, rrs := range rrsets {
+			for _, rr := range rrs {
+				if srvRR, ok := rr.(*dns.SRV); ok {
+					if srvRR.Hdr.Name == "Home\\032Media._smb._tcp.home.arpa." {
+						found = true
+						if srvRR.Target != "samba.home.arpa." {
+							t.Errorf("Expected SRV target to be 'samba.home.arpa.', got %q", srvRR.Target)
+						}
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Tree walk failed: %v", err)
+	}
+
+	if !found {
+		t.Errorf("SRV record with original case not found in tree")
 	}
 }


### PR DESCRIPTION
### What this PR does

This PR ensures SRV record names and targets preserve their original case in responses, aligning with [RFC 6763 §4.1.1](https://datatracker.ietf.org/doc/html/rfc6763#section-4.1.1), which requires that service instance names be treated as user-friendly Unicode text and must retain casing and formatting.

---

### What Changed

- ✅ SRV **target** is no longer lowercased in `Insert()` (e.g. `samba.home.arpa.`)
- ✅ SRV **record name** now bypasses forced lowercasing during insert
- ✅ `less()` in `plugin/file/tree/less.go` now compares labels **case-insensitively**
- ✅ Verified with manual test zone using `dig`

```dns
_smb._tcp                     PTR Home\032Media._smb._tcp.home.arpa.
Home\032Media._smb._tcp       SRV 0 0 445 samba.home.arpa.
````

Query:

```bash
dig @127.0.0.1 -p 53 SRV "Home\\032Media._smb._tcp.home.arpa."
```

Expected response:

```dns
Home\032Media._smb._tcp.home.arpa. 5 IN SRV 0 0 445 samba.home.arpa.
```

---

### Why this is needed

Although DNS is case-insensitive, [[RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-4.1.1)](https://datatracker.ietf.org/doc/html/rfc6763#section-4.1.1) mandates that **SRV record names used in service discovery retain original case and formatting**, especially for mDNS, Bonjour, and DNS-SD clients.

Prior to this fix, CoreDNS returned lowercased instance names, breaking spec-compliant discovery clients.

---

### Limitations

This PR does **not preserve the casing of the query name**, as it is already normalized (lowercased) by CoreDNS or `miekg/dns` before plugin processing. This fix ensures the **record data** (response) complies with the spec.

---

### Related

Fixes https://github.com/coredns/coredns/issues/7237

