### PR TITLE
fix(multisocket): cap num sockets to prevent OOM

### DIFF
--- a/plugin/multisocket/README.md
+++ b/plugin/multisocket/README.md
@@ -19,7 +19,7 @@ large number of CPU cores.
 multisocket [NUM_SOCKETS]
 ~~~
 
-* **NUM_SOCKETS** - the number of servers that will listen on one port. Default value is equal to GOMAXPROCS.
+* **NUM_SOCKETS** - the number of servers that will listen on one port. Default value is equal to GOMAXPROCS. Maximum value is 1024.
 
 ## Examples
 

--- a/plugin/multisocket/multisocket.go
+++ b/plugin/multisocket/multisocket.go
@@ -11,6 +11,7 @@ import (
 )
 
 const pluginName = "multisocket"
+const maxNumSockets = 1024
 
 func init() { plugin.Register(pluginName, setup) }
 
@@ -44,6 +45,9 @@ func parseNumSockets(c *caddy.Controller) error {
 	}
 	if numSockets < 1 {
 		return fmt.Errorf("num sockets can not be zero or negative: %d", numSockets)
+	}
+	if numSockets > maxNumSockets {
+		return fmt.Errorf("num sockets exceeds maximum (%d): %d", maxNumSockets, numSockets)
 	}
 	config.NumSockets = numSockets
 

--- a/plugin/multisocket/multisocket_test.go
+++ b/plugin/multisocket/multisocket_test.go
@@ -19,10 +19,12 @@ func TestMultisocket(t *testing.T) {
 		// positive
 		{`multisocket`, false, runtime.GOMAXPROCS(0), ""},
 		{`multisocket 2`, false, 2, ""},
+		{`multisocket 1024`, false, 1024, ""},
 		{` multisocket 1`, false, 1, ""},
 		{`multisocket text`, true, 0, "invalid num sockets"},
 		{`multisocket 0`, true, 0, "num sockets can not be zero or negative"},
 		{`multisocket -1`, true, 0, "num sockets can not be zero or negative"},
+		{`multisocket 1025`, true, 0, "num sockets exceeds maximum"},
 		{`multisocket 2 2`, true, 0, "Wrong argument count or unexpected line ending after '2'"},
 		{`multisocket 2 {
 			block


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add hard maximum to number of sockets in the multisocket plugin. Unbounded value could cause CoreDNS to attempt creating an excessive number of listeners, leading to OOM at startup. Capping at 1024 mitigates misconfiguration while accomodating large environments. Add tests.

### 2. Which issues (if any) are related?

Fixes [OSS-Fuzz finding #451334054](https://issues.oss-fuzz.com/issues/451334054) (not publicly accessible).

### 3. Which documentation changes (if any) need to be made?

Added hard limit to documentation.

### 4. Does this introduce a backward incompatible change or deprecation?

Sets a sane maximum value for pathological input. Open to other views here.