### PR TITLE
Fix for misleading SOA parser warnings

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -166,16 +166,13 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 			return nil, err
 		}
 	}
-	if !seenSOA {
-		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
-	}
 	if zp.Err() != nil {
 		return nil, fmt.Errorf("failed to parse file %q for origin %s with error %v", fileName, origin, zp.Err())
 	}
-
-	if err := zp.Err(); err != nil {
-		return nil, err
+	if !seenSOA {
+		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
 	}
+
 
 	return z, nil
 }

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -173,6 +173,5 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
 	}
 
-
 	return z, nil
 }

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -63,10 +63,9 @@ func TestParseMalformedSOA(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Zone %q should have failed to load", "example.org.")
 	}
-	if strings.Contains(err.Error(), "no SOA record") {
-		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
+	if !strings.Contains(err.Error(), "bad SOA zone parameter") {
+		t.Fatalf("Expected parse error containing 'bad SOA zone parameter', got: %s", err)
 	}
-	// Should contain parse error, not "no SOA"
 }
 
 const dbMalformedSOA = `
@@ -86,14 +85,12 @@ www          IN  A      192.168.0.14
 
 func TestParseSOASerialTooLarge(t *testing.T) {
 	_, err := Parse(strings.NewReader(dbSOASerialTooLarge), "example.org.", "stdin", 0)
-	t.Logf("Error: %s", err)
 	if err == nil {
 		t.Fatalf("Zone %q should have failed to load", "example.org.")
 	}
-	if strings.Contains(err.Error(), "no SOA record") {
-		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
+	if !strings.Contains(err.Error(), "bad SOA zone parameter") {
+		t.Fatalf("Expected parse error containing 'bad SOA zone parameter', got: %s", err)
 	}
-	// Should contain parse error for serial exceeding uint32 max
 }
 
 const dbSOASerialTooLarge = `

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -57,3 +57,64 @@ www          IN  A      192.168.0.14
 mail         IN  A      192.168.0.15
 imap         IN  CNAME  mail
 `
+
+func TestParseMalformedSOA(t *testing.T) {
+	_, err := Parse(strings.NewReader(dbMalformedSOA), "example.org.", "stdin", 0)
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+	if strings.Contains(err.Error(), "no SOA record") {
+		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
+	}
+	// Should contain parse error, not "no SOA"
+}
+
+const dbMalformedSOA = `
+$TTL         1M
+$ORIGIN      example.org.
+
+@            IN  SOA    ns1.example.com. admin.example.com.  (
+                               abc ; Serial - invalid
+                               1200       ; Refresh
+                               144        ; Retry
+                               1814400    ; Expire
+                               2h )       ; Minimum
+@            IN  NS     ns1.example.com.
+
+www          IN  A      192.168.0.14
+func TestParseSOASerialTooLarge(t *testing.T) {
+	_, err := Parse(strings.NewReader(dbSOASerialTooLarge), "example.org.", "stdin", 0)
+	t.Logf("Error: %s", err)
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+	if strings.Contains(err.Error(), "no SOA record") {
+		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
+	}
+	// Should contain parse error for serial exceeding uint32 max
+}
+`
+
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+	if strings.Contains(err.Error(), "no SOA record") {
+		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
+	}
+	// Should contain parse error for serial exceeding uint32 max
+}
+
+const dbSOASerialTooLarge = `
+$TTL         1M
+$ORIGIN      example.org.
+
+@            IN  SOA    ns1.example.com. admin.example.com.  (
+                               202512200817 ; Serial - exceeds 32-bit uint
+                               1200       ; Refresh
+                               144        ; Retry
+                               1814400    ; Expire
+                               2h )       ; Minimum
+@            IN  NS     ns1.example.com.
+
+www          IN  A      192.168.0.14
+`

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -82,19 +82,11 @@ $ORIGIN      example.org.
 @            IN  NS     ns1.example.com.
 
 www          IN  A      192.168.0.14
+`
+
 func TestParseSOASerialTooLarge(t *testing.T) {
 	_, err := Parse(strings.NewReader(dbSOASerialTooLarge), "example.org.", "stdin", 0)
 	t.Logf("Error: %s", err)
-	if err == nil {
-		t.Fatalf("Zone %q should have failed to load", "example.org.")
-	}
-	if strings.Contains(err.Error(), "no SOA record") {
-		t.Fatalf("Zone %q should not fail with 'no SOA record', but with parse error: %s", "example.org.", err)
-	}
-	// Should contain parse error for serial exceeding uint32 max
-}
-`
-
 	if err == nil {
 		t.Fatalf("Zone %q should have failed to load", "example.org.")
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I was investigating an issue where what appeared to be valid zone files were being rejected with a 'missing SOA' error. The SOA was present and looked legitimate (to me, at least!). I was scratching my until I realised that it wasn't actually missing, it was just malformed because I'd gone over the 32bit uint limit. The error message was misleading.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No.