### PR TITLE
ci(dependabot): add 7-day cooldown for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       k8s.io:
         patterns:
@@ -18,4 +20,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 20


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Delay version update PRs for newly published releases, giving time for supply chain compromises to be detected. Security updates bypass cooldown.

Links:

- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
- https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age
- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

### 2. Which issues (if any) are related?

None, hardening task.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.