### PR TITLE
fix: handle cached connection closure in forward plugin

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -16,7 +16,7 @@ import (
 	"github.com/coredns/coredns/plugin/dnstap"
 	"github.com/coredns/coredns/plugin/metadata"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
-	"github.com/coredns/coredns/plugin/pkg/proxy"
+	proxyPkg "github.com/coredns/coredns/plugin/pkg/proxy"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -36,7 +36,7 @@ const (
 type Forward struct {
 	concurrent int64 // atomic counters need to be first in struct for proper alignment
 
-	proxies    []*proxy.Proxy
+	proxies    []*proxyPkg.Proxy
 	p          Policy
 	hcInterval time.Duration
 
@@ -52,7 +52,7 @@ type Forward struct {
 	maxConcurrent              int64
 	failfastUnhealthyUpstreams bool
 
-	opts proxy.Options // also here for testing
+	opts proxyPkg.Options // also here for testing
 
 	// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
 	// the maximum allowed (maxConcurrent)
@@ -65,18 +65,18 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: proxy.Options{ForceTCP: false, PreferUDP: false, HCRecursionDesired: true, HCDomain: "."}}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(random), from: ".", hcInterval: hcInterval, opts: proxyPkg.Options{ForceTCP: false, PreferUDP: false, HCRecursionDesired: true, HCDomain: "."}}
 	return f
 }
 
 // SetProxy appends p to the proxy list and starts healthchecking.
-func (f *Forward) SetProxy(p *proxy.Proxy) {
+func (f *Forward) SetProxy(p *proxyPkg.Proxy) {
 	f.proxies = append(f.proxies, p)
 	p.Start(f.hcInterval)
 }
 
 // SetProxyOptions setup proxy options
-func (f *Forward) SetProxyOptions(opts proxy.Options) {
+func (f *Forward) SetProxyOptions(opts proxyPkg.Options) {
 	f.opts = opts
 }
 
@@ -163,7 +163,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		for {
 			ret, err = proxy.Connect(ctx, state, opts)
 
-			if err == ErrCachedClosed { // Remote side closed conn, can only happen with TCP.
+			if err == proxyPkg.ErrCachedClosed { // Remote side closed conn, can only happen with TCP.
 				continue
 			}
 			// Retry with TCP if truncated and prefer_udp configured.
@@ -254,7 +254,7 @@ func (f *Forward) ForceTCP() bool { return f.opts.ForceTCP }
 func (f *Forward) PreferUDP() bool { return f.opts.PreferUDP }
 
 // List returns a set of proxies to be used for this client depending on the policy in f.
-func (f *Forward) List() []*proxy.Proxy { return f.p.List(f.proxies) }
+func (f *Forward) List() []*proxyPkg.Proxy { return f.p.List(f.proxies) }
 
 var (
 	// ErrNoHealthy means no healthy proxies left.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This pull request fixes a logic issue in the forward plugin where an error returned from the proxy package (ErrCachedClosed) was being compared using == against a locally defined error (ErrCachedClosed) in the forward package. Since these were two separate error instances (despite having the same error string), the comparison would always fail.

The change ensures the forward plugin uses the same ErrCachedClosed error instance defined in the proxy package, allowing the == comparison to work as intended. This enables proper detection of closed cached connections and allows for retry behavior, improving connection resilience.

### 2. Which issues (if any) are related?

No existing GitHub issue is linked to this, but the change addresses subtle error-handling logic that could cause missed retries when upstream connections are closed.

### 3. Which documentation changes (if any) need to be made?

None. This is an internal logic fix and does not affect the plugin's interface, configuration, or documented behavior.

### 4. Does this introduce a backward incompatible change or deprecation?

No, the change is backward compatible and does not affect external behavior. It corrects internal error comparison logic without altering the rest.
