### PR TITLE
plugin/nomad: Support service filtering

### DIFF
--- a/plugin/nomad/README.md
+++ b/plugin/nomad/README.md
@@ -80,12 +80,15 @@ With only the plugin specified, the *nomad* plugin will default to `service.noma
 ~~~ txt
 nomad [ZONE] {
     address URL
+    filter FILTER
     token TOKEN
     ttl DURATION
 }
 ~~~
 
 * `address` The address where a Nomad agent (server) is available. **URL** defaults to `http://127.0.0.1:4646`.
+
+* `filter` allows you to filter Nomad services. **FILTER** defaults to `""`. Uses [filtering](https://developer.hashicorp.com/nomad/api-docs#filtering) syntax.
 
 * `token` The SecretID of an ACL token to use to authenticate API requests with if the Nomad cluster has ACL enabled. **TOKEN** defaults to `""`.
 

--- a/plugin/nomad/nomad.go
+++ b/plugin/nomad/nomad.go
@@ -29,6 +29,7 @@ type Nomad struct {
 	Zone    string
 	clients []*api.Client
 	current int
+	filter  string
 }
 
 func (n *Nomad) Name() string {
@@ -103,7 +104,7 @@ func fetchServiceRegistrations(n Nomad, serviceName, namespace string) ([]*api.S
 	if err != nil {
 		return nil, nil, err
 	}
-	return nc.Services().Get(serviceName, (&api.QueryOptions{Namespace: namespace}))
+	return nc.Services().Get(serviceName, (&api.QueryOptions{Namespace: namespace, Filter: n.filter}))
 }
 
 func handleServiceLookupError(w dns.ResponseWriter, m *dns.Msg, ctx context.Context, namespace string) (int, error) {

--- a/plugin/nomad/setup.go
+++ b/plugin/nomad/setup.go
@@ -77,6 +77,12 @@ func parse(c *caddy.Controller, n *Nomad) error {
 				return c.Err("at least one address is required")
 			}
 			addresses = append(addresses, args...)
+		case "filter":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return c.Err("exactly one filter is required")
+			}
+			n.filter = args[0]
 		case "token":
 			args := c.RemainingArgs()
 			if len(args) != 1 {

--- a/plugin/nomad/setup_test.go
+++ b/plugin/nomad/setup_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestSetupNomad(t *testing.T) {
 	tests := []struct {
-		name        string
-		config      string
-		shouldErr   bool
-		expectedTTL uint32
+		name           string
+		config         string
+		shouldErr      bool
+		expectedFilter string
+		expectedTTL    uint32
 	}{
 		{
 			name: "valid_config_default_ttl",
@@ -22,19 +23,22 @@ nomad service.nomad {
     address http://127.0.0.1:4646
     token test-token
 }`,
-			shouldErr:   false,
-			expectedTTL: uint32(defaultTTL),
+			shouldErr:      false,
+			expectedFilter: "",
+			expectedTTL:    uint32(defaultTTL),
 		},
 		{
-			name: "valid_config_custom_ttl",
+			name: "valid_config_custom_filter_and_ttl",
 			config: `
 nomad service.nomad {
     address http://127.0.0.1:4646
+	filter "Tags not contains candidate"
     token test-token
     ttl 60
 }`,
-			shouldErr:   false,
-			expectedTTL: 60,
+			shouldErr:      false,
+			expectedFilter: "Tags not contains candidate",
+			expectedTTL:    60,
 		},
 		{
 			name: "invalid_ttl_negative",
@@ -85,6 +89,7 @@ nomad service.nomad {
 				ttl:     uint32(defaultTTL),
 				clients: make([]*nomad.Client, 0),
 				current: -1,
+				filter:  "",
 			}
 
 			err := parse(c, n)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Allow user to use filters like `Tags not contains candidate` which are useful example with [Blue/Green deployments](https://developer.hashicorp.com/nomad/docs/job-declare/strategy/blue-green-canary#blue-green-deployments).

When [canary_tags](https://developer.hashicorp.com/nomad/docs/job-specification/service#canary_tags) is provided in service registrations this:
```hcl
service {
  name = "example"
  provider = "nomad"
  address_mode = "driver"
  canary_tags = [
    "candidate"
  ],
  tags = [
    "traefik.enable=true",
    "traefik.http.routers.example.entrypoints=web",
    "traefik.http.routers.example.rule=PathPrefix(`/`)"
  ]
}
```
tags defined in [tags](https://developer.hashicorp.com/nomad/docs/job-specification/service#tags) will be listed only in already promoted services so new container versions will be started in parallel but they will not get any traffic before promotion.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
Readme updated.

### 4. Does this introduce a backward incompatible change or deprecation?
No