### PR TITLE
chore(docs): update Docker build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ setup a Go environment, you could build CoreDNS easily:
 ```
 docker run --rm -i -t \
     -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns \
-        golang:1.24 sh -c 'GOFLAGS="-buildvcs=false" make gen && GOFLAGS="-buildvcs=false" make'
+        golang:1.25 sh -c 'GOFLAGS="-buildvcs=false" make gen && GOFLAGS="-buildvcs=false" make'
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Update the `docker build` command in README.

Still referenced Go 1.24 even though minimum version is at 1.25.


### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

This is the documentation change.

### 4. Does this introduce a backward incompatible change or deprecation?

No.