### PR TITLE
Include all upstream answer records after cname rewrite to support multiple levels of cnames.

### DIFF
--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -102,9 +102,7 @@ func (r *cnameTargetRuleWithReqState) RewriteResponse(res *dns.Msg, rr dns.RR) {
 				}
 				// iterate over upstream response received
 				for _, rr := range upRes.Answer {
-					if rr.Header().Name == toTarget {
-						newAnswer = append(newAnswer, rr)
-					}
+					newAnswer = append(newAnswer, rr)
 				}
 				res.Answer = newAnswer
 				// if not propagated, the truncated response might get cached,

--- a/plugin/rewrite/cname_target_test.go
+++ b/plugin/rewrite/cname_target_test.go
@@ -61,6 +61,12 @@ func (u *MockedUpstream) Lookup(ctx context.Context, state request.Request, name
 		}
 		m.Truncated = true
 		return m, nil
+	case "cname1.example.com.":
+		m.Answer = []dns.RR{
+			test.CNAME("cname1.example.com.   200   IN  CNAME  cname2.example.com."),
+			test.A("cname2.example.com.   3600  IN  A   3.4.5.6"),
+		}
+		return m, nil
 	}
 	return &dns.Msg{}, nil
 }
@@ -76,6 +82,7 @@ func TestCNameTargetRewrite(t *testing.T) {
 		{[]string{"continue", "cname", "substring", "efgh", "zzzz.www"}, reflect.TypeFor[*cnameTargetRule]()},
 		{[]string{"continue", "cname", "regex", `(.*)\.web\.(.*)\.site\.`, `{1}.webapp.{2}.org.`}, reflect.TypeFor[*cnameTargetRule]()},
 		{[]string{"continue", "cname", "exact", "music.truncated.spotify.com.", "music.truncated.spotify.com."}, reflect.TypeFor[*cnameTargetRule]()},
+		{[]string{"continue", "cname", "exact", "cname.example.com.", "cname1.example.com."}, reflect.TypeFor[*cnameTargetRule]()},
 	}
 	rules := make([]Rule, 0, len(ruleset))
 	for i, r := range ruleset {
@@ -179,6 +186,18 @@ func doTestCNameTargetTests(t *testing.T, rules []Rule) {
 				test.A("music.truncated.spotify.com.   120  IN  A   10.1.0.9"),
 			},
 			true,
+		},
+		{"double-cname-rewrite.example.com", dns.TypeA,
+			[]dns.RR{
+				test.CNAME("double-cname-rewrite.example.com.  200  IN  CNAME  cname.example.com."),
+				test.A("cname.example.com.    200  IN  A   1.2.3.4"),
+			},
+			[]dns.RR{
+				test.CNAME("double-cname-rewrite.example.com.  200   IN  CNAME  cname1.example.com."),
+				test.CNAME("cname1.example.com.   200   IN  CNAME  cname2.example.com."),
+				test.A("cname2.example.com.   3600  IN  A   3.4.5.6"),
+			},
+			false,
 		},
 	}
 	ctx := context.TODO()


### PR DESCRIPTION
Currently, when using the rewrite plugin cname target, only the exactly matching record from the upstream response is returned, which means that if that record is another cname, any other records in the upstream response that recursively resolve it are omitted. 

I'm not sure why this choice was made and all tests pass if i remove the guard and just include all records. This also intuitively makes sense to me since what the rewrite should essentially do is prepend a cname record to the upstream response. But I'm not a DNS expert, so please let me know if I've overlooked something. 