### PR TITLE
plugin: Use %w to wrap user error

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -67,7 +67,7 @@ func (f HandlerFunc) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 func (f HandlerFunc) Name() string { return "handlerfunc" }
 
 // Error returns err with 'plugin/name: ' prefixed to it.
-func Error(name string, err error) error { return fmt.Errorf("%s/%s: %s", "plugin", name, err) }
+func Error(name string, err error) error { return fmt.Errorf("%s/%s: %w", "plugin", name, err) }
 
 // NextOrFailure calls next.ServeDNS when next is not nil, otherwise it will return, a ServerFailure and a `no next plugin found` error.
 func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Use the `%w` to wrap rather than embed error provided by the user. This allows plugins to coordinate error handling.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
