### PR TITLE
test(dnssec): fix err in TestZoneSigningDouble

### DIFF
--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -48,10 +48,10 @@ func TestZoneSigningDouble(t *testing.T) {
 	state := request.Request{Req: m, Zone: "miek.nl."}
 	m = d.Sign(state, time.Now().UTC(), server)
 	if !section(m.Answer, 2) {
-		t.Errorf("Answer section should have 1 RRSIG")
+		t.Errorf("Answer section should have 2 RRSIGs")
 	}
 	if !section(m.Ns, 2) {
-		t.Errorf("Authority section should have 1 RRSIG")
+		t.Errorf("Authority section should have 2 RRSIGs")
 	}
 }
 


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

The test `TestZoneSigningDouble` asserts 2 RRSIGs but the error messages incorrectly said "should have 1 RRSIG", possibly due to a copy-paste from `TestZoneSigning`.

### 2. Which issues (if any) are related?

Fixes #7968 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
