### PR TITLE
fix(sign): reject invalid UTF‑8 dbfile token

### DIFF
--- a/plugin/sign/setup.go
+++ b/plugin/sign/setup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/coredns/caddy"
@@ -48,6 +49,11 @@ func parse(c *caddy.Controller) (*Sign, error) {
 		dbfile := c.Val()
 		if !filepath.IsAbs(dbfile) && config.Root != "" {
 			dbfile = filepath.Join(config.Root, dbfile)
+		}
+
+		// Validate dbfile token to avoid infinite signing loops caused by invalid paths
+		if strings.ContainsRune(dbfile, '\uFFFD') {
+			return nil, fmt.Errorf("dbfile %q contains invalid characters", dbfile)
 		}
 
 		origins := plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)

--- a/plugin/sign/setup_test.go
+++ b/plugin/sign/setup_test.go
@@ -73,3 +73,14 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+// With setup validation in place, an invalid utf-8 dbfile token must cause parse() to error.
+func TestParseRejectsInvalidDbfileToken(t *testing.T) {
+	input := "sign \"\xff\" 8.44.in-addr.arpa. 9.44.in-addr.arpa. {}"
+	c := caddy.NewTestController("dns", input)
+
+	_, err := parse(c)
+	if err == nil {
+		t.Fatalf("expected parse to fail for invalid dbfile token")
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The coredns/caddy lexer replaces invalid UTF‑8 bytes in tokens with U+FFFD. When that lossy-decoded value is used as `dbfile` in the sign plugin, the source zone file path never exists. On startup/refresh, the `resign()` function sees the signed file missing and triggers signing. Consequently `Sign()` then fails opening the bogus path, the signed file is never created, and the cycle repeats across all expanded origins (e.g., reverse CIDRs), causing unbounded churn/OOM.

Validate `dbfile` in setup and error if it contains U+FFFD. Add a regression test.

Note: Unicode paths are supported; only U+FFFD (replacement-rune) is rejected.

### 2. Which issues (if any) are related?

Fixes OSS-Fuzz finding [#448571099](https://issues.oss-fuzz.com/issues/448571099) (not publicly accessible yet).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.