### PR TITLE
 Performance tuning for plugin/file

### DIFF
--- a/plugin/file/tree/less.go
+++ b/plugin/file/tree/less.go
@@ -16,12 +16,11 @@ import (
 //
 // The values of a and b are *not* lowercased before the comparison!
 func less(a, b string) int {
-	i := 1
 	aj := len(a)
 	bj := len(b)
 	for {
-		ai, oka := dns.PrevLabel(a, i)
-		bi, okb := dns.PrevLabel(b, i)
+		ai, oka := dns.PrevLabel(a[:aj], 1)
+		bi, okb := dns.PrevLabel(b[:bj], 1)
 		if oka && okb {
 			return 0
 		}
@@ -38,7 +37,6 @@ func less(a, b string) int {
 			return res
 		}
 
-		i++
 		aj, bj = ai, bi
 	}
 }

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -163,19 +163,22 @@ func (z *Zone) nameFromRight(qname string, i int) (string, bool) {
 		return z.origin, false
 	}
 
+	n := len(qname)
 	for j := 1; j <= z.origLen; j++ {
-		if _, shot := dns.PrevLabel(qname, j); shot {
+		if m, shot := dns.PrevLabel(qname[:n], 1); shot {
 			return qname, shot
+		} else {
+			n = m
 		}
 	}
 
-	k := 0
-	var shot bool
 	for j := 1; j <= i; j++ {
-		k, shot = dns.PrevLabel(qname, j+z.origLen)
+		m, shot := dns.PrevLabel(qname[:n], 1)
 		if shot {
 			return qname, shot
+		} else {
+			n = m
 		}
 	}
-	return qname[k:], false
+	return qname[n:], false
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The functions `tree.less` and `nameFromRight` are in the critical DNS data processing path of file plugin. Optimization of the two functions can help reduce server load and boost throughput of CoreDNS server significantly. 

Note that both functions call `dns.PrevLabel` in a loop, and always start each call from the tail of the domain name. This patch improves the two functions performance by calling `dns.PrevLabel` starting from the last processed label, which dramatically reduces the cost of `dns.PrevLabel`.

As the benchmark results showed, the performance of `tree.less` is improved by about 15%,
```
$ go test -bench=Less -run=^$
goos: linux
goarch: amd64
pkg: github.com/coredns/coredns/plugin/file/tree
cpu: Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz
BenchmarkLess/base-16              99003             12105 ns/op
BenchmarkLess/optimized-16        114522             10590 ns/op
PASS
ok      github.com/coredns/coredns/plugin/file/tree     2.416s
```
and performance of `nameFromRight` with the optimization is gained by double or triple.

```
### Benchmark test result for the original implementation:
$ go test -bench=. -run=^$                                                                                                                  
goos: linux
goarch: amd64
pkg: github.com/coredns/coredns/plugin/file
cpu: Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz
BenchmarkFileLookupDNSSEC-16              173002              5902 ns/op
BenchmarkFileParseInsert-16                15434             78844 ns/op
BenchmarkFileLookup-16                    469035              2535 ns/op
BenchmarkNameFromRight/i0_origin-16     430719652                2.794 ns/op
BenchmarkNameFromRight/eq_origin_i1_shot-16             30933135                37.52 ns/op
BenchmarkNameFromRight/two_labels_i1-16                 29375857                40.71 ns/op
BenchmarkNameFromRight/two_labels_i2-16                 18556830                63.97 ns/op
BenchmarkNameFromRight/two_labels_i3_shot-16            14678812                84.73 ns/op
BenchmarkNameFromRight/ten_labels_i5-16                  8522132               133.0 ns/op
BenchmarkNameFromRight/ten_labels_i11_shot-16            3154410               378.2 ns/op
BenchmarkNameFromRight/not_subdomain_shot-16            35297224                33.59 ns/op
BenchmarkNameFromRightRandomized-16                     10638702               113.4 ns/op             0 B/op          0 allocs/op                                                                               
PASS
ok      github.com/coredns/coredns/plugin/file  14.276s

$ vim zone.go  ## apply the optimization

### Benchmark test result after optimized:
$ go test -bench=. -run=^$
goos: linux
goarch: amd64
pkg: github.com/coredns/coredns/plugin/file
cpu: Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz
BenchmarkFileLookupDNSSEC-16              185454              5870 ns/op
BenchmarkFileParseInsert-16                15174             78894 ns/op
BenchmarkFileLookup-16                    461064              2528 ns/op
BenchmarkNameFromRight/i0_origin-16     425864671                2.808 ns/op
BenchmarkNameFromRight/eq_origin_i1_shot-16             60903428                19.53 ns/op
BenchmarkNameFromRight/two_labels_i1-16                 50209297                24.21 ns/op
BenchmarkNameFromRight/two_labels_i2-16                 42483711                27.88 ns/op
BenchmarkNameFromRight/two_labels_i3_shot-16            40898925                29.24 ns/op
BenchmarkNameFromRight/ten_labels_i5-16                 27916532                44.54 ns/op
BenchmarkNameFromRight/ten_labels_i11_shot-16           17540040                67.59 ns/op
BenchmarkNameFromRight/not_subdomain_shot-16            67180514                17.46 ns/op
BenchmarkNameFromRightRandomized-16                     32692081                38.21 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/coredns/coredns/plugin/file  14.344s
```

### 2. Which issues (if any) are related?

nothing

### 3. Which documentation changes (if any) need to be made?

nothing

### 4. Does this introduce a backward incompatible change or deprecation?

no
