### PR TITLE
Fix minor typos and grammar improvements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ CoreDNS is a [Cloud Native Computing Foundation](https://cncf.io) graduated proj
 
 CoreDNS is a fast and flexible DNS server. The key word here is *flexible*: with CoreDNS you
 are able to do what you want with your DNS data by utilizing plugins. If some functionality is not
-provided out of the box you can add it by [writing a plugin](https://coredns.io/explugins).
+provided out of the box, you can add it by [writing a plugin](https://coredns.io/explugins).
 
 CoreDNS can listen for DNS requests coming in over:
-* UDP/TCP (go'old DNS).
+* UDP/TCP (good old DNS).
 * TLS - DoT ([RFC 7858](https://tools.ietf.org/html/rfc7858)).
 * DNS over HTTP/2 - DoH ([RFC 8484](https://tools.ietf.org/html/rfc8484)).
 * DNS over HTTP/3 - DoH3
@@ -67,7 +67,7 @@ $ cd coredns
 $ make
 ~~~
 
-> **_NOTE:_**  extra plugins may be enabled when building by setting the `COREDNS_PLUGINS` environment variable with comma separate list of plugins in the same format as plugin.cfg
+> **_NOTE:_**  Extra plugins may be enabled when building by setting the `COREDNS_PLUGINS` environment variable with comma separate list of plugins in the same format as plugin.cfg
 
 This should yield a `coredns` binary.
 
@@ -225,7 +225,7 @@ IP addresses are also allowed. They are automatically converted to reverse zones
     whoami
 }
 ~~~
-Means you are authoritative for `0.0.10.in-addr.arpa.`.
+This Means you are authoritative for `0.0.10.in-addr.arpa.`.
 
 This also works for IPv6 addresses. If for some reason you want to serve a zone named `10.0.0.0/24`
 add the closing dot: `10.0.0.0/24.` as this also stops the conversion.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ IP addresses are also allowed. They are automatically converted to reverse zones
     whoami
 }
 ~~~
-This Means you are authoritative for `0.0.10.in-addr.arpa.`.
+This means you are authoritative for `0.0.10.in-addr.arpa.`.
 
 This also works for IPv6 addresses. If for some reason you want to serve a zone named `10.0.0.0/24`
 add the closing dot: `10.0.0.0/24.` as this also stops the conversion.


### PR DESCRIPTION
This PR fixes a few minor typos and improves grammar in the README for clarity:

- Fix "go'old DNS" → "good old DNS"
- Improve wording in plugin description
- Fix grammar in Docker build section
- Improve readability in CIDR explanation

No functional changes.

### 1. Why is this pull request needed and what does it do?

This PR fixes a few minor typos and improves grammar in the documentation for better readability and clarity. No functional changes are introduced.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

This PR directly updates the documentation by correcting typos and improving wording.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
