### PR TITLE
plugin/pkg/replacer: fix usage of sync.Pool to save an alloc

### DIFF
--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -257,12 +257,14 @@ func loadFormat(s string) replacer {
 // bufPool stores pointers to scratch buffers.
 var bufPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 0, 256)
+		b := make([]byte, 0, 256)
+		return &b
 	},
 }
 
 func (r replacer) Replace(ctx context.Context, state request.Request, rr *dnstest.Recorder) string {
-	b := bufPool.Get().([]byte)
+	p := bufPool.Get().(*[]byte)
+	b := *p
 	for _, s := range r {
 		switch s.typ {
 		case typeLabel:
@@ -278,7 +280,7 @@ func (r replacer) Replace(ctx context.Context, state request.Request, rr *dnstes
 		}
 	}
 	s := string(b)
-	//nolint:staticcheck
-	bufPool.Put(b[:0])
+	*p = b[:0]
+	bufPool.Put(p)
 	return s
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This commit changes the replacer's sync.Pool to store a pointer to a byte slice instead of the byte slice value itself. This is the correct usage of sync.Pool and saves an alloc since converting a byte slice to the "any" type requires an allocation whereas using a pointer does not.

For context, I wrote most the replacer code back in 2019.

Benchmarks:

```
goos: darwin
goarch: arm64
pkg: github.com/coredns/coredns/plugin/pkg/replacer cpu: Apple M4 Pro
                            │ base.10.txt  │             new.10.txt              │
                            │    sec/op    │   sec/op     vs base                │
Replacer-14                   109.95n ± 1%   91.53n ± 2%  -16.75% (p=0.000 n=10)
Replacer_CommonLogFormat-14    581.5n ± 1%   565.4n ± 1%   -2.78% (p=0.000 n=10)
geomean                        252.9n        227.5n       -10.04%

                            │ base.10.txt │             new.10.txt             │
                            │    B/op     │    B/op     vs base                │
Replacer-14                    48.00 ± 0%   24.00 ± 0%  -50.00% (p=0.000 n=10)
Replacer_CommonLogFormat-14    517.0 ± 0%   493.0 ± 0%   -4.64% (p=0.000 n=10)
geomean                        157.5        108.8       -30.95%

                            │ base.10.txt │             new.10.txt             │
                            │  allocs/op  │ allocs/op   vs base                │
Replacer-14                    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Replacer_CommonLogFormat-14    18.00 ± 0%   17.00 ± 0%   -5.56% (p=0.000 n=10)
geomean                        6.000        4.123       -31.28%
```

### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A