### PR TITLE
chore(lint): modernize Go

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,3 +21,5 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
           version: v2.4.0
+      - name: modernize
+        run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@2e31135b736b96cd609904370c71563ce5447826 -diff -test ./... # v0.20.0

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -4,6 +4,7 @@ package dnsserver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"runtime"
 	"runtime/debug"
@@ -99,9 +100,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		}
 
 		// copy tsig secrets
-		for key, secret := range site.TsigSecret {
-			s.tsigSecret[key] = secret
-		}
+		maps.Copy(s.tsigSecret, site.TsigSecret)
 
 		// compile custom plugin for everything
 		var stack plugin.Handler

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -62,7 +62,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 	s.m.Unlock()
 
 	if s.Tracer() != nil {
-		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp interface{}) bool {
+		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp any) bool {
 			return parentSpanCtx != nil
 		}
 		intercept := otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -115,8 +115,8 @@ func BenchmarkCoreServeDNS(b *testing.B) {
 	m.SetQuestion("aaa.example.com.", dns.TypeTXT)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		s.ServeDNS(ctx, w, m)
 	}
 }

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -89,7 +89,7 @@ func Run() {
 // enabled. If this process is an upgrade, however, and the user
 // might not be there anymore, this just logs to the process
 // log and exits.
-func mustLogFatal(args ...interface{}) {
+func mustLogFatal(args ...any) {
 	if !caddy.IsUpgrade() {
 		log.SetOutput(os.Stderr)
 	}

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -469,10 +469,7 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 // SOA returns a SOA record from the backend.
 func SOA(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) ([]dns.RR, error) {
 	minTTL := b.MinTTL(state)
-	ttl := uint32(300)
-	if minTTL < ttl {
-		ttl = minTTL
-	}
+	ttl := min(minTTL, uint32(300))
 
 	header := dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Ttl: ttl, Class: dns.ClassINET}
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -117,13 +117,7 @@ func hash(qname string, qtype uint16, do, cd bool) uint64 {
 }
 
 func computeTTL(msgTTL, minTTL, maxTTL time.Duration) time.Duration {
-	ttl := msgTTL
-	if ttl < minTTL {
-		ttl = minTTL
-	}
-	if ttl > maxTTL {
-		ttl = maxTTL
-	}
+	ttl := min(max(msgTTL, minTTL), maxTTL)
 	return ttl
 }
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -600,10 +600,8 @@ func BenchmarkCacheResponse(b *testing.B) {
 		reqs[i].SetQuestion(q+".example.org.", dns.TypeA)
 	}
 
-	b.StartTimer()
-
 	j := 0
-	for range b.N {
+	for b.Loop() {
 		req := reqs[j]
 		c.ServeDNS(ctx, &test.ResponseWriter{}, req)
 		j = (j + 1) % 5

--- a/plugin/debug/pcap.go
+++ b/plugin/debug/pcap.go
@@ -22,7 +22,7 @@ import (
 // is prefixed with 'debug: ' so the data can be easily extracted.
 //
 // msg will prefix the pcap dump.
-func Hexdump(m *dns.Msg, v ...interface{}) {
+func Hexdump(m *dns.Msg, v ...any) {
 	if !log.D.Value() {
 		return
 	}
@@ -38,7 +38,7 @@ func Hexdump(m *dns.Msg, v ...interface{}) {
 }
 
 // Hexdumpf dumps a DNS message as Hexdump, but allows a format string.
-func Hexdumpf(m *dns.Msg, format string, v ...interface{}) {
+func Hexdumpf(m *dns.Msg, format string, v ...any) {
 	if !log.D.Value() {
 		return
 	}

--- a/plugin/dns64/dns64.go
+++ b/plugin/dns64/dns64.go
@@ -160,10 +160,7 @@ func (d *DNS64) Synthesize(origReq, origResponse, resp *dns.Msg) *dns.Msg {
 		aaaa, _ := to6(d.Prefix, rr.(*dns.A).A)
 
 		// ttl is min of SOA TTL and A TTL
-		ttl := SOATtl
-		if rr.Header().Ttl < ttl {
-			ttl = rr.Header().Ttl
-		}
+		ttl := min(rr.Header().Ttl, SOATtl)
 
 		// Replace A answer with a DNS64 AAAA answer
 		ret.Answer = append(ret.Answer, &dns.AAAA{

--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -32,7 +32,7 @@ func periodicClean(c *cache.Cache, stop <-chan struct{}) {
 			// we sign for 8 days, check if a signature in the cache reached 75% of that (i.e. 6), if found delete
 			// the signature
 			is75 := time.Now().UTC().Add(twoDays)
-			c.Walk(func(items map[uint64]interface{}, key uint64) bool {
+			c.Walk(func(items map[uint64]any, key uint64) bool {
 				for _, rr := range items[key].([]dns.RR) {
 					if !rr.(*dns.RRSIG).ValidityPeriod(is75) {
 						delete(items, key)

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -118,7 +118,7 @@ func (d Dnssec) sign(rrs []dns.RR, signerName string, ttl, incep, expir uint32, 
 		return sgs, nil
 	}
 
-	sigs, err := d.inflight.Do(k, func() (interface{}, error) {
+	sigs, err := d.inflight.Do(k, func() (any, error) {
 		var sigs []dns.RR
 		for _, k := range d.keys {
 			if d.splitkeys {

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -3,6 +3,7 @@ package dnssec
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -94,13 +95,7 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 	// Check if each keys owner name can actually sign the zones we want them to sign.
 	for _, k := range keys {
 		kname := plugin.Name(k.K.Header().Name)
-		ok := false
-		for i := range zones {
-			if kname.Matches(zones[i]) {
-				ok = true
-				break
-			}
-		}
+		ok := slices.ContainsFunc(zones, kname.Matches)
 		if !ok {
 			return zones, keys, capacity, splitkeys, fmt.Errorf("key %s (keyid: %d) can not sign any of the zones", string(kname), k.tag)
 		}

--- a/plugin/errors/benchmark_test.go
+++ b/plugin/errors/benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkServeDNS(b *testing.B) {
 	w := &test.ResponseWriter{}
 	ctx := context.TODO()
 
-	for range b.N {
+	for b.Loop() {
 		_, err := h.ServeDNS(ctx, w, r)
 		if err != nil {
 			b.Errorf("ServeDNS returned error: %s", err)

--- a/plugin/errors/errors.go
+++ b/plugin/errors/errors.go
@@ -22,7 +22,7 @@ type pattern struct {
 	count       uint32
 	period      time.Duration
 	pattern     *regexp.Regexp
-	logCallback func(format string, v ...interface{})
+	logCallback func(format string, v ...any)
 }
 
 func (p *pattern) timer() *time.Timer {

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -73,7 +73,7 @@ func TestErrors(t *testing.T) {
 
 func TestLogPattern(t *testing.T) {
 	type args struct {
-		logCallback func(format string, v ...interface{})
+		logCallback func(format string, v ...any)
 	}
 	tests := []struct {
 		name string

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -89,7 +89,7 @@ func parseConsolidate(c *caddy.Controller) (*pattern, error) {
 	return &pattern{period: p, pattern: re, logCallback: lc}, nil
 }
 
-func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...interface{}), error) {
+func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...any), error) {
 	if len(args) != 3 {
 		return log.Errorf, nil
 	}

--- a/plugin/file/dnssec_test.go
+++ b/plugin/file/dnssec_test.go
@@ -167,9 +167,7 @@ func BenchmarkFileLookupDNSSEC(b *testing.B) {
 
 	m := tc.Msg()
 
-	b.ResetTimer()
-
-	for range b.N {
+	for b.Loop() {
 		fm.ServeDNS(ctx, rec, m)
 	}
 }

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BenchmarkFileParseInsert(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		Parse(strings.NewReader(dbMiekENTNL), testzone, "stdin", 0)
 	}
 }

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -316,9 +316,7 @@ func BenchmarkFileLookup(b *testing.B) {
 
 	m := tc.Msg()
 
-	b.ResetTimer()
-
-	for range b.N {
+	for b.Loop() {
 		fm.ServeDNS(ctx, rec, m)
 	}
 }

--- a/plugin/kubernetes/autopath_test.go
+++ b/plugin/kubernetes/autopath_test.go
@@ -68,9 +68,8 @@ func BenchmarkAutoPath(b *testing.B) {
 	state := request.Request{W: &test.ResponseWriter{}, Req: req}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		result := k.AutoPath(state)
 		_ = result
 	}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -239,7 +239,7 @@ func (dns *dnsControl) EndpointSliceLatencyRecorder() *object.EndpointLatencyRec
 	}
 }
 
-func podIPIndexFunc(obj interface{}) ([]string, error) {
+func podIPIndexFunc(obj any) ([]string, error) {
 	p, ok := obj.(*object.Pod)
 	if !ok {
 		return nil, errObj
@@ -247,7 +247,7 @@ func podIPIndexFunc(obj interface{}) ([]string, error) {
 	return []string{p.PodIP}, nil
 }
 
-func svcIPIndexFunc(obj interface{}) ([]string, error) {
+func svcIPIndexFunc(obj any) ([]string, error) {
 	svc, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -257,7 +257,7 @@ func svcIPIndexFunc(obj interface{}) ([]string, error) {
 	return idx, nil
 }
 
-func svcExtIPIndexFunc(obj interface{}) ([]string, error) {
+func svcExtIPIndexFunc(obj any) ([]string, error) {
 	svc, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -267,7 +267,7 @@ func svcExtIPIndexFunc(obj interface{}) ([]string, error) {
 	return idx, nil
 }
 
-func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func svcNameNamespaceIndexFunc(obj any) ([]string, error) {
 	s, ok := obj.(*object.Service)
 	if !ok {
 		return nil, errObj
@@ -275,7 +275,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.Index}, nil
 }
 
-func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func epNameNamespaceIndexFunc(obj any) ([]string, error) {
 	s, ok := obj.(*object.Endpoints)
 	if !ok {
 		return nil, errObj
@@ -283,7 +283,7 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.Index}, nil
 }
 
-func epIPIndexFunc(obj interface{}) ([]string, error) {
+func epIPIndexFunc(obj any) ([]string, error) {
 	ep, ok := obj.(*object.Endpoints)
 	if !ok {
 		return nil, errObj
@@ -291,7 +291,7 @@ func epIPIndexFunc(obj interface{}) ([]string, error) {
 	return ep.IndexIP, nil
 }
 
-func svcImportNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func svcImportNameNamespaceIndexFunc(obj any) ([]string, error) {
 	s, ok := obj.(*object.ServiceImport)
 	if !ok {
 		return nil, errObj
@@ -299,7 +299,7 @@ func svcImportNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.Index}, nil
 }
 
-func mcEpNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func mcEpNameNamespaceIndexFunc(obj any) ([]string, error) {
 	mcEp, ok := obj.(*object.MultiClusterEndpoints)
 	if !ok {
 		return nil, errObj
@@ -647,12 +647,12 @@ func (dns *dnsControl) GetNamespaceByName(name string) (*object.Namespace, error
 	return ns, nil
 }
 
-func (dns *dnsControl) Add(obj interface{})               { dns.updateModified() }
-func (dns *dnsControl) Delete(obj interface{})            { dns.updateModified() }
-func (dns *dnsControl) Update(oldObj, newObj interface{}) { dns.detectChanges(oldObj, newObj) }
+func (dns *dnsControl) Add(obj any)               { dns.updateModified() }
+func (dns *dnsControl) Delete(obj any)            { dns.updateModified() }
+func (dns *dnsControl) Update(oldObj, newObj any) { dns.detectChanges(oldObj, newObj) }
 
 // detectChanges detects changes in objects, and updates the modified timestamp
-func (dns *dnsControl) detectChanges(oldObj, newObj interface{}) {
+func (dns *dnsControl) detectChanges(oldObj, newObj any) {
 	// If both objects have the same resource version, they are identical.
 	if newObj != nil && oldObj != nil && (oldObj.(meta.Object).GetResourceVersion() == newObj.(meta.Object).GetResourceVersion()) {
 		return
@@ -771,7 +771,7 @@ func multiclusterEndpointsEquivalent(a, b *object.MultiClusterEndpoints) bool {
 // serviceModified checks the services passed for changes that result in changes
 // to internal and or external records.  It returns two booleans, one for internal
 // record changes, and a second for external record changes
-func serviceModified(oldObj, newObj interface{}) (intSvc, extSvc bool) {
+func serviceModified(oldObj, newObj any) (intSvc, extSvc bool) {
 	if oldObj != nil && newObj == nil {
 		// deleted service only modifies external zone records if it had external ips
 		return true, len(oldObj.(*object.Service).ExternalIPs) > 0
@@ -825,7 +825,7 @@ func serviceModified(oldObj, newObj interface{}) (intSvc, extSvc bool) {
 
 // serviceImportEquivalent checks if the update to a ServiceImport is something
 // that matters to us or if they are effectively equivalent.
-func serviceImportEquivalent(oldObj, newObj interface{}) bool {
+func serviceImportEquivalent(oldObj, newObj any) bool {
 	if oldObj != nil && newObj == nil {
 		return false
 	}

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -69,8 +69,7 @@ func BenchmarkController(b *testing.B) {
 	m := new(dns.Msg)
 	m.SetQuestion("svc1.testns.svc.cluster.local.", dns.TypeA)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		k.ServeDNS(ctx, rw, m)
 	}
 }
@@ -294,8 +293,8 @@ func createMultiClusterHeadlessSvc(suffix int, mcsClient mcsClientset.Multiclust
 
 func TestServiceModified(t *testing.T) {
 	tests := []struct {
-		oldSvc   interface{}
-		newSvc   interface{}
+		oldSvc   any
+		newSvc   any
 		ichanged bool
 		echanged bool
 	}{

--- a/plugin/kubernetes/logger.go
+++ b/plugin/kubernetes/logger.go
@@ -21,15 +21,15 @@ func (l *loggerAdapter) Enabled(_ int) bool {
 	return true
 }
 
-func (l *loggerAdapter) Info(_ int, msg string, _ ...interface{}) {
+func (l *loggerAdapter) Info(_ int, msg string, _ ...any) {
 	l.P.Info(msg)
 }
 
-func (l *loggerAdapter) Error(_ error, msg string, _ ...interface{}) {
+func (l *loggerAdapter) Error(_ error, msg string, _ ...any) {
 	l.P.Error(msg)
 }
 
-func (l *loggerAdapter) WithValues(_ ...interface{}) logr.LogSink {
+func (l *loggerAdapter) WithValues(_ ...any) logr.LogSink {
 	return l
 }
 

--- a/plugin/kubernetes/object/informer.go
+++ b/plugin/kubernetes/object/informer.go
@@ -28,7 +28,7 @@ type RecordLatencyFunc func(meta.Object)
 // DefaultProcessor is based on the Process function from cache.NewIndexerInformer except it does a conversion.
 func DefaultProcessor(convert ToFunc, recordLatency *EndpointLatencyRecorder) ProcessorBuilder {
 	return func(clientState cache.Indexer, h cache.ResourceEventHandler) cache.ProcessFunc {
-		return func(obj interface{}, isInitialList bool) error {
+		return func(obj any, isInitialList bool) error {
 			for _, d := range obj.(cache.Deltas) {
 				if recordLatency != nil {
 					if o, ok := d.Object.(meta.Object); ok {
@@ -59,7 +59,7 @@ func DefaultProcessor(convert ToFunc, recordLatency *EndpointLatencyRecorder) Pr
 						recordLatency.record()
 					}
 				case cache.Deleted:
-					var obj interface{}
+					var obj any
 					obj, ok := d.Object.(cache.DeletedFinalStateUnknown)
 					if !ok {
 						var err error

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -273,8 +273,7 @@ func BenchmarkLogged(b *testing.B) {
 
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 
-	b.StartTimer()
-	for range b.N {
+	for b.Loop() {
 		logger.ServeDNS(ctx, rec, r)
 	}
 }

--- a/plugin/pkg/cache/cache_test.go
+++ b/plugin/pkg/cache/cache_test.go
@@ -63,7 +63,7 @@ func TestCacheWalk(t *testing.T) {
 		exp[i] = 1
 	}
 	got := make([]int, 10*2)
-	c.Walk(func(items map[uint64]interface{}, key uint64) bool {
+	c.Walk(func(items map[uint64]any, key uint64) bool {
 		got[key] = items[key].(int)
 		return true
 	})
@@ -78,7 +78,7 @@ func BenchmarkCache(b *testing.B) {
 	b.ReportAllocs()
 
 	c := New(4)
-	for range b.N {
+	for b.Loop() {
 		c.Add(1, 1)
 		c.Get(1)
 	}

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -62,8 +62,7 @@ func BenchmarkMinimalTTL(b *testing.B) {
 	utc := time.Now().UTC()
 	mt, _ := response.Typify(m, utc)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		dur := MinimalTTL(m, mt)
 		if dur != 1000*time.Second {
 			b.Fatalf("Wrong MinimalTTL %d, expected %d", dur, 1000*time.Second)

--- a/plugin/pkg/expression/expression.go
+++ b/plugin/pkg/expression/expression.go
@@ -10,8 +10,8 @@ import (
 )
 
 // DefaultEnv returns the default set of custom state variables and functions available to for use in expression evaluation.
-func DefaultEnv(ctx context.Context, state *request.Request) map[string]interface{} {
-	return map[string]interface{}{
+func DefaultEnv(ctx context.Context, state *request.Request) map[string]any {
+	return map[string]any{
 		"incidr": func(ipStr, cidrStr string) (bool, error) {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {

--- a/plugin/pkg/log/listener.go
+++ b/plugin/pkg/log/listener.go
@@ -9,16 +9,16 @@ import (
 // A usage example is, the external plugin k8s_event will replicate log prints to Kubernetes events.
 type Listener interface {
 	Name() string
-	Debug(plugin string, v ...interface{})
-	Debugf(plugin string, format string, v ...interface{})
-	Info(plugin string, v ...interface{})
-	Infof(plugin string, format string, v ...interface{})
-	Warning(plugin string, v ...interface{})
-	Warningf(plugin string, format string, v ...interface{})
-	Error(plugin string, v ...interface{})
-	Errorf(plugin string, format string, v ...interface{})
-	Fatal(plugin string, v ...interface{})
-	Fatalf(plugin string, format string, v ...interface{})
+	Debug(plugin string, v ...any)
+	Debugf(plugin string, format string, v ...any)
+	Info(plugin string, v ...any)
+	Infof(plugin string, format string, v ...any)
+	Warning(plugin string, v ...any)
+	Warningf(plugin string, format string, v ...any)
+	Error(plugin string, v ...any)
+	Errorf(plugin string, format string, v ...any)
+	Fatal(plugin string, v ...any)
+	Fatalf(plugin string, format string, v ...any)
 }
 
 type listeners struct {
@@ -60,7 +60,7 @@ func DeregisterListener(old Listener) error {
 	return nil
 }
 
-func (ls *listeners) debug(plugin string, v ...interface{}) {
+func (ls *listeners) debug(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Debug(plugin, v...)
@@ -68,7 +68,7 @@ func (ls *listeners) debug(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) debugf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) debugf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Debugf(plugin, format, v...)
@@ -76,7 +76,7 @@ func (ls *listeners) debugf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) info(plugin string, v ...interface{}) {
+func (ls *listeners) info(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Info(plugin, v...)
@@ -84,7 +84,7 @@ func (ls *listeners) info(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) infof(plugin string, format string, v ...interface{}) {
+func (ls *listeners) infof(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Infof(plugin, format, v...)
@@ -92,7 +92,7 @@ func (ls *listeners) infof(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) warning(plugin string, v ...interface{}) {
+func (ls *listeners) warning(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Warning(plugin, v...)
@@ -100,7 +100,7 @@ func (ls *listeners) warning(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) warningf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) warningf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Warningf(plugin, format, v...)
@@ -108,7 +108,7 @@ func (ls *listeners) warningf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) error(plugin string, v ...interface{}) {
+func (ls *listeners) error(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Error(plugin, v...)
@@ -116,7 +116,7 @@ func (ls *listeners) error(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) errorf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) errorf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Errorf(plugin, format, v...)
@@ -124,7 +124,7 @@ func (ls *listeners) errorf(plugin string, format string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) fatal(plugin string, v ...interface{}) {
+func (ls *listeners) fatal(plugin string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Fatal(plugin, v...)
@@ -132,7 +132,7 @@ func (ls *listeners) fatal(plugin string, v ...interface{}) {
 	ls.RUnlock()
 }
 
-func (ls *listeners) fatalf(plugin string, format string, v ...interface{}) {
+func (ls *listeners) fatalf(plugin string, format string, v ...any) {
 	ls.RLock()
 	for _, l := range ls.listeners {
 		l.Fatalf(plugin, format, v...)

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -80,42 +80,42 @@ func (l *mockListener) Name() string {
 	return l.name
 }
 
-func (l *mockListener) Debug(plugin string, v ...interface{}) {
+func (l *mockListener) Debug(plugin string, v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Debugf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Debugf(plugin string, format string, v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Info(plugin string, v ...interface{}) {
+func (l *mockListener) Info(plugin string, v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Infof(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Infof(plugin string, format string, v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Warning(plugin string, v ...interface{}) {
+func (l *mockListener) Warning(plugin string, v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Warningf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Warningf(plugin string, format string, v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Error(plugin string, v ...interface{}) {
+func (l *mockListener) Error(plugin string, v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Errorf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Errorf(plugin string, format string, v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Fatal(plugin string, v ...interface{}) {
+func (l *mockListener) Fatal(plugin string, v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }
 
-func (l *mockListener) Fatalf(plugin string, format string, v ...interface{}) {
+func (l *mockListener) Fatalf(plugin string, format string, v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -40,18 +40,18 @@ func (d *d) Value() bool {
 }
 
 // logf calls log.Printf prefixed with level.
-func logf(level, format string, v ...interface{}) {
+func logf(level, format string, v ...any) {
 	golog.Print(level, fmt.Sprintf(format, v...))
 }
 
 // log calls log.Print prefixed with level.
-func log(level string, v ...interface{}) {
+func log(level string, v ...any) {
 	golog.Print(level, fmt.Sprint(v...))
 }
 
 // Debug is equivalent to log.Print(), but prefixed with "[DEBUG] ". It only outputs something
 // if D is true.
-func Debug(v ...interface{}) {
+func Debug(v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -60,7 +60,7 @@ func Debug(v ...interface{}) {
 
 // Debugf is equivalent to log.Printf(), but prefixed with "[DEBUG] ". It only outputs something
 // if D is true.
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -68,30 +68,30 @@ func Debugf(format string, v ...interface{}) {
 }
 
 // Info is equivalent to log.Print, but prefixed with "[INFO] ".
-func Info(v ...interface{}) { log(info, v...) }
+func Info(v ...any) { log(info, v...) }
 
 // Infof is equivalent to log.Printf, but prefixed with "[INFO] ".
-func Infof(format string, v ...interface{}) { logf(info, format, v...) }
+func Infof(format string, v ...any) { logf(info, format, v...) }
 
 // Warning is equivalent to log.Print, but prefixed with "[WARNING] ".
-func Warning(v ...interface{}) { log(warning, v...) }
+func Warning(v ...any) { log(warning, v...) }
 
 // Warningf is equivalent to log.Printf, but prefixed with "[WARNING] ".
-func Warningf(format string, v ...interface{}) { logf(warning, format, v...) }
+func Warningf(format string, v ...any) { logf(warning, format, v...) }
 
 // Error is equivalent to log.Print, but prefixed with "[ERROR] ".
-func Error(v ...interface{}) { log(err, v...) }
+func Error(v ...any) { log(err, v...) }
 
 // Errorf is equivalent to log.Printf, but prefixed with "[ERROR] ".
-func Errorf(format string, v ...interface{}) { logf(err, format, v...) }
+func Errorf(format string, v ...any) { logf(err, format, v...) }
 
 // Fatal is equivalent to log.Print, but prefixed with "[FATAL] ", and calling
 // os.Exit(1).
-func Fatal(v ...interface{}) { log(fatal, v...); os.Exit(1) }
+func Fatal(v ...any) { log(fatal, v...); os.Exit(1) }
 
 // Fatalf is equivalent to log.Printf, but prefixed with "[FATAL] ", and calling
 // os.Exit(1)
-func Fatalf(format string, v ...interface{}) { logf(fatal, format, v...); os.Exit(1) }
+func Fatalf(format string, v ...any) { logf(fatal, format, v...); os.Exit(1) }
 
 // Discard sets the log output to /dev/null.
 func Discard() { golog.SetOutput(io.Discard) }

--- a/plugin/pkg/log/plugin.go
+++ b/plugin/pkg/log/plugin.go
@@ -14,16 +14,16 @@ type P struct {
 // I.e [INFO] plugin/<name>: message.
 func NewWithPlugin(name string) P { return P{"plugin/" + name + ": "} }
 
-func (p P) logf(level, format string, v ...interface{}) {
+func (p P) logf(level, format string, v ...any) {
 	log(level, p.plugin, fmt.Sprintf(format, v...))
 }
 
-func (p P) log(level string, v ...interface{}) {
+func (p P) log(level string, v ...any) {
 	log(level+p.plugin, v...)
 }
 
 // Debug logs as log.Debug.
-func (p P) Debug(v ...interface{}) {
+func (p P) Debug(v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -32,7 +32,7 @@ func (p P) Debug(v ...interface{}) {
 }
 
 // Debugf logs as log.Debugf.
-func (p P) Debugf(format string, v ...interface{}) {
+func (p P) Debugf(format string, v ...any) {
 	if !D.Value() {
 		return
 	}
@@ -41,50 +41,50 @@ func (p P) Debugf(format string, v ...interface{}) {
 }
 
 // Info logs as log.Info.
-func (p P) Info(v ...interface{}) {
+func (p P) Info(v ...any) {
 	ls.info(p.plugin, v...)
 	p.log(info, v...)
 }
 
 // Infof logs as log.Infof.
-func (p P) Infof(format string, v ...interface{}) {
+func (p P) Infof(format string, v ...any) {
 	ls.infof(p.plugin, format, v...)
 	p.logf(info, format, v...)
 }
 
 // Warning logs as log.Warning.
-func (p P) Warning(v ...interface{}) {
+func (p P) Warning(v ...any) {
 	ls.warning(p.plugin, v...)
 	p.log(warning, v...)
 }
 
 // Warningf logs as log.Warningf.
-func (p P) Warningf(format string, v ...interface{}) {
+func (p P) Warningf(format string, v ...any) {
 	ls.warningf(p.plugin, format, v...)
 	p.logf(warning, format, v...)
 }
 
 // Error logs as log.Error.
-func (p P) Error(v ...interface{}) {
+func (p P) Error(v ...any) {
 	ls.error(p.plugin, v...)
 	p.log(err, v...)
 }
 
 // Errorf logs as log.Errorf.
-func (p P) Errorf(format string, v ...interface{}) {
+func (p P) Errorf(format string, v ...any) {
 	ls.errorf(p.plugin, format, v...)
 	p.logf(err, format, v...)
 }
 
 // Fatal logs as log.Fatal and calls os.Exit(1).
-func (p P) Fatal(v ...interface{}) {
+func (p P) Fatal(v ...any) {
 	ls.fatal(p.plugin, v...)
 	p.log(fatal, v...)
 	os.Exit(1)
 }
 
 // Fatalf logs as log.Fatalf and calls os.Exit(1).
-func (p P) Fatalf(format string, v ...interface{}) {
+func (p P) Fatalf(format string, v ...any) {
 	ls.fatalf(p.plugin, format, v...)
 	p.logf(fatal, format, v...)
 	os.Exit(1)

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -123,10 +123,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options
 	}
 
 	// Set buffer size correctly for this client.
-	pc.c.UDPSize = uint16(state.Size())
-	if pc.c.UDPSize < 512 {
-		pc.c.UDPSize = 512
-	}
+	pc.c.UDPSize = max(uint16(state.Size()), 512)
 
 	pc.c.SetWriteDeadline(time.Now().Add(maxTimeout))
 	// records the origin Id before upstream.

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -256,7 +256,7 @@ func loadFormat(s string) replacer {
 
 // bufPool stores pointers to scratch buffers.
 var bufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return make([]byte, 0, 256)
 	},
 }

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -272,11 +272,10 @@ func BenchmarkReplacer(b *testing.B) {
 	r.AuthenticatedData = true
 	state := request.Request{W: w, Req: r}
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
 	replacer := New()
-	for range b.N {
+	for b.Loop() {
 		replacer.Replace(context.TODO(), state, nil, "{type} {name} {size}")
 	}
 }
@@ -295,15 +294,14 @@ func BenchmarkReplacer_CommonLogFormat(b *testing.B) {
 	replacer := New()
 	ctxt := context.TODO()
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		replacer.Replace(ctxt, state, w, CommonLogFormat)
 	}
 }
 
 func BenchmarkParseFormat(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		parseFormat(CommonLogFormat)
 	}
 }

--- a/plugin/pkg/singleflight/singleflight.go
+++ b/plugin/pkg/singleflight/singleflight.go
@@ -23,7 +23,7 @@ import "sync"
 // call is an in-flight or completed Do call
 type call struct {
 	wg  sync.WaitGroup
-	val interface{}
+	val any
 	err error
 }
 
@@ -38,7 +38,7 @@ type Group struct {
 // sure that only one execution is in-flight for a given key at a
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
-func (g *Group) Do(key uint64, fn func() (interface{}, error)) (interface{}, error) {
+func (g *Group) Do(key uint64, fn func() (any, error)) (any, error) {
 	g.mu.Lock()
 	if g.m == nil {
 		g.m = make(map[uint64]*call)

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDo(t *testing.T) {
 	var g Group
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do(1, func() (any, error) {
 		return "bar", nil
 	})
 	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
@@ -41,7 +41,7 @@ func TestDo(t *testing.T) {
 func TestDoErr(t *testing.T) {
 	var g Group
 	someErr := errors.New("some error")
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do(1, func() (any, error) {
 		return nil, someErr
 	})
 	if err != someErr {
@@ -56,7 +56,7 @@ func TestDoDupSuppress(t *testing.T) {
 	var g Group
 	c := make(chan string)
 	var calls int32
-	fn := func() (interface{}, error) {
+	fn := func() (any, error) {
 		atomic.AddInt32(&calls, 1)
 		return <-c, nil
 	}

--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -60,7 +60,7 @@ func parse(corefile caddy.Input) ([]byte, error) {
 	return json.Marshal(serverBlocks)
 }
 
-func hook(event caddy.EventName, info interface{}) error {
+func hook(event caddy.EventName, info any) error {
 	if event != caddy.InstanceStartupEvent {
 		return nil
 	}

--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -40,8 +40,8 @@ func (r *cnameTargetRule) getFromAndToTarget(inputCName string) (from string, to
 	case ExactMatch:
 		return r.paramFromTarget, r.paramToTarget
 	case PrefixMatch:
-		if strings.HasPrefix(inputCName, r.paramFromTarget) {
-			return inputCName, r.paramToTarget + strings.TrimPrefix(inputCName, r.paramFromTarget)
+		if after, ok := strings.CutPrefix(inputCName, r.paramFromTarget); ok {
+			return inputCName, r.paramToTarget + after
 		}
 	case SuffixMatch:
 		if strings.HasSuffix(inputCName, r.paramFromTarget) {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -203,8 +203,8 @@ func newPrefixNameRule(nextAction string, auto bool, prefix, replacement string,
 }
 
 func (rule *prefixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
-	if strings.HasPrefix(state.Name(), rule.prefix) {
-		state.Req.Question[0].Name = rule.replacement + strings.TrimPrefix(state.Name(), rule.prefix)
+	if after, ok := strings.CutPrefix(state.Name(), rule.prefix); ok {
+		state.Req.Question[0].Name = rule.replacement + after
 		return rule.responseRuleFor(state)
 	}
 	return nil, RewriteIgnored

--- a/plugin/rewrite/name_test.go
+++ b/plugin/rewrite/name_test.go
@@ -33,8 +33,7 @@ func TestRewriteIllegalName(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffix(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string
@@ -75,8 +74,7 @@ func TestRewriteNamePrefixSuffix(t *testing.T) {
 }
 
 func TestRewriteNameNoRewrite(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string
@@ -117,8 +115,7 @@ func TestRewriteNameNoRewrite(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffixNoAutoAnswer(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string
@@ -159,8 +156,7 @@ func TestRewriteNamePrefixSuffixNoAutoAnswer(t *testing.T) {
 }
 
 func TestRewriteNamePrefixSuffixAutoAnswer(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string
@@ -207,8 +203,7 @@ func TestRewriteNamePrefixSuffixAutoAnswer(t *testing.T) {
 }
 
 func TestRewriteNameExactAnswer(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string
@@ -255,8 +250,7 @@ func TestRewriteNameExactAnswer(t *testing.T) {
 }
 
 func TestRewriteNameRegexAnswer(t *testing.T) {
-	ctx, close := context.WithCancel(context.TODO())
-	defer close()
+	ctx := t.Context()
 
 	tests := []struct {
 		next     string

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -75,8 +75,7 @@ func (fakeRoute53) ListResourceRecordSets(_ context.Context, in *route53.ListRes
 }
 
 func TestRoute53(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Minute)
 	if err != nil {

--- a/plugin/sign/nsec.go
+++ b/plugin/sign/nsec.go
@@ -1,7 +1,7 @@
 package sign
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/coredns/coredns/plugin/file"
 	"github.com/coredns/coredns/plugin/file/tree"
@@ -26,7 +26,7 @@ func names(origin string, z *file.Zone) []string {
 
 // NSEC returns an NSEC record according to name, next, ttl and bitmap. Note that the bitmap is sorted before use.
 func NSEC(name, next string, ttl uint32, bitmap []uint16) *dns.NSEC {
-	sort.Slice(bitmap, func(i, j int) bool { return bitmap[i] < bitmap[j] })
+	slices.Sort(bitmap)
 
 	return &dns.NSEC{
 		Hdr:        dns.RR_Header{Name: name, Ttl: ttl, Rrtype: dns.TypeNSEC, Class: dns.ClassINET},

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -36,10 +36,10 @@ import (
 type (
 	// MetricFamily holds a prometheus metric.
 	MetricFamily struct {
-		Name    string        `json:"name"`
-		Help    string        `json:"help"`
-		Type    string        `json:"type"`
-		Metrics []interface{} `json:"metrics,omitempty"` // Either metric or summary.
+		Name    string `json:"name"`
+		Help    string `json:"help"`
+		Type    string `json:"type"`
+		Metrics []any  `json:"metrics,omitempty"` // Either metric or summary.
 	}
 
 	// metric is for all "single value" metrics.
@@ -150,7 +150,7 @@ func newMetricFamily(dtoMF *dto.MetricFamily) *MetricFamily {
 		Name:    dtoMF.GetName(),
 		Help:    dtoMF.GetHelp(),
 		Type:    dtoMF.GetType().String(),
-		Metrics: make([]interface{}, len(dtoMF.GetMetric())),
+		Metrics: make([]any, len(dtoMF.GetMetric())),
 	}
 	for i, m := range dtoMF.GetMetric() {
 		if dtoMF.GetType() == dto.MetricType_SUMMARY {

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -319,7 +319,7 @@ func TestRequestMatch(t *testing.T) {
 func BenchmarkRequestDo(b *testing.B) {
 	st := testRequest()
 
-	for range b.N {
+	for b.Loop() {
 		st.Do()
 	}
 }
@@ -327,7 +327,7 @@ func BenchmarkRequestDo(b *testing.B) {
 func BenchmarkRequestSize(b *testing.B) {
 	st := testRequest()
 
-	for range b.N {
+	for b.Loop() {
 		st.Size()
 	}
 }
@@ -346,8 +346,7 @@ func BenchmarkRequestScrub(b *testing.B) {
 			fmt.Sprintf("10-0-0-%d.default.pod.k8s.example.com. 10 IN A 10.0.0.%d", i, i)))
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		st.Scrub(reply.Copy())
 	}
 }

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -70,8 +70,7 @@ func BenchmarkProxyLookup(b *testing.B) {
 	m := new(dns.Msg)
 	m.SetQuestion("example.org.", dns.TypeA)
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		if _, err := dns.Exchange(m, udp); err != nil {
 			b.Fatal("Expected to receive reply, but didn't")
 		}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Use modern Go constructs through the modernize analyzer from the [golang.org/x/tools package](https://pkg.go.dev/golang.org/x/tools/gopls@v0.20.0/internal/analysis/modernize). Sadly not part of `golangci-lint`.

Add a separate linter step to run `modernize -diff -test ./...` command. It prints out the analyzer output, so it's clear what needs to be done to remediate. Looks like this:

```
/git/coredns/plugin/pkg/log/listener.go:12:28: interface{} can be replaced by any
/git/coredns/plugin/backend_lookup.go:473:5: if statement can be modernized using min
/git/coredns/core/dnsserver/server.go:103:4: Replace m[k]=v loop with maps.Copy
...
```

The analyzer is compatible with the Go versions used by CoreDNS (1.24, 1.25). 

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
