### PR TITLE
plugin/reload: Allow disabling jitter with 0s

### DIFF
--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -52,16 +52,19 @@ func setup(c *caddy.Controller) error {
 		}
 		j = d
 	}
-	if j < minJitter {
-		return plugin.Error("reload", fmt.Errorf("jitter value must be greater or equal to %v", minJitter))
+
+	if j != 0 && j < minJitter {
+		return plugin.Error("reload", fmt.Errorf("jitter value must be 0 or greater or equal to %v", minJitter))
 	}
 
-	if j > i/2 {
+	if j > 0 && j > i/2 {
 		j = i / 2
 	}
 
-	jitter := time.Duration(rand.Int63n(j.Nanoseconds()) - (j.Nanoseconds() / 2)) // #nosec G404 -- non-cryptographic jitter.
-	i = i + jitter
+	if j > 0 {
+		jitter := time.Duration(rand.Int63n(j.Nanoseconds()) - (j.Nanoseconds() / 2)) // #nosec G404 -- non-cryptographic jitter.
+		i = i + jitter
+	}
 
 	// prepare info for next onInstanceStartup event
 	r.setInterval(i)

--- a/plugin/reload/setup_test.go
+++ b/plugin/reload/setup_test.go
@@ -22,6 +22,11 @@ func TestSetupReload(t *testing.T) {
 		t.Fatalf("Expected no errors, but got: %v", err)
 	}
 
+	c = caddy.NewTestController("dns", `reload 2s 0s`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
 	c = caddy.NewTestController("dns", `reload foo`)
 	if err := setup(c); err == nil {
 		t.Fatalf("Expected errors, but got: %v", err)


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes #7894 by allowing reload 2s 0s as documented.
### 2. Which issues (if any) are related?
#7894 
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
no