### PR TITLE
lint: enable prealloc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - ineffassign
     - intrange
     - nolintlint
+    - prealloc
     - protogetter
     - staticcheck
     - thelper

--- a/plugin/header/header.go
+++ b/plugin/header/header.go
@@ -63,7 +63,7 @@ func newRules(key string, args []string) ([]Rule, error) {
 		return nil, fmt.Errorf("unknown flag action=%s, should be set or clear", action)
 	}
 
-	var rules []Rule
+	rules := make([]Rule, 0, len(args))
 	for _, arg := range args {
 		flag := strings.ToLower(arg)
 		switch flag {

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -224,8 +224,10 @@ func (k *Kubernetes) ExternalReverse(ip string) ([]msg.Service, error) {
 }
 
 func (k *Kubernetes) serviceRecordForExternalIP(ip string) []msg.Service {
-	var svcs []msg.Service
-	for _, service := range k.APIConn.SvcExtIndexReverse(ip) {
+	svcList := k.APIConn.SvcExtIndexReverse(ip)
+	svcLen := len(svcList)
+	svcs := make([]msg.Service, 0, svcLen)
+	for _, service := range svcList {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
 			continue
 		}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -257,8 +257,7 @@ func emitAddressRecord(c chan<- []dns.RR, s msg.Service) string {
 // calcSRVWeight borrows the logic implemented in plugin.SRV for dynamically
 // calculating the srv weight and priority
 func calcSRVWeight(numservices int) uint16 {
-	var services []msg.Service
-
+	services := make([]msg.Service, 0, numservices)
 	for range numservices {
 		services = append(services, msg.Service{})
 	}

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -30,7 +30,7 @@ func stripZone(host string) string {
 // and in case of filename a resolv.conf like file is (assumed) and parsed and
 // the nameservers found are returned.
 func HostPortOrFile(s ...string) ([]string, error) {
-	var servers []string
+	var servers []string //nolint:prealloc // impossible to know the final length upfront
 	for _, h := range s {
 		trans, host := Transport(h)
 		if len(host) == 0 {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable prealloc linter and right-size slices where safe.

- plugin/header: preallocate rules in header plugin using args length.
- plugin/kubernetes: preallocate services in k8s external and xfr paths.
- pkg/parse: add nolint for prealloc since result size varies per input and may expand via resolv.conf parsing.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None, code quality improvement.

### 4. Does this introduce a backward incompatible change or deprecation?

No functional changes.
