### PR TITLE
lint: add missing prealloc to backend lookup test

### DIFF
--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -213,8 +213,9 @@ func TestCNAMEHostIsNameAndIpIgnored(t *testing.T) {
 
 func TestCNAMEChainLimitAndLoop(t *testing.T) {
 	// Construct internal CNAME chain longer than maxCnameChainLength and ensure truncation of chain
-	var names []string
-	for i := range maxCnameChainLength + 2 {
+	chainLength := maxCnameChainLength + 2
+	names := make([]string, 0, chainLength)
+	for i := range chainLength {
 		names = append(names, fmt.Sprintf("c%d.example.org.", i))
 	}
 	chain := map[string]string{}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add missing prealloc to backend lookup test. Currently causes a lint error on `master`.

Linter merged in #7493 and lookup tests in #7496.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

No, affects a single test only.

### 4. Does this introduce a backward incompatible change or deprecation?

No.