### PR TITLE
fix: prevent QUIC reload panic by lazily initializing the listener

### DIFF
--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -103,6 +103,14 @@ func NewServerQUIC(addr string, group []*Config) (*ServerQUIC, error) {
 // ServePacket implements caddy.UDPServer interface.
 func (s *ServerQUIC) ServePacket(p net.PacketConn) error {
 	s.m.Lock()
+	if s.quicListener == nil {
+		listener, err := quic.Listen(p, s.tlsConfig, s.quicConfig)
+		if err != nil {
+			s.m.Unlock()
+			return err
+		}
+		s.quicListener = listener
+	}
 	s.listenAddr = s.quicListener.Addr()
 	s.m.Unlock()
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fixes a reload crash in DNS-over-QUIC by lazily creating s.quicListener inside ServePacket when it’s nil, so the reused socket from reload no longer causes a panic.
### 2. Which issues (if any) are related?
fixes #7679
 
### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No