### PR TITLE
fix(auto): limit regex length

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -27,7 +27,8 @@ are used.
   used to extract the origin. **ORIGIN_TEMPLATE** will be used as a template for the origin. Strings
   like `{<number>}` are replaced with the respective matches in the file name, e.g. `{1}` is the
   first match, `{2}` is the second. The default is: `db\.(.*)  {1}` i.e. from a file with the
-  name `db.example.com`, the extracted origin will be `example.com`.
+  name `db.example.com`, the extracted origin will be `example.com`. **REGEXP** must not be longer
+  than 10000 characters.
 * `reload` interval to perform reloads of zones if SOA version changes and zonefiles. It specifies how often CoreDNS should scan the directory to watch for file removal and addition. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -18,6 +18,8 @@ import (
 
 var log = clog.NewWithPlugin("auto")
 
+const maxRegexpLen = 10000
+
 func init() { plugin.Register("auto", setup) }
 
 func setup(c *caddy.Controller) error {
@@ -126,6 +128,9 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 
 				// regexp template
 				if c.NextArg() {
+					if len(c.Val()) > maxRegexpLen {
+						return a, c.Errf("regexp too large")
+					}
 					a.re, err = regexp.Compile(c.Val())
 					if err != nil {
 						return a, err

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -2,6 +2,7 @@ package auto
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -203,5 +204,21 @@ func TestSetupReload(t *testing.T) {
 				t.Errorf("Error: setup() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestAutoParseLargeRegex(t *testing.T) {
+	largeRegex := strings.Repeat("a", maxRegexpLen+1)
+	config := fmt.Sprintf(`auto {
+        directory /tmp %s {1}
+    }`, largeRegex)
+
+	c := caddy.NewTestController("dns", config)
+	_, err := autoParse(c)
+	if err == nil {
+		t.Fatal("Expected error for large regex, got nil")
+	}
+	if !strings.Contains(err.Error(), "regexp too large") {
+		t.Errorf("Expected 'regexp too large' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

A very large regex for the auto plugin in the Corefile could cause CoreDNS to OOM. This change adds an artificial limit of 10k characters for the regex pattern.

### 2. Which issues (if any) are related?

Fixes OSS-Fuzz finding [#466745384](https://issues.oss-fuzz.com/issues/466745384?pli=1) (not publicly accessible).

### 3. Which documentation changes (if any) need to be made?

Added a note to plugin README.

### 4. Does this introduce a backward incompatible change or deprecation?

The limit is supposed to be abundantly high to cover any and all real use cases.