### PR TITLE
WIP server: Support handling of RFC 8490 messages.

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -79,6 +79,8 @@ type Config struct {
 
 	// Compiled plugin stack.
 	pluginChain plugin.Handler
+	// Compiled DSO plugin stack.
+	dsoPluginChain plugin.DSOHandler
 
 	// Plugin interested in announcing that they exist, so other plugin can call methods
 	// on them should register themselves here. The name should be the name as return by the

--- a/plugin/pkg/dso/dso.go
+++ b/plugin/pkg/dso/dso.go
@@ -1,0 +1,246 @@
+package dso
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// SessionState is the list of session states.
+type SessionState uint32
+
+// Possible transitions:
+// SessionWaiting -> SessionClosed (RetryDelay unidirectional)
+// SessionWaiting -> sessionPending -> SessionClosed (writing error)
+// SessionWaiting -> sessionPending -> SessionEstablished -> SessionClosed (RetryDelay unidirectional)
+const (
+	// The session is waiting for an establishing exchange.
+	SessionWaiting SessionState = 0
+	// The session is being established.
+	sessionPending SessionState = 1 << iota
+	// The session is successfully established.
+	SessionEstablished
+	// The session is closed and no longer accepts new messages.
+	SessionClosed
+)
+
+// Session implements state management of RFC 8490 DNS Stateful Operations session.
+type Session struct {
+	idleTimeout time.Duration
+
+	state     atomic.Uint32
+	mu        *sync.RWMutex // serialize writes of close vs all other
+	pendingCh chan struct{} // closed if state is (SessionEstablished | SessionClosed)
+
+	ka *dns.DSOKeepAlive
+}
+
+// NewSession instantiates new Session.
+//
+// idleTimeout is used to derive appropriate values for the KeepAlive TLV.
+func NewSession(idleTimeout time.Duration) *Session {
+	s := new(Session)
+	s.idleTimeout = idleTimeout
+	s.mu = new(sync.RWMutex)
+	s.pendingCh = make(chan struct{})
+	return s
+}
+
+// NewClosedSession instantiates new closed Session.
+func NewClosedSession(idleTimeout time.Duration) *Session {
+	s := new(Session)
+	s.idleTimeout = idleTimeout
+	s.state.Store(uint32(SessionClosed))
+	// s.mu is left uninitialized
+	// s.pendingCh is left uninitialized
+	return s
+}
+
+// State returns current session state.
+//
+// Blocks while the session is pending.
+func (s *Session) State() SessionState {
+	state := SessionState(s.state.Load())
+	if state == SessionClosed {
+		return SessionClosed
+	}
+	if state == sessionPending {
+		<-s.pendingCh
+		state = SessionState(s.state.Load())
+	}
+	return state
+}
+
+// IsValidState checks whether the session state is valid to handle the DSO message.
+//
+// Returns ErrSessionClosed if session is closed, ErrSessionState if it's in the wrong state.
+func (s *Session) IsValidState(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) error {
+	state := SessionState(s.state.Load())
+	if state == SessionClosed {
+		return ErrSessionClosed
+	}
+	if state != SessionEstablished && !dns.IsDSOResponse(r) {
+		return ErrSessionState
+	}
+	return nil
+}
+
+// WriteMsg writes message and updates associated session state if necessary.
+//
+// Returns ErrSessionClosed if the connection is closed, ErrSessionState if the message is not appropriate
+// for current state or the writing error.
+// Session is considered closed on writing error.
+func (s *Session) WriteMsg(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (err error) {
+	// Messages can be written concurrently with the following exceptions:
+	// 1. Requests, unidirectional and consequent successful responses must wait
+	//    until the 1st successful reponse is sent
+	// 2. No messages can be written after Close unidirectional
+	isCloseUnidirectional := dns.IsDSOUnidirectional(r) && r.Stateful[0].DSOType() == dns.StatefulTypeRetryDelay
+	var locker sync.Locker
+	if isCloseUnidirectional {
+		locker = s.mu
+	} else {
+		locker = s.mu.RLocker()
+	}
+
+	locker.Lock()
+	defer locker.Unlock()
+
+	switch {
+	case isCloseUnidirectional:
+		err = s.writeCloseUnidirectional(ctx, w, r)
+	case dns.IsDSOUnidirectional(r):
+		err = s.writeUnidirectional(ctx, w, r)
+	case dns.IsDSORequest(r):
+		err = s.writeRequest(ctx, w, r)
+	default:
+		err = s.writeResponse(ctx, w, r)
+	}
+
+	if err != nil && !errors.Is(err, ErrSessionState) {
+		// Close session on writing error.
+		s.state.Store(uint32(SessionClosed))
+	}
+
+	return nil
+}
+
+func (s *Session) writeCloseUnidirectional(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (err error) {
+	// isCloseUnidirectional has exclusive access and thus session cannot be in transient state.
+	switch SessionState(s.state.Load()) {
+	case SessionWaiting:
+		s.state.Store(uint32(SessionClosed))
+		close(s.pendingCh)
+		return nil
+	case SessionEstablished:
+		s.state.Store(uint32(SessionClosed)) // set state early, before waiting for write
+		return w.WriteMsg(r)
+	case SessionClosed:
+		return nil
+	default:
+		panic("unexpected DSO state")
+	}
+}
+
+func (s *Session) writeUnidirectional(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (err error) {
+	state := SessionState(s.state.Load())
+	if state == sessionPending {
+		<-s.pendingCh
+		state = SessionState(s.state.Load())
+	}
+
+	switch state {
+	case SessionWaiting:
+		return ErrSessionState
+	case SessionEstablished:
+		return w.WriteMsg(r)
+	case SessionClosed:
+		return ErrSessionClosed
+	default:
+		panic("unexpected DSO state")
+	}
+}
+
+func (s *Session) writeRequest(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (err error) {
+	state := SessionState(s.state.Load())
+	if state == sessionPending {
+		<-s.pendingCh
+		state = SessionState(s.state.Load())
+	}
+
+	switch state {
+	case SessionWaiting:
+		return ErrSessionState
+	case SessionEstablished:
+		return w.WriteMsg(r)
+	case SessionClosed:
+		return ErrSessionClosed
+	default:
+		panic("unexpected DSO state")
+	}
+}
+
+func (s *Session) writeResponse(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (err error) {
+	state := SessionState(s.state.Load())
+	isEstablishingResponse := state == SessionWaiting && r.Rcode == dns.RcodeSuccess
+	if isEstablishingResponse && !s.state.CompareAndSwap(uint32(SessionWaiting), uint32(sessionPending)) {
+		isEstablishingResponse = false
+		<-s.pendingCh
+		state = SessionState(s.state.Load())
+	}
+
+	switch state {
+	case SessionWaiting:
+		fallthrough
+	case SessionEstablished:
+		err = w.WriteMsg(r)
+		if isEstablishingResponse {
+			switch {
+			case err == nil && s.state.CompareAndSwap(uint32(sessionPending), uint32(SessionEstablished)):
+				fallthrough
+			case err != nil && s.state.CompareAndSwap(uint32(sessionPending), uint32(SessionClosed)):
+				close(s.pendingCh)
+			}
+			if err == nil && (len(r.Stateful) == 0 || r.Stateful[0].DSOType() != dns.StatefulTypeKeepAlive) {
+				// The session is established via a non-KeepAlive exchange. Tell the client our timeouts.
+				m := new(dns.Msg)
+				dns.SetDSOUnidirectional(m)
+				m.Stateful = append(m.Stateful, s.DefaultKeepAlive())
+				err = w.WriteMsg(m)
+			}
+		}
+		return err
+	case SessionClosed:
+		return ErrSessionClosed
+	default:
+		panic("unexpected DSO state")
+	}
+}
+
+// Abort forcibly aborts the connection.
+func (s *Session) Abort(ctx context.Context, w dns.ResponseWriter) {
+	w.(dns.ResponseWriterExtra).Abort()
+}
+
+// DefaultKeepAlive returns default KeepAlive TLV configured with server's timeouts.
+//
+// You can adjust the values before the first use.
+func (s *Session) DefaultKeepAlive() *dns.DSOKeepAlive {
+	if s.ka == nil {
+		s.ka = &dns.DSOKeepAlive{
+			InactivityTimeout: uint32(max(0*time.Second, min(s.idleTimeout-5*time.Second, s.idleTimeout/2)).Milliseconds()),
+			KeepAliveInterval: uint32(max(dns.DSOKeepAliveIntervalMin, s.idleTimeout/2).Milliseconds()),
+		}
+	}
+	return s.ka
+}
+
+var (
+	ErrSessionState  = errors.New("bad DSO state")
+	ErrSessionClosed = fmt.Errorf("%w: closed", ErrSessionState)
+)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -52,6 +52,16 @@ type (
 		Name() string
 	}
 
+	// DSOHandler is implemented by plugins that can handle RFC 8490
+	// DNS Stateful Operations messages.
+	DSOHandler interface {
+		Handler
+		// ServeDSO is like Handler.ServeDNS, but for dns.OpcodeStateful messages.
+		ServeDSO(context.Context, dns.ResponseWriter, *dns.Msg) (int, error)
+		// SetNextDSO chains the receiver with the next DSOHandler.
+		SetNextDSO(DSOHandler)
+	}
+
 	// HandlerFunc is a convenience type like dns.HandlerFunc, except
 	// ServeDNS returns an rcode and an error. See Handler
 	// documentation for more information.
@@ -77,7 +87,13 @@ func NextOrFailure(name string, next Handler, ctx context.Context, w dns.Respons
 			defer child.Finish()
 			ctx = ot.ContextWithSpan(ctx, child)
 		}
-		return next.ServeDNS(ctx, w, r)
+		switch r.Opcode {
+		case dns.OpcodeStateful:
+			// It's caller's responsibility to ensure that next is a DSOHandler (or nil).
+			return next.(DSOHandler).ServeDSO(ctx, w, r)
+		default:
+			return next.ServeDNS(ctx, w, r)
+		}
 	}
 
 	return dns.RcodeServerFailure, Error(name, errors.New("no next plugin found"))


### PR DESCRIPTION
This PR is Work In Progress for discussion. You need to replace the `github.com/miekg/dns` with https://github.com/Kentzo/dns/tree/master

### 1. Why is this pull request needed and what does it do?

~~Currently CoreDNS cannot handle [RFC 8490](https://datatracker.ietf.org/doc/html/rfc8490) (Opcode == 6) messages nor it's possible to add support via plugins.

DNS Stateful Operations (DSO) messages share a header with "standard" DNS messages but instead of RRs the data payload consists of DSO TLVs. Lack of RRs is significant as CoreDNS (and all plugins) so far only allowed messages with [at least one question RRs](https://github.com/coredns/coredns/blob/abef207695afd5523dddc7cd4a2e75b21dcc01af/core/dnsserver/server.go#L255-L258). Therefore the existing serving algorithm is not suitable for DSO messages for backward compatibility reasons.

In order to preserve backward compatibility with existing plugins, each site config maintains an additional stack of plugins (`dsoPluginChain`) that implement `plugin.DSOHandler`. If the server has at least one such plugin, its `dns.Server.MsgAcceptFunc` is modified to accept DSO messages. Then, when processing DNS message, it uses `dsoPluginChain` rather than `pluginChain` for DSO.~~

### 2. Which issues (if any) are related?

None that I'm aware of.

### 3. Which documentation changes (if any) need to be made?

No changes for end-users, but need to document plugin.DSOHandler interface for plugin developers.

### 4. Does this introduce a backward incompatible change or deprecation?

No