### PR TITLE
dnsserver.Server: Export timeout values

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -75,9 +75,9 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 	}
 
 	srv := &http.Server{
-		ReadTimeout:  s.readTimeout,
-		WriteTimeout: s.writeTimeout,
-		IdleTimeout:  s.idleTimeout,
+		ReadTimeout:  s.ReadTimeout,
+		WriteTimeout: s.WriteTimeout,
+		IdleTimeout:  s.IdleTimeout,
 		ErrorLog:     stdlog.New(&loggerAdapter{}, "", 0),
 	}
 	sh := &ServerHTTPS{

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -84,7 +84,7 @@ func NewServerQUIC(addr string, group []*Config) (*ServerQUIC, error) {
 	}
 
 	var quicConfig = &quic.Config{
-		MaxIdleTimeout:        s.idleTimeout,
+		MaxIdleTimeout:        s.IdleTimeout,
 		MaxIncomingStreams:    int64(maxStreams),
 		MaxIncomingUniStreams: int64(maxStreams),
 		// Enable 0-RTT by default for all connections on the server-side.

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -54,10 +54,10 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 	s.server[tcp] = &dns.Server{Listener: l,
 		Net:           "tcp-tls",
 		MaxTCPQueries: tlsMaxQueries,
-		ReadTimeout:   s.readTimeout,
-		WriteTimeout:  s.writeTimeout,
+		ReadTimeout:   s.ReadTimeout,
+		WriteTimeout:  s.WriteTimeout,
 		IdleTimeout: func() time.Duration {
-			return s.idleTimeout
+			return s.IdleTimeout
 		},
 		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 			ctx := context.WithValue(context.Background(), Key{}, s.Server)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Before `dnsserver.Server` starts `dns.Server` (that actually serves TCP connections) it considers all server blocks in Corefile that [apply to a given listening endpoint](https://github.com/coredns/coredns/blob/5ec2796ab66d4a7ca6b04e4c22434e056a4b05d5/core/dnsserver/register.go#L141) before picking the final timeout values ([only one value gets applied](https://github.com/coredns/coredns/blob/5ec2796ab66d4a7ca6b04e4c22434e056a4b05d5/core/dnsserver/server.go#L97-L99), all other are silently disregarded). Unfortunately this happens after plugins are set up.

I'm currently working on a plugin that implements RFC 8490. This protocol allows to communicate to the client that it needs to send KeepAlive messages to maintain the TCP connection. Since dns.Server [will terminate an idle tcp connection](https://github.com/miekg/dns/blob/4145b39037ad661aef1d2802af1469e1deb88143/server.go#L585-L589), I need to communicate a value that's sufficient to prevent that. Therefore inside plugin's ServeDNS I need to be able to access actual IdleTimeout used by dnsserver.Server (and, by extension, dns.Server).

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No