### PR TITLE
chore(ci): pin workflow dependencies

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test With Coverage
         run: |
-          go install github.com/fatih/faillint@latest
+          go install github.com/fatih/faillint@c56e3ec6dbfc933bbeb884fd31f2bcd41f712657 # v1.15.0
           for d in request core coremain plugin test; do \
              ( cd $d; go test -coverprofile=cover.out -covermode=atomic -race ./...; [ -f cover.out ] && cat cover.out >> ../coverage.txt ); \
           done

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Test
         run: |
-          go install github.com/fatih/faillint@latest
+          go install github.com/fatih/faillint@c56e3ec6dbfc933bbeb884fd31f2bcd41f712657 # v1.15.0
           ( cd test; go test -race ./... )
 
   test-makefile-release:


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

CI workflows which reference "faillint" were missing a version pin.

Should improve OpenSSF scorecard once merged.

### 2. Which issues (if any) are related?

Part of https://github.com/coredns/coredns/issues/6795.

Closes https://github.com/coredns/coredns/pull/6823 about the same change set (stale PR with conflicts).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, purely a CI related change.

