### PR TITLE
core: Reject oversized GET dns query parameter of DoH

### DIFF
--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -95,6 +95,9 @@ func requestToMsgPost(req *http.Request) (*dns.Msg, error) {
 	return toMsg(req.Body)
 }
 
+const maxDNSQuerySize = 65536
+const maxBase64Len = (maxDNSQuerySize*8 + 5) / 6
+
 // requestToMsgGet extract the dns message from the GET request.
 func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 	values := req.URL.Query()
@@ -105,18 +108,14 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 	if len(b64) != 1 {
 		return nil, fmt.Errorf("multiple 'dns' query values found")
 	}
-
-	// 65536 decoded bytes is the existing POST-side limit.
-	// For base64url without padding, max encoded length is ceil(65536*8/6) = 87382.
-	if len(b64[0]) > (65536*8+5)/6 {
+	if len(b64[0]) > maxBase64Len {
 		return nil, fmt.Errorf("dns query too large")
 	}
-
 	return base64ToMsg(b64[0])
 }
 
 func toMsg(r io.ReadCloser) (*dns.Msg, error) {
-	buf, err := io.ReadAll(http.MaxBytesReader(nil, r, 65536))
+	buf, err := io.ReadAll(http.MaxBytesReader(nil, r, maxDNSQuerySize))
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -105,6 +105,13 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, error) {
 	if len(b64) != 1 {
 		return nil, fmt.Errorf("multiple 'dns' query values found")
 	}
+
+	// 65536 decoded bytes is the existing POST-side limit.
+	// For base64url without padding, max encoded length is ceil(65536*8/6) = 87382.
+	if len(b64[0]) > (65536*8+5)/6 {
+		return nil, fmt.Errorf("dns query too large")
+	}
+
 	return base64ToMsg(b64[0])
 }
 

--- a/plugin/pkg/doh/doh_test.go
+++ b/plugin/pkg/doh/doh_test.go
@@ -44,3 +44,26 @@ func TestDoH(t *testing.T) {
 		})
 	}
 }
+
+func TestDoHGETRejectsOversizedDNSQuery(t *testing.T) {
+	// Exceeding max size 65536
+	raw := make([]byte, 65536+1)
+	b64 := b64Enc.EncodeToString(raw)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"https://example.org"+Path+"?dns="+b64,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	_, err = RequestToMsg(req)
+	if err == nil {
+		t.Fatalf("expected oversized GET dns query to be rejected")
+	}
+	if err.Error() != "dns query too large" {
+		t.Fatalf("expected %q, got %v", "dns query too large", err)
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The DoH POST path limits request size using http.MaxBytesReader(..., 65536), but the GET path passes the dns query value directly to base64ToMsg() with no equivalent bound.

This PR adds length check.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a