### PR TITLE
plugin/file: fix label offset problem in ClosestEncloser

### DIFF
--- a/plugin/file/closest.go
+++ b/plugin/file/closest.go
@@ -16,7 +16,7 @@ func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
 		}
 		qname = qname[offset:]
 
-		offset, end = dns.NextLabel(qname, offset)
+		offset, end = dns.NextLabel(qname, 0)
 	}
 
 	return z.Search(z.origin)

--- a/plugin/file/closest_test.go
+++ b/plugin/file/closest_test.go
@@ -21,6 +21,7 @@ func TestClosestEncloser(t *testing.T) {
 		{"blaat.www.miek.nl.", "www.miek.nl."},
 		{"www.blaat.miek.nl.", "miek.nl."},
 		{"blaat.a.miek.nl.", "a.miek.nl."},
+		{"blaat.z.a.miek.nl.", "a.miek.nl."},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The current label in`qname` was trimmed. In search of next label for the trimmed `qname`, we must start from offset 0. Otherwise, some labels may be skipped unexpectedly.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
