### PR TITLE
feat: optimize tsig, secondary, and transfer plugin

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -74,6 +74,9 @@ type Config struct {
 	// TSIG secrets, [name]key.
 	TsigSecret map[string]string
 
+	// TSIG algorithms, [name]algorithm.
+	TsigAlgorithm map[string]string
+
 	// Plugin stack.
 	Plugin []plugin.Plugin
 

--- a/core/dnsserver/tsig_provider.go
+++ b/core/dnsserver/tsig_provider.go
@@ -1,0 +1,104 @@
+package dnsserver
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"hash"
+
+	"github.com/miekg/dns"
+)
+
+type tsigProvider struct {
+	TsigSecret    map[string]string
+	TsigAlgorithm map[string]string
+}
+
+var _ dns.TsigProvider = &tsigProvider{}
+
+// Generate a digest using specific algorithm.
+func (p *tsigProvider) Generate(msg []byte, t *dns.TSIG) ([]byte, error) {
+	secret, ok := p.match(t)
+	if !ok {
+		return nil, dns.ErrKey
+	}
+
+	// copied from github.com/miekg/dns/tsig.go
+	rawsecret, err := fromBase64([]byte(secret))
+	if err != nil {
+		return nil, err
+	}
+	var h hash.Hash
+	switch dns.CanonicalName(t.Algorithm) {
+	case dns.HmacSHA1:
+		h = hmac.New(sha1.New, rawsecret)
+	case dns.HmacSHA224:
+		h = hmac.New(sha256.New224, rawsecret)
+	case dns.HmacSHA256:
+		h = hmac.New(sha256.New, rawsecret)
+	case dns.HmacSHA384:
+		h = hmac.New(sha512.New384, rawsecret)
+	case dns.HmacSHA512:
+		h = hmac.New(sha512.New, rawsecret)
+	default:
+		return nil, dns.ErrKeyAlg
+	}
+	h.Write(msg)
+	return h.Sum(nil), nil
+}
+
+func fromBase64(s []byte) (buf []byte, err error) {
+	buflen := base64.StdEncoding.DecodedLen(len(s))
+	buf = make([]byte, buflen)
+	n, err := base64.StdEncoding.Decode(buf, s)
+	buf = buf[:n]
+	return
+}
+
+// Verify the digest of TSIG RR.
+func (p *tsigProvider) Verify(msg []byte, t *dns.TSIG) error {
+	b, err := p.Generate(msg, t)
+	if err != nil {
+		return err
+	}
+	mac, err := hex.DecodeString(t.MAC)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(b, mac) {
+		return dns.ErrSig
+	}
+	return nil
+}
+
+// match the name and algorithm of TSIG RR. if true, return the TSIG key.
+func (p *tsigProvider) match(t *dns.TSIG) (string, bool) {
+	// https://datatracker.ietf.org/doc/html/rfc8945#section-1.2-2
+	// Use of TSIG presumes prior agreement between the two parties involved
+	// (e.g., resolver and server) as to any algorithm and key to be used.
+	// The way that this agreement is reached is outside the scope of the document.
+	secret, ok := p.TsigSecret[t.Hdr.Name]
+	if !ok {
+		return "", false
+	}
+
+	if p.TsigAlgorithm[t.Hdr.Name] != t.Algorithm {
+		return "", false
+	}
+
+	return secret, true
+}
+
+// NewTsigProvider create a TSIG provider based on exact RR name matching and algorithms for verifying or generating digests.
+func NewTsigProvider(tsigSecret, tsigAlgorithm map[string]string) dns.TsigProvider {
+	if len(tsigSecret) == 0 || len(tsigAlgorithm) == 0 {
+		return nil
+	}
+	return &tsigProvider{
+		TsigSecret:    tsigSecret,
+		TsigAlgorithm: tsigAlgorithm,
+	}
+}

--- a/plugin/file/notify.go
+++ b/plugin/file/notify.go
@@ -15,6 +15,12 @@ func (z *Zone) isNotify(state request.Request) bool {
 	if state.Req.Opcode != dns.OpcodeNotify {
 		return false
 	}
+	// https://datatracker.ietf.org/doc/html/rfc9103#section-5.3.1-4
+	// But since the only query type (QTYPE) for NOTIFY defined at the time of this writing is SOA,
+	// this does not pose a potential leak.
+	if len(state.Req.Question) != 1 || state.Req.Question[0].Qtype != dns.TypeSOA {
+		return false
+	}
 	if len(z.TransferFrom) == 0 {
 		return false
 	}

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -140,7 +140,7 @@ func TestIsNotify(t *testing.T) {
 
 func newRequest(zone string, qtype uint16) request.Request {
 	m := new(dns.Msg)
-	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetQuestion(zone, qtype)
 	m.SetEdns0(4097, true)
 	return request.Request{W: &test.ResponseWriter{}, Req: m}
 }

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -27,6 +27,9 @@ type Zone struct {
 	StartupOnce  sync.Once
 	TransferFrom []string
 
+	TsigSecret    map[string]string
+	TsigAlgorithm map[string]string
+
 	ReloadInterval time.Duration
 	reloadShutdown chan bool
 
@@ -181,4 +184,15 @@ func (z *Zone) nameFromRight(qname string, i int) (string, bool) {
 		}
 	}
 	return qname[n:], false
+}
+
+func (z *Zone) needTsig() bool {
+	return len(z.TsigSecret) > 0
+}
+
+func (z *Zone) getTsigName() string {
+	for name := range z.TsigSecret {
+		return name
+	}
+	return ""
 }

--- a/plugin/transfer/setup.go
+++ b/plugin/transfer/setup.go
@@ -30,6 +30,7 @@ func setup(c *caddy.Controller) error {
 	c.OnStartup(func() error {
 		config := dnsserver.GetConfig(c)
 		t.tsigSecret = config.TsigSecret
+		t.tsigAlgorithm = config.TsigAlgorithm
 		// find all plugins that implement Transferer and add them to Transferers
 		plugins := config.Handlers()
 		for _, pl := range plugins {

--- a/plugin/tsig/setup.go
+++ b/plugin/tsig/setup.go
@@ -30,6 +30,7 @@ func setup(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
 
 	config.TsigSecret = t.secrets
+	config.TsigAlgorithm = t.algorithms
 
 	config.AddPlugin(func(next plugin.Handler) plugin.Handler {
 		t.Next = next
@@ -41,8 +42,9 @@ func setup(c *caddy.Controller) error {
 
 func parse(c *caddy.Controller) (*TSIGServer, error) {
 	t := &TSIGServer{
-		secrets: make(map[string]string),
-		types:   defaultQTypes,
+		secrets:    make(map[string]string),
+		algorithms: make(map[string]string),
+		types:      defaultQTypes,
 	}
 
 	for i := 0; c.Next(); i++ {
@@ -55,7 +57,7 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 			switch c.Val() {
 			case "secret":
 				args := c.RemainingArgs()
-				if len(args) != 2 {
+				if len(args) < 2 {
 					return nil, c.ArgErr()
 				}
 				k := plugin.Name(args[0]).Normalize()
@@ -63,6 +65,16 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 					return nil, fmt.Errorf("key %q redefined", k)
 				}
 				t.secrets[k] = args[1]
+				if len(args) > 2 {
+					algorithm := plugin.Name(args[2]).Normalize()
+					if !validateAlgorithm(algorithm) {
+						return nil, c.ArgErr()
+					}
+					t.algorithms[k] = algorithm
+				} else {
+					// algorithm recommended by rfc8945
+					t.algorithms[k] = dns.HmacSHA256
+				}
 			case "secrets":
 				args := c.RemainingArgs()
 				if len(args) != 1 {
@@ -72,7 +84,7 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 				if err != nil {
 					return nil, err
 				}
-				secrets, err := parseKeyFile(f)
+				secrets, algorithms, err := parseKeyFile(f)
 				if err != nil {
 					return nil, err
 				}
@@ -81,6 +93,12 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 						return nil, fmt.Errorf("key %q redefined", k)
 					}
 					t.secrets[k] = s
+				}
+				for k, s := range algorithms {
+					if _, exists := t.algorithms[k]; exists {
+						return nil, fmt.Errorf("key %q redefined", k)
+					}
+					t.algorithms[k] = s
 				}
 			case "require":
 				t.types = qTypes{}
@@ -110,8 +128,9 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 	return t, nil
 }
 
-func parseKeyFile(f io.Reader) (map[string]string, error) {
+func parseKeyFile(f io.Reader) (map[string]string, map[string]string, error) {
 	secrets := make(map[string]string)
+	algorithms := make(map[string]string)
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		fields := strings.Fields(s.Text())
@@ -119,18 +138,18 @@ func parseKeyFile(f io.Reader) (map[string]string, error) {
 			continue
 		}
 		if fields[0] != "key" {
-			return nil, fmt.Errorf("unexpected token %q", fields[0])
+			return nil, nil, fmt.Errorf("unexpected token %q", fields[0])
 		}
 		if len(fields) < 2 {
-			return nil, fmt.Errorf("expected key name %q", s.Text())
+			return nil, nil, fmt.Errorf("expected key name %q", s.Text())
 		}
 		key := strings.Trim(fields[1], "\"{")
 		if len(key) == 0 {
-			return nil, fmt.Errorf("expected key name %q", s.Text())
+			return nil, nil, fmt.Errorf("expected key name %q", s.Text())
 		}
 		key = plugin.Name(key).Normalize()
 		if _, ok := secrets[key]; ok {
-			return nil, fmt.Errorf("key %q redefined", key)
+			return nil, nil, fmt.Errorf("key %q redefined", key)
 		}
 	key:
 		for s.Scan() {
@@ -140,14 +159,21 @@ func parseKeyFile(f io.Reader) (map[string]string, error) {
 			}
 			switch fields[0] {
 			case "algorithm":
-				continue
+				if len(fields) < 2 {
+					return nil, nil, fmt.Errorf("expected secret algorithm %q", s.Text())
+				}
+				algorithm := dns.Fqdn(strings.ToLower(strings.Trim(fields[1], "\";")))
+				if len(algorithm) == 0 || !validateAlgorithm(algorithm) {
+					return nil, nil, fmt.Errorf("expected secret algorithm %q", s.Text())
+				}
+				algorithms[key] = algorithm
 			case "secret":
 				if len(fields) < 2 {
-					return nil, fmt.Errorf("expected secret key %q", s.Text())
+					return nil, nil, fmt.Errorf("expected secret key %q", s.Text())
 				}
 				secret := strings.Trim(fields[1], "\";")
 				if len(secret) == 0 {
-					return nil, fmt.Errorf("expected secret key %q", s.Text())
+					return nil, nil, fmt.Errorf("expected secret key %q", s.Text())
 				}
 				secrets[key] = secret
 			case "}":
@@ -155,14 +181,28 @@ func parseKeyFile(f io.Reader) (map[string]string, error) {
 			case "};":
 				break key
 			default:
-				return nil, fmt.Errorf("unexpected token %q", fields[0])
+				return nil, nil, fmt.Errorf("unexpected token %q", fields[0])
 			}
 		}
 		if _, ok := secrets[key]; !ok {
-			return nil, fmt.Errorf("expected secret for key %q", key)
+			return nil, nil, fmt.Errorf("expected secret for key %q", key)
 		}
 	}
-	return secrets, nil
+	for key := range secrets {
+		if _, ok := algorithms[key]; !ok {
+			algorithms[key] = dns.HmacSHA256
+		}
+	}
+	return secrets, algorithms, nil
+}
+
+func validateAlgorithm(algorithm string) bool {
+	switch algorithm {
+	case dns.HmacSHA1, dns.HmacSHA224, dns.HmacSHA256, dns.HmacSHA384, dns.HmacSHA512:
+		return true
+	default:
+		return false
+	}
 }
 
 var defaultQTypes = qTypes{}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
1. plugin/secondary: sign/verify transfer requests/responses when TSIG is configured.
2. plugin/secondary: fixed an issue where secondary plugin reloading did not close update goroutine.
3. plugin/tsig: supports specifying the algorithm type of the key.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/5606
https://github.com/coredns/coredns/issues/6714
https://github.com/coredns/coredns/issues/7141

### 3. Which documentation changes (if any) need to be made?

plugin/secondary
plugin/tsig

### 4. Does this introduce a backward incompatible change or deprecation?
the default algorithm of tsig is hmac-sha256.

