### PR TITLE
chore: Update `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
 ARG DEBIAN_IMAGE=debian:stable-slim
 ARG BASE=gcr.io/distroless/static-debian12:nonroot
-FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
-SHELL [ "/bin/sh", "-ec" ]
 
-RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
-           DEBIAN_FRONTEND=noninteractive \
-           DEBIAN_PRIORITY=critical \
-           TERM=linux ; \
-    apt-get -qq update ; \
-    apt-get -qq upgrade ; \
-    apt-get -qq --no-install-recommends install ca-certificates libcap2-bin; \
-    apt-get clean
+FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq update \
+    && apt-get -qq --no-install-recommends install libcap2-bin
 COPY coredns /coredns
 RUN setcap cap_net_bind_service=+ep /coredns
 
-FROM --platform=$TARGETPLATFORM ${BASE}
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+FROM ${BASE}
 COPY --from=build /coredns /coredns
 USER nonroot:nonroot
 # Reset the working directory inherited from the base image back to the expected default:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Housekeeping for the `Dockerfile`.

<details>
<summary>Change Overview and reasoning</summary>

- [`apt-get upgrade` was added for security reasons](https://github.com/coredns/coredns/pull/5571#issuecomment-1215094844), yet is redundant for an image that is published and ceases to receive future security updates [like a base image does](https://pythonspeed.com/articles/security-updates-in-docker/) (_the article encourages upgrading packages but lacks relevance for this `Dockerfile`_).
  - CoreDNS is not built with any of these upgraded packages. The only content copied over to the final stage is the `setcap` patched CoreDNS + redundant `ca-certificates.crt`. There is nothing gained here security wise from upgrading packages.
  - [Other operations and ENV from the `build` stage](https://github.com/coredns/coredns/pull/5571) were [related to supporting the automated upgrade](https://github.com/coredns/coredns/pull/5571#discussion_r945840442) apparently, justification was rather vague (_only `DEBIAN_FRONTEND` ENV seems relevant_).
- [There is no need](https://github.com/coredns/coredns/pull/5571#issuecomment-1215086349) to keep the `COPY` for `ca-certificates.crt`, the [image base `static-debian12:nonroot` already has that](https://github.com/GoogleContainerTools/distroless/blob/ee88fcca0b2256ee42ca1c53bc5cf594e2e2d896/base/README.md) (_unless the `BASE` reference `ARG` is changed_). I assume that the base image won't be changing much due to the expectation of `USER nonroot:nonroot` to be successful, thus value of overwriting the contents seems questionable?
  - The `COPY` for `ca-certificates.crt` is [from an earlier improvement for when the final stage was using `scratch`](https://github.com/coredns/coredns/pull/5571). The base image switch from `scratch` to distroless was [proposed in Nov 2022](https://github.com/coredns/coredns/pull/5732/files#r1012459980)
  - Later (_when the `scratch` image was still used_) a PR introduced the [ARG `BASE` to support switching final stage base image from `scratch`](https://github.com/coredns/coredns/pull/5931#issuecomment-1442786431)
    - That PR was not merged until later (_after [this rebase](https://github.com/coredns/coredns/pull/5931/commits/e97a888d78b2f849c0b57ce280cc0d532af68cd3)_) when the `Dockerfile` had since [switched to use `USER nonroot:nonroot` at runtime](https://github.com/coredns/coredns/pull/5969) (_which has a [compatibility issue in k8s](https://github.com/coredns/coredns/issues/7542) with associated [stale PR fix](https://github.com/coredns/coredns/pull/6416)_).
- The default platform for `FROM` should be the target platform, so that has been dropped as well. This was [introduced in Oct 2022](https://github.com/coredns/coredns/pull/5691) but AFAIK not well understood.
  - Only [this change](https://github.com/coredns/coredns/pull/5691/files#diff-9622619b5207ed1b3ace8ccab271f0f000e5271e1d6412a5b598a3171f5f1080R86) is relevant to fixing the arch association to the scratch image output from a build.
  - The PR also introduced `--platform=$BUILDPLATFORM`, which is a useful improvement to unify the `build` stage to only be handled on the native platform of the build host. Doing that has no affect on the runtime stage image (_unless you copy over platform specific content that is incompatible, which is not the case here_).

</details>

**NOTE:** The ARG `BASE` should probably be removed given context noted in the details above suggests it's no longer providing meaningful value.

### 2. Which issues (if any) are related?

This has been extracted from previous PRs that attempted to bundle these changes, so that the PR description and discussion can be focused on these changes alone (_which seem reasonable_):
- https://github.com/coredns/coredns/pull/6320#issue-1898103227
- https://github.com/coredns/coredns/pull/7435#issue-3298950667

I have been trying to push these through **since Sep 2023** 😕

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A
