### PR TITLE
fix(caddyfile): infinite loop on unclosed braces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.9
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.39.6
-	github.com/coredns/caddy v1.1.3
+	github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495
 	github.com/dnstap/golang-dnstap v0.4.0
 	github.com/expr-lang/expr v1.17.6
 	github.com/farsightsec/golang-framestream v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
-github.com/coredns/caddy v1.1.3 h1:zy+rYOAhG1Qjxnaf4QGIglYpR3io9YTJ67abYbEgfwY=
-github.com/coredns/caddy v1.1.3/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
+github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495 h1:JFeOmbjLnVRhvmLHyuO3M1pfXWlPWpwkdM8UqXZRtBg=
+github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/test/corefile_test.go
+++ b/test/corefile_test.go
@@ -4,21 +4,44 @@ import (
 	"testing"
 )
 
-func TestCorefile1(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("Expected no panic, but got %v", r)
-		}
-	}()
-
-	// this used to crash
-	corefile := `\\\\ȶ.
+// TestCorefileParsing tests the Corefile parsing functionality.
+// Expected to not panic or timeout.
+func TestCorefileParsing(t *testing.T) {
+	cases := []struct {
+		name     string
+		corefile string
+	}{
+		{
+			// See: https://github.com/coredns/coredns/pull/4637
+			name: "PR4637_" + "NoPanicOnEscapedBackslashesAndUnicode",
+			corefile: `\\\\ȶ.
 acl
-`
-	i, _, _, _ := CoreDNSServerAndPorts(corefile)
-	defer func() {
-		if i != nil {
-			i.Stop()
-		}
-	}()
+`,
+		},
+		{
+			// See: https://github.com/coredns/coredns/pull/7571
+			name: "PR7571_" + "InvalidBlockFailsToStart",
+			corefile: "\xD9//\n" +
+				"hosts#\x90\xD0{lc\x0C{\n" +
+				"'{mport\xEF1\x0C}\x0B''",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Expected no panic, but got %v", r)
+				}
+			}()
+
+			i, _, _, _ := CoreDNSServerAndPorts(tc.corefile)
+
+			defer func() {
+				if i != nil {
+					i.Stop()
+				}
+			}()
+		})
+	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Update `coredns/caddy` so `Dispenser.NextBlock()` checks `Next()` return value and stops at EOF. This prevents an infinite loop when a block is opened but its closing "`}`" is never seen before EOF. For example, due to a missing brace or malformed/commented input with control/non‑UTF‑8 bytes (such as `hosts#…\x0c{`) that hides the terminator.

Added a regression test and refactored the `corefile_test.go` to use test cases. If you run the test against `master` you will see it times out, due to infinite loop.

### 2. Which issues (if any) are related?

Fixes [OSS-Fuzz finding #446778634](https://issues.oss-fuzz.com/issues/446778634) + group `5160400776724480`.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
