### PR TITLE
build: add grpcnotrace tag to exclude x/net/trace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINARY:=coredns
 SYSTEM:=
 CHECKS:=check
 BUILDOPTS?=-v
+GOTAGS?=grpcnotrace
 GOPATH?=$(HOME)/go
 MAKEPWD:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 CGO_ENABLED?=0
@@ -19,7 +20,7 @@ all: coredns
 
 .PHONY: coredns
 coredns: $(CHECKS)
-	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) $(LDFLAGS) -o $(BINARY)
+	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -tags="$(GOTAGS)" $(LDFLAGS) -o $(BINARY)
 
 .PHONY: check
 check: core/plugin/zplugin.go core/dnsserver/zdirectives.go


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

gRPC imports `golang.org/x/net/trace` which pulls in `html/template` and `text/template`. CoreDNS never uses this trace facility. It uses OpenTracing via the `trace` plugin instead. The `grpcnotrace` build tag is supported by gRPC since v1.64 and replaces the trace integration with no-op stubs. See https://github.com/grpc/grpc-go/pull/6954 for more information.

This removes one of the blockers for the Go linker's method dead code elimination and drops `x/net/trace` from the dependency list.

A separate `GOTAGS` variable is used so that `Makefile.release` builds (which override `BUILDOPTS`) also pick up the tag.

As a result, the CoreDNS binary is somewhat ~300 KB lighter.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. While the library initialises this tracing facility it's never exposed to users.
