### PR TITLE
ci: use go-version-file instead of GITHUB_ENV

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -11,13 +11,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Go Version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
         id: go
 
       - name: Build
@@ -36,13 +33,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Go Version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
         id: go
 
       - name: Build
@@ -58,13 +52,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Go Version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
         id: go
 
       - name: Build

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Setup Go Version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:

--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -16,13 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Go Version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
 
       - name: Update Docs
         run: |


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Replace the pattern of reading `.go-version` into `GITHUB_ENV` with the `go-version-file` input natively supported by `actions/setup-go`. This eliminates a `GITHUB_ENV` injection vector.

### 2. Which issues (if any) are related?

None, hardening task.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
