### PR TITLE
plugin/metrics: add timeouts to metrics HTTP server

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -98,7 +98,12 @@ func (m *Metrics) OnStartup() error {
 	m.mux.Handle("/metrics", promhttp.HandlerFor(m.Reg, promhttp.HandlerOpts{}))
 
 	// creating some helper variables to avoid data races on m.srv and m.ln
-	server := &http.Server{Handler: m.mux}
+	server := &http.Server{
+		Handler:      m.mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  5 * time.Second,
+	}
 	m.srv = server
 
 	go func() {


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add ReadTimeout, WriteTimeout, and IdleTimeout (5s each) to metrics HTTP server and test to verify timeout behavior prevents hanging connections.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.