### PR TITLE
fix: correct spelling of MaximumDefaultTTL in cache and dnsutil packages

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -302,9 +302,9 @@ func (w *verifyStaleResponseWriter) WriteMsg(res *dns.Msg) error {
 }
 
 const (
-	maxTTL  = dnsutil.MaximumDefaulTTL
+	maxTTL  = dnsutil.MaximumDefaultTTL
 	minTTL  = dnsutil.MinimalDefaultTTL
-	maxNTTL = dnsutil.MaximumDefaulTTL / 2
+	maxNTTL = dnsutil.MaximumDefaultTTL / 2
 	minNTTL = dnsutil.MinimalDefaultTTL
 
 	defaultCap = 10000 // default capacity of the cache.

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -47,7 +47,8 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 const (
 	// MinimalDefaultTTL is the absolute lowest TTL we use in CoreDNS.
 	MinimalDefaultTTL = 5 * time.Second
-	// MaximumDefaulTTL is the maximum TTL was use on RRsets in CoreDNS.
-	// TODO: rename as MaximumDefaultTTL
-	MaximumDefaulTTL = 1 * time.Hour
+	// MaximumDefaultTTL is the maximum TTL was use on RRsets in CoreDNS.
+	MaximumDefaultTTL = 1 * time.Hour
+	// Deprecated: use MaximumDefaultTTL instead.
+	MaximumDefaulTTL = MaximumDefaultTTL
 )


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fixing a typo in constant name

### 2. Which issues (if any) are related?

There was a "TODO" comment on source code - `// TODO: rename as MaximumDefaultTTL`

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

Yes, we’re keeping the old constant with deprecation notice for backward compatibility
