### PR TITLE
fix: fix reload causing secondary plugin goroutine to leak.

### DIFF
--- a/plugin/file/secondary.go
+++ b/plugin/file/secondary.go
@@ -107,7 +107,7 @@ func less(a, b uint32) bool {
 // and uses the SOA parameters. Every refresh it will check for a new SOA number. If that fails (for all
 // server) it will retry every retry interval. If the zone failed to transfer before the expire, the zone
 // will be marked expired.
-func (z *Zone) Update() error {
+func (z *Zone) Update(updateShutdown chan bool) error {
 	// If we don't have a SOA, we don't have a zone, wait for it to appear.
 	for z.SOA == nil {
 		time.Sleep(1 * time.Second)
@@ -183,6 +183,12 @@ Restart:
 			retryTicker.Stop()
 			expireTicker.Stop()
 			goto Restart
+
+		case <-updateShutdown:
+			refreshTicker.Stop()
+			retryTicker.Stop()
+			expireTicker.Stop()
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
plugin/secondary: fixed an issue where secondary plugin reloading did not close update goroutine.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/6714
https://github.com/coredns/coredns/issues/7141

### 3. Which documentation changes (if any) need to be made?
no

### 4. Does this introduce a backward incompatible change or deprecation?
no
