### PR TITLE
plugin: guard nil lookups across plugins

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -64,7 +64,7 @@ func A(ctx context.Context, b ServiceBackend, zone string, state request.Request
 			target := newRecord.Target
 			// Lookup
 			m1, e1 := b.Lookup(ctx, state, target, state.QType())
-			if e1 != nil {
+			if e1 != nil || m1 == nil {
 				continue
 			}
 			if m1.Truncated {
@@ -137,7 +137,7 @@ func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Requ
 			// This means we can not complete the CNAME, try to look else where.
 			target := newRecord.Target
 			m1, e1 := b.Lookup(ctx, state, target, state.QType())
-			if e1 != nil {
+			if e1 != nil || m1 == nil {
 				continue
 			}
 			if m1.Truncated {
@@ -219,12 +219,12 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 
 			if !dns.IsSubDomain(zone, srv.Target) {
 				m1, e1 := b.Lookup(ctx, state, srv.Target, dns.TypeA)
-				if e1 == nil {
+				if e1 == nil && m1 != nil {
 					extra = append(extra, m1.Answer...)
 				}
 
 				m1, e1 = b.Lookup(ctx, state, srv.Target, dns.TypeAAAA)
-				if e1 == nil {
+				if e1 == nil && m1 != nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
 						if _, ok := a.(*dns.CNAME); !ok {
@@ -286,12 +286,12 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 
 			if !dns.IsSubDomain(zone, mx.Mx) {
 				m1, e1 := b.Lookup(ctx, state, mx.Mx, dns.TypeA)
-				if e1 == nil {
+				if e1 == nil && m1 != nil {
 					extra = append(extra, m1.Answer...)
 				}
 
 				m1, e1 = b.Lookup(ctx, state, mx.Mx, dns.TypeAAAA)
-				if e1 == nil {
+				if e1 == nil && m1 != nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
 						if _, ok := a.(*dns.CNAME); !ok {
@@ -390,7 +390,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			target := newRecord.Target
 			// Lookup
 			m1, e1 := b.Lookup(ctx, state, target, state.QType())
-			if e1 != nil {
+			if e1 != nil || m1 == nil {
 				continue
 			}
 			// Len(m1.Answer) > 0 here is well?


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`Upstream.Lookup()` captures the response from a self-query and doesn’t surface chain errors. If no plugin writes a response (drop/cancel), it can return (nil, nil). 

Many plugins take this into account already. But for example the CNAME rewrite response path dereferenced this, causing a panic in certain scenarios, and backend lookup helpers also assumed a non-nil message.

This change adds nil checks to avoid deferencing a nil message. It also adds a unit test that simulates a nil upstream in the rewrite plugin. The test panics if you run it against the current `master`.

### 2. Which issues (if any) are related?

None found.

### 3. Which documentation changes (if any) need to be made?

None required.

### 4. Does this introduce a backward incompatible change or deprecation?

No, just a code quality improvement.