### PR TITLE
fix: upgrade Go to 1.26.0 to resolve stdlib CVE-2025-68121

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,13 @@
+FROM golang:1.26 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o coredns .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /app/coredns /coredns
+USER nonroot:nonroot
+WORKDIR /
+EXPOSE 53 53/udp
+ENTRYPOINT ["/coredns"]

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/coredns/coredns
 
 // Note this minimum version requirement. CoreDNS supports the last two
 // Go versions. This follows the upstream Go project support.
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible


### PR DESCRIPTION
## Summary\nThis PR originally aimed to upgrade Go version to 1.25.7 to fix CVE-2025-68121. However, upon re-scanning the original image, this specific CVE was not identified.\n\n## Re-evaluation of Vulnerability Findings\n\n### Trivy Scan Command (Original Image)\n```\ntrivy image --severity HIGH,CRITICAL registry.k8s.io/coredns/coredns:v1.12.0\n```\n\n### Original Image Vulnerabilities (registry.k8s.io/coredns/coredns:v1.12.0)\n```\ncoredns (gobinary)\n==================\nTotal: 14 (HIGH: 12, CRITICAL: 2)\n\n| Library                     | Vulnerability  | Severity | Installed Version | Fixed Version | Title                                                 |
|-----------------------------|----------------|----------|-------------------|---------------|-------------------------------------------------------|
| github.com/expr-lang/expr   | CVE-2025-29786 | HIGH     | v1.16.9           | 1.17.0        | Memory Exhaustion in Expr Parser                      |
| github.com/expr-lang/expr   | CVE-2025-68156 | HIGH     | v1.16.9           | 1.17.7        | Denial of Service via uncontrolled recursion          |
| github.com/golang-jwt/jwt/v4| CVE-2025-30204 | HIGH     | v4.5.1            | 4.5.2         | Excessive memory allocation during header parsing     |
| github.com/quic-go/quic-go  | CVE-2025-59530 | HIGH     | v0.48.1           | 0.49.1, 0.54.1| Crash Due to Premature HANDSHAKE_DONE Frame           |
| golang.org/x/crypto         | CVE-2024-45337 | CRITICAL | v0.29.0           | 0.31.0        | Misuse of ServerConfig.PublicKeyCallback              |
| golang.org/x/crypto         | CVE-2025-22869 | HIGH     | v0.29.0           | 0.35.0        | Denial of Service in Key Exchange                     |
| golang.org/x/oauth2         | CVE-2025-22868 | HIGH     | v0.24.0           | 0.27.0        | Unexpected memory consumption during token parsing    |
```\n
### Conclusion\nThis PR targeted CVE-2025-68121, which was not found in the original image. Therefore, this PR is not directly addressing the actual critical vulnerabilities present in the  image.\n\n**Action:** Recommending closure of this PR. Further investigation is needed to address the actual CVEs listed above (CVE-2024-45337, etc.) through appropriate dependency updates.