### PR TITLE
fix(plugin): prevent panic when ListenHosts is empty

### DIFF
--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -31,7 +31,10 @@ func setup(c *caddy.Controller) error {
 		go func() {
 			deadline := time.Now().Add(30 * time.Second)
 			conf := dnsserver.GetConfig(c)
-			lh := conf.ListenHosts[0]
+			lh := ""
+			if len(conf.ListenHosts) > 0 {
+				lh = conf.ListenHosts[0]
+			}
 			addr := net.JoinHostPort(lh, conf.Port)
 
 			for time.Now().Before(deadline) {

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -37,7 +37,7 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	)
 
 	cfg := dnsserver.GetConfig(c)
-	if cfg.ListenHosts[0] != "" {
+	if len(cfg.ListenHosts) > 0 && cfg.ListenHosts[0] != "" {
 		tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
 	}
 

--- a/test/bind_test.go
+++ b/test/bind_test.go
@@ -1,0 +1,24 @@
+package test
+
+import "testing"
+
+func TestBind_FilterAll(t *testing.T) {
+	t.Parallel()
+	corefile := `.:0 {
+        bind 127.0.0.1 {
+            except 127.0.0.1
+        }
+        trace
+        loop
+        whoami
+    }`
+	inst, err := CoreDNSServer(corefile)
+	if inst != nil {
+		CoreDNSServerStop(inst)
+	}
+	if err == nil {
+		t.Log("server started; stopping immediately")
+	} else {
+		t.Logf("server failed to start as expected without listeners: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fix a runtime panic caused by direct indexing into an empty `ListenHosts` slice. The trace plugin accessed `cfg.ListenHosts[0]` to build a service endpoint. The loop plugin used `conf.ListenHosts[0]` to construct a self-query address. When bind resolves no addresses or excludes all configured addresses, `ListenHosts` can be empty. Both plugins now check length before indexing.

### 2. Which issues (if any) are related?

[OSS-Fuzz finding #42515496](https://issues.oss-fuzz.com/issues/42515496)

You can run `TestBind_FilterAll` against `master` branch and the test will panic on:

`panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]`

<details>
<code>
--- FAIL: TestBind_FilterAll (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]

goroutine 99 [running]:
testing.tRunner.func1.2({0x10586dc60, 0x1400061a0a8})
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1875 +0x31c
panic({0x10586dc60?, 0x1400061a0a8?})
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/runtime/panic.go:783 +0x120
github.com/coredns/coredns/plugin/trace.traceParse(0x1400023d440)
        /git/coredns/plugin/trace/setup.go:40 +0x8f0
github.com/coredns/coredns/plugin/trace.setup(0x1400023d440)
        /git/coredns/plugin/trace/setup.go:17 +0x24
github.com/coredns/caddy.executeDirectives(0x140001e4600, {0x104e2a6e8, 0x8}, {0x107425f80, 0x36, 0x1?}, {0x14000606440, 0x1, 0x10744c840?}, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:663 +0x480
github.com/coredns/caddy.ValidateAndExecuteDirectives({0x105a9a3e0, 0x14000612210}, 0x1400009fd28?, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:614 +0x2cc
github.com/coredns/caddy.startWithListenerFds({0x105a9a3e0, 0x14000612210}, 0x140001e4600, 0x0)
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:517 +0x224
github.com/coredns/caddy.Start({0x105a9a3e0, 0x14000612210})
        /go/pkg/mod/github.com/coredns/caddy@v1.1.2-0.20241029205200-8de985351a98/caddy.go:474 +0xbc
github.com/coredns/coredns/test.CoreDNSServer({0x104efe2e5?, 0x10307ad20?})
        /git/coredns/test/server.go:21 +0x144
github.com/coredns/coredns/test.TestBind_FilterAll(0x140002ee8c0)
        /git/coredns/test/corefile_test.go:36 +0x30
testing.tRunner(0x140002ee8c0, 0x105a6ac38)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x364
exit status 2
FAIL    github.com/coredns/coredns/test 0.664s
</code>
</details>

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, code hardening.
