### PR TITLE
plugin/cache: remove superfluous allocations in item.toMsg

### DIFF
--- a/plugin/cache/dnssec.go
+++ b/plugin/cache/dnssec.go
@@ -6,8 +6,14 @@ import "github.com/miekg/dns"
 // If dup is true the RRs in rrs are _copied_ before adjusting their
 // TTL and the slice of copied RRs is returned.
 func filterRRSlice(rrs []dns.RR, ttl uint32, dup bool) []dns.RR {
+	n := 0
+	for _, r := range rrs {
+		if r.Header().Rrtype != dns.TypeOPT {
+			n++
+		}
+	}
+	rs := make([]dns.RR, n)
 	j := 0
-	rs := make([]dns.RR, len(rrs))
 	for _, r := range rrs {
 		if r.Header().Rrtype == dns.TypeOPT {
 			continue
@@ -20,5 +26,5 @@ func filterRRSlice(rrs []dns.RR, ttl uint32, dup bool) []dns.RR {
 		rs[j].Header().Ttl = ttl
 		j++
 	}
-	return rs[:j]
+	return rs
 }

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -82,10 +82,6 @@ func (i *item) toMsg(m *dns.Msg, now time.Time, do bool, ad bool) *dns.Msg {
 	m1.RecursionAvailable = i.RecursionAvailable
 	m1.Rcode = i.Rcode
 
-	m1.Answer = make([]dns.RR, len(i.Answer))
-	m1.Ns = make([]dns.RR, len(i.Ns))
-	m1.Extra = make([]dns.RR, len(i.Extra))
-
 	ttl := uint32(i.ttl(now))
 	m1.Answer = filterRRSlice(i.Answer, ttl, true)
 	m1.Ns = filterRRSlice(i.Ns, ttl, true)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This commit removes superfluous allocations of the Answer, Ns, and Extra slices when copying a cached a dns.Msg. The allocations are superfluous because we immediately overwrite the newly copied slices with filterRRSlice. It also updates filterRRSlice to pre-calculate the size of the slice being copied into.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/coredns/coredns/plugin/cache
cpu: Apple M4 Pro
                 │ base.10.txt │             new.10.txt             │
                 │   sec/op    │   sec/op     vs base               │
CacheResponse-14   471.1n ± 0%   462.9n ± 2%  -1.74% (p=0.009 n=10)

                 │ base.10.txt │            new.10.txt             │
                 │    B/op     │    B/op     vs base               │
CacheResponse-14    672.0 ± 0%   656.0 ± 0%  -2.38% (p=0.000 n=10)

                 │ base.10.txt │            new.10.txt             │
                 │  allocs/op  │ allocs/op   vs base               │
CacheResponse-14    13.00 ± 0%   12.00 ± 0%  -7.69% (p=0.000 n=10)
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A