### PR TITLE
plugin/import: add high caps for snippet/file import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.58.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.4
-	github.com/coredns/caddy v1.1.2-0.20241029205200-8de985351a98
+	github.com/coredns/caddy v1.1.3
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/expr-lang/expr v1.17.6
 	github.com/farsightsec/golang-framestream v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
-github.com/coredns/caddy v1.1.2-0.20241029205200-8de985351a98 h1:c+Epklw9xk6BZ1OFBPWLA2PcL8QalKvl3if8CP9x8uw=
-github.com/coredns/caddy v1.1.2-0.20241029205200-8de985351a98/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
+github.com/coredns/caddy v1.1.3 h1:zy+rYOAhG1Qjxnaf4QGIglYpR3io9YTJ67abYbEgfwY=
+github.com/coredns/caddy v1.1.3/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/plugin/import/README.md
+++ b/plugin/import/README.md
@@ -21,6 +21,8 @@ import PATTERN
 *   **PATTERN** is the file, glob pattern (`*`) or snippet to include. Its contents will replace
     this line, as if that file's contents appeared here to begin with.
 
+Corefile may contain at most 10000 import statements. A glob pattern counts as a single import. The limit protects the configuration from recursive imports.
+
 ## Files
 
 You can use *import* to include a file or files. This file's location is relative to the


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

To fix Corefile related import cycle issue. See https://github.com/coredns/caddy/pull/8 and https://github.com/coredns/caddy/pull/9 for further information. Fixed in [coredns/caddy v1.1.3](https://github.com/coredns/caddy/releases/tag/v1.1.3).

### 2. Which issues (if any) are related?

Fixes [OSS-Fuzz #42486385](https://issues.oss-fuzz.com/issues/42486385). I ran the reproducer locally to validate.

### 3. Which documentation changes (if any) need to be made?

Added docs about the import limit.

### 4. Does this introduce a backward incompatible change or deprecation?

See above. The import limit is arbitrary but generous. Worth noting that a glob pattern counts as one. Importing a directory that has any number of configuration is fine.