### PR TITLE
plugin/kubernetes: rate limits to api server

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -34,6 +34,9 @@ kubernetes [ZONES...] {
     endpoint URL
     tls CERT KEY CACERT
     kubeconfig KUBECONFIG [CONTEXT]
+    apiserver_qps QPS
+    apiserver_burst BURST
+    apiserver_max_inflight MAX
     namespaces NAMESPACE...
     labels EXPRESSION
     pods POD-MODE
@@ -55,6 +58,12 @@ kubernetes [ZONES...] {
    **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
    It supports TLS, username and password, or token-based authentication.
    This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+* `apiserver_qps` **QPS** sets the maximum queries per second (QPS) rate limit for requests.
+   This allows you to control the rate at which the plugin sends requests to the API server to prevent overwhelming it.
+* `apiserver_burst` **BURST** sets the maximum burst size for requests.
+   This allows temporary spikes in request rate up to this value, even if it exceeds the QPS limit.
+* `apiserver_max_inflight` **MAX** sets the maximum number of concurrent in-flight requests.
+   This caps the total number of simultaneous requests the plugin can make to the API server.
 * `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
 * `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -244,6 +244,45 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 					return nil, fmt.Errorf("failed to parse startup_timeout: %v, %s", args[0], err)
 				}
 			}
+		case "apiserver_qps":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return nil, c.ArgErr()
+			}
+			qps, err := strconv.ParseFloat(args[0], 32)
+			if err != nil {
+				return nil, c.Errf("invalid apiserver_qps %q: %v", args[0], err)
+			}
+			if qps < 0 {
+				return nil, c.Errf("apiserver_qps must be >= 0")
+			}
+			k8s.apiQPS = float32(qps)
+		case "apiserver_burst":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return nil, c.ArgErr()
+			}
+			burst, err := strconv.Atoi(args[0])
+			if err != nil {
+				return nil, c.Errf("invalid apiserver_burst %q: %v", args[0], err)
+			}
+			if burst < 0 {
+				return nil, c.Errf("apiserver_burst must be >= 0")
+			}
+			k8s.apiBurst = burst
+		case "apiserver_max_inflight":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return nil, c.ArgErr()
+			}
+			max, err := strconv.Atoi(args[0])
+			if err != nil {
+				return nil, c.Errf("invalid apiserver_max_inflight %q: %v", args[0], err)
+			}
+			if max < 0 {
+				return nil, c.Errf("apiserver_max_inflight must be >= 0")
+			}
+			k8s.apiMaxInflight = max
 		default:
 			return nil, c.Errf("unknown property '%s'", c.Val())
 		}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This adds optional configuration knobs to the `kubernetes` plugin to limit load on the Kubernetes API server, which allows to prevent CoreDNS from overwhelming it in large clusters or under high DNS load.

### 2. Which issues (if any) are related?

None I am aware of

### 3. Which documentation changes (if any) need to be made?

Updated `kubernetes` plugin doc with new directives

### 4. Does this introduce a backward incompatible change or deprecation?

No