### PR TITLE
core: Propagate TSIG secrets to DoT server

### DIFF
--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -54,6 +54,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 	// Only fill out the TCP server for this one.
 	s.server[tcp] = &dns.Server{Listener: l,
 		Net:           "tcp-tls",
+		TsigSecret:    s.tsigSecret,
 		MaxTCPQueries: tlsMaxQueries,
 		ReadTimeout:   s.ReadTimeout,
 		WriteTimeout:  s.WriteTimeout,

--- a/core/dnsserver/server_tls_test.go
+++ b/core/dnsserver/server_tls_test.go
@@ -1,0 +1,56 @@
+package dnsserver
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+type stubListener struct {
+	addr net.Addr
+}
+
+func (l *stubListener) Accept() (net.Conn, error) {
+	return nil, errors.New("test listener closed")
+}
+
+func (l *stubListener) Close() error {
+	return nil
+}
+
+func (l *stubListener) Addr() net.Addr {
+	if l.addr != nil {
+		return l.addr
+	}
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+}
+
+func TestServerTLSSetsTsigSecret(t *testing.T) {
+	server, err := NewServerTLS("tls://127.0.0.1:0", []*Config{testConfig("tls", testPlugin{})})
+	if err != nil {
+		t.Fatalf("NewServerTLS() failed: %v", err)
+	}
+
+	server.tsigSecret = map[string]string{
+		"test.": "abcd",
+	}
+
+	l := &stubListener{}
+
+	err = server.Serve(l)
+	if err == nil {
+		t.Fatal("expected Serve() to return from stub listener")
+	}
+
+	if server.server[tcp] == nil {
+		t.Fatal("expected tcp server to be initialized")
+	}
+
+	if server.server[tcp].TsigSecret == nil {
+		t.Fatal("expected TsigSecret to be propagated")
+	}
+
+	if got := server.server[tcp].TsigSecret["test."]; got != "abcd" {
+		t.Fatalf("expected tsig secret %q, got %q", "abcd", got)
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR ensure the TLS (tcp-tls) DNS server sets TsigSecret so TSIG verification works the same as plain TCP/UDP. Adds a unit test to verify the secret is propagated to the underlying dns.Server.
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a