### PR TITLE
fix: lint issues from plugin/forward and plugin/pkg/dnstest

### DIFF
--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -429,7 +429,6 @@ func TestFailfastAllUnhealthyUpstreams(t *testing.T) {
 }
 
 func TestFailover(t *testing.T) {
-
 	server_fail_s := dnstest.NewMultipleServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetRcode(r, dns.RcodeServerFailure)

--- a/plugin/pkg/dnstest/server.go
+++ b/plugin/pkg/dnstest/server.go
@@ -65,10 +65,10 @@ func NewMultipleServer(f dns.HandlerFunc) *Server {
 	ch2 := make(chan bool)
 
 	s1 := &dns.Server{
-		Handler: dns.HandlerFunc(f),
+		Handler: f,
 	} // udp
 	s2 := &dns.Server{
-		Handler: dns.HandlerFunc(f),
+		Handler: f,
 	} // tcp
 
 	for range 5 { // 5 attempts


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

To fix CI pipeline issues on `master` branch: 

```
plugin/pkg/dnstest/server.go:68:27: unnecessary conversion (unconvert)
                Handler: dns.HandlerFunc(f),
                                        ^
plugin/pkg/dnstest/server.go:71:27: unnecessary conversion (unconvert)
                Handler: dns.HandlerFunc(f),
                                        ^
plugin/forward/setup_test.go:431:34: unnecessary leading newline (whitespace)
func TestFailover(t *testing.T) {
                                 ^
```

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
