### PR TITLE
fix(test): prevent data race in TestReadme

### DIFF
--- a/test/quic_test.go
+++ b/test/quic_test.go
@@ -26,7 +26,7 @@ var quicCorefile = `quic://.:0 {
 var quicReloadCorefile = `quic://.:0 {
 		tls ../plugin/tls/test_cert.pem ../plugin/tls/test_key.pem ../plugin/tls/test_ca.pem
 		whoami
-		reload 2s
+		quic
 	}`
 
 // Corefile with custom stream limits


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Affects the QUIC integration test originally from #7680.

Replace "reload 2s" with "quic" in `quicReloadCorefile` to avoid spawning a background goroutine that reads `dnsserver.Port` while `TestReadme` modifies it. The test `TestQUICReloadDoesNotPanic` still verifies the QUIC reload panic fix via explicit `inst.Restart()` call.

I also ran the test with the proposed config against a commit pre-dating #7680. I was able to reproduce the panic, without the `reload 2s`.

### 2. Which issues (if any) are related?

See a failed CI run [here](https://github.com/coredns/coredns/actions/runs/20233134003/job/58080838260?pr=7759).

<details>
<code>
WARNING: DATA RACE
Read at 0x0000068eb120 by goroutine 325060:
  github.com/coredns/coredns/core/dnsserver.init.0.func2()
      /home/runner/work/coredns/coredns/core/dnsserver/register.go:25 +0x2a
  github.com/coredns/caddy.DefaultInput()
      /home/runner/go/pkg/mod/github.com/coredns/caddy@v1.1.4-0.20250930002214-15135a999495/caddy.go:1009 +0xf6
  github.com/coredns/caddy.LoadCaddyfile()
      /home/runner/go/pkg/mod/github.com/coredns/caddy@v1.1.4-0.20250930002214-15135a999495/caddy.go:417 +0x124
  github.com/coredns/coredns/plugin/reload.hook.func1()
      /home/runner/work/coredns/coredns/plugin/reload/reload.go:91 +0x1c6

Previous write at 0x0000068eb120 by goroutine 325145:
  github.com/coredns/coredns/test.TestReadme()
      /home/runner/work/coredns/coredns/test/readme_test.go:85 +0x6eb
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1997 +0x44
</code>
</details>

### 3. Which documentation changes (if any) need to be made?

None, tests only.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
