### PR TITLE
Improve caddy.GracefulServer conformance checks

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -364,5 +364,3 @@ var (
 	// GracefulTimeout is the maximum duration of a graceful shutdown.
 	GracefulTimeout time.Duration
 )
-
-var _ caddy.GracefulServer = new(Server)

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -52,8 +52,8 @@ func NewServergRPC(addr string, group []*Config) (*ServergRPC, error) {
 	return &ServergRPC{Server: s, tlsConfig: tlsConfig}, nil
 }
 
-// Compile-time check to ensure Server implements the caddy.GracefulServer interface
-var _ caddy.GracefulServer = &Server{}
+// Compile-time check to ensure ServergRPC implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &ServergRPC{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServergRPC) Serve(l net.Listener) error {

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -88,8 +88,8 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 	return sh, nil
 }
 
-// Compile-time check to ensure Server implements the caddy.GracefulServer interface
-var _ caddy.GracefulServer = &Server{}
+// Compile-time check to ensure ServerHTTPS implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &ServerHTTPS{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Serve(l net.Listener) error {

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -39,8 +39,8 @@ func NewServerTLS(addr string, group []*Config) (*ServerTLS, error) {
 	return &ServerTLS{Server: s, tlsConfig: tlsConfig}, nil
 }
 
-// Compile-time check to ensure Server implements the caddy.GracefulServer interface
-var _ caddy.GracefulServer = &Server{}
+// Compile-time check to ensure ServerTLS implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &ServerTLS{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerTLS) Serve(l net.Listener) error {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Current `caddy.GracefulServer` interface guards do not check all available Server types. This change fixes that.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No