### PR TITLE
plugin/forward: fix parsing error when handling TLS+IPv6 address

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -99,16 +99,27 @@ func parseForward(c *caddy.Controller) ([]*Forward, error) {
 
 // Splits the zone, preserving any port that comes after the zone
 func splitZone(host string) (newHost string, zone string) {
+	trans, host, found := strings.Cut(host, "://")
+	if !found {
+		host, trans = trans, ""
+	}
 	newHost = host
 	if strings.Contains(host, "%") {
 		lastPercent := strings.LastIndex(host, "%")
 		newHost = host[:lastPercent]
+		if strings.HasPrefix(newHost, "[") {
+			newHost = newHost + "]"
+		}
 		zone = host[lastPercent+1:]
 		if strings.Contains(zone, ":") {
 			lastColon := strings.LastIndex(zone, ":")
 			newHost += zone[lastColon:]
 			zone = zone[:lastColon]
+			zone = strings.TrimSuffix(zone, "]")
 		}
+	}
+	if trans != "" {
+		newHost = trans + "://" + newHost
 	}
 	return
 }

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -46,6 +46,7 @@ func HostPortOrFile(s ...string) ([]string, error) {
 
 		if err != nil {
 			// Parse didn't work, it is not a addr:port combo
+			host = strings.Trim(host, "[]")
 			hostNoZone := stripZone(host)
 			if net.ParseIP(hostNoZone) == nil {
 				ss, err := tryFile(host)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
fix plugin/forward bug: when handling TLS+IPv6 config like `forward . tls://::1%example.net ...`, the ipv6 host will not be correctly parsed,  but got weird `[::1:853`. The cause is there is a function `splitZone` not support ipv6 format.
<img width="794" height="445" alt="2026-02-10_09-29-42" src="https://github.com/user-attachments/assets/ae109e8d-102e-45fc-886c-70de6a8cdb7f" />


### 2. Which issues (if any) are related?

- [#7847](https://github.com/coredns/coredns/issues/7847)

### 3. Which documentation changes (if any) need to be made?
no
### 4. Does this introduce a backward incompatible change or deprecation?
no