### PR TITLE
fix(forward): disallow NOERROR in failover

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -100,7 +100,7 @@ forward FROM TO... {
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
-* `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). If all upstreams have been tried, the response from the last attempt is returned.
+* `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls_servername` for different upstreams you're out of luck.

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -320,15 +320,12 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		toRcode := dns.StringToRcode
 
 		for _, rcode := range args {
-			var rc int
-			var ok bool
-
-			if rc, ok = toRcode[strings.ToUpper(rcode)]; !ok {
-				if rc == dns.RcodeSuccess {
-					return fmt.Errorf("NoError cannot be used in failover")
-				}
-
+			rc, ok := toRcode[strings.ToUpper(rcode)]
+			if !ok {
 				return fmt.Errorf("%s is not a valid rcode", rcode)
+			}
+			if rc == dns.RcodeSuccess {
+				return fmt.Errorf("NoError cannot be used in failover")
 			}
 
 			f.failoverRcodes = append(f.failoverRcodes, rc)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Previously the parsing logic in the `forward` plugin setup failed to recognise when `NOERROR` was used as a failover RCODE criteria. The check was in the wrong code branch. This PR fixes it and adds validation tests. Also updates the plugin README.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

Updated plugin README.

### 4. Does this introduce a backward incompatible change or deprecation?
