### PR TITLE
chore: Minor changes to `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
            DEBIAN_PRIORITY=critical \
            TERM=linux ; \
     apt-get -qq update ; \
-    apt-get -yyqq upgrade ; \
-    apt-get -yyqq install ca-certificates libcap2-bin; \
+    apt-get -qq upgrade ; \
+    apt-get -qq --no-install-recommends install ca-certificates libcap2-bin; \
     apt-get clean
 COPY coredns /coredns
 RUN setcap cap_net_bind_service=+ep /coredns
@@ -18,6 +18,8 @@ FROM --platform=$TARGETPLATFORM ${BASE}
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /coredns /coredns
 USER nonroot:nonroot
+# Reset the working directory inherited from the base image back to the expected default:
+# https://github.com/coredns/coredns/issues/7009#issuecomment-3124851608
 WORKDIR /
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

- [`-qq` implies `-y`](https://manpages.ubuntu.com/manpages/lunar/man8/apt-get.8.html) for `apt-get`. Also there never was `-yy` (_introduced from [this PR](https://github.com/coredns/coredns/pull/5571), likely with other changes that aren't actually all that relevant_), only `-y`.
- `--no-install-recommends` was also added via [PR feedback request](https://github.com/coredns/coredns/pull/7428#discussion_r2241137962).
- Add a reference comment for better context of why `WORKDIR` is explicitly set to the default, as [this was a fix](https://github.com/coredns/coredns/pull/6731) for an [implicit change when the base image was swapped](https://github.com/coredns/coredns/pull/5969#issuecomment-1712368430) (_originally a breaking change for users of the image at the time_).

### 2. Which issues (if any) are related?

#6249

#7009 

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No