### PR TITLE
ci(release): use env vars for expressions in shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,12 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
       - name: Set up info
+        env:
+          INPUT_COMMIT: ${{ github.event.inputs.commit }}
         run: |
           set -x -e
           VERSION=$(make -f Makefile.release version)
-          COMMIT=$(git rev-parse --quiet --verify ${{ github.event.inputs.commit }})
+          COMMIT=$(git rev-parse --quiet --verify "${INPUT_COMMIT}")
           if [[ "$(git tag -l v${VERSION})" == "v${VERSION}" ]]; then
             echo "v${VERSION} already released"
             exit 1
@@ -38,13 +40,18 @@ jobs:
       - name: Build release binary sha256
         run: (cd release; for asset in `ls -A *.tgz *.zip`; do sha256sum $asset > $asset.sha256; done)
       - name: Remove hidden section
-        run: sed '/+++/,//d' notes/coredns-${{ steps.info.outputs.version}}.md > release.md
+        env:
+          VERSION: ${{ steps.info.outputs.version }}
+        run: sed '/+++/,//d' "notes/coredns-${VERSION}.md" > release.md
       - name: Log release info
+        env:
+          COMMIT: ${{ steps.info.outputs.commit }}
+          VERSION: ${{ steps.info.outputs.version }}
         run: |
           set -x -e
           git log -1
-          echo ${{ steps.info.outputs.commit }}
-          echo ${{ steps.info.outputs.version }}
+          echo "${COMMIT}"
+          echo "${VERSION}"
           cat release.md
           sha256sum release/*.tgz release/*.zip
       - name: Draft release


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Move all `${{ }}` expressions out of `run:` blocks into step-level `env:` and reference them as quoted shell variables. This is hardening against crafted `workflow_dispatch` inputs or step outputs that could contain shell metacharacters.

### 2. Which issues (if any) are related?

None, hardening task.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.