### PR TITLE
Bump version to 1.14.1

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.14.0"
+	CoreVersion = "1.14.1"
 	CoreName    = "CoreDNS"
 	serverType  = "dns"
 )

--- a/notes/coredns-1.14.1.md
+++ b/notes/coredns-1.14.1.md
@@ -1,0 +1,24 @@
++++
+title = "CoreDNS-1.14. Release"
+description = "CoreDNS-1.14.1 Release Notes."
+tags = ["Release", "1.14.1", "Notes"]
+release = "1.14.1"
+date = "2026-01-15T00:00:00+00:00"
+author = "coredns"
++++
+
+This release primarily addresses security vulnerabilities affecting Go versions prior to
+Go 1.25.6 and Go 1.24.12 (CVE-2025-61728, CVE-2025-61726, CVE-2025-68121, CVE-2025-61731,
+CVE-2025-68119). It also includes performance improvements to the proxy plugin via
+multiplexed connections, along with various documentation updates.
+
+## Brought to You By
+
+Alex Massy
+Shiv Tyagi
+Ville Vesilehto
+Yong Tang
+
+## Noteworthy Changes
+
+* plugin/proxy: Use mutex-based connection pool (https://github.com/coredns/coredns/pull/7790)


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR bumps version to 1.14.1, added the release note, in anticipation of the upcoming release for seccurity fixes related to golang.
### 2. Which issues (if any) are related?
#7825
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a