### PR TITLE
Properly create hostname from IPv6

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -351,7 +351,11 @@ func endpointHostname(addr object.EndpointAddress, endpointNameMode bool) string
 		return strings.ReplaceAll(addr.IP, ".", "-")
 	}
 	if strings.Contains(addr.IP, ":") {
-		return strings.ReplaceAll(addr.IP, ":", "-")
+		ipv6Hostname := strings.ReplaceAll(addr.IP, ":", "-")
+		if strings.HasSuffix(ipv6Hostname, "-") {
+			return ipv6Hostname + "0"
+		}
+		return ipv6Hostname
 	}
 	return ""
 }

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -30,6 +30,8 @@ func TestEndpointHostname(t *testing.T) {
 		{"10.11.12.13", "epname", "epname", "hello-abcde", false},
 		{"10.11.12.13", "epname", "epname", "hello-abcde", true},
 		{"10.11.12.13", "", "hello-abcde", "hello-abcde", true},
+		{"2001:db8:3333:4444:5555:6666:7777:8888", "", "2001-db8-3333-4444-5555-6666-7777-8888", "", false},
+		{"2001:db8:3333:4444:5555:6666::", "", "2001-db8-3333-4444-5555-6666--0", "", false},
 	}
 	for _, test := range tests {
 		result := endpointHostname(object.EndpointAddress{IP: test.ip, Hostname: test.hostname, TargetRefName: test.podName}, test.endpointNameMode)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Hostname for an IPV6 address can be invalid if the address ends with `::`.

### 2. Which issues (if any) are related?
Fixes: https://github.com/coredns/coredns/issues/7430

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

Generated hostname will be different if IP address ends with `::`.