### PR TITLE
plugin/transfter: Fix longestMatch to select the most specific zone correctly

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -209,10 +209,11 @@ func longestMatch(xfrs []*xfr, name string) *xfr {
 	zone := "" // longest zone match wins
 	for _, xfr := range xfrs {
 		if z := plugin.Zones(xfr.Zones).Matches(name); z != "" {
-			if len(z) > len(zone) {
+			if len(z) > len(zone) || (len(z) == len(zone) && z > zone) {
 				zone = z
 				x = xfr
 			}
+
 		}
 	}
 	return x

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -213,7 +213,6 @@ func longestMatch(xfrs []*xfr, name string) *xfr {
 				zone = z
 				x = xfr
 			}
-
 		}
 	}
 	return x

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -209,7 +209,7 @@ func longestMatch(xfrs []*xfr, name string) *xfr {
 	zone := "" // longest zone match wins
 	for _, xfr := range xfrs {
 		if z := plugin.Zones(xfr.Zones).Matches(name); z != "" {
-			if z > zone {
+			if len(z) > len(zone) {
 				zone = z
 				x = xfr
 			}

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -369,3 +369,22 @@ func TestAXFRZoneMatchCaseInsensitive(t *testing.T) {
 
 	validateAXFRResponse(t, w)
 }
+
+func TestLongestMatchMostSpecificZone(t *testing.T) {
+	x1 := &xfr{Zones: []string{"example.org."}}
+	x2 := &xfr{Zones: []string{"a.example.org."}}
+
+	got := longestMatch([]*xfr{x1, x2}, "host.a.example.org.")
+	if got != x2 {
+		t.Fatalf("expected most specific zone (a.example.org.) to match, got %+v", got)
+	}
+}
+
+func TestLongestMatchNilWhenNoMatch(t *testing.T) {
+	x1 := &xfr{Zones: []string{"example.org."}}
+
+	got := longestMatch([]*xfr{x1}, "other.net.")
+	if got != nil {
+		t.Fatalf("expected nil when no zones match, got %+v", got)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR Fix longestMatch to select the most specific zone correctly.The previous implementation used lexicographic string comparison, which could choose the wrong zone; this change selects the longest matching zone instead.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a