### PR TITLE
fix(dnstap): add bounds for plugin args

### DIFF
--- a/plugin/dnstap/README.md
+++ b/plugin/dnstap/README.md
@@ -25,10 +25,13 @@ dnstap SOCKET [full] [writebuffer] [queue] {
 
 * **SOCKET** is the socket (path) supplied to the dnstap command line tool.
 * `full` to include the wire-format DNS message.
+* **writebuffer** sets the TCP write buffer multiplier in MiB. Valid range: [1, 1024].
+* **queue** sets the queue multiplier, applied to 10,000 messages. Valid range: [1, 4096].
 * **IDENTITY** to override the identity of the server. Defaults to the hostname.
 * **VERSION** to override the version field. Defaults to the CoreDNS version.
 * **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
 * `skipverify` to skip tls verification during connection. Default to be secure
+
 
 ## Examples
 
@@ -38,7 +41,7 @@ Log information about client requests and responses to */tmp/dnstap.sock*.
 dnstap /tmp/dnstap.sock
 ~~~
 
-Log information about client requests and responses and tcp write buffer is 1024*Mb and queue is 2048*10000. 
+Log information about client requests and responses with a custom TCP write buffer (1024 MiB) and queue capacity (2048 x 10000).
 
 ~~~ txt
 dnstap /tmp/dnstap.sock full 1024 2048

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -54,6 +54,14 @@ func TestConfig(t *testing.T) {
 		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
 		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
 		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{"dnstap.sock", false, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		// Limits and parsing for writebuffer (MiB) and queue (x10k)
+		{"dnstap dnstap.sock full 1024 2048", false, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1024, 2048}}},
+		{"dnstap dnstap.sock full 1025 1", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		{"dnstap dnstap.sock full 1 4097", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		{"dnstap dnstap.sock full 0 10", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		{"dnstap dnstap.sock full 10 0", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		{"dnstap dnstap.sock full x 10", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
+		{"dnstap dnstap.sock full 10 y", true, []results{{"dnstap.sock", true, "unix", []byte(hostname), []byte("-"), "", 1, 1}}},
 	}
 	for i, tc := range tests {
 		c := caddy.NewTestController("dns", tc.in)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Validate dnstap writebuffer (MiB) and queue (x10k) args. Reject non-integers and out-of-range values with clear errors. Updated plugin documentation and tests.

Should fix the following OSS-Fuzz findings:

- [go-coredns:fuzz_core: ASSERT: makechan: size out of range](https://issues.oss-fuzz.com/issues/376091887)
- [go-coredns:fuzz_core: Fatal error in out of memory](https://issues.oss-fuzz.com/issues/386547446)

Verified locally that the reproducer didn't work after the patch. Should clear out automatically after this PR is merged in.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

Added additional documentation on TCP max buffer size and queue capacity for the plugin.

### 4. Does this introduce a backward incompatible change or deprecation?

The sizes are quite generous I think. Should not be an incompatible change.
