### PR TITLE
plugin/tsig: add require_opcode directive for opcode-based TSIG

### DIFF
--- a/plugin/tsig/README.md
+++ b/plugin/tsig/README.md
@@ -19,6 +19,7 @@ tsig [ZONE...] {
   secret NAME KEY
   secrets FILE
   require [QTYPE...]
+  require_opcode [OPCODE...]
 }
 ~~~
 
@@ -36,9 +37,14 @@ tsig [ZONE...] {
      ```
      Each key may also specify an `algorithm` e.g. `algorithm hmac-sha256;`, but this is currently ignored by the plugin.
 
-     * `require` **QTYPE...** - the query types that must be TSIG'd. Requests of the specified types
-   will be `REFUSED` if they are not signed.`require all` will require requests of all types to be
+   * `require` **QTYPE...** - the query types that must be TSIG'd. Requests of the specified types
+   will be `REFUSED` if they are not signed. `require all` will require requests of all types to be
    signed. `require none` will not require requests any types to be signed. Default behavior is to not require.
+
+   * `require_opcode` **OPCODE...** - the opcodes that must be TSIG'd. Requests with the specified opcodes
+   will be `REFUSED` if they are not signed. Valid opcodes are: `QUERY`, `IQUERY`, `STATUS`, `NOTIFY`, `UPDATE`.
+   `require_opcode all` will require requests with all opcodes to be signed. `require_opcode none` will not
+   require requests with any opcode to be signed. Default behavior is to not require.
 
 ## Examples
 
@@ -65,6 +71,17 @@ auth.zone {
     require all
   }
   forward . 10.1.0.2
+}
+```
+
+Require TSIG signed transactions for UPDATE and NOTIFY operations to `dynamic.zone`.
+
+```
+dynamic.zone {
+  tsig {
+    secret dynamic.zone.key. NoTCJU+DMqFWywaPyxSijrDEA/eC3nK0xi3AMEZuPVk=
+    require_opcode UPDATE NOTIFY
+  }
 }
 ```
 

--- a/plugin/tsig/setup.go
+++ b/plugin/tsig/setup.go
@@ -43,6 +43,7 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 	t := &TSIGServer{
 		secrets: make(map[string]string),
 		types:   defaultQTypes,
+		opcodes: defaultOpCodes,
 	}
 
 	for i := 0; c.Next(); i++ {
@@ -89,7 +90,7 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 					return nil, c.ArgErr()
 				}
 				if args[0] == "all" {
-					t.all = true
+					t.allTypes = true
 					continue
 				}
 				if args[0] == "none" {
@@ -101,6 +102,26 @@ func parse(c *caddy.Controller) (*TSIGServer, error) {
 						return nil, c.Errf("unknown query type '%s'", str)
 					}
 					t.types[qt] = struct{}{}
+				}
+			case "require_opcode":
+				t.opcodes = opCodes{}
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				if args[0] == "all" {
+					t.allOpcodes = true
+					continue
+				}
+				if args[0] == "none" {
+					continue
+				}
+				for _, str := range args {
+					op, ok := dns.StringToOpcode[str]
+					if !ok {
+						return nil, c.Errf("unknown opcode '%s'", str)
+					}
+					t.opcodes[op] = struct{}{}
 				}
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())
@@ -166,3 +187,4 @@ func parseKeyFile(f io.Reader) (map[string]string, error) {
 }
 
 var defaultQTypes = qTypes{}
+var defaultOpCodes = opCodes{}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Extend the tsig plugin to require TSIG signatures based on DNS opcodes, similar to the existing qtype-based requirement.

The new require_opcode directive accepts opcode names (QUERY, IQUERY, STATUS, NOTIFY, UPDATE) or the special values "all" and "none".

This is useful for requiring TSIG on dynamic update (UPDATE) or zone transfer notification (NOTIFY) requests while allowing unsigned queries.

Example:
```
  tsig {
    secret key. NoTCJU+DMqFWywaPyxSijrDEA/eC3nK0xi3AMEZuPVk=
    require_opcode UPDATE NOTIFY
  }
```

### 4. Does this introduce a backward incompatible change or deprecation?

No