### PR TITLE
lint: enable durationcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
   enable:
     - canonicalheader
     - copyloopvar
+    - durationcheck
     - govet
     - ineffassign
     - intrange

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -31,7 +31,6 @@ func setup(c *caddy.Controller) error {
 				z.StartupOnce.Do(func() {
 					go func() {
 						dur := time.Millisecond * 250
-						step := time.Duration(2)
 						max := time.Second * 10
 						for {
 							err := z.TransferIn()
@@ -40,7 +39,7 @@ func setup(c *caddy.Controller) error {
 							}
 							log.Warningf("All '%s' masters failed to transfer, retrying in %s: %s", n, dur.String(), err)
 							time.Sleep(dur)
-							dur = step * dur
+							dur <<= 1 // double the duration
 							if dur > max {
 								dur = max
 							}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable the [durationcheck linter](https://github.com/charithe/durationcheck) and adjust `plugin/secondary`'s retry backoff to avoid multiplying durations. Use bit shifting to double the delay and cap at 10s. 

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Behavior is unchanged. Backoff is still capped at 10s.