### PR TITLE
fix: impossible condition in metrics test

### DIFF
--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -329,9 +329,7 @@ func TestMetricsSeveralBlocs(t *testing.T) {
 	}
 
 	endCacheSize := test.ScrapeMetricAsInt(addrMetrics, cacheSizeMetricName, "", 0)
-	if err != nil {
-		t.Errorf("Unexpected metric data retrieved for %s : %s", cacheSizeMetricName, err)
-	}
+
 	if endCacheSize-beginCacheSize != 1 {
 		t.Errorf("Expected metric data retrieved for %s, expected %d, got %d", cacheSizeMetricName, 1, endCacheSize-beginCacheSize)
 	}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Bumping golangci-lint to v2.7.2 in #7783 found it:

```
nilness: impossible condition: nil != nil (govet)
```

There is an err check above this line already, so we can just remove it.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.