### PR TITLE
fix: `Dockerfile` - Remove `setcap` stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,7 @@
-ARG DEBIAN_IMAGE=debian:stable-slim
 ARG BASE=gcr.io/distroless/static-debian12:nonroot
-FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
-SHELL [ "/bin/sh", "-ec" ]
-
-RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
-           DEBIAN_FRONTEND=noninteractive \
-           DEBIAN_PRIORITY=critical \
-           TERM=linux ; \
-    apt-get -qq update ; \
-    apt-get -qq upgrade ; \
-    apt-get -qq --no-install-recommends install ca-certificates libcap2-bin; \
-    apt-get clean
+FROM ${BASE}
 COPY coredns /coredns
-RUN setcap cap_net_bind_service=+ep /coredns
 
-FROM --platform=$TARGETPLATFORM ${BASE}
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /coredns /coredns
 USER nonroot:nonroot
 # Reset the working directory inherited from the base image back to the expected default:
 # https://github.com/coredns/coredns/issues/7009#issuecomment-3124851608


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR is effectively a rebase of https://github.com/coredns/coredns/pull/6320 which seems to have been left ignored.

`setcap` should not be needed, and if it is for any supported container runtimes those should be documented, along with only using `setcap` to apply the permitted capability and the equivalent Go logic added to conditionally raise the required capability at runtime from permitted to effective.

Enforcing the capability via `setcap` prevents using the binary for even [simple commands that don't require it such as `--help`](https://github.com/caddyserver/caddy-docker/pull/299#issuecomment-2132444711), unless the capability is successfully raised into effective set prior to execution.

**Changes:**
- Remove `setcap` to drop the kernel check enforcement, [it is unnecessarily restrictive](https://github.com/coredns/coredns/pull/6320#issuecomment-1721209536) and [should not be required](https://github.com/coredns/coredns/pull/6320#issuecomment-2506728786) for it's intended purpose.
- Remove the first stage entirely.
  - [`apt-get upgrade` for security reasons](https://github.com/coredns/coredns/pull/5571#issuecomment-1215094844) is redundant for an image that is published and ceases to receive future security updates [like a base image does](https://pythonspeed.com/articles/security-updates-in-docker/) (_the article encourages upgrading packages but lacks relevance for this `Dockerfile`_).
  - CoreDNS is not built with any upgraded packages, and the only content copied over to the final stage is the patched CoreDNS + certs (_[not relevant](https://github.com/coredns/coredns/pull/5571#issuecomment-1215086349)_), making any security gain largely redundant?
  - [Other operations and ENV from that stage](https://github.com/coredns/coredns/pull/5571) were [related to supporting the automated upgrade](https://github.com/coredns/coredns/pull/5571#discussion_r945840442) apparently (_I did not compare to `apt-get upgrade`, but beyond the typical `DEBIAN_FRONTEND` ENV, there was no improvement with `apt-get install` output being reduced from what I could see_), justification was rather vague.


<details>
<summary>Full details via associated commit message (click to view)</summary>

When the image was migrated to run as a non-root user some container engines had not yet relaxed `cap_net_bind_service` by default to permit non-root container users to bind to ports below 1024. Today it is common to find this capability for containers configured to `0`.

Using `setcap` with `e` enforces the capability requirement via a kernel check before the binary itself is executed, failing to run if the capability has been forbidden (_even when it is not required if the container were configured to run as the container user as root_). This type of workaround is considered ["capability-dumb"](https://man7.org/linux/man-pages/man7/capabilities.7.html), instead of properly handling it by the application itself at runtime to raise the capability from the permitted set into the effective set.

As such, those who are more security conscious and drop all capabilities by default must explicitly add capabilities a program enforces, even when they should not be required for the runtime configuration to succeed.

The correct approach would have been to use `setcap` with only `p` (permitted set), with application code raising the capability as necessary (_in this case the CoreDNS process is run unprivileged and binding to a port below the associated sysctl `net.ipv4.ip_unprivileged_port_start`_).

---

The remainder of the removed stage was intended to improve security, however this is questionable given:
- As has been previously communicated to maintainers, the certs copied have been demonstrated to be unaffected by the `upgrade`.
- The delta between an upgrade to packages being available since the last published revision of the base image tag is smaller than the frequency of CoreDNS image tags being updated, notably weakening the justification.
- Furthermore, given the multi-stage `Dockerfile` relying on `COPY` for the CoreDNS binary instead of building it within the container, and that none of the upgraded content of the images beyond the certificates were being carried over into the final runtime stage, there is nothing to gain from the upgrade step.

As such, it is better to drop the stage entirely in favor of keeping the `Dockerfile` simple and focused.

---

The default platform for `FROM` should be the target platform, so that has been dropped as well.

</details>

### 2. Which issues (if any) are related?

- See issues referenced [here](https://github.com/coredns/coredns/pull/6320), and issues that have reference linked that PR since it was opened.
- https://github.com/coredns/coredns/pull/6320#issuecomment-2505496070 (_another use-case cited_)

Closes: https://github.com/coredns/coredns/pull/6320

### 3. Which documentation changes (if any) need to be made?

None? Might be worth communicating the change to the Docker image via the changelog (_similar to [this change](https://github.com/coredns/coredns/pull/7428)_).

Or defer to a user opening an issue about breakage which has typically been the approach for previous changes to the image (_at least when a [change was implicit and not communicated via the changelog entry](https://github.com/coredns/coredns/pull/5969#issuecomment-1721209342)_).

### 4. Does this introduce a backward incompatible change or deprecation?

**TL;DR:** Some outdated environments may need to update their configuration slightly. Modern environments should be unaffected unless niche.

It may potentially affect some systems running container engines that haven't been updated to releases in recent years, or for whatever reason have not lowered the privilege ports for this capability to `0`.

Affected users could presumably set the associated sysctl `net.ipv4.ip_unprivileged_port_start=0` themselves, but I would not expect it to affect the bulk of the ecosystem? (_**EDIT:** According to the tests, the CI k8s deployment lacks this change_)

---

For added context, running the image as a rootful container with a non-root container user typically has marginal security benefits via convenience, but can lead to more support caveats like this particular issue that had the `setcap` workaround (_a common workaround adopted, and sometimes one that has reduced security unintentionally_).

These days, it's more advisable AFAIK that interested users run rootless containers, which can be secure with a container user running as root internally. In either case the container could be configured to run as a non-root user. A maintainer had also [questioned if reverting from non-root was worth considering](https://github.com/coredns/coredns/pull/6320#issuecomment-1856042726).
