### PR TITLE
ci(yamllint): replace third-party action with uvx

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: 'Yamllint'
-        uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2
         with:
-          yamllint_file_or_dir: '.'
-          yamllint_strict: false
-          yamllint_comment: true
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - name: 'Setup uv'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+      - name: 'Yamllint'
+        run: |
+          uvx --from 'yamllint==1.38.0' yamllint .
+          echo "yamllint passed"


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Use `astral-sh/setup-uv` with uvx to run `yamllint` directly, eliminating the third-party supply chain risk.


### 2. Which issues (if any) are related?

None, hardening task.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
