### PR TITLE
fix(sign): report parser err before missing SOA

### DIFF
--- a/plugin/sign/file.go
+++ b/plugin/sign/file.go
@@ -80,12 +80,11 @@ func Parse(f io.Reader, origin, fileName string) (*file.Zone, error) {
 			}
 		}
 	}
-	if !seenSOA {
-		return nil, fmt.Errorf("file %q has no SOA record", fileName)
-	}
-
 	if err := zp.Err(); err != nil {
 		return nil, err
+	}
+	if !seenSOA {
+		return nil, fmt.Errorf("file %q has no SOA record", fileName)
 	}
 
 	return z, nil

--- a/plugin/sign/file_test.go
+++ b/plugin/sign/file_test.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -39,5 +40,43 @@ func TestFileParse(t *testing.T) {
 	key := apex.Type(dns.TypeDNSKEY)
 	if key != nil {
 		t.Errorf("Expected no DNSKEYs, but got %d", len(key))
+	}
+}
+
+func TestParseSyntaxErrorBeforeSOA(t *testing.T) {
+	const dbSyntaxErrorBeforeSOA = `
+$TTL         1M
+$ORIGIN      example.org.
+
+@            IN  SOA    ns1.example.com. admin.example.com.  (
+                               foobarbaz  ; Invalid serial
+                               1200       ; Refresh
+                               144        ; Retry
+                               1814400    ; Expire
+                               2h )       ; Minimum
+`
+	_, err := Parse(strings.NewReader(dbSyntaxErrorBeforeSOA), "example.org.", "stdin")
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+
+	if !strings.Contains(err.Error(), "bad SOA zone parameter") {
+		t.Fatalf("Expected parser error, but got: %v", err)
+	}
+}
+
+func TestParseNoSOA(t *testing.T) {
+	const dbNoSOA = `
+$TTL         1M
+$ORIGIN      example.org.
+
+www          IN  A      192.168.0.14
+`
+	_, err := Parse(strings.NewReader(dbNoSOA), "example.org.", "stdin")
+	if err == nil {
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
+	}
+	if !strings.Contains(err.Error(), "has no SOA record") {
+		t.Fatalf("Expected 'no SOA record' error, but got: %v", err)
 	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Affects the "sign" plugin.

Ensure that syntax errors encountered during zone parsing are reported immediately, rather than falling through to a misleading "no SOA record" error if the failure happens before the SOA record is reached. Added regression tests.

### 2. Which issues (if any) are related?

Similarly as #7774 for the file plugin, thanks to @rossigee.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
