### PR TITLE
core: Avoid spawning waiter goroutines when QUIC worker pool is full

### DIFF
--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -136,6 +136,15 @@ func (s *ServerQUIC) ServeQUIC() error {
 	}
 }
 
+func acquireQUICWorker(ctx context.Context, pool chan struct{}) bool {
+	select {
+	case pool <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // serveQUICConnection handles a new QUIC connection. It waits for new streams
 // and passes them to serveQUICStream.
 func (s *ServerQUIC) serveQUICConnection(conn *quic.Conn) {
@@ -157,29 +166,15 @@ func (s *ServerQUIC) serveQUICConnection(conn *quic.Conn) {
 			return
 		}
 
-		// Use a bounded worker pool with context cancellation
-		select {
-		case s.streamProcessPool <- struct{}{}:
-			// Got worker slot immediately
-			go func(st *quic.Stream, cn *quic.Conn) {
-				defer func() { <-s.streamProcessPool }() // Release worker slot
-				s.serveQUICStream(st, cn)
-			}(stream, conn)
-		default:
-			// Worker pool full, check for context cancellation
-			go func(st *quic.Stream, cn *quic.Conn) {
-				select {
-				case s.streamProcessPool <- struct{}{}:
-					// Got worker slot after waiting
-					defer func() { <-s.streamProcessPool }() // Release worker slot
-					s.serveQUICStream(st, cn)
-				case <-conn.Context().Done():
-					// Connection context was cancelled while waiting
-					st.Close()
-					return
-				}
-			}(stream, conn)
+		if !acquireQUICWorker(conn.Context(), s.streamProcessPool) {
+			_ = stream.Close()
+			return
 		}
+
+		go func(st *quic.Stream, cn *quic.Conn) {
+			defer func() { <-s.streamProcessPool }()
+			s.serveQUICStream(st, cn)
+		}(stream, conn)
 	}
 }
 

--- a/core/dnsserver/server_quic_test.go
+++ b/core/dnsserver/server_quic_test.go
@@ -406,7 +406,7 @@ func TestAcquireQUICWorkerWaitsForSlot(t *testing.T) {
 	pool := make(chan struct{}, 1)
 	pool <- struct{}{}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	done := make(chan bool, 1)

--- a/core/dnsserver/server_quic_test.go
+++ b/core/dnsserver/server_quic_test.go
@@ -2,6 +2,7 @@ package dnsserver
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"testing"
@@ -398,5 +399,43 @@ func TestAddPrefix(t *testing.T) {
 				t.Errorf("AddPrefix() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestAcquireQUICWorkerWaitsForSlot(t *testing.T) {
+	pool := make(chan struct{}, 1)
+	pool <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- acquireQUICWorker(ctx, pool)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("acquireQUICWorker returned before a slot was released")
+	default:
+	}
+
+	<-pool
+
+	got := <-done
+	if !got {
+		t.Fatal("expected acquireQUICWorker to succeed after slot release")
+	}
+}
+
+func TestAcquireQUICWorkerReturnsFalseOnCancelledContext(t *testing.T) {
+	pool := make(chan struct{}, 1)
+	pool <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if got := acquireQUICWorker(ctx, pool); got {
+		t.Fatal("expected acquireQUICWorker to return false when context is cancelled")
 	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
When streamProcessPool is full, serveQUICConnection() currently spawns a goroutine that waits for a worker token. Under load this can create a large backlog of goroutines waiting on the pool.

This change removes the waiter goroutine and instead blocks in the connection loop until a worker slot becomes available or the connection context is canceled.
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a