### PR TITLE
fix(plugin): normalize panics on invalid origins

### DIFF
--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -179,7 +179,11 @@ func OriginsFromArgsOrServerBlock(args, serverblock []string) []string {
 		s := make([]string, len(serverblock))
 		copy(s, serverblock)
 		for i := range s {
-			s[i] = Host(s[i]).NormalizeExact()[0] // expansion of these already happened in dnsserver/register.go
+			sx := Host(s[i]).NormalizeExact() // expansion of these already happened in dnsserver/register.go
+			if len(sx) == 0 {
+				continue
+			}
+			s[i] = sx[0]
 		}
 		return s
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Previously `OriginsFromArgsOrServerBlock()` from the `plugin` package accessed the output of `NormalizeExact()` by index 0, which could panic when normalization returned an empty slice on error. This happens with malformed input surfaced by fuzzing, for example "unix://<non‑UTF8>".

This change hardens normalization in the server block path. If normalization yields no entries, the original value is preserved. The function still returns a newly copied slice.

This preserves legacy semantics for valid inputs while eliminating the crash on malformed ones.

Added tests to validate. The function is now fully covered with the unit tests.

### 2. Which issues (if any) are related?

Fixes the following OSS-Fuzz finding: https://issues.oss-fuzz.com/issues/42525010

Reproducible by:

```
printf 'unix://\xFF\n{\n  etcd\n}\n' > Corefile.poc && ./coredns -conf Corefile.poc
```

Stacktrace:

<details>
<code>
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/coredns/coredns/plugin.OriginsFromArgsOrServerBlock({0x0?, 0x104777aac?, 0x2000?}, {0x1400068e3a0?, 0x1, 0x100000006?})
        /git/coredns/plugin/normalize.go:182 +0x108
github.com/coredns/coredns/plugin/etcd.etcdParse(0x14000182000)
        /git/coredns/plugin/etcd/setup.go:56 +0xf4
github.com/coredns/coredns/plugin/etcd.setup(0x14000182000)
        /git/coredns/plugin/etcd/setup.go:23 +0x24
github.com/coredns/caddy.executeDirectives(0x1400014a200, {0x16b6a36c0, 0xc}, {0x108aa46a0, 0x36, 0x1?}, {0x140005442a0, 0x1, 0x108aca580?}, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:663 +0x480
github.com/coredns/caddy.ValidateAndExecuteDirectives({0x10715bf30, 0x14000256ac0}, 0x140005bdd08?, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:614 +0x2cc
github.com/coredns/caddy.startWithListenerFds({0x10715bf30, 0x14000256ac0}, 0x1400014a200, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:517 +0x224
github.com/coredns/caddy.Start({0x10715bf30, 0x14000256ac0})
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:474 +0xbc
github.com/coredns/coredns/coremain.Run()
        /git/coredns/coremain/run.go:73 +0x24c
main.main()
        /git/coredns/coredns.go:12 +0x1c
</code>
</details>


Validated locally that the OSS-Fuzz reproducer no longer crashes.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

None, preserves existing functionality.
