### PR TITLE
core: Preserve TSIG status in gRPC transport

### DIFF
--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -195,6 +195,14 @@ func (s *ServergRPC) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket
 
 	w := &gRPCresponse{localAddr: s.listenAddr, remoteAddr: a, Msg: msg}
 
+	if tsig := msg.IsTsig(); tsig != nil {
+		if s.tsigSecret == nil {
+			w.tsigStatus = dns.ErrSecret
+		} else if _, ok := s.tsigSecret[tsig.Hdr.Name]; !ok {
+			w.tsigStatus = dns.ErrSecret
+		}
+	}
+
 	dnsCtx := context.WithValue(ctx, Key{}, s.Server)
 	dnsCtx = context.WithValue(dnsCtx, LoopKey{}, 0)
 	s.ServeDNS(dnsCtx, w, msg)
@@ -219,6 +227,7 @@ type gRPCresponse struct {
 	localAddr  net.Addr
 	remoteAddr net.Addr
 	Msg        *dns.Msg
+	tsigStatus error
 }
 
 // Write is the hack that makes this work. It does not actually write the message
@@ -232,7 +241,7 @@ func (r *gRPCresponse) Write(b []byte) (int, error) {
 // These methods implement the dns.ResponseWriter interface from Go DNS.
 
 func (r *gRPCresponse) Close() error              { return nil }
-func (r *gRPCresponse) TsigStatus() error         { return nil }
+func (r *gRPCresponse) TsigStatus() error         { return r.tsigStatus }
 func (r *gRPCresponse) TsigTimersOnly(b bool)     {}
 func (r *gRPCresponse) Hijack()                   {}
 func (r *gRPCresponse) LocalAddr() net.Addr       { return r.localAddr }

--- a/core/dnsserver/server_grpc_test.go
+++ b/core/dnsserver/server_grpc_test.go
@@ -3,6 +3,7 @@ package dnsserver
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"testing"
 
@@ -445,5 +446,17 @@ func TestServergRPC_Query_MaxSizeMessage(t *testing.T) {
 	_, err = server.Query(ctx, dnsPacket)
 	if err != nil {
 		t.Errorf("Expected no error for max size message, got: %v", err)
+	}
+}
+
+func TestGRPCResponseTsigStatusReturnsStoredStatus(t *testing.T) {
+	want := errors.New("bad tsig")
+
+	r := &gRPCresponse{
+		tsigStatus: want,
+	}
+
+	if got := r.TsigStatus(); got != want {
+		t.Fatalf("TsigStatus() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR ensure gRPC response writer returns a non-nil TSIG status when secrets are missing or mismatched, instead of always returning nil. This prevents TSIG authentication bypass on DNS-over-gRPC.
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a