### PR TITLE
fix(dnstap): Better error handling (redial & logging) when Dnstap is busy

### DIFF
--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -27,7 +27,7 @@ type tapper interface {
 }
 
 type WarnLogger interface {
-	Warningf(format string, v ...interface{})
+	Warningf(format string, v ...any)
 }
 
 // dio implements the Tapper interface.

--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -14,8 +14,9 @@ const (
 	tcpWriteBufSize = 1024 * 1024 // there is no good explanation for why this number has this value.
 	queueSize       = 10000       // idem.
 
-	tcpTimeout   = 4 * time.Second
-	flushTimeout = 1 * time.Second
+	tcpTimeout         = 4 * time.Second
+	flushTimeout       = 1 * time.Second
+	errorCheckInterval = 10 * time.Second
 
 	skipVerify = false // by default, every tls connection is verified to be secure
 )
@@ -31,17 +32,18 @@ type WarnLogger interface {
 
 // dio implements the Tapper interface.
 type dio struct {
-	endpoint        string
-	proto           string
-	enc             *encoder
-	queue           chan *tap.Dnstap
-	dropped         uint32
-	quit            chan struct{}
-	flushTimeout    time.Duration
-	tcpTimeout      time.Duration
-	skipVerify      bool
-	tcpWriteBufSize int
-	logger          WarnLogger
+	endpoint           string
+	proto              string
+	enc                *encoder
+	queue              chan *tap.Dnstap
+	dropped            uint32
+	quit               chan struct{}
+	flushTimeout       time.Duration
+	tcpTimeout         time.Duration
+	skipVerify         bool
+	tcpWriteBufSize    int
+	logger             WarnLogger
+	errorCheckInterval time.Duration
 }
 
 var noOutputError = errors.New("dnstap not connected to output socket")
@@ -49,15 +51,16 @@ var noOutputError = errors.New("dnstap not connected to output socket")
 // newIO returns a new and initialized pointer to a dio.
 func newIO(proto, endpoint string, multipleQueue int, multipleTcpWriteBuf int) *dio {
 	return &dio{
-		endpoint:        endpoint,
-		proto:           proto,
-		queue:           make(chan *tap.Dnstap, multipleQueue*queueSize),
-		quit:            make(chan struct{}),
-		flushTimeout:    flushTimeout,
-		tcpTimeout:      tcpTimeout,
-		skipVerify:      skipVerify,
-		tcpWriteBufSize: multipleTcpWriteBuf * tcpWriteBufSize,
-		logger:          log,
+		endpoint:           endpoint,
+		proto:              proto,
+		queue:              make(chan *tap.Dnstap, multipleQueue*queueSize),
+		quit:               make(chan struct{}),
+		flushTimeout:       flushTimeout,
+		tcpTimeout:         tcpTimeout,
+		skipVerify:         skipVerify,
+		tcpWriteBufSize:    multipleTcpWriteBuf * tcpWriteBufSize,
+		logger:             log,
+		errorCheckInterval: errorCheckInterval,
 	}
 }
 
@@ -121,9 +124,28 @@ func (d *dio) write(payload *tap.Dnstap) error {
 	return nil
 }
 
+func (d *dio) checkError() {
+	errorCheckTicker := time.NewTicker(d.errorCheckInterval)
+	defer errorCheckTicker.Stop()
+	for {
+		select {
+		case <-d.quit:
+			return
+		case <-errorCheckTicker.C:
+			if dropped := atomic.SwapUint32(&d.dropped, 0); dropped > 0 {
+				d.logger.Warningf("Dropped dnstap messages: %d\n", dropped)
+			}
+			if d.enc == nil {
+				d.dial()
+			}
+		}
+	}
+}
+
 func (d *dio) serve() {
 	flushTicker := time.NewTicker(d.flushTimeout)
 	defer flushTicker.Stop()
+	go d.checkError()
 	for {
 		select {
 		case <-d.quit:
@@ -136,15 +158,13 @@ func (d *dio) serve() {
 		case payload := <-d.queue:
 			if err := d.write(payload); err != nil {
 				atomic.AddUint32(&d.dropped, 1)
-				d.dial()
+				if !errors.Is(err, noOutputError) {
+					// Redial immediately if it's not an output connection error
+					d.dial()
+				}
 			}
 		case <-flushTicker.C:
-			if dropped := atomic.SwapUint32(&d.dropped, 0); dropped > 0 {
-				d.logger.Warningf("Dropped dnstap messages: %d", dropped)
-			}
-			if d.enc == nil {
-				d.dial()
-			} else {
+			if d.enc != nil {
 				d.enc.flush()
 			}
 		}

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -2,7 +2,6 @@ package dnstap
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net"
 	"sync"
 	"testing"
@@ -12,6 +11,7 @@ import (
 
 	tap "github.com/dnstap/golang-dnstap"
 	fs "github.com/farsightsec/golang-framestream"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -141,8 +141,6 @@ func TestReconnect(t *testing.T) {
 		dio := newIO("tcp", addr, 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
 		dio.flushTimeout = 30 * time.Millisecond
-		// Check error frequently to log every dropped message
-		dio.errorCheckTimeout = 20 * time.Millisecond
 		dio.logger = &logger
 		dio.connect()
 		defer dio.close()
@@ -198,7 +196,6 @@ func TestReconnect(t *testing.T) {
 		dio := newIO("tcp", addr, 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
 		dio.flushTimeout = 30 * time.Millisecond
-		dio.errorCheckTimeout = 200 * time.Millisecond
 		dio.logger = &logger
 		dio.connect()
 		defer dio.close()
@@ -257,7 +254,6 @@ func TestFullQueueWriteFail(t *testing.T) {
 	logger := MockLogger{}
 	dio := newIO("unix", l.Addr().String(), 1, 1)
 	dio.flushTimeout = 500 * time.Millisecond
-	dio.errorCheckTimeout = 1 * time.Millisecond
 	dio.logger = &logger
 	dio.queue = make(chan *tap.Dnstap, 1)
 	dio.connect()
@@ -266,7 +262,7 @@ func TestFullQueueWriteFail(t *testing.T) {
 	// WHEN
 	//		messages overwhelms the queue
 	count := 100
-	for i := 0; i < count; i++ {
+	for _ = range count {
 		dio.Dnstap(&tmsg)
 	}
 	wg.Wait()

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -267,7 +267,7 @@ func TestFullQueueWriteFail(t *testing.T) {
 	// WHEN
 	//		messages overwhelms the queue
 	count := 100
-	for _ = range count {
+	for range count {
 		dio.Dnstap(&tmsg)
 	}
 	wg.Wait()

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -24,7 +24,7 @@ type MockLogger struct {
 	WarnLog   string
 }
 
-func (l *MockLogger) Warningf(format string, v ...interface{}) {
+func (l *MockLogger) Warningf(format string, v ...any) {
 	l.WarnCount++
 	l.WarnLog += fmt.Sprintf(format, v...)
 }

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -1,6 +1,8 @@
 package dnstap
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"net"
 	"sync"
 	"testing"
@@ -16,6 +18,16 @@ var (
 	msgType = tap.Dnstap_MESSAGE
 	tmsg    = tap.Dnstap{Type: &msgType}
 )
+
+type MockLogger struct {
+	WarnCount int
+	WarnLog   string
+}
+
+func (l *MockLogger) Warningf(format string, v ...interface{}) {
+	l.WarnCount++
+	l.WarnLog += fmt.Sprintf(format, v...)
+}
 
 func accept(t *testing.T, l net.Listener, count int) {
 	t.Helper()
@@ -108,12 +120,132 @@ func TestRace(t *testing.T) {
 }
 
 func TestReconnect(t *testing.T) {
-	count := 5
+	t.Run("ConnectedOnStart", func(t *testing.T) {
+		// GIVEN
+		// 		TCP connection available before DnsTap start up
+		//		DnsTap successfully established output connection on start up
+		l, err := reuseport.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("Cannot start listener: %s", err)
+		}
 
-	l, err := reuseport.Listen("tcp", ":0")
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			accept(t, l, 1)
+			wg.Done()
+		}()
+
+		addr := l.Addr().String()
+		logger := MockLogger{}
+		dio := newIO("tcp", addr, 1, 1)
+		dio.tcpTimeout = 10 * time.Millisecond
+		dio.flushTimeout = 30 * time.Millisecond
+		// Check error frequently to log every dropped message
+		dio.errorCheckTimeout = 20 * time.Millisecond
+		dio.logger = &logger
+		dio.connect()
+		defer dio.close()
+
+		// WHEN
+		//		TCP connection closed when DnsTap is still running
+		//		TCP listener starts again on the same port
+		//		DnsTap send multiple messages
+		dio.Dnstap(&tmsg)
+		wg.Wait()
+
+		// Close listener
+		l.Close()
+		// And start TCP listener again on the same port
+		l, err = reuseport.Listen("tcp", addr)
+		if err != nil {
+			t.Fatalf("Cannot start listener: %s", err)
+		}
+		defer l.Close()
+
+		wg.Add(1)
+		go func() {
+			accept(t, l, 1)
+			wg.Done()
+		}()
+
+		messageCount := 5
+		for range messageCount {
+			time.Sleep(100 * time.Millisecond)
+			dio.Dnstap(&tmsg)
+		}
+		wg.Wait()
+
+		// THEN
+		//		DnsTap is able to reconnect
+		//		Messages can be sent eventually
+		require.NotNil(t, dio.enc)
+		require.Equal(t, 0, len(dio.queue))
+		require.Less(t, logger.WarnCount, messageCount)
+	})
+
+	t.Run("NotConnectedOnStart", func(t *testing.T) {
+		// GIVEN
+		// 		No TCP connection established at DnsTap start up
+		l, err := reuseport.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("Cannot start listener: %s", err)
+		}
+		l.Close()
+
+		logger := MockLogger{}
+		addr := l.Addr().String()
+		dio := newIO("tcp", addr, 1, 1)
+		dio.tcpTimeout = 10 * time.Millisecond
+		dio.flushTimeout = 30 * time.Millisecond
+		dio.errorCheckTimeout = 200 * time.Millisecond
+		dio.logger = &logger
+		dio.connect()
+		defer dio.close()
+
+		// WHEN
+		//		DnsTap is already running
+		//		TCP listener starts on DnsTap's configured port
+		//		DnsTap send multiple messages
+		dio.Dnstap(&tmsg)
+
+		l, err = reuseport.Listen("tcp", addr)
+		if err != nil {
+			t.Fatalf("Cannot start listener: %s", err)
+		}
+		defer l.Close()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		messageCount := 5
+		go func() {
+			accept(t, l, messageCount)
+			wg.Done()
+		}()
+
+		for range messageCount {
+			time.Sleep(100 * time.Millisecond)
+			dio.Dnstap(&tmsg)
+		}
+		wg.Wait()
+
+		// THEN
+		//		DnsTap is able to reconnect
+		//		Messages can be sent eventually
+		require.NotNil(t, dio.enc)
+		require.Equal(t, 0, len(dio.queue))
+		require.Less(t, logger.WarnCount, messageCount)
+	})
+}
+
+func TestFullQueueWriteFail(t *testing.T) {
+	// GIVEN
+	// 		DnsTap I/O with a small queue
+	l, err := reuseport.Listen("unix", "dn2stap.sock")
 	if err != nil {
 		t.Fatalf("Cannot start listener: %s", err)
 	}
+	defer l.Close()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -122,35 +254,25 @@ func TestReconnect(t *testing.T) {
 		wg.Done()
 	}()
 
-	addr := l.Addr().String()
-	dio := newIO("tcp", addr, 1, 1)
-	dio.tcpTimeout = 10 * time.Millisecond
-	dio.flushTimeout = 30 * time.Millisecond
+	logger := MockLogger{}
+	dio := newIO("unix", l.Addr().String(), 1, 1)
+	dio.flushTimeout = 500 * time.Millisecond
+	dio.errorCheckTimeout = 1 * time.Millisecond
+	dio.logger = &logger
+	dio.queue = make(chan *tap.Dnstap, 1)
 	dio.connect()
 	defer dio.close()
 
-	dio.Dnstap(&tmsg)
-
-	wg.Wait()
-
-	// Close listener
-	l.Close()
-	// And start TCP listener again on the same port
-	l, err = reuseport.Listen("tcp", addr)
-	if err != nil {
-		t.Fatalf("Cannot start listener: %s", err)
-	}
-	defer l.Close()
-
-	wg.Add(1)
-	go func() {
-		accept(t, l, 1)
-		wg.Done()
-	}()
-
-	for range count {
-		time.Sleep(100 * time.Millisecond)
+	// WHEN
+	//		messages overwhelms the queue
+	count := 100
+	for i := 0; i < count; i++ {
 		dio.Dnstap(&tmsg)
 	}
 	wg.Wait()
+
+	// THEN
+	//		Dropped messages are logged
+	require.NotEqual(t, 0, logger.WarnCount)
+	require.Contains(t, logger.WarnLog, "Dropped dnstap messages")
 }

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -76,6 +76,7 @@ func TestTransport(t *testing.T) {
 		dio := newIO(param[0], l.Addr().String(), 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
 		dio.flushTimeout = 30 * time.Millisecond
+		dio.errorCheckInterval = 50 * time.Millisecond
 		dio.connect()
 
 		dio.Dnstap(&tmsg)
@@ -105,6 +106,7 @@ func TestRace(t *testing.T) {
 	dio := newIO("tcp", l.Addr().String(), 1, 1)
 	dio.tcpTimeout = 10 * time.Millisecond
 	dio.flushTimeout = 30 * time.Millisecond
+	dio.errorCheckInterval = 50 * time.Millisecond
 	dio.connect()
 	defer dio.close()
 
@@ -141,6 +143,7 @@ func TestReconnect(t *testing.T) {
 		dio := newIO("tcp", addr, 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
 		dio.flushTimeout = 30 * time.Millisecond
+		dio.errorCheckInterval = 50 * time.Millisecond
 		dio.logger = &logger
 		dio.connect()
 		defer dio.close()
@@ -196,6 +199,7 @@ func TestReconnect(t *testing.T) {
 		dio := newIO("tcp", addr, 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
 		dio.flushTimeout = 30 * time.Millisecond
+		dio.errorCheckInterval = 50 * time.Millisecond
 		dio.logger = &logger
 		dio.connect()
 		defer dio.close()
@@ -254,6 +258,7 @@ func TestFullQueueWriteFail(t *testing.T) {
 	logger := MockLogger{}
 	dio := newIO("unix", l.Addr().String(), 1, 1)
 	dio.flushTimeout = 500 * time.Millisecond
+	dio.errorCheckInterval = 50 * time.Millisecond
 	dio.logger = &logger
 	dio.queue = make(chan *tap.Dnstap, 1)
 	dio.connect()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

#### Bug / Current behaviour 
Both behaviours are caused by the same bug, when the internal queue is always full, we re-enter the for loop very frequently and keeps resetting the flush timer, so the timer never expires to enter the flush clause.

- When Dnstap fails to connect to output socket at startup, it never redials until the internal buffer queue is empty. When CoreDNS is constantly busy, Dnstap can fail to output for hours. 
- Dropped messages are never reported if the queue constantly receives incoming messages, they are only logged when the buffer is empty.

#### Changes
- Change `Timer` and `Reset` to `time.Ticker()` so that the flush/error reporting/redial actions are triggered every 1s
- Return error from write() on missing encoder, so that the plugin redials the socket on every failed messages.


### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
Don't think anything needs to be particularly noted on docs.

### 4. Does this introduce a backward incompatible change or deprecation?
No
