### PR TITLE
fix: kubernetes plugin logging

### DIFF
--- a/plugin/kubernetes/logger.go
+++ b/plugin/kubernetes/logger.go
@@ -25,8 +25,8 @@ func (l *loggerAdapter) Info(_ int, msg string, _ ...any) {
 	l.P.Info(msg)
 }
 
-func (l *loggerAdapter) Error(_ error, msg string, _ ...any) {
-	l.P.Error(msg)
+func (l *loggerAdapter) Error(err error, msg string, _ ...any) {
+	l.Errorf("%s: %s", msg, err)
 }
 
 func (l *loggerAdapter) WithValues(_ ...any) logr.LogSink {


### PR DESCRIPTION
The plugin dropped the actual error message from the log, so the log becomes completely useless.

Before:

```
[ERROR] plugin/kubernetes: Failed to watch
```

After:

```
[ERROR] plugin/kubernetes: Failed to watch: failed to list *v1.Namespace: Get "https://10.96.0.1:443/api/v1/namespaces?limit=500&resourceVersion=0": tls: failed to parse certificate from server: x509: SAN dNSName is malformed
```

### 1. Why is this pull request needed and what does it do?

Fixes a bug which makes troubleshooting next to impossible.

### 2. Which issues (if any) are related?

None, but due to Go 1.25.2 changes to strict SAN validation, CoreDNS might fail to access Kubernetes API on version 1.13.1.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Nope.