### PR TITLE
lint: enable nakedret

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - intrange
+    - nakedret
     - nolintlint
     - prealloc
     - protogetter

--- a/plugin/file/tree/tree.go
+++ b/plugin/file/tree/tree.go
@@ -213,7 +213,7 @@ func (n *Node) insert(rr dns.RR) (root *Node, d int) {
 
 	root = n
 
-	return
+	return root, d
 }
 
 // DeleteMin deletes the node with the minimum value in the tree.

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -192,7 +192,7 @@ func countRecords(result []dns.RR) (cname int, address int, mx int, sorted bool)
 			state = Any
 		}
 	}
-	return
+	return cname, address, mx, sorted
 }
 
 func handler() plugin.Handler {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -417,7 +417,7 @@ func parseAnswerRules(name string, args []string) (auto bool, rules ResponseRule
 	if auto && nameRules > 0 {
 		return false, nil, fmt.Errorf("auto name answer rule cannot be combined with explicit name anwer rules")
 	}
-	return
+	return auto, rules, nil
 }
 
 // hasClosingDot returns true if s has a closing dot at the end.

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -158,5 +158,5 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 		handler.Templates = append(handler.Templates, t)
 	}
 
-	return
+	return handler, nil
 }


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Replace naked returns with explicit return values to satisfy nakedret linter and improve readability.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No, code quality improvement.
