### PR TITLE
ci: Update k8s + kind versions for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ integrationDefaults: &integrationDefaults
     image: default
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/coredns
   environment:
-    - K8S_VERSION: v1.29.4
-    - KIND_VERSION: v0.25.0
+    - K8S_VERSION: v1.34.0
+    - KIND_VERSION: v0.30.0
     - KUBECONFIG: /home/circleci/.kube/kind-config-kind
 
 setupKubernetes: &setupKubernetes


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Bump K8s / KIND versions in integration tests.

[Last bump was Nov 2024](https://github.com/coredns/coredns/pull/6988) for [kind `0.25.0`](https://github.com/kubernetes-sigs/kind/releases/tag/v0.25.0) (Nov 2024). I'm not sure how that author decided on the `K8S_VERSION`, but I have bumped it to the default version supported by kind `0.30.0` (Aug 2025).

Potentially worth noting is [kind `0.27.0`](https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0) (Feb 2025) upgraded from containerd 1.x to 2.x.

### 2. Which issues (if any) are related?

This update contains a fix relevant to resolve a CI failure encountered that only occurs due to the aging kind environment, where defaults have changed (_which the PR expects_).

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
