### PR TITLE
plugin/forward: add max_age option to enforce an absolute connection lifetime

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -49,6 +49,7 @@ type Forward struct {
 	tlsServerName              string
 	maxfails                   uint32
 	expire                     time.Duration
+	maxAge                     time.Duration
 	maxIdleConns               int
 	maxConcurrent              int64
 	failfastUnhealthyUpstreams bool

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -157,6 +157,10 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 	}
 
+	if f.maxAge > 0 && f.maxAge < f.expire {
+		return f, fmt.Errorf("max_age (%s) must not be less than expire (%s)", f.maxAge, f.expire)
+	}
+
 	tlsServerNames := make([]string, len(toHosts))
 	perServerNameProxyCount := make(map[string]int)
 	transports := make([]string, len(toHosts))
@@ -207,6 +211,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 			}
 		}
 		f.proxies[i].SetExpire(f.expire)
+		f.proxies[i].SetMaxAge(f.maxAge)
 		f.proxies[i].SetMaxIdleConns(f.maxIdleConns)
 		f.proxies[i].GetHealthchecker().SetRecursionDesired(f.opts.HCRecursionDesired)
 		// when TLS is used, checks are set to tcp-tls
@@ -323,6 +328,18 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return fmt.Errorf("expire can't be negative: %s", dur)
 		}
 		f.expire = dur
+	case "max_age":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		dur, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		if dur < 0 {
+			return fmt.Errorf("max_age can't be negative: %s", dur)
+		}
+		f.maxAge = dur
 	case "max_idle_conns":
 		if !c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -707,3 +707,78 @@ func TestFailoverValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupMaxAge(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		shouldErr   bool
+		expectedVal time.Duration
+		expectedErr string
+	}{
+		{
+			name:        "default (no max_age)",
+			input:       "forward . 127.0.0.1\n",
+			expectedVal: 0,
+		},
+		{
+			name:        "valid max_age",
+			input:       "forward . 127.0.0.1 {\nmax_age 30s\n}\n",
+			expectedVal: 30 * time.Second,
+		},
+		{
+			name:        "max_age equal to expire",
+			input:       "forward . 127.0.0.1 {\nexpire 10s\nmax_age 10s\n}\n",
+			expectedVal: 10 * time.Second,
+		},
+		{
+			name:        "max_age zero (unlimited)",
+			input:       "forward . 127.0.0.1 {\nmax_age 0s\n}\n",
+			expectedVal: 0,
+		},
+		{
+			name:        "negative max_age",
+			input:       "forward . 127.0.0.1 {\nmax_age -1s\n}\n",
+			shouldErr:   true,
+			expectedErr: "negative",
+		},
+		{
+			name:        "invalid max_age value",
+			input:       "forward . 127.0.0.1 {\nmax_age invalid\n}\n",
+			shouldErr:   true,
+			expectedErr: "invalid",
+		},
+		{
+			name:        "max_age less than expire",
+			input:       "forward . 127.0.0.1 {\nexpire 30s\nmax_age 10s\n}\n",
+			shouldErr:   true,
+			expectedErr: "max_age",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := caddy.NewTestController("dns", test.input)
+			fs, err := parseForward(c)
+
+			if test.shouldErr {
+				if err == nil {
+					t.Errorf("expected error but found none for input %s", test.input)
+					return
+				}
+				if !strings.Contains(err.Error(), test.expectedErr) {
+					t.Errorf("expected error to contain %q, got: %v", test.expectedErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error but found: %v", err)
+				return
+			}
+			if fs[0].maxAge != test.expectedVal {
+				t.Errorf("expected maxAge %v, got %v", test.expectedVal, fs[0].maxAge)
+			}
+		})
+	}
+}

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -65,11 +65,20 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 	transtype := stringToTransportType(proto)
 
 	t.mu.Lock()
+	// Pre-compute max-age deadline outside the loop to avoid repeated time.Now() calls.
+	var maxAgeDeadline time.Time
+	if t.maxAge > 0 {
+		maxAgeDeadline = time.Now().Add(-t.maxAge)
+	}
 	// FIFO: take the oldest conn (front of slice) for source port diversity
 	for len(t.conns[transtype]) > 0 {
 		pc := t.conns[transtype][0]
 		t.conns[transtype] = t.conns[transtype][1:]
 		if time.Since(pc.used) > t.expire {
+			pc.c.Close()
+			continue
+		}
+		if !maxAgeDeadline.IsZero() && pc.created.Before(maxAgeDeadline) {
 			pc.c.Close()
 			continue
 		}
@@ -86,11 +95,11 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 	if proto == "tcp-tls" {
 		conn, err := dns.DialTimeoutWithTLS("tcp", t.addr, t.tlsConfig, timeout)
 		t.updateDialTimeout(time.Since(reqTime))
-		return &persistConn{c: conn}, false, err
+		return &persistConn{c: conn, created: time.Now()}, false, err
 	}
 	conn, err := dns.DialTimeout(proto, t.addr, timeout)
 	t.updateDialTimeout(time.Since(reqTime))
-	return &persistConn{c: conn}, false, err
+	return &persistConn{c: conn, created: time.Now()}, false, err
 }
 
 // Connect selects an upstream, sends the request and waits for a response.

--- a/plugin/pkg/proxy/persistent.go
+++ b/plugin/pkg/proxy/persistent.go
@@ -9,17 +9,19 @@ import (
 	"github.com/miekg/dns"
 )
 
-// a persistConn hold the dns.Conn and the last used time.
+// a persistConn holds the dns.Conn, its creation time, and the last used time.
 type persistConn struct {
-	c    *dns.Conn
-	used time.Time
+	c       *dns.Conn
+	created time.Time
+	used    time.Time
 }
 
 // Transport hold the persistent cache.
 type Transport struct {
 	avgDialTime  int64                          // kind of average time of dial time
 	conns        [typeTotalCount][]*persistConn // Buckets for udp, tcp and tcp-tls.
-	expire       time.Duration                  // After this duration a connection is expired.
+	expire       time.Duration                  // After this duration an idle connection is expired.
+	maxAge       time.Duration                  // After this duration a connection is closed regardless of activity; 0 means unlimited.
 	maxIdleConns int                            // Max idle connections per transport type; 0 means unlimited.
 	addr         string
 	tlsConfig    *tls.Config
@@ -68,7 +70,13 @@ func (t *Transport) cleanup(all bool) {
 	var toClose []*persistConn
 
 	t.mu.Lock()
-	staleTime := time.Now().Add(-t.expire)
+	now := time.Now()
+	staleTime := now.Add(-t.expire)
+	// Pre-compute max-age deadline outside the loop to avoid repeated time.Now() calls.
+	var maxAgeDeadline time.Time
+	if t.maxAge > 0 {
+		maxAgeDeadline = now.Add(-t.maxAge)
+	}
 	for transtype, stack := range t.conns {
 		if len(stack) == 0 {
 			continue
@@ -78,10 +86,26 @@ func (t *Transport) cleanup(all bool) {
 			toClose = append(toClose, stack...)
 			continue
 		}
-		if stack[0].used.After(staleTime) {
+
+		// When max-age is set, use a linear scan to evaluate both the idle-timeout
+		// (expire, based on last-used time) and the max-age (based on creation time).
+		if t.maxAge > 0 {
+			var alive []*persistConn
+			for _, pc := range stack {
+				if !pc.used.After(staleTime) || pc.created.Before(maxAgeDeadline) {
+					toClose = append(toClose, pc)
+				} else {
+					alive = append(alive, pc)
+				}
+			}
+			t.conns[transtype] = alive
 			continue
 		}
 
+		// Original expire-only path: connections are sorted by "used"; use binary search.
+		if stack[0].used.After(staleTime) {
+			continue
+		}
 		// connections in stack are sorted by "used"
 		good := sort.Search(len(stack), func(i int) bool {
 			return stack[i].used.After(staleTime)
@@ -129,6 +153,10 @@ func (t *Transport) Stop() { close(t.stop) }
 
 // SetExpire sets the connection expire time in transport.
 func (t *Transport) SetExpire(expire time.Duration) { t.expire = expire }
+
+// SetMaxAge sets the maximum lifetime of a connection regardless of activity.
+// A value of 0 (default) disables max-age and connections are only closed by expire (idle-timeout).
+func (t *Transport) SetMaxAge(maxAge time.Duration) { t.maxAge = maxAge }
 
 // SetMaxIdleConns sets the maximum idle connections per transport type.
 // A value of 0 means unlimited (default).

--- a/plugin/pkg/proxy/persistent_test.go
+++ b/plugin/pkg/proxy/persistent_test.go
@@ -98,7 +98,12 @@ func TestCleanupAll(t *testing.T) {
 	c2, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
 	c3, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
 
-	tr.conns[typeUDP] = []*persistConn{{c1, time.Now()}, {c2, time.Now()}, {c3, time.Now()}}
+	now := time.Now()
+	tr.conns[typeUDP] = []*persistConn{
+		{c: c1, created: now, used: now},
+		{c: c2, created: now, used: now},
+		{c: c3, created: now, used: now},
+	}
 
 	if len(tr.conns[typeUDP]) != 3 {
 		t.Error("Expected 3 connections")
@@ -223,6 +228,89 @@ func TestYieldAfterStop(t *testing.T) {
 
 	if poolSize != 0 {
 		t.Errorf("Expected pool size 0 after stop, got %d", poolSize)
+	}
+}
+
+// TestMaxAgeExpireByCreation verifies that a connection is rejected when its
+// creation time exceeds max_age, even if it was recently yielded (fresh used time).
+// This guards against the FIFO rotation bug where used time is continually
+// refreshed, preventing connections from expiring by idle-timeout alone.
+func TestMaxAgeExpireByCreation(t *testing.T) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	tr := newTransport("TestMaxAgeExpireByCreation", s.Addr)
+	tr.SetExpire(10 * time.Second)       // long idle-timeout: would not expire the connection
+	tr.SetMaxAge(100 * time.Millisecond) // short max-age: should close old connection
+	tr.Start()
+	defer tr.Stop()
+
+	// Inject a connection whose creation time is past max_age but whose used
+	// time is fresh, simulating a FIFO-rotated connection that is never idle.
+	oldConn, err := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	pc := &persistConn{
+		c:       oldConn,
+		created: time.Now().Add(-200 * time.Millisecond), // 2x max-age: should be closed
+		used:    time.Now(),                              // freshly used: idle-timeout would pass
+	}
+	tr.mu.Lock()
+	tr.conns[typeUDP] = []*persistConn{pc}
+	tr.mu.Unlock()
+
+	_, cached, _ := tr.Dial("udp")
+	if cached {
+		t.Error("connection should be closed by max_age, not reused despite fresh used time")
+	}
+}
+
+// TestMaxAgeFIFORotation verifies that connections in a FIFO pool are closed by
+// max_age even when continuously rotated (which refreshes their used timestamps).
+// Regression test for Scale up: new upstream pods should receive traffic after
+// existing connections exceed max_age, regardless of request rate.
+func TestMaxAgeFIFORotation(t *testing.T) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	tr := newTransport("TestMaxAgeFIFORotation", s.Addr)
+	tr.SetExpire(10 * time.Second)       // long idle-timeout: FIFO rotation keeps connections alive
+	tr.SetMaxAge(100 * time.Millisecond) // max-age: connections must be closed by creation age
+	tr.Start()
+	defer tr.Stop()
+
+	// Inject 3 connections old by creation time but with fresh used timestamps,
+	// simulating active FIFO rotation where idle-timeout never triggers.
+	tr.mu.Lock()
+	for range 3 {
+		c, err := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
+		if err != nil {
+			tr.mu.Unlock()
+			t.Fatalf("Failed to dial: %v", err)
+		}
+		tr.conns[typeUDP] = append(tr.conns[typeUDP], &persistConn{
+			c:       c,
+			created: time.Now().Add(-200 * time.Millisecond), // exceeds max-age
+			used:    time.Now(),                              // fresh: idle-timeout would pass
+		})
+	}
+	tr.mu.Unlock()
+
+	// All 3 connections must be rejected by max_age despite fresh used timestamps.
+	for i := range 3 {
+		_, cached, _ := tr.Dial("udp")
+		if cached {
+			t.Errorf("Dial %d: connection should be closed by max_age (FIFO rotation must not prevent max-age expiry)", i+1)
+		}
 	}
 }
 

--- a/plugin/pkg/proxy/proxy.go
+++ b/plugin/pkg/proxy/proxy.go
@@ -52,6 +52,10 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
 
+// SetMaxAge sets the maximum connection lifetime in the lower p.transport.
+// A value of 0 (default) disables max-age.
+func (p *Proxy) SetMaxAge(maxAge time.Duration) { p.transport.SetMaxAge(maxAge) }
+
 // SetMaxIdleConns sets the maximum idle connections per transport type.
 // A value of 0 means unlimited (default).
 func (p *Proxy) SetMaxIdleConns(n int) { p.transport.SetMaxIdleConns(n) }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

**Background**

PR #7790 changed the connection pool from LIFO to FIFO for source-port diversity. Under FIFO every connection is cycled through the pool on each request, continuously refreshing its `used` timestamp. When request rate is high enough that `pool_size / request_rate < expire`, no connection ever becomes idle and `expire` (which is based on last-used time) never fires.

This creates a regression in Kubernetes environments using ClusterIP services: because of conntrack pinning, each existing connection is pinned to one specific backend pod. After a transient network disruption or a scale-out event, affected pods receive no new traffic from CoreDNS until old connections are closed and re-dialled. Before #7790 (LIFO), the `expire` idle-timeout would eventually clear old connections during any quiet period. Under FIFO at sustained load, no such recovery occurs.

The following graph captures this regression in production. CoreDNS 1.14.1 forwards to a Kubernetes ClusterIP service backed by multiple bind9 pods. Around 16:50, one upstream pod experienced a brief network disruption. The blue line (that pod's query count) drops sharply to near zero. Despite the pod recovering quickly, the traffic imbalance persisted for over 55 minutes — CoreDNS never re-opened connections to that pod because the FIFO-rotated connection pool kept refreshing `used` timestamps, preventing `expire` from ever firing.

<img width="617" height="177" alt="image" src="https://github.com/user-attachments/assets/73a967c2-eb01-450e-bc2a-6d055ffbac5e" />

 **Bind Query Count** — Each line represents query traffic to one upstream bind9 pod behind a ClusterIP service. At 16:50, the blue pod suffered a brief network disruption. While the pod recovered within seconds, CoreDNS continued directing negligible traffic to it for the remainder of the observation window (~55 min), demonstrating that `expire` alone cannot restore balance under sustained FIFO rotation.

**What this PR does**

Adds a `max_age` option to the `forward` plugin (default `0` = unlimited, preserving existing behaviour) that closes connections based on **creation time** rather than idle time. When configured, connections older than `max_age` are rejected from the cache and re-dialled, ensuring traffic rebalances to recovered or newly scaled-out upstreams regardless of request rate.

Implementation details:
- `persistConn` gains a `created` field, set once at dial time.
- `Transport` gains `maxAge` (zero value = disabled) and `SetMaxAge()`.
- `Dial()`: checks `pc.created` against the max-age deadline before returning a cached connection. When `max_age` fires, `cleanup()` (which runs every `defaultExpire`) typically clears stale connections before `Dial()` encounters them, keeping the hot path O(1); the O(n) scan in `Dial()` is an existing characteristic of the FIFO pool and is not worsened by this change.
- `cleanup()`: when `maxAge > 0`, a linear scan evaluates both the idle-timeout (`used`) and max-age (`created`) predicates; when `maxAge == 0` the original O(log n) binary-search path is fully preserved.
- Both hot paths pre-compute the deadline (`time.Now().Add(-maxAge)`) outside inner loops to avoid repeated `time.Now()` calls.
- The parser rejects `max_age < expire` at startup with a clear error message, since a max-age shorter than the idle-timeout would make `expire` unreachable under active load.
- Two regression tests added: `TestMaxAgeExpireByCreation` (fresh `used`, old `created` must be rejected) and `TestMaxAgeFIFORotation` (FIFO-rotated pool must not bypass max-age).

**Example Corefile**

```corefile
forward . 1.2.3.4 {
    max_age 30s
}
```

### 2. Which issues (if any) are related?

Related to #6804, which proposes a similar `max_connection_age` option. Key differences from that PR:

| | #6804 | This PR |
|---|---|---|
| Option name | `max_connection_age` | `max_age` (consistent with `expire` style) |
| `expire` handling | Deprecates `expire`, introduces `idle_timeout` as replacement | `expire` fully preserved, zero changes to its semantics |
| Scope | Bundles LIFO→FIFO change with max-age | LIFO→FIFO already landed in #7790; this PR only adds `max_age` |
| `cleanup()` scan | Always linear O(n) | O(log n) binary search preserved when `max_age` is not set |
| Root cause context | Written before #7790 was merged | Specifically addresses the FIFO idle-timeout regression introduced by #7790 |
| Validation | Not mentioned | `max_age < expire` rejected at parse time |

The main motivation for a separate PR is that #6804's deprecation of `expire` is a backward-incompatible argument change, whereas this PR is purely additive.

### 3. Which documentation changes (if any) need to be made?

`plugin/forward/README.md` should document the new option. Suggested additions:

In the syntax block:
```
    max_age DURATION
```

In the description list:
```
* `max_age` **DURATION**, close cached connections that have been open longer than this duration,
  regardless of activity. Default is 0 (unlimited). Must not be less than `expire` if set.
  Useful for ensuring CoreDNS reconnects to newly scaled-out or recovered upstreams when
  `expire` (idle-timeout) cannot fire under sustained load.
```

### 4. Does this introduce a backward incompatible change or deprecation?

No. The default value is `0` (unlimited), identical to the current behaviour. All existing configurations continue to work without any change. `expire` semantics are completely untouched.