### PR TITLE
test(metrics): improve test coverage

### DIFF
--- a/plugin/metrics/setup_test.go
+++ b/plugin/metrics/setup_test.go
@@ -40,3 +40,10 @@ func TestPrometheusParse(t *testing.T) {
 		}
 	}
 }
+
+func TestSetupBasic(t *testing.T) {
+	c := caddy.NewTestController("dns", "prometheus localhost:9153")
+	if err := setup(c); err != nil {
+		t.Fatalf("setup returned error: %v", err)
+	}
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add more unit tests for metrics plugin, around registration deduplication, zone management, restart/shutdown behavior and context helpers.

Increases test coverage from 54.8% to 76.1%.

Note: tests fail on linting until #7539 is merged in.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, purely internal tests.
