### PR TITLE
plugin/trace: migrate dd-trace-go v1 to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.30
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.13
+	github.com/DataDog/dd-trace-go/v2 v2.2.2
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go-v2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/config v1.30.3
@@ -40,7 +41,6 @@ require (
 	google.golang.org/api v0.246.0
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.7
-	gopkg.in/DataDog/dd-trace-go.v1 v1.74.5
 	k8s.io/api v0.33.4
 	k8s.io/apimachinery v0.33.4
 	k8s.io/client-go v0.33.4
@@ -69,7 +69,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.67.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.6.0 // indirect
-	github.com/DataDog/dd-trace-go/v2 v2.2.2 // indirect
 	github.com/DataDog/go-libddwaf/v4 v4.3.2 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
-github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -532,8 +532,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.36.7 h1:IgrO7UwFQGJdRNXH/sQux4R1Dj1WAKcLElzeeRaXV2A=
 google.golang.org/protobuf v1.36.7/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
-gopkg.in/DataDog/dd-trace-go.v1 v1.74.5 h1:1bieplkmiiHV6RwefRAgkcSMQrGyjfrucvoKhBda0Og=
-gopkg.in/DataDog/dd-trace-go.v1 v1.74.5/go.mod h1:h35rC0PZzJBCbnql3z/IkQhVEvj4j9wF4/DvuS/7Dzc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -25,6 +25,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(t.OnStartup)
+	c.OnShutdown(t.OnShutdown)
 
 	return nil
 }

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -15,9 +16,10 @@ import (
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/miekg/dns"
 	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
+	openTracingMock "github.com/opentracing/opentracing-go/mocktracer"
 )
 
 func TestStartup(t *testing.T) {
@@ -83,7 +85,7 @@ func TestTrace(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := dnstest.NewRecorder(&test.ResponseWriter{})
-			m := mocktracer.New()
+			m := openTracingMock.New()
 			tr := &trace{
 				Next: test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 					if plugin.ClientWrite(tc.status) {
@@ -93,9 +95,9 @@ func TestTrace(t *testing.T) {
 					}
 					return tc.status, tc.err
 				}),
-				every:  1,
-				tracer: m,
-				tagSet: defaultTagSet,
+				every:        1,
+				zipkinTracer: m,
+				tagSet:       defaultTagSet,
 			}
 			ctx := context.TODO()
 			if _, err := tr.ServeDNS(ctx, w, tc.question); err != nil && tc.err == nil {
@@ -138,7 +140,7 @@ func TestTrace(t *testing.T) {
 
 func TestTrace_DOH_TraceHeaderExtraction(t *testing.T) {
 	w := dnstest.NewRecorder(&test.ResponseWriter{})
-	m := mocktracer.New()
+	m := openTracingMock.New()
 	tr := &trace{
 		Next: test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 			if plugin.ClientWrite(dns.RcodeSuccess) {
@@ -148,8 +150,8 @@ func TestTrace_DOH_TraceHeaderExtraction(t *testing.T) {
 			}
 			return dns.RcodeSuccess, nil
 		}),
-		every:  1,
-		tracer: m,
+		every:        1,
+		zipkinTracer: m,
 	}
 	q := new(dns.Msg).SetQuestion("example.net.", dns.TypeA)
 
@@ -166,9 +168,163 @@ func TestTrace_DOH_TraceHeaderExtraction(t *testing.T) {
 
 	fs := m.FinishedSpans()
 	rootCoreDNSspan := fs[1]
-	rootCoreDNSTraceID := rootCoreDNSspan.Context().(mocktracer.MockSpanContext).TraceID
-	outsideSpanTraceID := outsideSpan.Context().(mocktracer.MockSpanContext).TraceID
+	rootCoreDNSTraceID := rootCoreDNSspan.Context().(openTracingMock.MockSpanContext).TraceID
+	outsideSpanTraceID := outsideSpan.Context().(openTracingMock.MockSpanContext).TraceID
 	if rootCoreDNSTraceID != outsideSpanTraceID {
 		t.Errorf("Unexpected traceID: rootSpan.TraceID: want %v, got %v", rootCoreDNSTraceID, outsideSpanTraceID)
+	}
+}
+
+func TestStartup_Datadog(t *testing.T) {
+	m, err := traceParse(caddy.NewTestController("dns", `trace datadog localhost:8126`))
+	if err != nil {
+		t.Errorf("Error parsing test input: %s", err)
+		return
+	}
+	if m.Name() != "trace" {
+		t.Errorf("Wrong name from GetName: %s", m.Name())
+	}
+
+	// Test that we can start and stop the DataDog tracer without errors
+	err = m.OnStartup()
+	if err != nil {
+		t.Errorf("Error starting DataDog tracing plugin: %s", err)
+		return
+	}
+
+	if m.tagSet != tagByProvider["datadog"] {
+		t.Errorf("TagSet for DataDog hasn't been correctly initialized")
+	}
+
+	// Test shutdown
+	err = m.OnShutdown()
+	if err != nil {
+		t.Errorf("Error shutting down DataDog tracing plugin: %s", err)
+	}
+}
+
+func TestTrace_DataDog(t *testing.T) {
+	// Test the complete DataDog tracing flow using mocktracer
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	cases := []struct {
+		name     string
+		rcode    int
+		status   int
+		question *dns.Msg
+		err      error
+	}{
+		{
+			name:     "NXDOMAIN",
+			rcode:    dns.RcodeNameError,
+			status:   dns.RcodeSuccess,
+			question: new(dns.Msg).SetQuestion("example.org.", dns.TypeA),
+		},
+		{
+			name:     "NOERROR",
+			rcode:    dns.RcodeSuccess,
+			status:   dns.RcodeSuccess,
+			question: new(dns.Msg).SetQuestion("example.net.", dns.TypeCNAME),
+		},
+		{
+			name:     "SERVFAIL with error",
+			rcode:    dns.RcodeServerFailure,
+			status:   dns.RcodeSuccess,
+			question: new(dns.Msg).SetQuestion("example.net.", dns.TypeA),
+			err:      errors.New("test error"),
+		},
+	}
+
+	datadogTagSet := tagByProvider["datadog"]
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset spans for each test
+			mt.Reset()
+
+			w := dnstest.NewRecorder(&test.ResponseWriter{})
+			tr := &trace{
+				Next: test.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+					if plugin.ClientWrite(tc.status) {
+						m := new(dns.Msg)
+						m.SetRcode(r, tc.rcode)
+						w.WriteMsg(m)
+					}
+					return tc.status, tc.err
+				}),
+				every:        1,
+				EndpointType: "datadog",
+				tagSet:       datadogTagSet,
+			}
+
+			ctx := context.TODO()
+			if _, err := tr.ServeDNS(ctx, w, tc.question); err != nil && tc.err == nil {
+				t.Fatalf("Error during tr.ServeDNS(ctx, w, %v): %v", tc.question, err)
+			}
+
+			spans := mt.FinishedSpans()
+			if len(spans) == 0 {
+				t.Fatal("Expected at least one span, got none")
+			}
+
+			// Find the DNS span
+			var dnsSpan *mocktracer.Span
+			for _, span := range spans {
+				if span.OperationName() == defaultTopLevelSpanName {
+					dnsSpan = span
+					break
+				}
+			}
+
+			if dnsSpan == nil {
+				t.Fatal("Could not find DNS span with operation name 'servedns'")
+			}
+
+			req := request.Request{W: w, Req: tc.question}
+
+			// Test DataDog-specific tags
+			if dnsSpan.Tag(datadogTagSet.Name) != req.Name() {
+				t.Errorf("Unexpected span tag: span.Tag(%v): want %v, got %v",
+					datadogTagSet.Name, req.Name(), dnsSpan.Tag(datadogTagSet.Name))
+			}
+			if dnsSpan.Tag(datadogTagSet.Type) != req.Type() {
+				t.Errorf("Unexpected span tag: span.Tag(%v): want %v, got %v",
+					datadogTagSet.Type, req.Type(), dnsSpan.Tag(datadogTagSet.Type))
+			}
+			if dnsSpan.Tag(datadogTagSet.Proto) != req.Proto() {
+				t.Errorf("Unexpected span tag: span.Tag(%v): want %v, got %v",
+					datadogTagSet.Proto, req.Proto(), dnsSpan.Tag(datadogTagSet.Proto))
+			}
+			if dnsSpan.Tag(datadogTagSet.Remote) != req.IP() {
+				t.Errorf("Unexpected span tag: span.Tag(%v): want %v, got %v",
+					datadogTagSet.Remote, req.IP(), dnsSpan.Tag(datadogTagSet.Remote))
+			}
+			if dnsSpan.Tag(datadogTagSet.Rcode) != rcode.ToString(tc.rcode) {
+				t.Errorf("Unexpected span tag: span.Tag(%v): want %v, got %v",
+					datadogTagSet.Rcode, rcode.ToString(tc.rcode), dnsSpan.Tag(datadogTagSet.Rcode))
+			}
+
+			// Test DataDog v2 error handling
+			if tc.err != nil {
+				errorMsg := dnsSpan.Tag("error.message")
+				if errorMsg == nil {
+					t.Error("Expected error.message tag to be set")
+				} else if !strings.Contains(errorMsg.(string), "test error") {
+					t.Errorf("Expected error.message to contain 'test error', got %v", errorMsg)
+				}
+
+				// Check error type tag
+				errorType := dnsSpan.Tag("error.type")
+				if errorType == nil {
+					t.Error("Expected error.type tag to be set")
+				}
+			}
+
+			// Verify trace ID exists (mocktracer uses uint64)
+			traceID := dnsSpan.TraceID()
+			if traceID == 0 {
+				t.Error("Expected non-zero trace ID")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Migrates the DataDog tracing integration `dd-trace-go` from v1 to v2. Version 1 will be deprecated by the end of this year. See docs [here](https://docs.datadoghq.com/tracing/trace_collection/compatibility/go/?tab=v2).

Changes:

- Upgrade `dd-trace-go` dependency to v2.2.2
- Separate Zipkin and DataDog code paths for better maintainability
- Add proper tracer shutdown through `OnShutdown()`
- Replace deprecated `opentracer.New()` with `tracer.Start()`
- Add tests

Validated with a DataDog test account that spans are being spawned properly, with the proper tags.

### 2. Which issues (if any) are related?

Fixes #7372.

### 3. Which documentation changes (if any) need to be made?

None - configuration syntax and behavior remain identical for users.

### 4. Does this introduce a backward incompatible change or deprecation?

This change is fully backwards compatible:

- All span tag names preserved (`coredns.io@name`, `coredns.io@type`, etc.)
- Trace ID format unchanged
- Configuration syntax identical
- No functional changes for end users
