### PR TITLE
plugin: remove extra whitespace from some READMEs

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -107,7 +107,7 @@ kubernetes [ZONES...] {
   Services API (MCS-API). Specifying this option is generally paired with the
   installation of an MCS-API implementation and the ServiceImport and ServiceExport
   CRDs. The plugin MUST be authoritative for the zones listed here.
-* `startup_timeout` specifies the **DURATION** value that limits the time to wait for informer cache synced 
+* `startup_timeout` specifies the **DURATION** value that limits the time to wait for informer cache synced
   when the kubernetes plugin starts. If not specified, the default timeout will be 5s.
 
 Enabling zone transfer is done by using the *transfer* plugin.

--- a/plugin/ready/README.md
+++ b/plugin/ready/README.md
@@ -25,7 +25,7 @@ ready [ADDRESS] {
 
 *ready* optionally takes an address; the default is `:8181`. The path is fixed to `/ready`. The
 readiness endpoint returns a 200 response code and the word "OK" when this server is ready. It
-returns a 503 otherwise *and* the list of plugins that are not ready. 
+returns a 503 otherwise *and* the list of plugins that are not ready.
 By default, once a plugin has signaled it is ready it will not be queried again.
 
 The *ready* directive can include an optional `monitor` parameter, defaulting to `until-ready`. The following values are supported:

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -454,7 +454,7 @@ rewrite edns0 local unset 0xffee
 ### EDNS0_NSID
 
 This has no fields; it will add an NSID option with an empty string for the NSID. If the option already exists
-and the action is `replace` or `set`, then the NSID in the option will be set to the empty string.  
+and the action is `replace` or `set`, then the NSID in the option will be set to the empty string.
 The option can be removed with the `unset` action.
 
 ### EDNS0_SUBNET


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Minor issue, but this causes unnecessary drift in coredns.io repo when generating the website through `make` commands.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.