### PR TITLE
fix(cache): isolate metadata in prefetch goroutine

### DIFF
--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -92,6 +92,8 @@ func wildcardFunc(ctx context.Context) func() string {
 }
 
 func (c *Cache) doPrefetch(ctx context.Context, state request.Request, cw *ResponseWriter, i *item, now time.Time) {
+	// Use a fresh metadata map to avoid concurrent writes to the original request's metadata.
+	ctx = metadata.ContextWithMetadata(ctx)
 	cachePrefetches.WithLabelValues(cw.server, c.zonesMetricLabel, c.viewMetricLabel).Inc()
 	c.doRefresh(ctx, state, cw)
 

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -1,7 +1,12 @@
 package test
 
 import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -156,4 +161,116 @@ func TestLookupCacheWithoutEdns(t *testing.T) {
 		t.Fatalf("Expected no OPT RR, but got: %s", resp.Extra[0])
 	}
 	t.Fatalf("Expected empty additional section, got %v", resp.Extra)
+}
+
+// TestIssue7630 exercises the metadata map race reported in GitHub issue #7630.
+// It configures a server chain: metadata -> log -> forward -> cache with serve_stale
+// and very short TTLs to force prefetch. The test primes the cache, lets entries expire,
+// then sends concurrent queries mixing positive and NXDOMAIN lookups while the log plugin
+// formats lines that repeatedly read the {/forward/upstream} metadata key.
+//
+// Without the fix in cache.doPrefetch that creates a fresh metadata context for the
+// background prefetch goroutine, this scenario can crash with:
+//
+//	"fatal error: concurrent map read and map write"
+//
+// or trigger the race detector. With the fix, the test should be stable.
+// See: https://github.com/coredns/coredns/issues/7630
+func TestIssue7630(t *testing.T) {
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	upstreamCorefile := `example.org:0 {
+        file ` + name + `
+    }`
+
+	up, udpUp, _, err := CoreDNSServerAndPorts(upstreamCorefile)
+	if err != nil {
+		t.Fatalf("Could not start upstream CoreDNS: %s", err)
+	}
+	defer up.Stop()
+
+	// Build an intentionally heavy log format that repeatedly reads the same metadata
+	// to widen the read window.
+	const repeat = 100
+	logMetaReads := strings.Repeat("{/forward/upstream}", repeat)
+
+	// Caching/forwarding server under test. Use 1s TTL and min TTL 0 to expire quickly
+	// for both positive and negative responses.
+	// Enable serve_stale so that every post-expiration query spawns a prefetch goroutine.
+	// Include metadata and log that reads {/forward/upstream} set by forward.
+	underTestCorefile := `example.org:0 {
+        metadata
+        log . "` + logMetaReads + `"
+        forward . ` + udpUp + ` {
+            health_check 5s domain example.org
+        }
+        cache {
+            success 1000 1 0
+            denial 1000 1 0
+            serve_stale
+        }
+    }`
+
+	inst, udp, _, err := CoreDNSServerAndPorts(underTestCorefile)
+	if err != nil {
+		t.Fatalf("Could not start test CoreDNS: %s", err)
+	}
+	defer inst.Stop()
+
+	// Prime cache with some initial lookups to populate both positive and negative caches.
+	m := new(dns.Msg)
+	m.SetQuestion("short.example.org.", dns.TypeA)
+	if _, err := dns.Exchange(m, udp); err != nil {
+		t.Fatalf("priming positive query failed: %s", err)
+	}
+	// A few NXDOMAINs
+	for i := range 50 {
+		m := new(dns.Msg)
+		m.SetQuestion(fmt.Sprintf("nx%d.example.org.", i), dns.TypeA)
+		if _, err := dns.Exchange(m, udp); err != nil {
+			t.Fatalf("priming negative query failed: %s", err)
+		}
+	}
+
+	// Wait for TTL (1s) to expire so subsequent queries serve stale and trigger prefetch.
+	time.Sleep(1300 * time.Millisecond)
+
+	const (
+		concurrency = 10
+		iterations  = 100
+		names       = 256
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			for i := range iterations {
+				// Mix of positive and negative queries to trigger many independent prefetches.
+				var qname string
+				if i%4 == 0 {
+					qname = "short.example.org."
+				} else {
+					qname = fmt.Sprintf("nx%d.example.org.", r.Intn(names))
+				}
+				m := new(dns.Msg)
+				m.SetQuestion(qname, dns.TypeA)
+				if _, err := dns.Exchange(m, udp); err != nil {
+					// Any error here is unexpected; if the historical race regresses,
+					// the process may crash with concurrent map read/write before we see this.
+					t.Errorf("query failed: %v", err)
+					return
+				}
+				// Small delay to allow background prefetch to overlap with logging of other requests.
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Affects the `cache` plugin.

Wrap `doPrefetch` with a fresh metadata context to prevent concurrent writes to the request-scoped metadata map during background prefetch. Other plugins in the chain might do that.

Add a new integration test which triggers the issue. It hammers concurrent queries while log reads metadata fields repeatedly. If you run the test against `master` with `go test -race ./test` you will see the following:

<details>
<code>
==================
WARNING: DATA RACE
Read at 0x00c000820060 by goroutine 843:
  runtime.mapdelete_fast64()
      /opt/homebrew/Cellar/go/1.25.2/libexec/src/internal/runtime/maps/runtime_fast64_swiss.go:502 +0x8c
  github.com/coredns/coredns/plugin/metadata.ValueFunc()
      /git/coredns/plugin/metadata/provider.go:94 +0x74
  github.com/coredns/coredns/plugin/pkg/replacer.replacer.Replace()
      /git/coredns/plugin/pkg/replacer/replacer.go:273 +0x110
  github.com/coredns/coredns/plugin/pkg/replacer.Replacer.Replace()
      /git/coredns/plugin/pkg/replacer/replacer.go:28 +0x6c
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      /git/coredns/plugin/log/log.go:48 +0x424
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x90
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/metadata.(*Metadata).ServeDNS()
      /git/coredns/plugin/metadata/metadata.go:30 +0x70
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      /git/coredns/core/dnsserver/server.go:305 +0xd00
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1()
      /git/coredns/core/dnsserver/server.go:171 +0x9c
  github.com/miekg/dns.HandlerFunc.ServeDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:37 +0x48
  github.com/miekg/dns.(*Server).serveDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:681 +0x5d0
  github.com/miekg/dns.(*Server).serveUDPPacket()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:622 +0x2d4
  github.com/miekg/dns.(*Server).serveUDP.gowrap2()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x90
Previous write at 0x00c000820060 by goroutine 846:
  runtime.mapaccess2_faststr()
      /opt/homebrew/Cellar/go/1.25.2/libexec/src/internal/runtime/maps/runtime_faststr_swiss.go:162 +0x29c
  github.com/coredns/coredns/plugin/metadata.SetValueFunc()
      /git/coredns/plugin/metadata/provider.go:105 +0x78
  github.com/coredns/coredns/plugin/forward.(*Forward).ServeDNS()
      /git/coredns/plugin/forward/forward.go:154 +0x75c
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/cache.(*Cache).doRefresh()
      /git/coredns/plugin/cache/handler.go:107 +0x170
  github.com/coredns/coredns/plugin/cache.(*Cache).doPrefetch()
      /git/coredns/plugin/cache/handler.go:96 +0x120
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS.gowrap1()
      /git/coredns/plugin/cache/handler.go:59 +0xc4
Goroutine 843 (running) created at:
  github.com/miekg/dns.(*Server).serveUDP()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x5a4
  github.com/miekg/dns.(*Server).ActivateAndServe()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:388 +0x580
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket()
      /git/coredns/core/dnsserver/server.go:175 +0x250
  github.com/coredns/caddy.startServers.func1.2()
      /go/pkg/mod/github.com/coredns/caddy@v1.1.4-0.20250930002214-15135a999495/caddy.go:816 +0xb0
Goroutine 846 (running) created at:
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      /git/coredns/plugin/cache/handler.go:59 +0x748
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      /git/coredns/plugin/log/log.go:36 +0x28c
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x90
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/metadata.(*Metadata).ServeDNS()
      /git/coredns/plugin/metadata/metadata.go:30 +0x70
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      /git/coredns/core/dnsserver/server.go:305 +0xd00
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1()
      /git/coredns/core/dnsserver/server.go:171 +0x9c
  github.com/miekg/dns.HandlerFunc.ServeDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:37 +0x48
  github.com/miekg/dns.(*Server).serveDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:681 +0x5d0
  github.com/miekg/dns.(*Server).serveUDPPacket()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:622 +0x2d4
  github.com/miekg/dns.(*Server).serveUDP.gowrap2()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x90
==================
==================
WARNING: DATA RACE
Read at 0x00c0009b01b8 by goroutine 843:
  github.com/coredns/coredns/plugin/metadata.ValueFunc()
      /git/coredns/plugin/metadata/provider.go:94 +0x7c
  github.com/coredns/coredns/plugin/pkg/replacer.replacer.Replace()
      /git/coredns/plugin/pkg/replacer/replacer.go:273 +0x110
  github.com/coredns/coredns/plugin/pkg/replacer.Replacer.Replace()
      /git/coredns/plugin/pkg/replacer/replacer.go:28 +0x6c
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      /git/coredns/plugin/log/log.go:48 +0x424
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x90
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/metadata.(*Metadata).ServeDNS()
      /git/coredns/plugin/metadata/metadata.go:30 +0x70
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      /git/coredns/core/dnsserver/server.go:305 +0xd00
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1()
      /git/coredns/core/dnsserver/server.go:171 +0x9c
  github.com/miekg/dns.HandlerFunc.ServeDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:37 +0x48
  github.com/miekg/dns.(*Server).serveDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:681 +0x5d0
  github.com/miekg/dns.(*Server).serveUDPPacket()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:622 +0x2d4
  github.com/miekg/dns.(*Server).serveUDP.gowrap2()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x90
Previous write at 0x00c0009b01b8 by goroutine 846:
  github.com/coredns/coredns/plugin/metadata.SetValueFunc()
      /git/coredns/plugin/metadata/provider.go:105 +0x84
  github.com/coredns/coredns/plugin/forward.(*Forward).ServeDNS()
      /git/coredns/plugin/forward/forward.go:154 +0x75c
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/cache.(*Cache).doRefresh()
      /git/coredns/plugin/cache/handler.go:107 +0x170
  github.com/coredns/coredns/plugin/cache.(*Cache).doPrefetch()
      /git/coredns/plugin/cache/handler.go:96 +0x120
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS.gowrap1()
      /git/coredns/plugin/cache/handler.go:59 +0xc4
Goroutine 843 (running) created at:
  github.com/miekg/dns.(*Server).serveUDP()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x5a4
  github.com/miekg/dns.(*Server).ActivateAndServe()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:388 +0x580
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket()
      /git/coredns/core/dnsserver/server.go:175 +0x250
  github.com/coredns/caddy.startServers.func1.2()
      /go/pkg/mod/github.com/coredns/caddy@v1.1.4-0.20250930002214-15135a999495/caddy.go:816 +0xb0
Goroutine 846 (running) created at:
  github.com/coredns/coredns/plugin/cache.(*Cache).ServeDNS()
      /git/coredns/plugin/cache/handler.go:59 +0x748
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/log.Logger.ServeDNS()
      /git/coredns/plugin/log/log.go:36 +0x28c
  github.com/coredns/coredns/plugin/log.(*Logger).ServeDNS()
      <autogenerated>:1 +0x90
  github.com/coredns/coredns/plugin.NextOrFailure()
      /git/coredns/plugin/plugin.go:80 +0x1d8
  github.com/coredns/coredns/plugin/metadata.(*Metadata).ServeDNS()
      /git/coredns/plugin/metadata/metadata.go:30 +0x70
  github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS()
      /git/coredns/core/dnsserver/server.go:305 +0xd00
  github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1()
      /git/coredns/core/dnsserver/server.go:171 +0x9c
  github.com/miekg/dns.HandlerFunc.ServeDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:37 +0x48
  github.com/miekg/dns.(*Server).serveDNS()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:681 +0x5d0
  github.com/miekg/dns.(*Server).serveUDPPacket()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:622 +0x2d4
  github.com/miekg/dns.(*Server).serveUDP.gowrap2()
      /go/pkg/mod/github.com/miekg/dns@v1.1.68/server.go:552 +0x90
==================
--- FAIL: TestIssue7630 (2.66s)
    testing.go:1617: race detected during execution of test
</code>
</details>

### 2. Which issues (if any) are related?

Fixes #7630.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.