### PR TITLE
plugin: reorder rewrite before acl to prevent bypass

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -45,13 +45,13 @@ log:log
 dnstap:dnstap
 local:local
 dns64:dns64
-acl:acl
 any:any
 chaos:chaos
 loadbalance:loadbalance
 tsig:tsig
 cache:cache
 rewrite:rewrite
+acl:acl
 header:header
 dnssec:dnssec
 autopath:autopath


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
In the default `plugin.cfg`, the `acl` plugin (and other security/policy plugins) are ordered before the `rewrite` plugin. This creates a Time-of-Check Time-of-Use (TOCTOU) vulnerability where an access control check is performed on the original query name, but the query is subsequently rewritten to a restricted internal domain (e.g., in a Kubernetes multi-tenant cluster) and resolved by the backend.
### 2. Which issues (if any) are related?
Relates to GitHub Security Advisory: [GHSA-c9v3-4pv7-87pr](https://github.com/coredns/coredns/security/advisories/GHSA-c9v3-4pv7-87pr)
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
Yes and No. It changes the execution order of plugins. Users who implicitly relied on `acl` blocking a query before a `rewrite` rule applied to it will now have the rewrite applied first. This is the logically secure flow, but represents a behavior change in the pipeline order.