### PR TITLE
Update multisocket README.md

### DIFF
--- a/plugin/multisocket/README.md
+++ b/plugin/multisocket/README.md
@@ -62,6 +62,9 @@ If conducting such tests is difficult, follow these recommendations:
 
 ## Limitations
 
+The `multisocket` setting is only respected on the first zone block in the Corefile. If it is enabled there, it will
+take effect on zones. The setting is ignored in all subsequent zone blocks.
+
 The SO_REUSEPORT socket option is not available for some operating systems. It is available since Linux Kernel 3.9 and 
 not available for Windows at all.
 

--- a/plugin/multisocket/README.md
+++ b/plugin/multisocket/README.md
@@ -62,8 +62,9 @@ If conducting such tests is difficult, follow these recommendations:
 
 ## Limitations
 
-The `multisocket` setting is only respected on the first zone block in the Corefile. If it is enabled there, it will
-take effect on zones. The setting is ignored in all subsequent zone blocks.
+The `multisocket` value used for a given listen address is taken from the first server block that binds to that address
+in the Corefile. Subsequent server blocks using the same address will not change it. Different addresses may use
+different values.
 
 The SO_REUSEPORT socket option is not available for some operating systems. It is available since Linux Kernel 3.9 and 
 not available for Windows at all.


### PR DESCRIPTION
I was a bit confused why `multisocket` wasn't working for me, but I eventually found https://github.com/coredns/coredns/blob/38c020941b4938cf5642acfbf5ba5e52a71d320b/core/dnsserver/register.go#L308:
```
	// create one server by default if no NumSockets specified
	numSockets := 1
	if group[0].NumSockets > 0 {
		numSockets = group[0].NumSockets
	}
```

I tried to summarize my understanding in the README

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This is a documentation change

### 2. Which issues (if any) are related?

I haven't seen any filed issues here

### 3. Which documentation changes (if any) need to be made?

This is a documentation change

### 4. Does this introduce a backward incompatible change or deprecation?

No
