### PR TITLE
chore: bump minimum Go version to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ out-of-tree plugins.
 To compile CoreDNS, we assume you have a working Go setup. See various tutorials if you don’t have
 that already configured.
 
-First, make sure your golang version is 1.24.0 or higher as `go mod` support and other api is needed.
+First, make sure your golang version is 1.25.0 or higher as `go mod` support and other api is needed.
 See [here](https://github.com/golang/go/wiki/Modules) for `go mod` details.
 Then, check out the project and run `make` to compile the binary:
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -229,11 +229,9 @@ func (s *Server) Stop() error {
 				continue
 			}
 
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				s1.ShutdownContext(ctx)
-				wg.Done()
-			}()
+			})
 		}
 		s.m.Unlock()
 		wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/coredns/coredns
 
 // Note this minimum version requirement. CoreDNS supports the last two
 // Go versions. This follows the upstream Go project support.
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -363,13 +363,11 @@ func TestCloudDNSConcurrentServeDNS(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Concurrently refresh zones to race with Lookup reads.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 50 {
 			_ = r.updateZones(ctx)
 		}
-	}()
+	})
 
 	const workers = 32
 	const iterations = 200

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -67,11 +67,9 @@ func TestTransport(t *testing.T) {
 		}
 
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			accept(t, l, 1)
-			wg.Done()
-		}()
+		})
 
 		dio := newIO(param[0], l.Addr().String(), 1, 1)
 		dio.tcpTimeout = 10 * time.Millisecond
@@ -97,11 +95,9 @@ func TestRace(t *testing.T) {
 	defer l.Close()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		accept(t, l, count)
-		wg.Done()
-	}()
+	})
 
 	dio := newIO("tcp", l.Addr().String(), 1, 1)
 	dio.tcpTimeout = 10 * time.Millisecond
@@ -132,11 +128,9 @@ func TestReconnect(t *testing.T) {
 		}
 
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			accept(t, l, 1)
-			wg.Done()
-		}()
+		})
 
 		addr := l.Addr().String()
 		logger := MockLogger{}
@@ -164,11 +158,9 @@ func TestReconnect(t *testing.T) {
 		}
 		defer l.Close()
 
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			accept(t, l, 1)
-			wg.Done()
-		}()
+		})
 
 		messageCount := 5
 		for range messageCount {
@@ -249,11 +241,9 @@ func TestFullQueueWriteFail(t *testing.T) {
 	defer l.Close()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		accept(t, l, 1)
-		wg.Done()
-	}()
+	})
 
 	logger := MockLogger{}
 	dio := newIO("unix", l.Addr().String(), 1, 1)

--- a/plugin/erratic/xfr.go
+++ b/plugin/erratic/xfr.go
@@ -48,10 +48,8 @@ func xfr(state request.Request, truncate bool) {
 	}()
 
 	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		tr.Out(state.W, state.Req, ch)
-		wg.Done()
-	}()
+	})
 	wg.Wait()
 }

--- a/plugin/pkg/cache/shard_test.go
+++ b/plugin/pkg/cache/shard_test.go
@@ -102,12 +102,10 @@ func TestShardEvictParallel(t *testing.T) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for range shardSize {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			<-start
 			s.Evict()
-			wg.Done()
-		}()
+		})
 	}
 	close(start) // start evicting in parallel
 	wg.Wait()

--- a/plugin/pkg/rand/rand_test.go
+++ b/plugin/pkg/rand/rand_test.go
@@ -124,30 +124,26 @@ func TestConcurrentAccess(t *testing.T) {
 
 	// Test concurrent Int() calls
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range numOperations {
 				val := r.Int()
 				if val < 0 {
 					errors <- nil
 				}
 			}
-		}()
+		})
 	}
 
 	// Test concurrent Perm() calls
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range numOperations {
 				perm := r.Perm(5)
 				if len(perm) != 5 {
 					errors <- nil
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -64,8 +64,7 @@ func TestDoDupSuppress(t *testing.T) {
 	const n = 10
 	var wg sync.WaitGroup
 	for range n {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			v, err := g.Do(1, fn)
 			if err != nil {
 				t.Errorf("Do error: %v", err)
@@ -73,8 +72,7 @@ func TestDoDupSuppress(t *testing.T) {
 			if v.(string) != "bar" {
 				t.Errorf("Got %q; want %q", v, "bar")
 			}
-			wg.Done()
-		}()
+		})
 	}
 	time.Sleep(100 * time.Millisecond) // let goroutines above block
 	c <- "bar"


### PR DESCRIPTION


### 1. Why is this pull request needed and what does it do?

Bump version in `go.mod` and address linting errors.

Depends on #7856.

### 2. Which issues (if any) are related?

Required by #7776.

### 3. Which documentation changes (if any) need to be made?

README updated.

### 4. Does this introduce a backward incompatible change or deprecation?

Updates the minimum Go dependency to the latest supported version. Projects using older Go versions will have to upgrade, which they should do anyway regardless of this project, as Go 1.24 is no longer supported.

