### PR TITLE
docs(cache): clarify TTL directive

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -26,6 +26,10 @@ cache [TTL] [ZONES...]
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
+Note that **TTL** only caps the cache duration and does not extend it. A record with a 30s TTL
+will still be cached for 30s even with `cache 600`. The minimum cache duration defaults to 5
+seconds and can be adjusted per cache type using **MINTTL** in the `success` or `denial` directives.
+
 A cache is divided into 256 shards, each holding up to 39 items by default - for a total size
 of 256 * 39 = 9984 items.
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Clarifies in the cache plugin README that the top-level TTL parameter only caps cache duration and does not extend it beyond a record's original TTL. This addresses a misconception where users might expect `cache 600` to force all entries to be cached for 600 seconds, when in reality a record with a 30s TTL is still cached for 30s. Also notes the default 5s minimum cache duration and points to the success/denial directives for adjusting it.

### 2. Which issues (if any) are related?

See discussion in #7602.

### 3. Which documentation changes (if any) need to be made?

This one.

### 4. Does this introduce a backward incompatible change or deprecation?

No.