### PR TITLE
fix(lint): address G114 gosec findings in ready, pprof, and health plugins

### DIFF
--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -22,11 +22,14 @@ type health struct {
 	healthURI *url.URL
 
 	ln      net.Listener
+	srv     *http.Server
 	nlSetup bool
 	mux     *http.ServeMux
 
 	stop context.CancelFunc
 }
+
+const shutdownTimeout = 5 * time.Second
 
 func (h *health) OnStartup() error {
 	if h.Addr == "" {
@@ -63,8 +66,14 @@ func (h *health) OnStartup() error {
 	ctx := context.Background()
 	ctx, h.stop = context.WithCancel(ctx)
 
-	// #nosec G114 -- TODO
-	go func() { http.Serve(h.ln, h.mux) }()
+	h.srv = &http.Server{
+		Handler:      h.mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  5 * time.Second,
+	}
+
+	go func() { h.srv.Serve(h.ln) }()
 	go func() { h.overloaded(ctx) }()
 
 	return nil
@@ -82,7 +91,11 @@ func (h *health) OnFinalShutdown() error {
 
 	h.stop()
 
-	h.ln.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := h.srv.Shutdown(ctx); err != nil {
+		log.Infof("Failed to stop health http server: %s", err)
+	}
 	h.nlSetup = false
 	return nil
 }
@@ -94,7 +107,11 @@ func (h *health) OnReload() error {
 
 	h.stop()
 
-	h.ln.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := h.srv.Shutdown(ctx); err != nil {
+		log.Infof("Failed to stop health http server: %s", err)
+	}
 	h.nlSetup = false
 	return nil
 }

--- a/plugin/pprof/pprof.go
+++ b/plugin/pprof/pprof.go
@@ -3,10 +3,12 @@
 package pprof
 
 import (
+	"context"
 	"net"
 	"net/http"
 	pp "net/http/pprof"
 	"runtime"
+	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 )
@@ -15,8 +17,11 @@ type handler struct {
 	addr     string
 	rateBloc int
 	ln       net.Listener
+	srv      *http.Server
 	mux      *http.ServeMux
 }
+
+const shutdownTimeout = 5 * time.Second
 
 func (h *handler) Startup() error {
 	// Reloading the plugin without changing the listening address results
@@ -42,16 +47,25 @@ func (h *handler) Startup() error {
 
 	runtime.SetBlockProfileRate(h.rateBloc)
 
-	go func() {
-		// #nosec G114 -- TODO
-		http.Serve(h.ln, h.mux)
-	}()
+	h.srv = &http.Server{
+		Handler:      h.mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  5 * time.Second,
+	}
+
+	go func() { h.srv.Serve(h.ln) }()
 	return nil
 }
 
 func (h *handler) Shutdown() error {
-	if h.ln != nil {
-		return h.ln.Close()
+	if h.srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := h.srv.Shutdown(ctx); err != nil {
+			log.Infof("Failed to stop pprof http server: %s", err)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Replace http.Serve() with http.Server{} configured with timeouts to address G114 gosec findings (HTTP server without timeouts). This prevents potential slowloris attacks and resource exhaustion.

Changes:
- Add ReadTimeout, WriteTimeout, IdleTimeout (5s each) to HTTP servers
- Use srv.Shutdown(ctx) for graceful shutdown instead of ln.Close()
- Follow existing pattern from plugin/metrics

Fixes part of #7793