### PR TITLE
perf(metrics): implement plugin chain tracking

### DIFF
--- a/plugin/metrics/recorder.go
+++ b/plugin/metrics/recorder.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"runtime"
-
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
 	"github.com/miekg/dns"
@@ -11,8 +9,9 @@ import (
 // Recorder is a dnstest.Recorder specific to the metrics plugin.
 type Recorder struct {
 	*dnstest.Recorder
-	// CallerN holds the string return value of the call to runtime.Caller(N+1)
-	Caller [3]string
+	// Plugin holds the name of the plugin that wrote the response.
+	// This is set automatically by the plugin chain via the PluginTracker interface.
+	Plugin string
 }
 
 // NewRecorder makes and returns a new Recorder.
@@ -21,8 +20,15 @@ func NewRecorder(w dns.ResponseWriter) *Recorder { return &Recorder{Recorder: dn
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *Recorder) WriteMsg(res *dns.Msg) error {
-	_, r.Caller[0], _, _ = runtime.Caller(1)
-	_, r.Caller[1], _, _ = runtime.Caller(2)
-	_, r.Caller[2], _, _ = runtime.Caller(3)
 	return r.Recorder.WriteMsg(res)
+}
+
+// SetPlugin implements the plugin.PluginTracker interface.
+func (r *Recorder) SetPlugin(name string) {
+	r.Plugin = name
+}
+
+// GetPlugin implements the plugin.PluginTracker interface.
+func (r *Recorder) GetPlugin() string {
+	return r.Plugin
 }

--- a/plugin/metrics/recorder_test.go
+++ b/plugin/metrics/recorder_test.go
@@ -23,6 +23,34 @@ func (r *inmemoryWriter) Write(buf []byte) (int, error) {
 	return r.ResponseWriter.Write(buf)
 }
 
+func TestRecorder_PluginTracker(t *testing.T) {
+	tw := inmemoryWriter{ResponseWriter: test.ResponseWriter{}}
+	rec := NewRecorder(&tw)
+
+	// Initially Plugin should be empty
+	if rec.Plugin != "" {
+		t.Errorf("Expected empty Plugin, got %q", rec.Plugin)
+	}
+	if rec.GetPlugin() != "" {
+		t.Errorf("Expected GetPlugin() to return empty string, got %q", rec.GetPlugin())
+	}
+
+	// SetPlugin should set the plugin name
+	rec.SetPlugin("whoami")
+	if rec.Plugin != "whoami" {
+		t.Errorf("Expected Plugin to be 'whoami', got %q", rec.Plugin)
+	}
+	if rec.GetPlugin() != "whoami" {
+		t.Errorf("Expected GetPlugin() to return 'whoami', got %q", rec.GetPlugin())
+	}
+
+	// SetPlugin should overwrite previous value
+	rec.SetPlugin("cache")
+	if rec.Plugin != "cache" {
+		t.Errorf("Expected Plugin to be 'cache', got %q", rec.Plugin)
+	}
+}
+
 func TestRecorder_WriteMsg(t *testing.T) {
 	successResp := dns.Msg{}
 	successResp.Answer = []dns.RR{

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,170 @@
+package plugin
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// mockResponseWriter implements dns.ResponseWriter for testing
+type mockResponseWriter struct {
+	msg *dns.Msg
+}
+
+func (m *mockResponseWriter) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 53}
+}
+func (m *mockResponseWriter) RemoteAddr() net.Addr {
+	return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 40212}
+}
+func (m *mockResponseWriter) WriteMsg(msg *dns.Msg) error { m.msg = msg; return nil }
+func (m *mockResponseWriter) Write([]byte) (int, error)   { return 0, nil }
+func (m *mockResponseWriter) Close() error                { return nil }
+func (m *mockResponseWriter) TsigStatus() error           { return nil }
+func (m *mockResponseWriter) TsigTimersOnly(bool)         {}
+func (m *mockResponseWriter) Hijack()                     {}
+
+// mockPluginTracker implements PluginTracker for testing
+type mockPluginTracker struct {
+	mockResponseWriter
+	plugin string
+}
+
+func (m *mockPluginTracker) SetPlugin(name string) { m.plugin = name }
+func (m *mockPluginTracker) GetPlugin() string     { return m.plugin }
+
+// mockHandler implements Handler for testing
+type mockHandler struct {
+	name      string
+	writeMsg  bool
+	returnErr error
+}
+
+func (m *mockHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	if m.writeMsg {
+		resp := new(dns.Msg)
+		resp.SetReply(r)
+		w.WriteMsg(resp)
+	}
+	if m.returnErr != nil {
+		return dns.RcodeServerFailure, m.returnErr
+	}
+	return dns.RcodeSuccess, nil
+}
+
+func (m *mockHandler) Name() string { return m.name }
+
+func TestPluginWriter_WriteMsg_SetsPlugin(t *testing.T) {
+	tracker := &mockPluginTracker{}
+	pw := &pluginWriter{ResponseWriter: tracker, plugin: "whoami"}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	err := pw.WriteMsg(msg)
+	if err != nil {
+		t.Fatalf("WriteMsg returned error: %v", err)
+	}
+
+	if tracker.plugin != "whoami" {
+		t.Errorf("Expected plugin to be 'whoami', got %q", tracker.plugin)
+	}
+}
+
+func TestPluginWriter_Write_SetsPlugin(t *testing.T) {
+	tracker := &mockPluginTracker{}
+	pw := &pluginWriter{ResponseWriter: tracker, plugin: "forward"}
+
+	_, err := pw.Write([]byte("test"))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	if tracker.plugin != "forward" {
+		t.Errorf("Expected plugin to be 'forward', got %q", tracker.plugin)
+	}
+}
+
+func TestPluginWriter_NonTracker_NoError(t *testing.T) {
+	// When the underlying writer doesn't implement PluginTracker,
+	// WriteMsg should still work without error
+	mock := &mockResponseWriter{}
+	pw := &pluginWriter{ResponseWriter: mock, plugin: "whoami"}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	err := pw.WriteMsg(msg)
+	if err != nil {
+		t.Fatalf("WriteMsg returned error: %v", err)
+	}
+
+	if mock.msg == nil {
+		t.Error("Expected message to be written")
+	}
+}
+
+func TestNextOrFailure_WrapsWithPluginWriter(t *testing.T) {
+	tracker := &mockPluginTracker{}
+	handler := &mockHandler{name: "testplugin", writeMsg: true}
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+
+	_, err := NextOrFailure("caller", handler, context.Background(), tracker, req)
+	if err != nil {
+		t.Fatalf("NextOrFailure returned error: %v", err)
+	}
+
+	// The handler should have written a message, which should have set the plugin
+	if tracker.plugin != "testplugin" {
+		t.Errorf("Expected plugin to be 'testplugin', got %q", tracker.plugin)
+	}
+}
+
+func TestNextOrFailure_NilHandler(t *testing.T) {
+	mock := &mockResponseWriter{}
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+
+	rcode, err := NextOrFailure("caller", nil, context.Background(), mock, req)
+	if err == nil {
+		t.Error("Expected error for nil handler")
+	}
+	if rcode != dns.RcodeServerFailure {
+		t.Errorf("Expected RcodeServerFailure, got %d", rcode)
+	}
+}
+
+func TestPluginWriter_DelegatesMethods(t *testing.T) {
+	mock := &mockResponseWriter{}
+	pw := &pluginWriter{ResponseWriter: mock, plugin: "test"}
+
+	// Test LocalAddr
+	if pw.LocalAddr() == nil {
+		t.Error("LocalAddr should not return nil")
+	}
+
+	// Test RemoteAddr
+	if pw.RemoteAddr() == nil {
+		t.Error("RemoteAddr should not return nil")
+	}
+
+	// Test Close
+	if err := pw.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+
+	// Test TsigStatus
+	if err := pw.TsigStatus(); err != nil {
+		t.Errorf("TsigStatus returned error: %v", err)
+	}
+
+	// Test TsigTimersOnly (should not panic)
+	pw.TsigTimersOnly(true)
+
+	// Test Hijack (should not panic)
+	pw.Hijack()
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

#### Motivation

The metrics plugin calls `runtime.Caller` three times on every DNS response to determine which plugin wrote the response. This is expensive as `runtime.Caller` walks the call stack and allocates strings for file paths on each invocation.

Consider this `Corefile`:

```
. {
    cache
    whoami
    pprof
    prometheus
}
```

And this as the workload:

```bash
dnsperf -s 127.0.0.1 -p 53 -d queries.txt -c 200 -T 16 -l 10
```

Profiling with `pprof` shows `metrics.(*Recorder).WriteMsg` as the number one allocator:

```
$ go tool pprof -top -alloc_space allocs.pprof

Duration: 10s, Total samples = 875.71MB
      flat  flat%   sum%        cum   cum%
  295.57MB 33.75% 33.75%   331.07MB 37.81%  github.com/coredns/coredns/plugin/metrics.(*Recorder).WriteMsg
   62.01MB  7.08% 40.83%   752.61MB 85.94%  github.com/miekg/dns.(*Server).serveDNS
   ...
```

Object allocation count:
```
$ go tool pprof -top -alloc_objects allocs.pprof

Duration: 10s, Total samples = 11161488
      flat  flat%   sum%        cum   cum%
   1933607 17.32% 17.32%    2296628 20.58%  github.com/coredns/coredns/plugin/metrics.(*Recorder).WriteMsg
    808314  7.24% 24.57%     808314  7.24%  context.WithValue
   ...
```

So in total the `runtime.Caller` calls inside `WriteMsg` were responsible for:
- ~33% of total allocation space
- ~17% of total allocations

#### Changes

This PR replaces the `runtime.Caller` approach with automatic plugin tracking through the plugin chain:

1. `NextOrFailure` now wraps the `ResponseWriter` with a `pluginWriter` that knows the next plugin's name.
2. When `WriteMsg` is called, the wrapper sets the plugin name on any `PluginTracker`-implementing writer.
3. The metrics `Recorder` implements `PluginTracker` to receive the plugin name.

After the fix, pprof shows `metrics.(*Recorder).WriteMsg` is completely gone from top allocators:

```
$ go tool pprof -top -alloc_space allocs_after.pprof

Duration: 8s, Total samples = 586.97MB
      flat  flat%   sum%        cum   cum%
   62.01MB 10.56% 10.56%    74.51MB 12.69%  github.com/miekg/dns.(*Msg).Copy
   62.01MB 10.56% 21.13%   470.55MB 80.17%  github.com/miekg/dns.(*Server).serveDNS
   ...
```

In this context, the comparison looks like this:

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| QPS | 49,550 | 53,589 | **+8.1%** |
| Total Allocations | 875MB | 587MB | **-33%** |
| Avg Latency | 1.624ms | 1.593ms | **-1.9%** |

Also increases test coverage for `plugin` pkg from 76.6% to 78.7%.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None, see below.

### 4. Does this introduce a backward incompatible change or deprecation?

The `plugin` label in `coredns_dns_responses_total` metric continues to be populated with the same values. The change is purely internal to how the plugin name is determined.