### PR TITLE
chore(lint): enable reflecttypefor in modernize

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,9 +43,6 @@ linters:
     govet:
       enable:
         - nilness
-    modernize:
-      disable:
-        - reflecttypefor
     perfsprint:
       error-format: false
     revive:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

As the `reflecttypefor` issues were fixed in #7696, lets enable the linter.

### 2. Which issues (if any) are related?

#7646 

### 3. Which documentation changes (if any) need to be made?

No.

### 4. Does this introduce a backward incompatible change or deprecation?

No.