### PR TITLE
Fix case-sensitive zone handling in the transfer plugin for AXFR/IXFR.

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -63,7 +63,7 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return dns.RcodeRefused, nil
 	}
 
-	x := longestMatch(t.xfrs, state.QName())
+	x := longestMatch(t.xfrs, state.Name())
 	if x == nil {
 		return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
 	}
@@ -93,7 +93,7 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	var pchan <-chan []dns.RR
 	var err error
 	for _, p := range t.Transferers {
-		pchan, err = p.Transfer(state.QName(), serial)
+		pchan, err = p.Transfer(state.Name(), serial)
 		if err == ErrNotAuthoritative {
 			// plugin was not authoritative for the zone, try next plugin
 			continue

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -339,3 +339,33 @@ func TestTransferDrainsProducerOnClientError(t *testing.T) {
 		t.Fatal("producer goroutine did not finish; channel likely not drained on client error")
 	}
 }
+
+type nopHandler struct{}
+
+func (nopHandler) Name() string { return "nop" }
+func (nopHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return dns.RcodeSuccess, nil
+}
+
+func TestAXFRZoneMatchCaseInsensitive(t *testing.T) {
+	next := &transfererPlugin{Zone: "example.org.", Serial: 12345}
+	next.Next = nopHandler{}
+
+	tr := &Transfer{
+		Transferers: []Transferer{next},
+		xfrs:        []*xfr{{Zones: []string{"example.org."}, to: []string{"*"}}},
+		Next:        next,
+	}
+
+	ctx := context.TODO()
+	w := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
+	m := new(dns.Msg)
+	m.SetAxfr("ExAmPlE.OrG.") // mixed case
+
+	_, err := tr.ServeDNS(ctx, w, m)
+	if err != nil {
+		t.Fatalf("ServeDNS error: %v", err)
+	}
+
+	validateAXFRResponse(t, w)
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes Fix case-sensitive zone handling in the transfer plugin for AXFR/IXFR, raised in #7898

### 2. Which issues (if any) are related?
Fixes #7898
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a