### PR TITLE
plugin/errors: add show_first option to consolidate (#7702)

### DIFF
--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -23,7 +23,7 @@ Extra knobs are available with an expanded syntax:
 ~~~
 errors {
 	stacktrace
-	consolidate DURATION REGEXP [LEVEL]
+	consolidate DURATION REGEXP [LEVEL] [show_first]
 }
 ~~~
 
@@ -33,6 +33,21 @@ Option `consolidate` allows collecting several error messages matching the regul
 log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.
 ~~~
 2 errors like '^read udp .* i/o timeout$' occurred in last 30s
+~~~
+
+If the optional `show_first` flag is specified, the first error will be logged immediately when it occurs, and then subsequent matching errors will be consolidated. When the consolidation period ends:
+- If only one error occurred, no summary is printed (since it was already logged)
+- If multiple errors occurred, a summary is printed showing the total count
+
+Example with 3 errors:
+~~~
+[WARNING] 2 example.org. A: read udp 10.0.0.1:53->8.8.8.8:53: i/o timeout
+[WARNING] 3 errors like '^read udp .* i/o timeout$' occurred in last 30s
+~~~
+
+Example with 1 error:
+~~~
+[WARNING] 2 example.org. A: read udp 10.0.0.1:53->8.8.8.8:53: i/o timeout
 ~~~
 
 Multiple `consolidate` options with different **DURATION** and **REGEXP** are allowed. In case if some error message corresponds to several defined regular expressions the message will be associated with the first appropriate **REGEXP**.
@@ -60,6 +75,19 @@ and errors with prefix "Failed to " as errors.
     errors {
         consolidate 5m ".* i/o timeout$" warning
         consolidate 30s "^Failed to .+"
+    }
+}
+~~~
+
+Use the *forward* plugin and consolidate timeout errors with `show_first` option to see both
+the summary and the first occurrence of the error:
+
+~~~ corefile
+. {
+    forward . 8.8.8.8
+    errors {
+        consolidate 5m ".* i/o timeout$" warning show_first
+        consolidate 30s "^Failed to .+" error show_first
     }
 }
 ~~~

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -71,7 +71,7 @@ func errorsParse(c *caddy.Controller) (*errorHandler, error) {
 
 func parseConsolidate(c *caddy.Controller) (*pattern, error) {
 	args := c.RemainingArgs()
-	if len(args) < 2 || len(args) > 3 {
+	if len(args) < 2 || len(args) > 4 {
 		return nil, c.ArgErr()
 	}
 	p, err := time.ParseDuration(args[0])
@@ -82,28 +82,48 @@ func parseConsolidate(c *caddy.Controller) (*pattern, error) {
 	if err != nil {
 		return nil, c.Err(err.Error())
 	}
-	lc, err := parseLogLevel(c, args)
+
+	lc, showFirst, err := parseOptionalParams(c, args[2:])
 	if err != nil {
 		return nil, err
 	}
-	return &pattern{period: p, pattern: re, logCallback: lc}, nil
+
+	return &pattern{period: p, pattern: re, logCallback: lc, showFirst: showFirst}, nil
 }
 
-func parseLogLevel(c *caddy.Controller, args []string) (func(format string, v ...any), error) {
-	if len(args) != 3 {
-		return log.Errorf, nil
+// parseOptionalParams parses optional parameters (log level and show_first flag).
+// Order: log level (optional) must come before show_first (optional).
+func parseOptionalParams(c *caddy.Controller, args []string) (func(format string, v ...any), bool, error) {
+	logLevels := map[string]func(format string, v ...any){
+		"warning": log.Warningf,
+		"error":   log.Errorf,
+		"info":    log.Infof,
+		"debug":   log.Debugf,
 	}
 
-	switch args[2] {
-	case "warning":
-		return log.Warningf, nil
-	case "error":
-		return log.Errorf, nil
-	case "info":
-		return log.Infof, nil
-	case "debug":
-		return log.Debugf, nil
-	default:
-		return nil, c.Errf("unknown log level argument in consolidate: %s", args[2])
+	var logCallback func(format string, v ...any) // nil means not set yet
+	showFirst := false
+
+	for _, arg := range args {
+		if callback, isLogLevel := logLevels[arg]; isLogLevel {
+			if logCallback != nil {
+				return nil, false, c.Errf("multiple log levels specified in consolidate")
+			}
+			if showFirst {
+				return nil, false, c.Errf("log level must come before show_first in consolidate")
+			}
+			logCallback = callback
+		} else if arg == "show_first" {
+			showFirst = true
+		} else {
+			return nil, false, c.Errf("unknown option in consolidate: %s", arg)
+		}
 	}
+
+	// Use default log level if not specified
+	if logCallback == nil {
+		logCallback = log.Errorf
+	}
+
+	return logCallback, showFirst, nil
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Add optional show_first flag to consolidate directive that logs
the first error immediately and then consolidates subsequent errors.

When show_first is enabled:

The first matching error is logged immediately with full details
(rcode, domain, type, error message) using the configured log level
Subsequent matching errors are consolidated during the period
At period end:
If only one error occurred, no summary is printed (already logged)
If multiple errors occurred, summary shows the total count

### 2. Which issues (if any) are related?
[#7702 ](https://github.com/coredns/coredns/issues/7702)

### 3. Which documentation changes (if any) need to be made?
Update errors plugin docs to include show_first   settings and examples

### 4. Does this introduce a backward incompatible change or deprecation?
No breaking changes. The show_first option disable by default .