### PR TITLE
fix: return SOA and NS records when queried for a record CNAMEd to origin

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -331,7 +331,7 @@ func (z *Zone) externalLookup(ctx context.Context, state request.Request, elem *
 
 	targetName := rrs[0].(*dns.CNAME).Target
 	elem, _ = z.Search(targetName)
-	if elem == nil {
+	if elem == nil || (qtype == dns.TypeNS || qtype == dns.TypeSOA && targetName == z.origin) {
 		lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
 		rrs = append(rrs, lookupRRs...)
 		return rrs, z.ns(do), nil, result
@@ -351,7 +351,7 @@ Redo:
 		}
 		targetName := cname[0].(*dns.CNAME).Target
 		elem, _ = z.Search(targetName)
-		if elem == nil {
+		if elem == nil || (qtype == dns.TypeNS || qtype == dns.TypeSOA && targetName == z.origin) {
 			lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
 			rrs = append(rrs, lookupRRs...)
 			return rrs, z.ns(do), nil, result

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -12,5 +12,6 @@ short   1    IN  A      127.0.0.3
 *.w     3600 IN  TXT    "Wildcard"
 a.b.c.w      IN  TXT    "Not a wildcard"
 cname        IN  CNAME  h.gtld-servers.net.
+cname-origin IN  CNAME  @
 service      IN  SRV    8080 10 10 @
 `


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This fixes the file plugin to return answer to an NS/SOA query for a record which is CNAMEd to zone origin. This brings it inline with standard bind9 behaviour. 

The problem was that we were ignoring SOA and NS records while looking up for the CNAME target (since those records are not stored in the zone tree). A simple fix is to propagate the query to upstream with target name and query type, which would return the answer correctly (as the upstream search still begins with current plugin and returns answer to NS/SOA records).

### 2. Which issues (if any) are related?
Fixes #6630 

### 3. Which documentation changes (if any) need to be made?
NA

### 4. Does this introduce a backward incompatible change or deprecation?
NA