### PR TITLE
plugin/proxy: add upstream_response_duration_seconds metric (#7382)

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -141,6 +141,8 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 		return nil, err
 	}
 
+	upstreamStart := time.Now()
+
 	var ret *dns.Msg
 	pc.c.SetReadDeadline(time.Now().Add(p.readTimeout))
 	for {
@@ -173,6 +175,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 			break
 		}
 	}
+
 	// recovery the origin Id after upstream.
 	ret.Id = originId
 
@@ -182,6 +185,8 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 	if !ok {
 		rc = strconv.Itoa(ret.Rcode)
 	}
+
+	upstreamResponseDuration.WithLabelValues(p.addr, proto, rc, p.proxyName).Observe(time.Since(upstreamStart).Seconds())
 
 	requestDuration.WithLabelValues(p.proxyName, p.addr, rc).Observe(time.Since(start).Seconds())
 

--- a/plugin/pkg/proxy/metrics.go
+++ b/plugin/pkg/proxy/metrics.go
@@ -38,4 +38,12 @@ var (
 		Name:      "conn_cache_misses_total",
 		Help:      "Counter of connection cache misses per upstream and protocol.",
 	}, []string{"proxy_name", "to", "proto"})
+
+	upstreamResponseDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "proxy",
+		Name:      "upstream_response_duration_seconds",
+		Buckets:   plugin.TimeBuckets,
+		Help:      "Histogram of time taken from sending a DNS request to receiving a response from the upstream (excluding CoreDNS delays).",
+	}, []string{"to", "protocol", "rcode", "server"})
 )


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This pull request introduces a new Prometheus metric `proxy_upstream_response_duration_seconds` to the `proxy` plugin.  
Unlike the existing `request_duration_seconds` metric, this new histogram measures the precise time taken between when a DNS request is sent to the upstream server and when a response is received — excluding any CoreDNS-internal delays such as scheduling, queueing, or write overhead.

This gives operators deeper insight into upstream latency and helps diagnose slow external DNS behavior more accurately.

### 2. Which issues (if any) are related?

Fixes: https://github.com/coredns/coredns/issues/7382

### 3. Which documentation changes (if any) need to be made?

No breaking or user-visible documentation changes required.  
Metric is self-describing via Prometheus output.  
A note can optionally be added to plugin documentation or the release notes.

### 4. Does this introduce a backward incompatible change or deprecation?

No. This is a backward-compatible enhancement that only adds a new metric. Existing metrics and behaviors are untouched.