### PR TITLE
plugin/grpc: fix span leak and deadline on error attempt

### DIFF
--- a/plugin/grpc/grpc_test.go
+++ b/plugin/grpc/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/pb"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -12,6 +13,9 @@ import (
 	"github.com/coredns/coredns/plugin/test"
 
 	"github.com/miekg/dns"
+	ot "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	grpcgo "google.golang.org/grpc"
 )
 
 func TestGRPC(t *testing.T) {
@@ -100,5 +104,78 @@ func TestGRPCFallthroughNoNext(t *testing.T) {
 	// Should return SERVFAIL
 	if rcode != dns.RcodeServerFailure {
 		t.Errorf("Expected SERVFAIL when no backends and no next plugin, got: %d", rcode)
+	}
+}
+
+// deadlineCheckingClient records whether a deadline was attached to ctx.
+type deadlineCheckingClient struct {
+	sawDeadline  bool
+	lastDeadline time.Time
+	dnsPacket    *pb.DnsPacket
+	err          error
+}
+
+func (c *deadlineCheckingClient) Query(ctx context.Context, in *pb.DnsPacket, opts ...grpcgo.CallOption) (*pb.DnsPacket, error) {
+	if dl, ok := ctx.Deadline(); ok {
+		c.sawDeadline = true
+		c.lastDeadline = dl
+	}
+	return c.dnsPacket, c.err
+}
+
+// Test that on error paths we still finish child spans, and that we set a per-call deadline.
+func TestGRPC_SpansOnErrorPath(t *testing.T) {
+	m := &dns.Msg{}
+	msgBytes, err := m.Pack()
+	if err != nil {
+		t.Fatalf("Error packing response: %s", err)
+	}
+	dnsPacket := &pb.DnsPacket{Msg: msgBytes}
+
+	// Proxy 1: returns error, we should still finish its child span and have a deadline
+	p1 := &deadlineCheckingClient{dnsPacket: nil, err: errors.New("kaboom")}
+	// Proxy 2: returns success
+	p2 := &deadlineCheckingClient{dnsPacket: dnsPacket, err: nil}
+
+	g := newGRPC()
+	g.from = "."
+	g.proxies = []*Proxy{{client: p1}, {client: p2}}
+
+	// Ensure deterministic order of the retries: try p1 then p2
+	g.p = new(sequential)
+
+	// Set a parent span in context so ServeDNS creates child spans per attempt
+	tracer := mocktracer.New()
+	prev := ot.GlobalTracer()
+	ot.SetGlobalTracer(tracer)
+	defer ot.SetGlobalTracer(prev)
+
+	parent := tracer.StartSpan("parent")
+	ctx := ot.ContextWithSpan(t.Context(), parent)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	if _, err := g.ServeDNS(ctx, rec, m); err != nil {
+		t.Fatalf("ServeDNS returned error: %v", err)
+	}
+
+	// Assert both attempts finished child spans with retries
+	// (2 query spans: error + success)
+	finished := tracer.FinishedSpans()
+	var finishedQueries int
+	for _, s := range finished {
+		if s.OperationName == "query" {
+			finishedQueries++
+		}
+	}
+	if finishedQueries != 2 {
+		t.Fatalf("expected 2 finished 'query' spans, got %d (finished: %v)", finishedQueries, finished)
+	}
+
+	// Assert we set a deadline on the call contexts
+	if !p1.sawDeadline {
+		t.Fatalf("expected deadline to be set on first proxy call context")
+	}
+	if !p2.sawDeadline {
+		t.Fatalf("expected deadline to be set on second proxy call context")
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fixes leaked child tracing spans in `grpc.ServeDNS` on error paths. Previously spans were not always finished when a proxy attempt failed.

Each attempt now derives a context with a deadline, derived from the overall request timeline. Previously there was no per-RPC deadline and the loop’s timeout was only evaluated after the call returned.

I added a test to validate the behaviour:

- Both error and success create _and finish_ their child spans
- Deadline is always set

If you run the test against current `master` you'll see that it fails:

```bash
grpc_test.go:167: expected 2 finished 'query' spans, got 1 (finished: [traceId=43, spanId=46, parentId=44, sampled=true, name=query])
```


While at it, I also refactored the code to use `opentracing.StartSpanFromContext` for a bit cleaner span init.

### 2. Which issues (if any) are related?

None found.

### 3. Which documentation changes (if any) need to be made?

None. Purely an implementation internal matter.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Query handling and responses are unchanged; only tracing and timeout handling improved.
