### PR TITLE
fix(forward): deflake TestFailover

### DIFF
--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -482,6 +483,12 @@ func TestFailover(t *testing.T) {
 		}
 		f.OnStartup()
 		defer f.OnShutdown()
+
+		// Reduce per-upstream read timeout to make the test fit within the
+		// per-query deadline defaultTimeout of 5 seconds.
+		for _, p := range f.proxies {
+			p.SetReadTimeout(500 * time.Millisecond)
+		}
 
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

In CI, the first two upstream attempts can stall on UDP and each consume the default 2s read timeout. Possibly exhausting most of the 5s forward deadline before the healthy third upstream is tried. Lower the read timeout to make retries faster.

### 2. Which issues (if any) are related?

CI failures as of late, see [this CI run](https://github.com/coredns/coredns/actions/runs/17741389383/job/50415955446) for an example.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, tests only change.
