### PR TITLE
fix(file): data race in tree Elem.Name

### DIFF
--- a/plugin/file/tree/elem.go
+++ b/plugin/file/tree/elem.go
@@ -12,6 +12,8 @@ type Elem struct {
 func newElem(rr dns.RR) *Elem {
 	e := Elem{m: make(map[uint16][]dns.RR)}
 	e.m[rr.Header().Rrtype] = []dns.RR{rr}
+	// Eagerly set the cached owner name to avoid racy lazy writes later.
+	e.name = rr.Header().Name
 	return &e
 }
 
@@ -56,12 +58,12 @@ func (e *Elem) All() []dns.RR {
 
 // Name returns the name for this node.
 func (e *Elem) Name() string {
+	// Read-only: name is eagerly set in newElem and should not be mutated here.
 	if e.name != "" {
 		return e.name
 	}
 	for _, rrs := range e.m {
-		e.name = rrs[0].Header().Name
-		return e.name
+		return rrs[0].Header().Name
 	}
 	return ""
 }

--- a/plugin/file/tree/elem_test.go
+++ b/plugin/file/tree/elem_test.go
@@ -1,0 +1,41 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Test that Name() falls back to reading from the stored RRs when the cached name is empty.
+func TestElemName_FallbackWhenCachedEmpty(t *testing.T) {
+	rr, err := dns.NewRR("a.example. 3600 IN A 1.2.3.4")
+	if err != nil {
+		t.Fatalf("failed to create RR: %v", err)
+	}
+
+	// Build via newElem to ensure m is populated
+	e := newElem(rr)
+	got := e.Name()
+	want := "a.example."
+	if got != want {
+		t.Fatalf("unexpected name; want %q, got %q", want, got)
+	}
+
+	// clear the cached name
+	e.name = ""
+
+	got = e.Name()
+	want = "a.example."
+	if got != want {
+		t.Fatalf("unexpected name; want %q, got %q", want, got)
+	}
+
+	// clear the map
+	e.m = make(map[uint16][]dns.RR, 0)
+
+	got = e.Name()
+	want = ""
+	if got != want {
+		t.Fatalf("unexpected name after clearing RR map; want %q, got %q", want, got)
+	}
+}

--- a/plugin/file/tree/less_test.go
+++ b/plugin/file/tree/less_test.go
@@ -3,7 +3,10 @@ package tree
 import (
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/miekg/dns"
 )
 
 type set []string
@@ -77,4 +80,42 @@ Tests:
 			}
 		}
 	}
+}
+
+func TestLess_EmptyVsName(t *testing.T) {
+	if d := less("", "a."); d >= 0 {
+		t.Fatalf("expected < 0, got %d", d)
+	}
+	if d := less("a.", ""); d <= 0 {
+		t.Fatalf("expected > 0, got %d", d)
+	}
+}
+
+func TestLess_EmptyVsEmpty(t *testing.T) {
+	if d := less("", ""); d != 0 {
+		t.Fatalf("expected 0, got %d", d)
+	}
+}
+
+// Test that concurrent calls to Less (which calls Elem.Name) do not race or panic.
+// See issue #7561 for reference.
+func TestLess_ConcurrentNameAccess(t *testing.T) {
+	rr, err := dns.NewRR("a.example. 3600 IN A 1.2.3.4")
+	if err != nil {
+		t.Fatalf("failed to create RR: %v", err)
+	}
+	e := newElem(rr)
+
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			// Compare the same name repeatedly; previously this could race due to lazy Name() writes.
+			_ = Less(e, "a.example.")
+			_ = e.Name()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fixes a data race in `plugin/file/tree` where `Elem.Name()` lazily wrote the cached owner name without synchronization. Under high concurrency (e.g., clouddns lookups), this could produce torn Go strings and cause a panic in `github.com/miekg/dns.PrevLabel` while comparing names.

The fix is to eagerly set the name in `newElem()` and make `Name()` read-only.  The cached name is set once and immutable. An alternative would be a mutex on `Name()` but it adds lock overhead right in the hot comparator path.

Also added a few tests to cover concurrent access like observed here. If the test `TestLess_ConcurrentNameAccess` is run against `master` you'll see a data race.

<details>
<code>
WARNING: DATA RACE
Read at 0x00c00000c338 by goroutine 11:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:59 +0x38
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.TestLess_ConcurrentNameAccess.func1()
      /git/coredns/plugin/file/tree/less_test.go:101 +0x74
Previous write at 0x00c00000c338 by goroutine 13:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:63 +0x10c
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.TestLess_ConcurrentNameAccess.func1()
      /git/coredns/plugin/file/tree/less_test.go:101 +0x74
Goroutine 11 (running) created at:
  github.com/coredns/coredns/plugin/file/tree.TestLess_ConcurrentNameAccess()
      /git/coredns/plugin/file/tree/less_test.go:98 +0x204
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
Goroutine 13 (finished) created at:
  github.com/coredns/coredns/plugin/file/tree.TestLess_ConcurrentNameAccess()
      /git/coredns/plugin/file/tree/less_test.go:98 +0x204
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
==================
--- FAIL: TestLess_ConcurrentNameAccess (0.00s)
    testing.go:1617: race detected during execution of test
</code>
</details>

Also two additional CloudDNS tests are added:

-  `TestCloudDNSConcurrentServeDNS`: Run concurrent zone updates while concurrent queries.

<details>
<code>
==================
WARNING: DATA RACE
Write at 0x00c00061c350 by goroutine 27:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:63 +0x10c
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.(*Node).search()
      /git/coredns/plugin/file/tree/tree.go:155 +0x54
  github.com/coredns/coredns/plugin/file/tree.(*Tree).Search()
      /git/coredns/plugin/file/tree/tree.go:145 +0x58
  github.com/coredns/coredns/plugin/file.(*Zone).Lookup()
      /git/coredns/plugin/file/lookup.go:96 +0x680
  github.com/coredns/coredns/plugin/clouddns.(*CloudDNS).ServeDNS()
      /git/coredns/plugin/clouddns/clouddns.go:126 +0x464
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS.func2()
      /git/coredns/plugin/clouddns/clouddns_test.go:377 +0x2ec
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS.gowrap1()
      /git/coredns/plugin/clouddns/clouddns_test.go:387 +0x40
Previous read at 0x00c00061c350 by goroutine 36:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:64 +0x148
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.(*Node).search()
      /git/coredns/plugin/file/tree/tree.go:155 +0x54
  github.com/coredns/coredns/plugin/file/tree.(*Tree).Search()
      /git/coredns/plugin/file/tree/tree.go:145 +0x58
  github.com/coredns/coredns/plugin/file.(*Zone).Lookup()
      /git/coredns/plugin/file/lookup.go:96 +0x680
  github.com/coredns/coredns/plugin/clouddns.(*CloudDNS).ServeDNS()
      /git/coredns/plugin/clouddns/clouddns.go:126 +0x464
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS.func2()
      /git/coredns/plugin/clouddns/clouddns_test.go:377 +0x2ec
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS.gowrap1()
      /git/coredns/plugin/clouddns/clouddns_test.go:387 +0x40
Goroutine 27 (running) created at:
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS()
      /git/coredns/plugin/clouddns/clouddns_test.go:370 +0x5d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
Goroutine 36 (running) created at:
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentServeDNS()
      /git/coredns/plugin/clouddns/clouddns_test.go:370 +0x5d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
==================
--- FAIL: TestCloudDNSConcurrentServeDNS (0.04s)
    testing.go:1617: race detected during execution of test
</code>
</details>


- `TestCloudDNSConcurrentLookupNameCache`: Run concurrent queries and lookups, stressing the path even more.
<details>
<code>
==================
WARNING: DATA RACE
Read at 0x00c00000ec98 by goroutine 61:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:59 +0x38
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.(*Node).search()
      /git/coredns/plugin/file/tree/tree.go:155 +0x54
  github.com/coredns/coredns/plugin/file/tree.(*Tree).Search()
      /git/coredns/plugin/file/tree/tree.go:145 +0x58
  github.com/coredns/coredns/plugin/file.(*Zone).Lookup()
      /git/coredns/plugin/file/lookup.go:96 +0x680
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache.func1()
      /git/coredns/plugin/clouddns/clouddns_test.go:437 +0x110
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache.gowrap1()
      /git/coredns/plugin/clouddns/clouddns_test.go:439 +0x50
Previous write at 0x00c00000ec98 by goroutine 86:
  github.com/coredns/coredns/plugin/file/tree.(*Elem).Name()
      /git/coredns/plugin/file/tree/elem.go:63 +0x10c
  github.com/coredns/coredns/plugin/file/tree.Less()
      /git/coredns/plugin/file/tree/elem.go:101 +0x30
  github.com/coredns/coredns/plugin/file/tree.(*Node).search()
      /git/coredns/plugin/file/tree/tree.go:155 +0x54
  github.com/coredns/coredns/plugin/file/tree.(*Tree).Search()
      /git/coredns/plugin/file/tree/tree.go:145 +0x58
  github.com/coredns/coredns/plugin/file.(*Zone).Lookup()
      /git/coredns/plugin/file/lookup.go:96 +0x680
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache.func1()
      /git/coredns/plugin/clouddns/clouddns_test.go:437 +0x110
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache.gowrap1()
      /git/coredns/plugin/clouddns/clouddns_test.go:439 +0x50
Goroutine 61 (running) created at:
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache()
      /git/coredns/plugin/clouddns/clouddns_test.go:429 +0x604
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
Goroutine 86 (running) created at:
  github.com/coredns/coredns/plugin/clouddns.TestCloudDNSConcurrentLookupNameCache()
      /git/coredns/plugin/clouddns/clouddns_test.go:429 +0x604
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.25.1/libexec/src/testing/testing.go:1997 +0x3c
==================
--- FAIL: TestCloudDNSConcurrentLookupNameCache (0.05s)
    testing.go:1617: race detected during execution of test
</code>
</details>

These both panic on `master` branch.

### 2. Which issues (if any) are related?

Fixes #7561.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
