### PR TITLE
lint: enable revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - protogetter
     - staticcheck
     - thelper
+    - revive
     - unconvert
     - unused
     - usetesting
@@ -52,16 +53,14 @@ linters:
         - name: blank-imports
 
         - name: context-as-argument
-          arguments:
-            - allowTypesBefore: "*testing.T"
+          disabled: true
 
         - name: context-keys-type
 
         - name: dot-imports
 
         - name: early-return
-          arguments:
-            - "preserveScope"
+          disabled: true
 
         - name: empty-block
           disabled: true
@@ -77,8 +76,7 @@ linters:
         - name: increment-decrement
 
         - name: indent-error-flow
-          arguments:
-            - "preserveScope"
+          disabled: true
 
         - name: range
 
@@ -98,12 +96,13 @@ linters:
           disabled: true
 
         - name: unnecessary-stmt
+          disabled: true
 
         - name: unreachable-code
+          disabled: true
 
         - name: unused-parameter
-          arguments:
-            - allowRegex: "^_"
+          disabled: true
 
         - name: use-any
 


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Enable the `revive` linter, which was previously configured but not activated. Disable rules that have existing violations to be addressed in follow-up PRs:

- `context-as-argument`: #7976
- `early-return`: #7974 
- `indent-error-flow`: #7977
- `unnecessary-stmt`: #7978 
- `unreachable-code`: #7979 
- `unused-parameter`: #7980 

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.