### PR TITLE
feat(grpc): add connection pooling support

### DIFF
--- a/plugin/grpc/README.md
+++ b/plugin/grpc/README.md
@@ -34,6 +34,10 @@ grpc FROM TO... {
     tls_servername NAME
     policy random|round_robin|sequential
     fallthrough [ZONES...]
+    pool_size SIZE
+    expire DURATION
+    health_check DURATION
+    max_fails COUNT
 }
 ~~~
 
@@ -61,18 +65,33 @@ grpc FROM TO... {
   don't actually belong to that zone (e.g., search path queries). If **[ZONES...]** is omitted, then
   fallthrough happens for all zones. If specific zones are listed, then only queries for those zones
   will be subject to fallthrough.
+* `pool_size` **SIZE** sets the maximum number of gRPC connections to maintain in the pool for each
+  upstream server. Default is `1` (no pooling). Maximum is `100`. Setting this to a value greater than 1
+  enables connection pooling for improved performance in high-throughput scenarios.
+* `expire` **DURATION** sets the idle TTL for pooled connections. A connection that has not been used
+  for this duration is closed and removed from the pool during the next maintenance cycle. Default is
+  `10s`. Only applies when `pool_size > 1`. Examples: `30s`, `1m`, `5m`.
+* `health_check` **DURATION** sets the interval for health check probes to upstream servers. Only active
+  when `max_fails > 0`. Default is `500ms`.
+* `max_fails` **COUNT** sets the number of consecutive failures before marking an upstream server as down.
+  Default is `0` (disabled). Set to a positive value to enable health-based upstream skipping. When a
+  proxy accumulates this many consecutive health check failures, it will be skipped until health checks
+  succeed.
 
 Also note the TLS config is "global" for the whole grpc proxy if you need a different
 `tls-name` for different upstreams you're out of luck.
 
 ## Metrics
 
-If monitoring is enabled (via the *prometheus* plugin) then the following metric are exported:
+If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
 
 * `coredns_grpc_request_duration_seconds{to}` - duration per upstream interaction.
 * `coredns_grpc_requests_total{to}` - query count per upstream.
 * `coredns_grpc_responses_total{to, rcode}` - count of RCODEs per upstream.
-  and we are randomly (this always uses the `random` policy) spraying to an upstream.
+* `coredns_grpc_pool_hits_total{to}` - connection pool cache hits per upstream.
+* `coredns_grpc_pool_misses_total{to}` - connection pool cache misses (new connections created) per upstream.
+* `coredns_grpc_pool_size{to}` - current number of connections in the pool per upstream.
+* `coredns_grpc_healthcheck_failures_total{to}` - health check failure count per upstream.
 
 ## Examples
 
@@ -152,6 +171,20 @@ example.org {
         fallthrough
     }
     forward . 8.8.8.8
+}
+~~~
+
+Enable connection pooling with 5 connections per upstream for high-throughput scenarios, with health checking enabled.
+
+~~~ corefile
+. {
+    grpc . 10.0.0.10:9005 10.0.0.11:9005 {
+        pool_size 5
+        expire 30s
+        health_check 1s
+        max_fails 3
+        policy round_robin
+    }
 }
 ~~~
 

--- a/plugin/grpc/README.md
+++ b/plugin/grpc/README.md
@@ -35,7 +35,6 @@ grpc FROM TO... {
     policy random|round_robin|sequential
     fallthrough [ZONES...]
     pool_size SIZE
-    expire DURATION
     health_check DURATION
     max_fails COUNT
 }
@@ -68,9 +67,6 @@ grpc FROM TO... {
 * `pool_size` **SIZE** sets the maximum number of gRPC connections to maintain in the pool for each
   upstream server. Default is `1` (no pooling). Maximum is `100`. Setting this to a value greater than 1
   enables connection pooling for improved performance in high-throughput scenarios.
-* `expire` **DURATION** sets the idle TTL for pooled connections. A connection that has not been used
-  for this duration is closed and removed from the pool during the next maintenance cycle. Default is
-  `10s`. Only applies when `pool_size > 1`. Examples: `30s`, `1m`, `5m`.
 * `health_check` **DURATION** sets the interval for health check probes to upstream servers. Only active
   when `max_fails > 0`. Default is `500ms`.
 * `max_fails` **COUNT** sets the number of consecutive failures before marking an upstream server as down.
@@ -180,7 +176,6 @@ Enable connection pooling with 5 connections per upstream for high-throughput sc
 . {
     grpc . 10.0.0.10:9005 10.0.0.11:9005 {
         pool_size 5
-        expire 30s
         health_check 1s
         max_fails 3
         policy round_robin

--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -27,6 +27,10 @@ type GRPC struct {
 	tlsConfig     *tls.Config
 	tlsServerName string
 
+	// maxFails is the threshold for marking a pooled proxy as down.
+	// 0 (default) disables health-based skipping.
+	maxFails uint32
+
 	Fall fall.F
 	Next plugin.Handler
 }
@@ -43,10 +47,11 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	var (
-		span ot.Span
-		ret  *dns.Msg
-		err  error
-		i    int
+		span  ot.Span
+		ret   *dns.Msg
+		err   error
+		i     int
+		fails int
 	)
 	span = ot.SpanFromContext(ctx)
 	list := g.list()
@@ -65,6 +70,17 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		proxy := list[i]
 		i++
 
+		// Check if proxy is down due to health checks (pooled proxies only;
+		// Down always returns false when maxFails == 0).
+		if proxy.Down(g.maxFails) {
+			fails++
+			if fails < len(g.proxies) {
+				// Skip this down proxy and try next
+				continue
+			}
+			// All proxies are down, try anyway (last resort)
+		}
+
 		callCtx := ctx
 		var child ot.Span
 		if span != nil {
@@ -81,6 +97,10 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 			child.Finish()
 		}
 		if err != nil {
+			// Trigger health check on error if health checking is enabled
+			if g.maxFails != 0 {
+				proxy.Healthcheck()
+			}
 			// Continue with the next proxy
 			continue
 		}
@@ -125,12 +145,11 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	return dns.RcodeServerFailure, ErrNoHealthy
 }
 
-// NewGRPC returns a new GRPC.
+// newGRPC returns a new GRPC with default configuration.
 func newGRPC() *GRPC {
-	g := &GRPC{
+	return &GRPC{
 		p: new(random),
 	}
-	return g
 }
 
 // Name implements the Handler interface.
@@ -162,6 +181,24 @@ func (g *GRPC) isAllowedDomain(name string) bool {
 
 // List returns a set of proxies to be used for this client depending on the policy in p.
 func (g *GRPC) list() []*Proxy { return g.p.List(g.proxies) }
+
+// OnStartup starts all proxies (transport and health checking for pooled proxies).
+// This is a no-op for single-connection proxies.
+func (g *GRPC) OnStartup() error {
+	for _, p := range g.proxies {
+		p.Start()
+	}
+	return nil
+}
+
+// OnShutdown stops all proxies cleanly.
+// This is a no-op for single-connection proxies.
+func (g *GRPC) OnShutdown() error {
+	for _, p := range g.proxies {
+		p.Stop()
+	}
+	return nil
+}
 
 const defaultTimeout = 5 * time.Second
 

--- a/plugin/grpc/grpc_test.go
+++ b/plugin/grpc/grpc_test.go
@@ -20,9 +20,8 @@ import (
 
 // newTestPooledProxy creates a Proxy with a mock transport for testing pooled behavior.
 func newTestPooledProxy(addr string, client pb.DnsServiceClient) *Proxy {
-	tr := newTransport("grpc", addr, nil, 1, 0)
+	tr := newTransport("grpc", addr, nil, 1)
 	tr.connList.Store(&connList{conns: []*grpcConn{{client: client}}})
-	tr.Start()
 	return &Proxy{addr: addr, transport: tr}
 }
 

--- a/plugin/grpc/grpc_test.go
+++ b/plugin/grpc/grpc_test.go
@@ -18,6 +18,14 @@ import (
 	grpcgo "google.golang.org/grpc"
 )
 
+// newTestPooledProxy creates a Proxy with a mock transport for testing pooled behavior.
+func newTestPooledProxy(addr string, client pb.DnsServiceClient) *Proxy {
+	tr := newTransport("grpc", addr, nil, 1, 0)
+	tr.connList.Store(&connList{conns: []*grpcConn{{client: client}}})
+	tr.Start()
+	return &Proxy{addr: addr, transport: tr}
+}
+
 func TestGRPC(t *testing.T) {
 	m := &dns.Msg{}
 	msg, err := m.Pack()
@@ -31,37 +39,37 @@ func TestGRPC(t *testing.T) {
 	}{
 		"single_proxy_ok": {
 			proxies: []*Proxy{
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test1", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
 			},
 			wantErr: false,
 		},
 		"multiple_proxies_ok": {
 			proxies: []*Proxy{
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test1", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test2", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test3", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
 			},
 			wantErr: false,
 		},
 		"single_proxy_ko": {
 			proxies: []*Proxy{
-				{client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
+				{addr: "test1", client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
 			},
 			wantErr: true,
 		},
 		"multiple_proxies_one_ko": {
 			proxies: []*Proxy{
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
-				{client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
-				{client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test1", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
+				{addr: "test2", client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
+				{addr: "test3", client: &testServiceClient{dnsPacket: dnsPacket, err: nil}},
 			},
 			wantErr: false,
 		},
 		"multiple_proxies_ko": {
 			proxies: []*Proxy{
-				{client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
-				{client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
-				{client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
+				{addr: "test1", client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
+				{addr: "test2", client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
+				{addr: "test3", client: &testServiceClient{dnsPacket: nil, err: errors.New("")}},
 			},
 			wantErr: true,
 		},
@@ -139,7 +147,7 @@ func TestGRPC_SpansOnErrorPath(t *testing.T) {
 
 	g := newGRPC()
 	g.from = "."
-	g.proxies = []*Proxy{{client: p1}, {client: p2}}
+	g.proxies = []*Proxy{{addr: "test1", client: p1}, {addr: "test2", client: p2}}
 
 	// Ensure deterministic order of the retries: try p1 then p2
 	g.p = new(sequential)
@@ -177,5 +185,25 @@ func TestGRPC_SpansOnErrorPath(t *testing.T) {
 	}
 	if !p2.sawDeadline {
 		t.Fatalf("expected deadline to be set on second proxy call context")
+	}
+}
+
+// TestGRPC_Pooled tests that the pooled path (transport != nil) works correctly via ServeDNS.
+func TestGRPC_Pooled(t *testing.T) {
+	// tests that pool_size > 1 path works: ServeDNS routes through transport
+	m := &dns.Msg{}
+	msg, _ := m.Pack()
+	dnsPacket := &pb.DnsPacket{Msg: msg}
+
+	p := newTestPooledProxy("test", &testServiceClient{dnsPacket: dnsPacket, err: nil})
+	defer p.Stop()
+
+	g := newGRPC()
+	g.from = "."
+	g.proxies = []*Proxy{p}
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	if _, err := g.ServeDNS(context.TODO(), rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
 	}
 }

--- a/plugin/grpc/metrics.go
+++ b/plugin/grpc/metrics.go
@@ -29,4 +29,34 @@ var (
 		NativeHistogramBucketFactor: plugin.NativeHistogramBucketFactor,
 		Help:                        "Histogram of the time each request took.",
 	}, []string{"to"})
+
+	// PoolHitsCount is the counter of connection pool cache hits.
+	PoolHitsCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "grpc",
+		Name:      "pool_hits_total",
+		Help:      "Counter of connection pool cache hits.",
+	}, []string{"to"})
+	// PoolMissesCount is the counter of connection pool cache misses.
+	PoolMissesCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "grpc",
+		Name:      "pool_misses_total",
+		Help:      "Counter of connection pool cache misses.",
+	}, []string{"to"})
+	// PoolSizeGauge is the gauge of current number of connections in pool per upstream.
+	PoolSizeGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "grpc",
+		Name:      "pool_size",
+		Help:      "Current number of connections in pool per upstream.",
+	}, []string{"to"})
+
+	// HealthcheckFailureCount is the counter of health check failures per upstream.
+	HealthcheckFailureCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "grpc",
+		Name:      "healthcheck_failures_total",
+		Help:      "Counter of health check failures per upstream.",
+	}, []string{"to"})
 )

--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -52,7 +52,6 @@ type Proxy struct {
 // proxyOptions holds configuration for creating a pooled proxy.
 type proxyOptions struct {
 	poolSize   int
-	expire     time.Duration
 	maxFails   uint32
 	hcInterval time.Duration
 }
@@ -109,7 +108,7 @@ func newPooledProxy(addr string, tlsConfig *tls.Config, opts *proxyOptions) (*Pr
 		),
 	)
 
-	p.transport = newTransport("grpc", p.addr, dialOpts, opts.poolSize, opts.expire)
+	p.transport = newTransport("grpc", p.addr, dialOpts, opts.poolSize)
 
 	// Only create probe and set hcInterval when health checking is opted into.
 	if opts.maxFails > 0 {
@@ -139,7 +138,7 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		gc     *grpcConn
 	)
 	if p.transport != nil {
-		gc, _, err = p.transport.Dial(ctx)
+		gc, err = p.transport.Dial(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -217,7 +216,7 @@ func (p *Proxy) healthCheck() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	gc, _, err := p.transport.Dial(ctx)
+	gc, err := p.transport.Dial(ctx)
 	if err != nil {
 		atomic.AddUint32(&p.fails, 1)
 		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)

--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -56,27 +56,30 @@ type proxyOptions struct {
 	hcInterval time.Duration
 }
 
+// buildDialOpts constructs the gRPC dial options shared by all proxy types.
+func buildDialOpts(tlsConfig *tls.Config) []grpc.DialOption {
+	var opts []grpc.DialOption
+	if tlsConfig != nil {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	// Cap send/recv sizes to avoid oversized messages.
+	// Note: gRPC size limits apply to the serialized protobuf message size.
+	opts = append(opts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(maxProtobufPayloadBytes),
+		grpc.MaxCallSendMsgSize(maxProtobufPayloadBytes),
+	))
+	return opts
+}
+
 // newProxy returns a new proxy with a single shared connection.
 // This is the default (pool_size=1) path, identical to the upstream model.
 func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 	p := &Proxy{
-		addr: addr,
+		addr:     addr,
+		dialOpts: buildDialOpts(tlsConfig),
 	}
-
-	if tlsConfig != nil {
-		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-	} else {
-		p.dialOpts = append(p.dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
-
-	// Cap send/recv sizes to avoid oversized messages.
-	// Note: gRPC size limits apply to the serialized protobuf message size.
-	p.dialOpts = append(p.dialOpts,
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(maxProtobufPayloadBytes),
-			grpc.MaxCallSendMsgSize(maxProtobufPayloadBytes),
-		),
-	)
 
 	conn, err := grpc.NewClient(p.addr, p.dialOpts...)
 	if err != nil {
@@ -94,21 +97,7 @@ func newPooledProxy(addr string, tlsConfig *tls.Config, opts *proxyOptions) (*Pr
 		addr: addr,
 	}
 
-	var dialOpts []grpc.DialOption
-	if tlsConfig != nil {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-	} else {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
-
-	dialOpts = append(dialOpts,
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(maxProtobufPayloadBytes),
-			grpc.MaxCallSendMsgSize(maxProtobufPayloadBytes),
-		),
-	)
-
-	p.transport = newTransport("grpc", p.addr, dialOpts, opts.poolSize)
+	p.transport = newTransport("grpc", p.addr, buildDialOpts(tlsConfig), opts.poolSize)
 
 	// Only create probe and set hcInterval when health checking is opted into.
 	if opts.maxFails > 0 {
@@ -138,7 +127,7 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		gc     *grpcConn
 	)
 	if p.transport != nil {
-		gc, err = p.transport.Dial(ctx)
+		gc, err = p.transport.Dial()
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +205,7 @@ func (p *Proxy) healthCheck() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	gc, err := p.transport.Dial(ctx)
+	gc, err := p.transport.Dial()
 	if err != nil {
 		atomic.AddUint32(&p.fails, 1)
 		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)

--- a/plugin/grpc/proxy.go
+++ b/plugin/grpc/proxy.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/coredns/coredns/pb"
+	"github.com/coredns/coredns/plugin/pkg/up"
 
 	"github.com/miekg/dns"
 	"google.golang.org/grpc"
@@ -36,12 +38,27 @@ var (
 type Proxy struct {
 	addr string
 
-	// connection
+	// single-connection mode (default, pool_size=1): zero overhead, unchanged from upstream
 	client   pb.DnsServiceClient
 	dialOpts []grpc.DialOption
+
+	// pooled mode (pool_size > 1, opt-in only)
+	transport  *grpcTransport
+	probe      *up.Probe
+	hcInterval time.Duration
+	fails      uint32 // atomic counter
 }
 
-// newProxy returns a new proxy.
+// proxyOptions holds configuration for creating a pooled proxy.
+type proxyOptions struct {
+	poolSize   int
+	expire     time.Duration
+	maxFails   uint32
+	hcInterval time.Duration
+}
+
+// newProxy returns a new proxy with a single shared connection.
+// This is the default (pool_size=1) path, identical to the upstream model.
 func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 	p := &Proxy{
 		addr: addr,
@@ -71,6 +88,38 @@ func newProxy(addr string, tlsConfig *tls.Config) (*Proxy, error) {
 	return p, nil
 }
 
+// newPooledProxy returns a new proxy with connection pooling and optional health checking.
+// Only used when pool_size > 1 is explicitly configured.
+func newPooledProxy(addr string, tlsConfig *tls.Config, opts *proxyOptions) (*Proxy, error) {
+	p := &Proxy{
+		addr: addr,
+	}
+
+	var dialOpts []grpc.DialOption
+	if tlsConfig != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	dialOpts = append(dialOpts,
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxProtobufPayloadBytes),
+			grpc.MaxCallSendMsgSize(maxProtobufPayloadBytes),
+		),
+	)
+
+	p.transport = newTransport("grpc", p.addr, dialOpts, opts.poolSize, opts.expire)
+
+	// Only create probe and set hcInterval when health checking is opted into.
+	if opts.maxFails > 0 {
+		p.probe = up.New()
+		p.hcInterval = opts.hcInterval
+	}
+
+	return p, nil
+}
+
 // query sends the request and waits for a response.
 func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 	start := time.Now()
@@ -84,8 +133,26 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		return nil, err
 	}
 
-	reply, err := p.client.Query(ctx, &pb.DnsPacket{Msg: msg})
+	// Resolve which client to use: pooled or single-connection.
+	var (
+		client pb.DnsServiceClient
+		gc     *grpcConn
+	)
+	if p.transport != nil {
+		gc, _, err = p.transport.Dial(ctx)
+		if err != nil {
+			return nil, err
+		}
+		client = gc.client
+	} else {
+		client = p.client
+	}
+
+	reply, err := client.Query(ctx, &pb.DnsPacket{Msg: msg})
 	if err != nil {
+		if gc != nil && status.Code(err) == codes.Unavailable {
+			p.transport.RemoveConn(gc)
+		}
 		// if not found message, return empty message with NXDomain code
 		if status.Code(err) == codes.NotFound {
 			m := new(dns.Msg).SetRcode(req, dns.RcodeNameError)
@@ -93,8 +160,8 @@ func (p *Proxy) query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
 		}
 		return nil, err
 	}
-	wire := reply.GetMsg()
 
+	wire := reply.GetMsg()
 	if err := validateDNSSize(wire); err != nil {
 		return nil, err
 	}
@@ -122,4 +189,82 @@ func validateDNSSize(data []byte) error {
 		return fmt.Errorf("%w: %d bytes (limit %d)", ErrDNSMessageTooLarge, l, maxDNSMessageBytes)
 	}
 	return nil
+}
+
+// Down returns true if this proxy has exceeded the max failure threshold.
+// Only meaningful for pooled proxies with health checking; always returns false when maxfails is 0.
+func (p *Proxy) Down(maxfails uint32) bool {
+	if maxfails == 0 {
+		return false
+	}
+	fails := atomic.LoadUint32(&p.fails)
+	return fails > maxfails
+}
+
+// Healthcheck triggers a health check probe for this proxy.
+// Only active for pooled proxies with health checking enabled (probe is nil otherwise).
+func (p *Proxy) Healthcheck() {
+	if p.probe == nil {
+		return
+	}
+	p.probe.Do(func() error {
+		return p.healthCheck()
+	})
+}
+
+// healthCheck performs a health check by sending a DNS query.
+func (p *Proxy) healthCheck() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	gc, _, err := p.transport.Dial(ctx)
+	if err != nil {
+		atomic.AddUint32(&p.fails, 1)
+		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)
+		return err
+	}
+
+	ping := new(dns.Msg)
+	ping.SetQuestion(".", dns.TypeNS)
+	msg, err := ping.Pack()
+	if err != nil {
+		atomic.AddUint32(&p.fails, 1)
+		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)
+		return err
+	}
+
+	_, err = gc.client.Query(ctx, &pb.DnsPacket{Msg: msg})
+	if err != nil {
+		atomic.AddUint32(&p.fails, 1)
+		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)
+		if status.Code(err) == codes.Unavailable {
+			p.transport.RemoveConn(gc)
+		}
+		return err
+	}
+
+	atomic.StoreUint32(&p.fails, 0)
+	return nil
+}
+
+// Start starts the proxy's transport and health checking.
+// This is a no-op for single-connection proxies.
+func (p *Proxy) Start() {
+	if p.transport != nil {
+		p.transport.Start()
+	}
+	if p.probe != nil {
+		p.probe.Start(p.hcInterval)
+	}
+}
+
+// Stop stops the proxy's transport and health checking.
+// This is a no-op for single-connection proxies.
+func (p *Proxy) Stop() {
+	if p.probe != nil {
+		p.probe.Stop()
+	}
+	if p.transport != nil {
+		p.transport.Stop()
+	}
 }

--- a/plugin/grpc/proxy_test.go
+++ b/plugin/grpc/proxy_test.go
@@ -63,9 +63,10 @@ func TestProxy(t *testing.T) {
 }
 
 func TestProxy_RejectsOversizedReply(t *testing.T) {
-	p := &Proxy{}
 	oversized := make([]byte, maxDNSMessageBytes+1)
-	p.client = testServiceClient{dnsPacket: &pb.DnsPacket{Msg: oversized}, err: nil}
+	mock := &testServiceClient{dnsPacket: &pb.DnsPacket{Msg: oversized}, err: nil}
+	p := &Proxy{addr: "test", client: mock}
+
 	_, err := p.query(context.TODO(), new(dns.Msg))
 	if !errors.Is(err, ErrDNSMessageTooLarge) {
 		t.Fatalf("expected %v, got %v", ErrDNSMessageTooLarge, err)
@@ -73,8 +74,8 @@ func TestProxy_RejectsOversizedReply(t *testing.T) {
 }
 
 func TestProxy_RejectsOversizedRequest(t *testing.T) {
-	p := &Proxy{}
-	p.client = testServiceClient{dnsPacket: &pb.DnsPacket{Msg: []byte("ok")}, err: nil}
+	mock := &testServiceClient{dnsPacket: &pb.DnsPacket{Msg: []byte("ok")}, err: nil}
+	p := &Proxy{addr: "test", client: mock}
 
 	oversizedMsg := &dns.Msg{}
 	oversizedMsg.SetQuestion("example.org.", dns.TypeA)
@@ -121,6 +122,12 @@ func TestProxyUnix(t *testing.T) {
 		t.Errorf("Failed to create forwarder: %s", err)
 	}
 
+	// Start the transports (this would normally be done by OnStartup)
+	if err := g.OnStartup(); err != nil {
+		t.Fatalf("Failed to start: %s", err)
+	}
+	defer g.OnShutdown()
+
 	m := new(dns.Msg)
 	m.SetQuestion("example.org.", dns.TypeA)
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
@@ -145,4 +152,17 @@ func (*grpcDnsServiceServer) Query(ctx context.Context, in *pb.DnsPacket) (*pb.D
 	answer.SetRcode(msg, dns.RcodeSuccess)
 	buf, _ := answer.Pack()
 	return &pb.DnsPacket{Msg: buf}, nil
+}
+
+// TestProxy_PooledPath tests the pooled dispatch path (transport != nil).
+func TestProxy_PooledPath(t *testing.T) {
+	msg, _ := new(dns.Msg).Pack()
+	mock := &testServiceClient{dnsPacket: &pb.DnsPacket{Msg: msg}, err: nil}
+	p := newTestPooledProxy("test", mock)
+	defer p.Stop()
+
+	_, err := p.query(context.TODO(), new(dns.Msg))
+	if err != nil {
+		t.Fatalf("Expected no error on pooled path, got: %v", err)
+	}
 }

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -29,6 +31,15 @@ func setup(c *caddy.Controller) error {
 		return g
 	})
 
+	// Register lifecycle hooks for pooled proxies (no-ops for single-connection proxies).
+	c.OnStartup(func() error {
+		return g.OnStartup()
+	})
+
+	c.OnShutdown(func() error {
+		return g.OnShutdown()
+	})
+
 	return nil
 }
 
@@ -51,8 +62,20 @@ func parseGRPC(c *caddy.Controller) (*GRPC, error) {
 	return g, nil
 }
 
+// defaultProxyOptions returns default configuration for proxy options.
+// maxFails defaults to 0 (health checking disabled).
+func defaultProxyOptions() *proxyOptions {
+	return &proxyOptions{
+		poolSize:   1,
+		expire:     10 * time.Second,
+		maxFails:   0,
+		hcInterval: 500 * time.Millisecond,
+	}
+}
+
 func parseStanza(c *caddy.Controller) (*GRPC, error) {
 	g := newGRPC()
+	opts := defaultProxyOptions()
 
 	if !c.Args(&g.from) {
 		return g, c.ArgErr()
@@ -73,8 +96,9 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 		return g, err
 	}
 
+	// Parse configuration block before creating proxies
 	for c.NextBlock() {
-		if err := parseBlock(c, g); err != nil {
+		if err := parseBlock(c, g, opts); err != nil {
 			return g, err
 		}
 	}
@@ -85,8 +109,16 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 		}
 		g.tlsConfig.ServerName = g.tlsServerName
 	}
+
+	// Create proxies: use single-connection model by default (pool_size=1),
+	// and the pooled model only when explicitly opted into (pool_size > 1).
 	for _, host := range toHosts {
-		pr, err := newProxy(host, g.tlsConfig)
+		var pr *Proxy
+		if opts.poolSize > 1 {
+			pr, err = newPooledProxy(host, g.tlsConfig, opts)
+		} else {
+			pr, err = newProxy(host, g.tlsConfig)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +128,7 @@ func parseStanza(c *caddy.Controller) (*GRPC, error) {
 	return g, nil
 }
 
-func parseBlock(c *caddy.Controller, g *GRPC) error {
+func parseBlock(c *caddy.Controller, g *GRPC, opts *proxyOptions) error {
 	switch c.Val() {
 	case "except":
 		ignore := c.RemainingArgs()
@@ -143,6 +175,61 @@ func parseBlock(c *caddy.Controller, g *GRPC) error {
 		}
 	case "fallthrough":
 		g.Fall.SetZonesFromArgs(c.RemainingArgs())
+
+	// Connection pooling directives (only take effect when pool_size > 1)
+	case "pool_size":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.Atoi(c.Val())
+		if err != nil {
+			return err
+		}
+		if n < 1 {
+			return fmt.Errorf("pool_size must be at least 1")
+		}
+		if n > 100 {
+			return fmt.Errorf("pool_size cannot exceed 100")
+		}
+		opts.poolSize = n
+
+	case "expire":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		dur, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		if dur < 0 {
+			return fmt.Errorf("expire can't be negative: %s", dur)
+		}
+		opts.expire = dur
+
+	case "health_check":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		dur, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		if dur < 0 {
+			return fmt.Errorf("health_check can't be negative: %s", dur)
+		}
+		opts.hcInterval = dur
+
+	case "max_fails":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.ParseUint(c.Val(), 10, 32)
+		if err != nil {
+			return err
+		}
+		g.maxFails = uint32(n)
+		opts.maxFails = uint32(n)
+
 	default:
 		if c.Val() != "}" {
 			return c.Errf("unknown property '%s'", c.Val())

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -67,7 +67,6 @@ func parseGRPC(c *caddy.Controller) (*GRPC, error) {
 func defaultProxyOptions() *proxyOptions {
 	return &proxyOptions{
 		poolSize:   1,
-		expire:     10 * time.Second,
 		maxFails:   0,
 		hcInterval: 500 * time.Millisecond,
 	}
@@ -192,19 +191,6 @@ func parseBlock(c *caddy.Controller, g *GRPC, opts *proxyOptions) error {
 			return fmt.Errorf("pool_size cannot exceed 100")
 		}
 		opts.poolSize = n
-
-	case "expire":
-		if !c.NextArg() {
-			return c.ArgErr()
-		}
-		dur, err := time.ParseDuration(c.Val())
-		if err != nil {
-			return err
-		}
-		if dur < 0 {
-			return fmt.Errorf("expire can't be negative: %s", dur)
-		}
-		opts.expire = dur
 
 	case "health_check":
 		if !c.NextArg() {

--- a/plugin/grpc/setup_test.go
+++ b/plugin/grpc/setup_test.go
@@ -197,3 +197,81 @@ func TestSetupFallthrough(t *testing.T) {
 		}
 	}
 }
+
+func TestSetupPooling(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		errStr    string
+	}{
+		// valid
+		{"grpc . 127.0.0.1 {\npool_size 2\n}", false, ""},
+		{"grpc . 127.0.0.1 {\npool_size 100\n}", false, ""},
+		{"grpc . 127.0.0.1 {\npool_size 2\nexpire 30s\nhealth_check 1s\nmax_fails 3\n}", false, ""},
+		// invalid
+		{"grpc . 127.0.0.1 {\npool_size 0\n}", true, "pool_size must be at least 1"},
+		{"grpc . 127.0.0.1 {\npool_size 101\n}", true, "pool_size cannot exceed 100"},
+		{"grpc . 127.0.0.1 {\npool_size -1\n}", true, ""},
+		{"grpc . 127.0.0.1 {\nexpire -1s\n}", true, "expire can't be negative"},
+		{"grpc . 127.0.0.1 {\nhealth_check -1s\n}", true, "health_check can't be negative"},
+	}
+	for i, tc := range tests {
+		c := caddy.NewTestController("dns", tc.input)
+		g, err := parseGRPC(c)
+		if tc.shouldErr && err == nil {
+			t.Errorf("Test %d: expected error but got none for input: %s", i, tc.input)
+		}
+		if !tc.shouldErr && err != nil {
+			t.Errorf("Test %d: expected no error but got: %v for input: %s", i, err, tc.input)
+		}
+		if tc.shouldErr && err != nil && tc.errStr != "" && !strings.Contains(err.Error(), tc.errStr) {
+			t.Errorf("Test %d: expected error containing %q, got: %v", i, tc.errStr, err)
+		}
+		// cleanup pooled proxies to avoid goroutine leaks
+		if err == nil && g != nil {
+			for _, p := range g.proxies {
+				p.Stop()
+			}
+		}
+	}
+}
+
+func TestSetupPooled_ProxyHasTransport(t *testing.T) {
+	// pool_size > 1 → proxy must have a transport
+	c := caddy.NewTestController("dns", "grpc . 127.0.0.1 {\npool_size 3\n}")
+	g, err := parseGRPC(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.proxies) == 0 {
+		t.Fatal("expected at least one proxy")
+	}
+	if g.proxies[0].transport == nil {
+		t.Error("expected proxy to have a transport when pool_size > 1")
+	}
+	if g.proxies[0].client != nil {
+		t.Error("expected proxy to NOT have a direct client when pool_size > 1")
+	}
+	// cleanup
+	for _, p := range g.proxies {
+		p.Stop()
+	}
+}
+
+func TestSetupSingle_ProxyHasClient(t *testing.T) {
+	// pool_size=1 (default) → proxy must have a client, no transport
+	c := caddy.NewTestController("dns", "grpc . 127.0.0.1")
+	g, err := parseGRPC(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(g.proxies) == 0 {
+		t.Fatal("expected at least one proxy")
+	}
+	if g.proxies[0].client == nil {
+		t.Error("expected proxy to have a direct client when pool_size=1")
+	}
+	if g.proxies[0].transport != nil {
+		t.Error("expected proxy to NOT have a transport when pool_size=1")
+	}
+}

--- a/plugin/grpc/setup_test.go
+++ b/plugin/grpc/setup_test.go
@@ -207,12 +207,12 @@ func TestSetupPooling(t *testing.T) {
 		// valid
 		{"grpc . 127.0.0.1 {\npool_size 2\n}", false, ""},
 		{"grpc . 127.0.0.1 {\npool_size 100\n}", false, ""},
-		{"grpc . 127.0.0.1 {\npool_size 2\nexpire 30s\nhealth_check 1s\nmax_fails 3\n}", false, ""},
+		{"grpc . 127.0.0.1 {\npool_size 2\nhealth_check 1s\nmax_fails 3\n}", false, ""},
 		// invalid
 		{"grpc . 127.0.0.1 {\npool_size 0\n}", true, "pool_size must be at least 1"},
 		{"grpc . 127.0.0.1 {\npool_size 101\n}", true, "pool_size cannot exceed 100"},
 		{"grpc . 127.0.0.1 {\npool_size -1\n}", true, ""},
-		{"grpc . 127.0.0.1 {\nexpire -1s\n}", true, "expire can't be negative"},
+		{"grpc . 127.0.0.1 {\nexpire 30s\n}", true, "unknown property"},
 		{"grpc . 127.0.0.1 {\nhealth_check -1s\n}", true, "health_check can't be negative"},
 	}
 	for i, tc := range tests {

--- a/plugin/grpc/transport.go
+++ b/plugin/grpc/transport.go
@@ -5,33 +5,16 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/coredns/coredns/pb"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 )
-
-const poolMaintainInterval = 5 * time.Second
 
 // grpcConn wraps a gRPC connection with its client for shared access.
 type grpcConn struct {
-	conn     *grpc.ClientConn
-	client   pb.DnsServiceClient
-	lastUsed atomic.Int64 // unix nanoseconds; updated on every Dial hit
-}
-
-// touch records the current time as the last-used time for this connection.
-func (gc *grpcConn) touch() { gc.lastUsed.Store(time.Now().UnixNano()) }
-
-// idleFor returns how long this connection has been idle.
-func (gc *grpcConn) idleFor() time.Duration {
-	last := gc.lastUsed.Load()
-	if last == 0 {
-		return 0
-	}
-	return time.Since(time.Unix(0, last))
+	conn   *grpc.ClientConn
+	client pb.DnsServiceClient
 }
 
 // connList is an immutable slice of connections for lock-free access.
@@ -41,43 +24,34 @@ type connList struct {
 
 // grpcTransport manages a pool of shared gRPC connections to a single upstream.
 // Uses lock-free atomic operations on the hot path for maximum throughput.
+//
+// gRPC ClientConn manages its own connection lifecycle: it reconnects
+// automatically on failure and multiplexes RPCs across a single connection.
+// No background maintenance goroutine is needed.
 type grpcTransport struct {
 	addr     string
 	dialOpts []grpc.DialOption
 	poolSize int
-	expire   time.Duration // idle TTL; zero means no TTL eviction
 
-	// Hot path: lock-free access via atomic pointer
+	// Hot path: lock-free access via atomic pointer.
 	connList atomic.Pointer[connList]
 	idx      atomic.Uint64
 
-	// Cold path: mutex for modifications
+	// Cold path: mutex for modifications.
 	mu sync.Mutex
 
-	// stopped is set before close(stop) to allow Dial to detect shutdown without a panic.
+	// stopped is set in Stop to prevent new connections from being added after shutdown.
 	stopped atomic.Bool
-	// started tracks whether Start() has been called, to avoid deadlock in Stop().
-	started atomic.Bool
-
-	stop chan struct{}
-	done chan struct{}
 
 	proxyName string
-
-	// Metrics counters (updated atomically, flushed periodically)
-	hits   atomic.Uint64
-	misses atomic.Uint64
 }
 
 // newTransport creates a new gRPC connection transport with shared connections.
-func newTransport(proxyName, addr string, dialOpts []grpc.DialOption, poolSize int, expire time.Duration) *grpcTransport {
+func newTransport(proxyName, addr string, dialOpts []grpc.DialOption, poolSize int) *grpcTransport {
 	t := &grpcTransport{
 		addr:      addr,
 		dialOpts:  dialOpts,
 		poolSize:  poolSize,
-		expire:    expire,
-		stop:      make(chan struct{}),
-		done:      make(chan struct{}),
 		proxyName: proxyName,
 	}
 	t.connList.Store(&connList{conns: make([]*grpcConn, 0, poolSize)})
@@ -86,9 +60,9 @@ func newTransport(proxyName, addr string, dialOpts []grpc.DialOption, poolSize i
 
 // Dial returns a shared connection from the pool using round-robin.
 // Returns ErrTransportStopped if the transport has been shut down.
-func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, bool, error) {
+func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, error) {
 	if t.stopped.Load() {
-		return nil, false, ErrTransportStopped
+		return nil, ErrTransportStopped
 	}
 
 	list := t.connList.Load()
@@ -97,19 +71,13 @@ func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, bool, error) {
 		idx := t.idx.Add(1)
 		gc := list.conns[idx%uint64(n)]
 		if gc != nil && gc.client != nil {
-			gc.touch()
-			t.hits.Add(1)
-			return gc, false, nil
+			PoolHitsCount.WithLabelValues(t.addr).Inc()
+			return gc, nil
 		}
 	}
 
-	t.misses.Add(1)
-	gc, err := t.createConn(ctx)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return gc, true, nil
+	PoolMissesCount.WithLabelValues(t.addr).Inc()
+	return t.createConn(ctx)
 }
 
 // createConn creates a new gRPC connection and attempts to add it to the pool.
@@ -125,7 +93,6 @@ func (t *grpcTransport) createConn(ctx context.Context) (*grpcConn, error) {
 		conn:   conn,
 		client: pb.NewDnsServiceClient(conn),
 	}
-	gc.touch()
 
 	if !t.addConn(gc) {
 		// Pool is full (concurrent creation race). Close the new connection
@@ -139,13 +106,19 @@ func (t *grpcTransport) createConn(ctx context.Context) (*grpcConn, error) {
 		return nil, ErrTransportStopped
 	}
 
+	PoolSizeGauge.WithLabelValues(t.addr).Inc()
 	return gc, nil
 }
 
-// addConn adds a connection to the pool. Returns false if the pool is already full.
+// addConn adds a connection to the pool. Returns false if the pool is already full
+// or the transport has been stopped.
 func (t *grpcTransport) addConn(gc *grpcConn) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.stopped.Load() {
+		return false
+	}
 
 	oldList := t.connList.Load()
 	if len(oldList.conns) >= t.poolSize {
@@ -176,33 +149,18 @@ func (t *grpcTransport) RemoveConn(gc *grpcConn) {
 	t.connList.Store(&connList{conns: newConns})
 	t.mu.Unlock()
 
+	PoolSizeGauge.WithLabelValues(t.addr).Dec()
+
 	if gc.conn != nil {
 		gc.conn.Close()
 	}
 }
 
-// healthChecker periodically maintains the connection pool.
-func (t *grpcTransport) healthChecker() {
-	ticker := time.NewTicker(poolMaintainInterval)
-	defer ticker.Stop()
-	defer close(t.done)
-
-	t.prewarm()
-
-	for {
-		select {
-		case <-ticker.C:
-			t.cleanupDeadConns()
-			t.flushMetrics()
-			t.prewarm()
-		case <-t.stop:
-			return
-		}
-	}
-}
-
-// prewarm creates connections up to pool size.
-func (t *grpcTransport) prewarm() {
+// Start pre-populates the pool up to poolSize.
+// grpc.NewClient is lazy: no TCP connection is established until the first RPC,
+// so this just pre-allocates ClientConn objects to avoid createConn overhead on
+// the first few requests.
+func (t *grpcTransport) Start() {
 	list := t.connList.Load()
 	needed := t.poolSize - len(list.conns)
 	for range needed {
@@ -218,68 +176,13 @@ func (t *grpcTransport) prewarm() {
 			conn.Close() // pool filled concurrently; don't leak
 			break
 		}
+		PoolSizeGauge.WithLabelValues(t.addr).Inc()
 	}
-}
-
-// flushMetrics updates Prometheus metrics from atomic counters.
-func (t *grpcTransport) flushMetrics() {
-	hits := t.hits.Swap(0)
-	misses := t.misses.Swap(0)
-	if hits > 0 {
-		PoolHitsCount.WithLabelValues(t.addr).Add(float64(hits))
-	}
-	if misses > 0 {
-		PoolMissesCount.WithLabelValues(t.addr).Add(float64(misses))
-	}
-	list := t.connList.Load()
-	PoolSizeGauge.WithLabelValues(t.addr).Set(float64(len(list.conns)))
-}
-
-// cleanupDeadConns removes connections that are in a failed gRPC state or have
-// exceeded the idle TTL (expire duration).
-func (t *grpcTransport) cleanupDeadConns() {
-	t.mu.Lock()
-	oldList := t.connList.Load()
-	var toClose []*grpcConn
-	newConns := make([]*grpcConn, 0, len(oldList.conns))
-
-	for _, gc := range oldList.conns {
-		if gc == nil || gc.conn == nil {
-			continue
-		}
-		state := gc.conn.GetState()
-		expired := t.expire > 0 && gc.idleFor() > t.expire
-		if state == connectivity.Shutdown || state == connectivity.TransientFailure || expired {
-			toClose = append(toClose, gc)
-		} else {
-			newConns = append(newConns, gc)
-		}
-	}
-
-	if len(toClose) > 0 {
-		t.connList.Store(&connList{conns: newConns})
-	}
-	t.mu.Unlock()
-
-	for _, gc := range toClose {
-		gc.conn.Close()
-	}
-}
-
-// Start starts the transport's connection pool maintenance goroutine.
-func (t *grpcTransport) Start() {
-	t.started.Store(true)
-	go t.healthChecker()
 }
 
 // Stop shuts down the transport and closes all pooled connections.
 func (t *grpcTransport) Stop() {
 	t.stopped.Store(true)
-	close(t.stop)
-	// Only wait for healthChecker to exit if Start() was called.
-	if t.started.Load() {
-		<-t.done
-	}
 
 	t.mu.Lock()
 	list := t.connList.Load()

--- a/plugin/grpc/transport.go
+++ b/plugin/grpc/transport.go
@@ -1,7 +1,6 @@
 package grpc
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -60,7 +59,7 @@ func newTransport(proxyName, addr string, dialOpts []grpc.DialOption, poolSize i
 
 // Dial returns a shared connection from the pool using round-robin.
 // Returns ErrTransportStopped if the transport has been shut down.
-func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, error) {
+func (t *grpcTransport) Dial() (*grpcConn, error) {
 	if t.stopped.Load() {
 		return nil, ErrTransportStopped
 	}
@@ -77,13 +76,13 @@ func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, error) {
 	}
 
 	PoolMissesCount.WithLabelValues(t.addr).Inc()
-	return t.createConn(ctx)
+	return t.createConn()
 }
 
 // createConn creates a new gRPC connection and attempts to add it to the pool.
 // If the pool is already full, the new connection is closed and an existing
 // pool connection is returned to avoid leaking resources.
-func (t *grpcTransport) createConn(ctx context.Context) (*grpcConn, error) {
+func (t *grpcTransport) createConn() (*grpcConn, error) {
 	conn, err := grpc.NewClient(t.addr, t.dialOpts...)
 	if err != nil {
 		return nil, err
@@ -133,6 +132,8 @@ func (t *grpcTransport) addConn(gc *grpcConn) bool {
 }
 
 // RemoveConn removes a failed connection from the pool and closes it.
+// If gc is not found in the pool (e.g. already removed by a concurrent call),
+// the gauge is not decremented and the connection is not closed again.
 func (t *grpcTransport) RemoveConn(gc *grpcConn) {
 	if gc == nil {
 		return
@@ -141,18 +142,24 @@ func (t *grpcTransport) RemoveConn(gc *grpcConn) {
 	t.mu.Lock()
 	oldList := t.connList.Load()
 	newConns := make([]*grpcConn, 0, len(oldList.conns))
+	removed := false
 	for _, c := range oldList.conns {
 		if c != gc {
 			newConns = append(newConns, c)
+		} else {
+			removed = true
 		}
 	}
-	t.connList.Store(&connList{conns: newConns})
+	if removed {
+		t.connList.Store(&connList{conns: newConns})
+	}
 	t.mu.Unlock()
 
-	PoolSizeGauge.WithLabelValues(t.addr).Dec()
-
-	if gc.conn != nil {
-		gc.conn.Close()
+	if removed {
+		PoolSizeGauge.WithLabelValues(t.addr).Dec()
+		if gc.conn != nil {
+			gc.conn.Close()
+		}
 	}
 }
 

--- a/plugin/grpc/transport.go
+++ b/plugin/grpc/transport.go
@@ -1,0 +1,298 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coredns/coredns/pb"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+const poolMaintainInterval = 5 * time.Second
+
+// grpcConn wraps a gRPC connection with its client for shared access.
+type grpcConn struct {
+	conn     *grpc.ClientConn
+	client   pb.DnsServiceClient
+	lastUsed atomic.Int64 // unix nanoseconds; updated on every Dial hit
+}
+
+// touch records the current time as the last-used time for this connection.
+func (gc *grpcConn) touch() { gc.lastUsed.Store(time.Now().UnixNano()) }
+
+// idleFor returns how long this connection has been idle.
+func (gc *grpcConn) idleFor() time.Duration {
+	last := gc.lastUsed.Load()
+	if last == 0 {
+		return 0
+	}
+	return time.Since(time.Unix(0, last))
+}
+
+// connList is an immutable slice of connections for lock-free access.
+type connList struct {
+	conns []*grpcConn
+}
+
+// grpcTransport manages a pool of shared gRPC connections to a single upstream.
+// Uses lock-free atomic operations on the hot path for maximum throughput.
+type grpcTransport struct {
+	addr     string
+	dialOpts []grpc.DialOption
+	poolSize int
+	expire   time.Duration // idle TTL; zero means no TTL eviction
+
+	// Hot path: lock-free access via atomic pointer
+	connList atomic.Pointer[connList]
+	idx      atomic.Uint64
+
+	// Cold path: mutex for modifications
+	mu sync.Mutex
+
+	// stopped is set before close(stop) to allow Dial to detect shutdown without a panic.
+	stopped atomic.Bool
+	// started tracks whether Start() has been called, to avoid deadlock in Stop().
+	started atomic.Bool
+
+	stop chan struct{}
+	done chan struct{}
+
+	proxyName string
+
+	// Metrics counters (updated atomically, flushed periodically)
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+// newTransport creates a new gRPC connection transport with shared connections.
+func newTransport(proxyName, addr string, dialOpts []grpc.DialOption, poolSize int, expire time.Duration) *grpcTransport {
+	t := &grpcTransport{
+		addr:      addr,
+		dialOpts:  dialOpts,
+		poolSize:  poolSize,
+		expire:    expire,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+		proxyName: proxyName,
+	}
+	t.connList.Store(&connList{conns: make([]*grpcConn, 0, poolSize)})
+	return t
+}
+
+// Dial returns a shared connection from the pool using round-robin.
+// Returns ErrTransportStopped if the transport has been shut down.
+func (t *grpcTransport) Dial(ctx context.Context) (*grpcConn, bool, error) {
+	if t.stopped.Load() {
+		return nil, false, ErrTransportStopped
+	}
+
+	list := t.connList.Load()
+	n := len(list.conns)
+	if n > 0 {
+		idx := t.idx.Add(1)
+		gc := list.conns[idx%uint64(n)]
+		if gc != nil && gc.client != nil {
+			gc.touch()
+			t.hits.Add(1)
+			return gc, false, nil
+		}
+	}
+
+	t.misses.Add(1)
+	gc, err := t.createConn(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return gc, true, nil
+}
+
+// createConn creates a new gRPC connection and attempts to add it to the pool.
+// If the pool is already full, the new connection is closed and an existing
+// pool connection is returned to avoid leaking resources.
+func (t *grpcTransport) createConn(ctx context.Context) (*grpcConn, error) {
+	conn, err := grpc.NewClient(t.addr, t.dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	gc := &grpcConn{
+		conn:   conn,
+		client: pb.NewDnsServiceClient(conn),
+	}
+	gc.touch()
+
+	if !t.addConn(gc) {
+		// Pool is full (concurrent creation race). Close the new connection
+		// to avoid leaking it and return an existing one from the pool.
+		conn.Close()
+		list := t.connList.Load()
+		if n := len(list.conns); n > 0 {
+			return list.conns[t.idx.Add(1)%uint64(n)], nil
+		}
+		// Shouldn't happen: pool was full but is now empty.
+		return nil, ErrTransportStopped
+	}
+
+	return gc, nil
+}
+
+// addConn adds a connection to the pool. Returns false if the pool is already full.
+func (t *grpcTransport) addConn(gc *grpcConn) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	oldList := t.connList.Load()
+	if len(oldList.conns) >= t.poolSize {
+		return false
+	}
+
+	newConns := make([]*grpcConn, len(oldList.conns)+1)
+	copy(newConns, oldList.conns)
+	newConns[len(oldList.conns)] = gc
+	t.connList.Store(&connList{conns: newConns})
+	return true
+}
+
+// RemoveConn removes a failed connection from the pool and closes it.
+func (t *grpcTransport) RemoveConn(gc *grpcConn) {
+	if gc == nil {
+		return
+	}
+
+	t.mu.Lock()
+	oldList := t.connList.Load()
+	newConns := make([]*grpcConn, 0, len(oldList.conns))
+	for _, c := range oldList.conns {
+		if c != gc {
+			newConns = append(newConns, c)
+		}
+	}
+	t.connList.Store(&connList{conns: newConns})
+	t.mu.Unlock()
+
+	if gc.conn != nil {
+		gc.conn.Close()
+	}
+}
+
+// healthChecker periodically maintains the connection pool.
+func (t *grpcTransport) healthChecker() {
+	ticker := time.NewTicker(poolMaintainInterval)
+	defer ticker.Stop()
+	defer close(t.done)
+
+	t.prewarm()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.cleanupDeadConns()
+			t.flushMetrics()
+			t.prewarm()
+		case <-t.stop:
+			return
+		}
+	}
+}
+
+// prewarm creates connections up to pool size.
+func (t *grpcTransport) prewarm() {
+	list := t.connList.Load()
+	needed := t.poolSize - len(list.conns)
+	for range needed {
+		conn, err := grpc.NewClient(t.addr, t.dialOpts...)
+		if err != nil {
+			continue
+		}
+		gc := &grpcConn{
+			conn:   conn,
+			client: pb.NewDnsServiceClient(conn),
+		}
+		if !t.addConn(gc) {
+			conn.Close() // pool filled concurrently; don't leak
+			break
+		}
+	}
+}
+
+// flushMetrics updates Prometheus metrics from atomic counters.
+func (t *grpcTransport) flushMetrics() {
+	hits := t.hits.Swap(0)
+	misses := t.misses.Swap(0)
+	if hits > 0 {
+		PoolHitsCount.WithLabelValues(t.addr).Add(float64(hits))
+	}
+	if misses > 0 {
+		PoolMissesCount.WithLabelValues(t.addr).Add(float64(misses))
+	}
+	list := t.connList.Load()
+	PoolSizeGauge.WithLabelValues(t.addr).Set(float64(len(list.conns)))
+}
+
+// cleanupDeadConns removes connections that are in a failed gRPC state or have
+// exceeded the idle TTL (expire duration).
+func (t *grpcTransport) cleanupDeadConns() {
+	t.mu.Lock()
+	oldList := t.connList.Load()
+	var toClose []*grpcConn
+	newConns := make([]*grpcConn, 0, len(oldList.conns))
+
+	for _, gc := range oldList.conns {
+		if gc == nil || gc.conn == nil {
+			continue
+		}
+		state := gc.conn.GetState()
+		expired := t.expire > 0 && gc.idleFor() > t.expire
+		if state == connectivity.Shutdown || state == connectivity.TransientFailure || expired {
+			toClose = append(toClose, gc)
+		} else {
+			newConns = append(newConns, gc)
+		}
+	}
+
+	if len(toClose) > 0 {
+		t.connList.Store(&connList{conns: newConns})
+	}
+	t.mu.Unlock()
+
+	for _, gc := range toClose {
+		gc.conn.Close()
+	}
+}
+
+// Start starts the transport's connection pool maintenance goroutine.
+func (t *grpcTransport) Start() {
+	t.started.Store(true)
+	go t.healthChecker()
+}
+
+// Stop shuts down the transport and closes all pooled connections.
+func (t *grpcTransport) Stop() {
+	t.stopped.Store(true)
+	close(t.stop)
+	// Only wait for healthChecker to exit if Start() was called.
+	if t.started.Load() {
+		<-t.done
+	}
+
+	t.mu.Lock()
+	list := t.connList.Load()
+	t.connList.Store(&connList{conns: nil})
+	t.mu.Unlock()
+
+	for _, gc := range list.conns {
+		if gc != nil && gc.conn != nil {
+			gc.conn.Close()
+		}
+	}
+	PoolSizeGauge.WithLabelValues(t.addr).Set(0)
+}
+
+// ErrTransportStopped is returned by Dial when the transport has been shut down.
+var ErrTransportStopped = errors.New("transport stopped")


### PR DESCRIPTION
Add connection pooling and health checking to the gRPC plugin for improved performance in high-throughput scenarios.

Features:
- Configurable connection pool (1-100 connections, default: 1)
- DNS query-based health checking with fail threshold
- Automatic connection expiration and cleanup
- Prometheus metrics (pool hits/misses, size, health failures)
- Lifecycle management (OnStartup/OnShutdown)

Configuration directives:
- pool_size: max connections per upstream
- expire: idle connection TTL
- health_check: health probe interval
- max_fails: fail threshold before marking down

Implementation follows forward plugin's connection pooling pattern using channel-based goroutine for thread-safety.

Fixes #7794
Relates to #7789
