### PR TITLE
chore(lint): update to golangci-lint v2.6.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
-          version: v2.5.0
-      - name: modernize
-        run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@2e31135b736b96cd609904370c71563ce5447826 -diff -test ./... # v0.20.0
+          version: v2.6.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - govet
     - ineffassign
     - intrange
+    - modernize
     - nakedret
     - nolintlint
     - perfsprint
@@ -42,6 +43,9 @@ linters:
     govet:
       enable:
         - nilness
+    modernize:
+      disable:
+        - reflecttypefor
     perfsprint:
       error-format: false
     revive:

--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -44,8 +44,8 @@ func (r *cnameTargetRule) getFromAndToTarget(inputCName string) (from string, to
 			return inputCName, r.paramToTarget + after
 		}
 	case SuffixMatch:
-		if strings.HasSuffix(inputCName, r.paramFromTarget) {
-			return inputCName, strings.TrimSuffix(inputCName, r.paramFromTarget) + r.paramToTarget
+		if before, ok := strings.CutSuffix(inputCName, r.paramFromTarget); ok {
+			return inputCName, before + r.paramToTarget
 		}
 	case SubstringMatch:
 		if strings.Contains(inputCName, r.paramFromTarget) {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -81,8 +81,8 @@ func newSuffixStringRewriter(orig, replacement string) stringRewriter {
 }
 
 func (r *suffixStringRewriter) rewriteString(src string) string {
-	if strings.HasSuffix(src, r.suffix) {
-		return strings.TrimSuffix(src, r.suffix) + r.replacement
+	if before, ok := strings.CutSuffix(src, r.suffix); ok {
+		return before + r.replacement
 	}
 	return src
 }
@@ -234,8 +234,8 @@ func newSuffixNameRule(nextAction string, auto bool, suffix, replacement string,
 }
 
 func (rule *suffixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
-	if strings.HasSuffix(state.Name(), rule.suffix) {
-		state.Req.Question[0].Name = strings.TrimSuffix(state.Name(), rule.suffix) + rule.replacement
+	if before, ok := strings.CutSuffix(state.Name(), rule.suffix); ok {
+		state.Req.Question[0].Name = before + rule.replacement
 		return rule.responseRuleFor(state)
 	}
 	return nil, RewriteIgnored


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Update to the [latest golangci-lint version v2.6.0](https://github.com/golangci/golangci-lint/releases/tag/v2.6.0) and use built-in modernize linter, instead of a custom CI step.

Fix a few new findings:

```
plugin/rewrite/cname_target.go:47:6: stringscutprefix: HasSuffix + TrimSuffix can be simplified to CutSuffix (modernize)
                if strings.HasSuffix(inputCName, r.paramFromTarget) {
                   ^
plugin/rewrite/name.go:84:5: stringscutprefix: HasSuffix + TrimSuffix can be simplified to CutSuffix (modernize)
        if strings.HasSuffix(src, r.suffix) {
           ^
plugin/rewrite/name.go:237:5: stringscutprefix: HasSuffix + TrimSuffix can be simplified to CutSuffix (modernize)
        if strings.HasSuffix(state.Name(), rule.suffix) {
           ^
```

I disabled `reflecttypefor` linter from this PR as it had a large number of changes. Example finding:

```
plugin/rewrite/rewrite_test.go:128:59: reflecttypefor: reflect.TypeOf call can be simplified using TypeFor (modernize)
                {[]string{"edns0", "subnet", "set", "24", "56"}, false, reflect.TypeOf(&edns0SubnetRule{})},
                                                                        ^
```


### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
