### PR TITLE
plugin/rewrite: pre-compile CNAME rewrite regexp

### DIFF
--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -25,7 +25,8 @@ type cnameTargetRule struct {
 	paramFromTarget string
 	paramToTarget   string
 	nextAction      string
-	Upstream        UpstreamInt // Upstream for looking up external names during the resolution process.
+	pattern         *regexp.Regexp // Compiled paramFromTarget regex for RegexMatch
+	Upstream        UpstreamInt    // Upstream for looking up external names during the resolution process.
 }
 
 // cnameTargetRuleWithReqState is cname target rewrite rule state
@@ -52,8 +53,7 @@ func (r *cnameTargetRule) getFromAndToTarget(inputCName string) (from string, to
 			return inputCName, strings.ReplaceAll(inputCName, r.paramFromTarget, r.paramToTarget)
 		}
 	case RegexMatch:
-		pattern := regexp.MustCompile(r.paramFromTarget)
-		regexGroups := pattern.FindStringSubmatch(inputCName)
+		regexGroups := r.pattern.FindStringSubmatch(inputCName)
 		if len(regexGroups) == 0 {
 			return "", ""
 		}
@@ -142,6 +142,13 @@ func newCNAMERule(nextAction string, args ...string) (Rule, error) {
 		paramToTarget:   paramToTarget,
 		nextAction:      nextAction,
 		Upstream:        upstream.New(),
+	}
+	if rewriteType == RegexMatch {
+		re, err := regexp.Compile(paramFromTarget)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cname rewrite regex pattern: %w", err)
+		}
+		rule.pattern = re
 	}
 	return &rule, nil
 }

--- a/plugin/rewrite/setup_test.go
+++ b/plugin/rewrite/setup_test.go
@@ -33,6 +33,7 @@ func TestParse(t *testing.T) {
 }`, true, "must begin with a name rule"},
 		{`rewrite stop`, true, ""},
 		{`rewrite continue`, true, ""},
+		{`rewrite stop name regex [bad[ bar answer name bar foo`, true, ""},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This commit changes the CNAME rewrite rule to use a pre-compiled regexp when the match type is RegexMatch instead of compiling it on-the-fly for each request. This will also allow for invalid regexp patterns to be identified during setup instead of causing a panic when the rule is first invoked.

### 1. Why is this pull request needed and what does it do?

This PR will increase the performance of the CNAME rewrite plugin when using a regex match and will allow for invalid regex patterns to be identified during plugin setup instead of causing a panic the first time the rewrite rule is invoked.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A
