### PR TITLE
Update github workflow to release windows builds in zip format.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build release binary
         run: make -f Makefile.release release
       - name: Build release binary sha256
-        run: (cd release; for asset in `ls -A *tgz`; do sha256sum $asset > $asset.sha256; done)
+        run: (cd release; for asset in `ls -A *.tgz *.zip`; do sha256sum $asset > $asset.sha256; done)
       - name: Remove hidden section
         run: sed '/+++/,//d' notes/coredns-${{ steps.info.outputs.version}}.md > release.md
       - name: Log release info
@@ -46,7 +46,7 @@ jobs:
           echo ${{ steps.info.outputs.commit }}
           echo ${{ steps.info.outputs.version }}
           cat release.md
-          sha256sum release/*.tgz
+          sha256sum release/*.tgz release/*.zip
       - name: Draft release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
@@ -57,4 +57,6 @@ jobs:
           files: |
             release/*.tgz
             release/*.tgz.sha256
+            release/*.zip
+            release/*.zip.sha256
           draft: true

--- a/Makefile.release
+++ b/Makefile.release
@@ -84,7 +84,7 @@ tar:
 	@rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_amd64.tgz -C build/darwin/amd64 $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_arm64.tgz -C build/darwin/arm64 $(NAME)
-	tar -zcf release/$(NAME)_$(VERSION)_windows_amd64.tgz -C build/windows/amd64 $(NAME).exe
+	zip -j release/$(NAME)_$(VERSION)_windows_amd64.zip build/windows/amd64/$(NAME).exe
 	for arch in $(LINUX_ARCH); do \
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done
@@ -97,15 +97,15 @@ else
 	@echo Releasing: $(VERSION)
 	@$(eval RELEASE:=$(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
 	@echo ReleaseID: $(RELEASE)
-	@( cd release; for asset in `ls -A *tgz`; do \
+	@( cd release; for asset in `ls -A *.tgz *.zip`; do \
 	    echo $$asset; \
 	    curl -o /dev/null -X POST \
-	      -H "Content-Type: application/gzip" \
+	      -H "Content-Type: application/octet-stream" \
 	      -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
 	      --data-binary "@$$asset" \
 	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}" ; \
 	done )
-	@( cd release; for asset in `ls -A *tgz`; do \
+	@( cd release; for asset in `ls -A *.tgz *.zip`; do \
 	    sha256sum $$asset > $$asset.sha256; \
 	done )
 	@( cd release; for asset in `ls -A *sha256`; do \

--- a/Makefile.release
+++ b/Makefile.release
@@ -84,6 +84,7 @@ tar:
 	@rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_amd64.tgz -C build/darwin/amd64 $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_arm64.tgz -C build/darwin/arm64 $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_windows_amd64.tgz -C build/windows/amd64 $(NAME).exe
 	zip -j release/$(NAME)_$(VERSION)_windows_amd64.zip build/windows/amd64/$(NAME).exe
 	for arch in $(LINUX_ARCH); do \
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do? We'd like to have coredns windows releases distributed via WinGet. Currently WinGet only supports portable/standalone installers in zip format. This should also make extraction easier across a wider variety of Windows versions.

### 2. Which issues (if any) are related? https://github.com/coredns/coredns/issues/6152

### 3. Which documentation changes (if any) need to be made? Likely none.

### 4. Does this introduce a backward incompatible change or deprecation? Unknown if anything is consuming Windows releases via automation in tgz format today.
