### PR TITLE
perf(proxy): avoid unnecessary alloc in Yield

### DIFF
--- a/plugin/pkg/proxy/persistent.go
+++ b/plugin/pkg/proxy/persistent.go
@@ -128,9 +128,15 @@ const yieldTimeout = 25 * time.Millisecond
 func (t *Transport) Yield(pc *persistConn) {
 	pc.used = time.Now() // update used time
 
-	// Make this non-blocking, because in the case of a very busy forwarder we will *block* on this yield. This
-	// blocks the outer go-routine and stuff will just pile up.  We timeout when the send fails to as returning
-	// these connection is an optimization anyway.
+	// Optimization: Try to return the connection immediately without creating a timer.
+	// If the receiver is not ready, we fall back to a timeout-based send to avoid blocking forever.
+	// Returning the connection is just an optimization, so dropping it on timeout is fine.
+	select {
+	case t.yield <- pc:
+		return
+	default:
+	}
+
 	select {
 	case t.yield <- pc:
 		return


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Context is the `plugin/pkg/proxy` helper package, namely the persistent connection pool.

Currently, `Yield` allocates a new timer on every call via "time.After", even if the yield channel has space. This creates unnecessary heap allocations and GC pressure under load.

This change adds a non-blocking select to try sending first, avoiding the timer allocation in the happy path. The timeout-based send is only used as a fallback when the receiver is not ready.

Bench run showing the performance difference in "best case" scenario, where a timer allocation is not needed:

```
goos: darwin
goarch: arm64
pkg: github.com/coredns/coredns/plugin/pkg/proxy
cpu: Apple M1 Pro
        │    before    │                after                │
        │    sec/op    │   sec/op     vs base                │
Yield-8   1140.0n ± 9%   821.1n ± 2%  -27.98% (p=0.000 n=10)

        │   before   │               after                │
        │    B/op    │    B/op     vs base                │
Yield-8   339.0 ± 4%   114.0 ± 2%  -66.37% (p=0.000 n=10)

        │   before   │                after                │
        │ allocs/op  │ allocs/op   vs base                 │
Yield-8   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.