### PR TITLE
plugin: Make RFC 8490 DNS Stateful Operations plugins possible

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -79,6 +79,8 @@ type Config struct {
 
 	// Compiled plugin stack.
 	pluginChain plugin.Handler
+	// Compiled DSO plugin stack.
+	dsoPluginChain plugin.DSOHandler
 
 	// Plugin interested in announcing that they exist, so other plugin can call methods
 	// on them should register themselves here. The name should be the name as return by the


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Make DSO plugins possible.

CoreDNS's plugin chain expects each DNS message to have at least one resource record in the Question section. DSO messages never satisfy this requirement since they substitute TLVs for traditional resource records, making the existing plugin chain unsuitable.

This PR adds a new chain: `Config.dsoPluginChain`. Plugins signal DSO message support by implementing the `DSOHandler` interface. When implemented, `DSOHandler.SetNextDSO` is called during `NewServer` to link with the DSO chain. If the server has at least one DSO plugin configured, `dns.Server.MsgAcceptFunc` is modified to accept DSO messages.

Name-based message routing is impossible with DSO. Therefore, DSO plugins must only be listed in the root zone config in Corefile. Note that `Request.Name()` returns the correct value for DSO messages despite the empty Question section.

When the server receives a DSO message and a DSO plugin exists in the root zone config, the plugin's `ServeDSO` is called. The plugin can either handle the message or pass down the chain via `plugin.NextOrFailure` using the value it received in `DSOHandler.SetNextDSO`.

This change is an independent step toward https://github.com/coredns/coredns/pull/7511.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

Documentation on writing plugins should mention how to handle DSO messages.

### 4. Does this introduce a backward incompatible change or deprecation?

No
