### PR TITLE
fix: prevent SIGTERM/reload deadlock

### DIFF
--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -105,6 +105,10 @@ func hook(event caddy.EventName, info any) error {
 					// now lets consider that plugin will not be reload, unless appear in next config file
 					// change status of usage will be reset in setup if the plugin appears in config file
 					r.setUsage(maybeUsed)
+					// If shutdown is in progress, avoid attempting a restart.
+					if shutdownRequested(r.quit) {
+						return
+					}
 					_, err := instance.Restart(corefile)
 					reloadInfo.WithLabelValues("sha512", hex.EncodeToString(sha512sum[:])).Set(1)
 					if err != nil {
@@ -125,4 +129,15 @@ func hook(event caddy.EventName, info any) error {
 	}()
 
 	return nil
+}
+
+// shutdownRequested reports whether a shutdown has been requested via quit channel.
+// helps with unit testing of the shutdown gate logic.
+func shutdownRequested(quit <-chan bool) bool {
+	select {
+	case <-quit:
+		return true
+	default:
+		return false
+	}
 }

--- a/plugin/reload/reload_test.go
+++ b/plugin/reload/reload_test.go
@@ -1,0 +1,50 @@
+package reload
+
+import (
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+// fakeInput implements caddy.Input for testing parse().
+type fakeInput struct {
+	p string
+	b []byte
+}
+
+func (f fakeInput) ServerType() string { return "dns" }
+func (f fakeInput) Body() []byte       { return f.b }
+func (f fakeInput) Path() string       { return f.p }
+
+// TestParseInvalidCorefile ensures parse returns an error for invalid Corefile syntax.
+func TestParseInvalidCorefile(t *testing.T) {
+	t.Parallel()
+
+	broken := fakeInput{p: "Corefile", b: []byte(". { errors\n")}
+	if _, err := parse(broken); err == nil {
+		t.Fatalf("expected parse error for invalid Corefile, got nil")
+	}
+}
+
+// TestShutdownGate ensures the shutdown gate helper recognizes when shutdown is requested.
+func TestShutdownGate(t *testing.T) {
+	t.Parallel()
+
+	q := make(chan bool, 1)
+	if shutdownRequested(q) {
+		t.Fatalf("expected no shutdown before signal")
+	}
+	q <- true
+	if !shutdownRequested(q) {
+		t.Fatalf("expected shutdown after signal")
+	}
+}
+
+// TestHookIgnoresNonStartupEvent ensures hook is a no-op for non-startup events.
+func TestHookIgnoresNonStartupEvent(t *testing.T) {
+	t.Parallel()
+
+	if err := hook(caddy.EventName("not-startup"), nil); err != nil {
+		t.Fatalf("expected no error for non-startup event, got %v", err)
+	}
+}

--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -20,7 +20,7 @@ func init() { plugin.Register("reload", setup) }
 // channel for QUIT is never changed in purpose.
 // WARNING: this data may be unsync after an invalid attempt of reload Corefile.
 var (
-	r              = reload{dur: defaultInterval, u: unused, quit: make(chan bool)}
+	r              = reload{dur: defaultInterval, u: unused, quit: make(chan bool, 1)}
 	once, shutOnce sync.Once
 )
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -378,6 +379,59 @@ func TestReloadUnreadyPlugin(t *testing.T) {
 	}
 
 	c1.Stop()
+}
+
+// TestReloadConcurrentRestartAndStop ensures there is no deadlock when a restart
+// races with a shutdown (issue #7314).
+func TestReloadConcurrentRestartAndStop(t *testing.T) {
+	corefileA := `.:0 {
+		reload 2s 1s
+		whoami
+	}`
+	corefileB := `.:0 {
+		reload 2s 1s
+		whoami
+		# change to trigger different config
+	}`
+
+	c, err := CoreDNSServer(corefileA)
+	if err != nil {
+		if strings.Contains(err.Error(), inUse) {
+			return
+		}
+		t.Fatalf("Could not start CoreDNS instance: %v", err)
+	}
+
+	restartErr := make(chan error, 1)
+	stopDone := make(chan struct{})
+
+	go func() {
+		_, err := c.Restart(NewInput(corefileB))
+		restartErr <- err
+	}()
+
+	// Small delay to increase overlap window
+	time.Sleep(50 * time.Millisecond)
+
+	go func() {
+		c.Stop()
+		close(stopDone)
+	}()
+
+	// Both operations should complete promptly; if not, we may be deadlocked.
+	select {
+	case <-stopDone:
+		// ok
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Stop did not complete in time (possible deadlock)")
+	}
+	select {
+	case <-restartErr:
+		// ok: restart either succeeded or returned an error
+		// we only care about not hanging
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Restart did not complete in time (possible deadlock)")
+	}
 }
 
 type unready struct {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

CoreDNS could deadlock when SIGTERM arrived during an in-flight reload. Caddy’s shutdown path held the instance mutex while the reload plugin’s final-shutdown callback attempted to send on an unbuffered channel. The reload goroutine was simultaneously trying to Restart (which needed the same mutex).

Changes to core:

- Makes dnsserver.Server.Stop idempotent using sync.Once.

Changes to plugin/reload:

- Reload channel is now buffered, so that final-shutdown send cannot block while the mutex is held.
- Reloads during shutdown are gated by checking a quit signal.

Adds an integration test to validate this works properly.

### 2. Which issues (if any) are related?

Fixes #7314. Validated locally that the hang no longer happens. Depending on when the kill hits it, you might see this instead:

```
[INFO] Reloading
[INFO] SIGTERM: Shutting down servers then terminating
[ERROR] plugin/errors: 2 google.com. A: read udp 192.168.1.20:60548->192.168.9.10:53: i/o timeout
[INFO] plugin/reload: Running configuration SHA512 = 9468cd793a52124b50323392e8f1b543b545c49c139c2948afcdc6799216fcb8900372bd5f5fba0c138c75b8d455cd7d9cde342d9046b30f97d81b83a59d3264
[INFO] Reloading complete
```

And then shut down.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
