### PR TITLE
chore: allow to override -ldflags via ENV VAR for make coredns target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ GOPATH?=$(HOME)/go
 MAKEPWD:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 CGO_ENABLED?=0
 GOLANG_VERSION ?= $(shell cat .go-version)
+STRIP_FLAGS?=-s -w
+LDFLAGS?=-ldflags="$(STRIP_FLAGS) -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)"
 
 export GOSUMDB = sum.golang.org
 export GOTOOLCHAIN = go$(GOLANG_VERSION)
@@ -17,7 +19,7 @@ all: coredns
 
 .PHONY: coredns
 coredns: $(CHECKS)
-	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
+	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) $(LDFLAGS) -o $(BINARY)
 
 .PHONY: check
 check: core/plugin/zplugin.go core/dnsserver/zdirectives.go


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This allows to override the `-ldflags` for the `go build` command under the `make coredns` target. The default behaviour for the target is unchanged. 

This is very useful to set those flags appropriately through an env variable while using the make target instead of having to manually run the go command.

I found the need to this while trying to setup debugger in my local environment which had a build step. With this I can remove the `-s -w` flags by setting the new `STRIP_FLAGS` env var to "" and get a binary with debug symbols.

### 2. Which issues (if any) are related?
NA 

### 3. Which documentation changes (if any) need to be made?
NA

### 4. Does this introduce a backward incompatible change or deprecation?
NA