### PR TITLE
plugin/loop: avoid panic on invalid server block

### DIFF
--- a/plugin/loop/loop_test.go
+++ b/plugin/loop/loop_test.go
@@ -1,11 +1,82 @@
 package loop
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
 
 func TestLoop(t *testing.T) {
 	l := New(".")
 	l.inc()
 	if l.seen() != 1 {
 		t.Errorf("Failed to inc loop, expected %d, got %d", 1, l.seen())
+	}
+}
+
+func TestLoop_NonHINFO(t *testing.T) {
+	l := New(".")
+	l.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	w := &test.ResponseWriter{}
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	if rc, _ := l.ServeDNS(context.Background(), w, m); rc != dns.RcodeSuccess {
+		t.Fatalf("expected %d, got %d", dns.RcodeSuccess, rc)
+	}
+}
+
+func TestLoop_Disabled(t *testing.T) {
+	l := New(".")
+	l.setDisabled()
+	l.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	w := &test.ResponseWriter{}
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeHINFO)
+	if rc, _ := l.ServeDNS(context.Background(), w, m); rc != dns.RcodeSuccess {
+		t.Fatalf("expected %d, got %d", dns.RcodeSuccess, rc)
+	}
+}
+
+func TestLoop_ZoneMismatch(t *testing.T) {
+	l := New("example.org.")
+	l.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	w := &test.ResponseWriter{}
+	m := new(dns.Msg)
+	m.SetQuestion("a.example.com.", dns.TypeHINFO)
+	if rc, _ := l.ServeDNS(context.Background(), w, m); rc != dns.RcodeSuccess {
+		t.Fatalf("expected %d, got %d", dns.RcodeSuccess, rc)
+	}
+}
+
+func TestLoop_MatchAndInc(t *testing.T) {
+	l := New(".")
+	l.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	l.qname = "1.2.example.org."
+	w := &test.ResponseWriter{}
+	m := new(dns.Msg)
+	m.SetQuestion(l.qname, dns.TypeHINFO)
+
+	if l.seen() != 0 {
+		t.Fatalf("expected initial seen 0, got %d", l.seen())
+	}
+	if _, err := l.ServeDNS(context.Background(), w, m); err != nil {
+		t.Fatalf("ServeDNS returned error: %v", err)
+	}
+	if l.seen() != 1 {
+		t.Fatalf("expected seen to be 1 after matching query, got %d", l.seen())
+	}
+}
+
+func TestLoop_SetAddressAndName(t *testing.T) {
+	l := New(".")
+	l.setAddress("127.0.0.1:1053")
+	if l.address() != "127.0.0.1:1053" {
+		t.Fatalf("expected address to be set")
+	}
+	if l.Name() != "loop" {
+		t.Fatalf("expected Name() to be 'loop', got %q", l.Name())
 	}
 }

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -73,7 +73,10 @@ func parse(c *caddy.Controller) (*Loop, error) {
 		}
 
 		if len(c.ServerBlockKeys) > 0 {
-			zones = plugin.Host(c.ServerBlockKeys[0]).NormalizeExact()
+			z := plugin.Host(c.ServerBlockKeys[0]).NormalizeExact()
+			if len(z) > 0 {
+				zones = z
+			}
 		}
 	}
 	return New(zones[0]), nil

--- a/plugin/loop/setup_test.go
+++ b/plugin/loop/setup_test.go
@@ -17,3 +17,32 @@ func TestSetup(t *testing.T) {
 		t.Fatal("Expected errors, but got none")
 	}
 }
+
+func TestParseServerBlockKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		want   string
+		wantOk bool
+	}{
+		{name: "valid domain", key: "example.org", want: "example.org.", wantOk: true},
+		{name: "invalid scheme", key: "unix://", want: ".", wantOk: true},
+		{name: "empty", key: "", want: ".", wantOk: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := caddy.NewTestController("dns", `loop`)
+			if tt.key != "" {
+				c.ServerBlockKeys = []string{tt.key}
+			}
+			l, err := parse(c)
+			if (err == nil) != tt.wantOk {
+				t.Fatalf("parse err=%v, wantOk=%v", err, tt.wantOk)
+			}
+			if l.zone != tt.want {
+				t.Fatalf("zone=%q, want %q", l.zone, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Ignore invalid ServerBlockKeys in loop plugin that fail normalization. Retain the default “.” zone instead of indexing into an empty slice. This prevents an index-out-of-range panic triggered by malformed inputs such as "unix://".

Added a test to validate and increase test coverage. Increases test coverage from 32.1% to 65.1%.

### 2. Which issues (if any) are related?

Fixes [OSS-Fuzz finding #446421108](https://issues.oss-fuzz.com/issues/446421108). Currently not publicly accessible.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.