### PR TITLE
fix(plugin): nilness findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,9 @@ linters:
       - legacy
       - std-error-handling
   settings:
+    govet:
+      enable:
+        - nilness
     revive:
       rules:
         - name: blank-imports

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -111,7 +111,7 @@ func TestMultiDnstap(t *testing.T) {
 	handlers := dnsserver.GetConfig(c).Handlers()
 	d1, ok := handlers[0].(*Dnstap)
 	if !ok {
-		t.Fatalf("expected first plugin to be Dnstap, got %v", reflect.TypeOf(d1.Next))
+		t.Fatalf("expected first plugin to be Dnstap, got %v", reflect.TypeOf(handlers[0]))
 	}
 
 	if d1.io.(*dio).endpoint != "dnstap1.sock" {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -112,7 +112,6 @@ func TestSetupTLS(t *testing.T) {
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
 		fs, err := parseForward(c)
-		f := fs[0]
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
@@ -127,6 +126,8 @@ func TestSetupTLS(t *testing.T) {
 				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
 			}
 		}
+
+		f := fs[0]
 
 		if !test.shouldErr && test.expectedServerName != "" && test.expectedServerName != f.tlsConfig.ServerName {
 			t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedServerName, f.tlsConfig.ServerName)
@@ -314,7 +315,7 @@ func TestMultiForward(t *testing.T) {
 	handlers := dnsserver.GetConfig(c).Handlers()
 	f1, ok := handlers[0].(*Forward)
 	if !ok {
-		t.Fatalf("expected first plugin to be Forward, got %v", reflect.TypeOf(f1.Next))
+		t.Fatalf("expected first plugin to be Forward, got %v", reflect.TypeOf(handlers[0]))
 	}
 
 	if f1.from != "1st.example.org." {

--- a/plugin/transfer/notify.go
+++ b/plugin/transfer/notify.go
@@ -39,10 +39,11 @@ func (t *Transfer) Notify(zone string) error {
 
 func sendNotify(c *dns.Client, m *dns.Msg, s string) error {
 	var err error
+	var ret *dns.Msg
 
 	code := dns.RcodeServerFailure
 	for range 3 {
-		ret, _, err := c.Exchange(m, s)
+		ret, _, err = c.Exchange(m, s)
 		if err != nil {
 			continue
 		}

--- a/plugin/view/setup.go
+++ b/plugin/view/setup.go
@@ -52,9 +52,6 @@ func parse(c *caddy.Controller) (*View, error) {
 					return v, err
 				}
 				v.progs = append(v.progs, prog)
-				if err != nil {
-					return nil, err
-				}
 				continue
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

PR to fix findings from the [Go nilness analyser](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness). This PR also enables the linter should these ever pop up again.

Plugin-by-plugin rationale:

- `plugin/transfer`: reuse error instead of shadowing it inside the for loop by declaring `ret` outside of the loop
- `plugin/view`: remove redundant err check
- `plugin/dnstap`: avoid possible nil dereference in error reporting path in setup test
- `plugin/forward`: prevent nil deference or empty-slice dereference on error paths in setup test

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, just a code quality improvement.
