### PR TITLE
Add metadata for response Type and Class to Log.

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -94,6 +94,19 @@ Each of these logs will be outputted with `log.Infof`, so a typical example look
 [INFO] [::1]:50759 - 29008 "A IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 68 0.037990251s
 ~~~
 
+## Additional metadata
+
+The log plugin adds the following metadata to allow for granular differentiation of NOERROR denial vs success messages. These are mapped from `plugin/pkg/response/classify.go` and `plugin/pkg/response/typify.go`.
+
+* `{/log/class}`: success, denial
+* `{/log/type}`: NODATA, NXDOMAIN, NOERROR
+
+~~~ corefile
+. {
+    log . "{proto} Request: {name} {type} {/log/class} {/log/type}"
+}
+~~~
+
 ## Examples
 
 Log all requests to stdout


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Adds metadata for response Class and Type to the log plugin. This allows differentiation of "NODATA" from other NOERROR log lines when logging success and denial. 

Adding `{/log/class} {/log/type}` to the default format yields uniquely parsable data for each of these three test cases:
```
[INFO] 127.0.0.1:41478 - 45106 SRV IN example.org. udp 29 false 512 NOERROR qr,aa,rd,ra 119 0.099735863s denial NODATA
[INFO] 127.0.0.1:37844 - 7183 A IN example.org. udp 29 false 512 NOERROR qr,rd,ra 83 0.102162208s success NOERROR
[INFO] 127.0.0.1:46590 - 39391 SRV IN example.fake. udp 30 false 512 NXDOMAIN qr,aa,rd,ra 105 0.099880694s denial NXDOMAIN
```

### 2. Which issues (if any) are related?
n/a

### 3. Which documentation changes (if any) need to be made?
Added a quick snippet in README.md.

### 4. Does this introduce a backward incompatible change or deprecation?
No.

I wasn't sure where this code should live and so I put it somewhere where it worked. I'm not familiar at all with this codebase. If it should go somewhere else please let me know.