### PR TITLE
fix: update broken link to `expr` language definition

### DIFF
--- a/plugin/view/README.md
+++ b/plugin/view/README.md
@@ -111,7 +111,7 @@ For example, an expression could look like:
 
 All expressions should be written to evaluate to a boolean value.
 
-See https://github.com/expr-lang/expr/blob/master/docs/Language-Definition.md as a detailed reference for valid syntax.
+See https://github.com/expr-lang/expr/blob/master/docs/language-definition.md as a detailed reference for valid syntax.
 
 ### Available Expression Functions
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This change updates an outdated link in the `view` plugin documentation.

### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?

n/a

### 4. Does this introduce a backward incompatible change or deprecation?

No