### PR TITLE
plugin/grpc: check proxy list length in policies

### DIFF
--- a/plugin/grpc/policy.go
+++ b/plugin/grpc/policy.go
@@ -20,6 +20,8 @@ func (r *random) String() string { return "random" }
 
 func (r *random) List(p []*Proxy) []*Proxy {
 	switch len(p) {
+	case 0:
+		return nil
 	case 1:
 		return p
 	case 2:
@@ -46,6 +48,9 @@ type roundRobin struct {
 func (r *roundRobin) String() string { return "round_robin" }
 
 func (r *roundRobin) List(p []*Proxy) []*Proxy {
+	if len(p) == 0 {
+		return nil
+	}
 	poolLen := uint32(len(p))
 	i := atomic.AddUint32(&r.robin, 1) % poolLen
 

--- a/plugin/grpc/policy_test.go
+++ b/plugin/grpc/policy_test.go
@@ -1,0 +1,128 @@
+package grpc
+
+import (
+	"testing"
+)
+
+func TestRoundRobinEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := &roundRobin{}
+	got := r.List(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected length 0, got %d", len(got))
+	}
+}
+
+func TestRandomEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := &random{}
+	got := r.List(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected length 0, got %d", len(got))
+	}
+}
+
+func TestSequentialEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := &sequential{}
+	got := r.List(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected length 0, got %d", len(got))
+	}
+}
+
+func TestPoliciesOrdering(t *testing.T) {
+	t.Parallel()
+
+	p0 := &Proxy{addr: "p0"}
+	p1 := &Proxy{addr: "p1"}
+	p2 := &Proxy{addr: "p2"}
+	in := []*Proxy{p0, p1, p2}
+
+	t.Run("sequential keeps order", func(t *testing.T) {
+		t.Parallel()
+
+		r := &sequential{}
+		got := r.List(in)
+		if len(got) != len(in) {
+			t.Fatalf("expected length %d, got %d", len(in), len(got))
+		}
+		for i := range in {
+			if got[i] != in[i] {
+				t.Fatalf("sequential order changed at %d: want %p, got %p", i, in[i], got[i])
+			}
+		}
+	})
+
+	t.Run("round robin advances and permutation", func(t *testing.T) {
+		t.Parallel()
+
+		r := &roundRobin{}
+
+		got1 := r.List(in)
+		if !isPermutation(in, got1) {
+			t.Fatalf("first call: expected permutation of input")
+		}
+		if got1[0] != p1 {
+			t.Fatalf("first element should advance to p1, got %p", got1[0])
+		}
+
+		got2 := r.List(in)
+		if !isPermutation(in, got2) {
+			t.Fatalf("second call: expected permutation of input")
+		}
+		if got2[0] != p2 {
+			t.Fatalf("first element should advance to p2 on second call, got %p", got2[0])
+		}
+
+		got3 := r.List(in)
+		if !isPermutation(in, got3) {
+			t.Fatalf("third call: expected permutation of input")
+		}
+		if got3[0] != p0 {
+			t.Fatalf("first element should wrap to p0 on third call, got %p", got3[0])
+		}
+	})
+
+	t.Run("random is a permutation", func(t *testing.T) {
+		t.Parallel()
+
+		r := &random{}
+		got := r.List(in)
+		if !isPermutation(in, got) {
+			t.Fatalf("random did not return a permutation of input")
+		}
+	})
+
+	t.Run("random with two proxies", func(t *testing.T) {
+		t.Parallel()
+
+		r := &random{}
+		in2 := []*Proxy{p0, p1}
+		got := r.List(in2)
+		if !isPermutation(in2, got) {
+			t.Fatalf("random did not return a permutation of input")
+		}
+	})
+}
+
+// Helper: returns true if b is a permutation of a (same multiset of pointers).
+func isPermutation(a, b []*Proxy) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	count := make(map[*Proxy]int, len(a))
+	for _, p := range a {
+		count[p]++
+	}
+	for _, p := range b {
+		count[p]--
+		if count[p] < 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

While the gRPC plugin setup requires at least one upstream, the missing proxy list length check in the policy implementation currently causes Go panics with a fuzzer.


<details>
<code>
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/coredns/coredns/plugin/grpc.(*roundRobin).List(0x101953708?, {0x0?, 0x140000d2180?, 0x0?})
        /git/coredns/plugin/grpc/policy.go:50 +0x1f4
github.com/coredns/coredns/plugin/grpc.(*GRPC).list(...)
        /git/coredns/plugin/grpc/grpc.go:159
github.com/coredns/coredns/plugin/grpc.(*GRPC).ServeDNS(0x140000b62d0, {0x101953708, 0x102045b60}, {0x101957f90, 0x140000d2180}, 0x140000b6360)
        /git/coredns/plugin/grpc/grpc.go:52 +0x158
github.com/coredns/coredns/plugin/pkg/fuzz.Do({0x10194f838, 0x140000b62d0}, {0x128e38001, 0xd, 0xd})
        /git/coredns/plugin/pkg/fuzz/do.go:26 +0x154
github.com/coredns/coredns/plugin/grpc.Fuzz({0x128e38000?, 0xe, 0x140001eded8?})
        /git/coredns/plugin/grpc/fuzz.go:154 +0x620
go-fuzz-dep.Main({0x140001edf30, 0x1, 0x101fa58c8?})
        go-fuzz-dep/main.go:36 +0x10c
main.main()
        github.com/coredns/coredns/plugin/grpc/go.fuzz.main/main.go:15 +0x34
exit status 2%
</code>
</details>


This commit adds a zero-length check as a defensive measure to affected policies. Also includes a set of unit tests, increasing the plugin test coverage from 74.5% to 79.1%.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None. No user facing changes.

### 4. Does this introduce a backward incompatible change or deprecation?

No, internal improvement.