### PR TITLE
fix(kubernetes): panic on empty ListenHosts

### DIFF
--- a/plugin/kubernetes/local.go
+++ b/plugin/kubernetes/local.go
@@ -11,7 +11,7 @@ import (
 func boundIPs(c *caddy.Controller) (ips []net.IP) {
 	conf := dnsserver.GetConfig(c)
 	hosts := conf.ListenHosts
-	if hosts == nil || hosts[0] == "" {
+	if len(hosts) == 0 || hosts[0] == "" {
 		hosts = nil
 		addrs, err := net.InterfaceAddrs()
 		if err != nil {


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The `boundIPs` function checked `ListenHosts` with a `nil` comparison, which missed the case of a non-nil empty slice. Accessing index 0 on that slice caused a panic found by OSS-Fuzz. Use `len()` instead, matching the guard already used in the loop and trace plugins.

### 2. Which issues (if any) are related?

Fixes OSS-Fuzz finding [#482318524](https://issues.oss-fuzz.com/issues/482318524) (not publicly accessible).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.