### PR TITLE
plugin/header: Remove deprecated syntax

### DIFF
--- a/plugin/header/README.md
+++ b/plugin/header/README.md
@@ -13,12 +13,12 @@ The modifications are made transparently for the client and subsequent plugins.
 
 ~~~
 header {
-    [SELECTOR] ACTION FLAGS...
-    [SELECTOR] ACTION FLAGS...
+    SELECTOR ACTION FLAGS...
+    SELECTOR ACTION FLAGS...
 }
 ~~~
 
-* **SELECTOR** defines if the action should be applied on `query` or `response`. In future CoreDNS version the selector will be mandatory. For backwards compatibility the action will be applied on `response` if the selector is undefined.
+* **SELECTOR** defines if the action should be applied on `query` or `response`.
 
 * **ACTION** defines the state for DNS message header flags. Actions are evaluated in the order they are defined so last one has the
   most precedence. Allowed values are:

--- a/plugin/header/setup.go
+++ b/plugin/header/setup.go
@@ -38,14 +38,6 @@ func parse(c *caddy.Controller) ([]Rule, []Rule, error) {
 
 			var action string
 			switch selector {
-			case "set", "clear":
-				log.Warningf("The selector for header rule in line %d isn't explicit defined. "+
-					"Assume rule applies for selector 'response'. This syntax is deprecated. "+
-					"In future versions of CoreDNS the selector must be explicit defined.",
-					c.Line())
-
-				action = selector
-				selector = "response"
 			case "query", "response":
 				if c.NextArg() {
 					action = c.Val()

--- a/plugin/header/setup_test.go
+++ b/plugin/header/setup_test.go
@@ -15,11 +15,11 @@ func TestSetupHeader(t *testing.T) {
 	}{
 		{`header {}`, true, "Wrong argument count or unexpected line ending after"},
 		{`header {
-					set
-}`, true, "invalid length for flags, at least one should be provided"},
-		{`header {
 					foo
 }`, true, "invalid selector=foo should be query or response"},
+		{`header {
+					response set
+}`, true, "invalid length for flags, at least one should be provided"},
 		{`header {
 					query foo
 }`, true, "invalid length for flags, at least one should be provided"},
@@ -27,20 +27,14 @@ func TestSetupHeader(t *testing.T) {
 					query foo rd
 }`, true, "unknown flag action=foo, should be set or clear"},
 		{`header {
-					set ra
-}`, false, ""},
-		{`header {
-					clear ra
-		}`, false, ""},
-		{`header {
 					query set rd
 		}`, false, ""},
 		{`header {
 					response set aa
 		}`, false, ""},
 		{`header {
-			set ra aa
-			clear rd
+			response set ra aa
+			query clear rd
 }`, false, ""},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

We switched to using the [new format for defining rules](https://github.com/coredns/coredns/pull/5556) for the header plugin. The legacy rule syntax was deprecated in the same change (v1.9.4), so enough time has passed to remove the deprecated syntax.

### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?

Header plugin documentation needs to be updated to use only the new syntax.

### 4. Does this introduce a backward incompatible change or deprecation?

No, it removes the depreciation.

### Testing Done:

#### before this PR

```
→ kubectl logs -n kube-system coredns-7fc4bbfc95-gntwd 
[WARNING] plugin/header: The selector for header rule in line 8 isn't explicit defined. Assume rule applies for selector 'response'. This syntax is deprecated. In future versions of CoreDNS the selector must be explicit defined.
.:53
```

#### after this PR

```
→ kubectl logs -n kube-system coredns-5bb867f95-s5xtw 
maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
plugin/header: setting up rule: invalid selector=set should be query or response
```

Tests has been updated as well! 