### PR TITLE
chore(lint): bump to v2.5.0 and enable godoclint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
-          version: v2.4.0
+          version: v2.5.0
       - name: modernize
         run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@2e31135b736b96cd609904370c71563ce5447826 -diff -test ./... # v0.20.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - canonicalheader
     - copyloopvar
     - durationcheck
+    - godoclint
     - govet
     - ineffassign
     - intrange

--- a/core/dnsserver/quic.go
+++ b/core/dnsserver/quic.go
@@ -60,6 +60,7 @@ func AddPrefix(b []byte) (m []byte) {
 }
 
 // These methods implement the dns.ResponseWriter interface from Go DNS.
+
 func (w *DoQWriter) TsigStatus() error     { return nil }
 func (w *DoQWriter) TsigTimersOnly(b bool) {}
 func (w *DoQWriter) Hijack()               {}

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -175,6 +175,7 @@ func (r *gRPCresponse) Write(b []byte) (int, error) {
 }
 
 // These methods implement the dns.ResponseWriter interface from Go DNS.
+
 func (r *gRPCresponse) Close() error              { return nil }
 func (r *gRPCresponse) TsigStatus() error         { return nil }
 func (r *gRPCresponse) TsigTimersOnly(b bool)     {}

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -192,6 +192,6 @@ var (
 	gitShortStat     string // git diff-index --shortstat
 	gitFilesModified string // git diff-index --name-only HEAD
 
-	// Gitcommit contains the commit where we built CoreDNS from.
+	// GitCommit contains the commit where we built CoreDNS from.
 	GitCommit string
 )

--- a/plugin/auto/zone.go
+++ b/plugin/auto/zone.go
@@ -1,4 +1,3 @@
-// Package auto implements a on-the-fly loading file backend.
 package auto
 
 import (

--- a/plugin/kubernetes/object/multicluster_endpoint.go
+++ b/plugin/kubernetes/object/multicluster_endpoint.go
@@ -8,7 +8,7 @@ import (
 	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
-// Endpoints is a stripped down api.Endpoints with only the items we need for CoreDNS.
+// MultiClusterEndpoints is a stripped down api.Endpoints with only the items we need for CoreDNS.
 type MultiClusterEndpoints struct {
 	Endpoints
 	ClusterId string
@@ -18,7 +18,7 @@ type MultiClusterEndpoints struct {
 // MultiClusterEndpointsKey returns a string using for the index.
 func MultiClusterEndpointsKey(name, namespace string) string { return name + "." + namespace }
 
-// EndpointSliceToEndpoints converts a *discovery.EndpointSlice to a *Endpoints.
+// EndpointSliceToMultiClusterEndpoints converts a *discovery.EndpointSlice to a *Endpoints.
 func EndpointSliceToMultiClusterEndpoints(obj meta.Object) (meta.Object, error) {
 	labels := maps.Clone(obj.GetLabels())
 	ends, err := EndpointSliceToEndpoints(obj)

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -1,4 +1,4 @@
-// Package loadbalance is a plugin for rewriting responses to do "load balancing"
+// Package loadbalance is a plugin for rewriting responses to do "load balancing".
 package loadbalance
 
 import (
@@ -9,7 +9,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// RoundRobin is a plugin to rewrite responses for "load balancing".
+// LoadBalance is a plugin to rewrite responses for "load balancing".
 type LoadBalance struct {
 	Next    plugin.Handler
 	shuffle func(*dns.Msg) *dns.Msg

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -1,4 +1,3 @@
-// Package loadbalance shuffles A, AAAA and MX records.
 package loadbalance
 
 import (

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -1,4 +1,3 @@
-// Package rewrite is a plugin for rewriting requests internally to something different.
 package rewrite
 
 import (

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -23,9 +23,9 @@ const (
 
 // These are defined processing mode.
 const (
-	// Processing should stop after completing this rule
+	// Stop processing should stop after completing this rule
 	Stop = "stop"
-	// Processing should continue to next rule
+	// Continue processing should continue to next rule
 	Continue = "continue"
 )
 

--- a/plugin/rewrite/type.go
+++ b/plugin/rewrite/type.go
@@ -1,4 +1,3 @@
-// Package rewrite is a plugin for rewriting requests internally to something different.
 package rewrite
 
 import (

--- a/plugin/test/doc.go
+++ b/plugin/test/doc.go
@@ -1,2 +1,0 @@
-// Package test contains helper functions for writing plugin tests.
-package test

--- a/plugin/test/scrape.go
+++ b/plugin/test/scrape.go
@@ -14,7 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package test will scrape a target and you can inspect the variables.
+// Package test contains helper functions for writing plugin tests.
+// For example to scrape a target and inspect the variables.
 // Basic usage:
 //
 //	result := Scrape("http://localhost:9153/metrics")


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Align code comments with godoclint with the latest [golangci-lint version 2.5.0](https://github.com/golangci/golangci-lint/releases/tag/v2.5.0). There were a few packages that had a package level comment in multiple places. For example, I removed the `plugin/test/doc.go` and modified `plugin/test/scrape.go` to cover full package level comment.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

No.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
