### PR TITLE
docs: clarify kubernetes auth docs

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -51,13 +51,14 @@ kubernetes [ZONES...] {
 ```
 
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
-   If omitted, it will connect to k8s in-cluster using the cluster service account.
+   If omitted, it will connect to k8s in-cluster using the cluster service account. Needs `tls` for clusters with authentication.
+   This option is ignored if `kubeconfig` is set.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file.
    **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
    It supports TLS, username and password, or token-based authentication.
-   This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+   This option is ignored if omitted. The cluster address in the `kubeconfig` is given preference.
 * `apiserver_qps` **QPS** sets the maximum queries per second (QPS) rate limit for requests.
    This allows you to control the rate at which the plugin sends requests to the API server to prevent overwhelming it.
 * `apiserver_burst` **BURST** sets the maximum burst size for requests.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Improving docs for the Kubernetes plugin

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
Kubernetes plugin auth section. Specify which parameters take preference.

**Background:**
I was experimenting with Kubernetes and my in-cluster-kube-endpoint was not usable. I wanted to set `endpoint` to override the used Kubernetes endpoint but use in cluster token auth. This is currently not supported by the plugin.  You need to use `kubeconfig` for that. The current implementation is here:

https://github.com/coredns/coredns/blob/80527fd389841310a728cf862491129321c8a112/plugin/kubernetes/kubernetes.go#L187-L205

### 4. Does this introduce a backward incompatible change or deprecation?
no