### PR TITLE
plugin/cache: added minimum positive/negative TTL 

### DIFF
--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -59,6 +59,8 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 				}
 				ca.pttl = time.Duration(ttl) * time.Second
 				ca.nttl = time.Duration(ttl) * time.Second
+				ca.minpttl = time.Duration(ttl) * time.Second
+				ca.minnttl = time.Duration(ttl) * time.Second
 				args = args[1:]
 			}
 		}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This small fix add's minimum positive/negative TTL to the cache plugin when initialized only like
```
cache 600 
```

Since without specific type (denial/success/...) overwrite the minimum TTL for the respective type is not added in the struct, any upstream resource in the chain (like forward . /etc/resolv.conf) still get's queried every 30 seconds.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
