### PR TITLE
lint(revive): fix early-return violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,8 @@ linters:
         - name: dot-imports
 
         - name: early-return
-          disabled: true
+          arguments:
+            - "preserveScope"
 
         - name: empty-block
           disabled: true

--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -69,15 +69,14 @@ func setup(c *caddy.Controller) error {
 			case "upstream":
 				c.RemainingArgs()
 			case "credentials":
-				if c.NextArg() {
-					credType, err := getCredType(c.Val())
-					if err != nil {
-						return plugin.Error("clouddns", c.Errf("invalid credentials file %q: %v", c.Val(), err))
-					}
-					opt = option.WithAuthCredentialsFile(credType, c.Val())
-				} else {
+				if !c.NextArg() {
 					return plugin.Error("clouddns", c.ArgErr())
 				}
+				credType, err := getCredType(c.Val())
+				if err != nil {
+					return plugin.Error("clouddns", c.Errf("invalid credentials file %q: %v", c.Val(), err))
+				}
+				opt = option.WithAuthCredentialsFile(credType, c.Val())
 			case "fallthrough":
 				fall.SetZonesFromArgs(c.RemainingArgs())
 			default:

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -46,25 +46,25 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 
 		if len(args) >= 3 {
 			tcpWriteBuf := args[2]
-			if v, err := strconv.Atoi(tcpWriteBuf); err == nil {
-				if v < 1 || v > maxMultipleTcpWriteBuf {
-					return nil, c.Errf("dnstap: MultipleTcpWriteBuf must be between 1 and %d (MiB units): %d", maxMultipleTcpWriteBuf, v)
-				}
-				d.MultipleTcpWriteBuf = v
-			} else {
+			v, err := strconv.Atoi(tcpWriteBuf)
+			if err != nil {
 				return nil, c.Errf("dnstap: invalid MultipleTcpWriteBuf %q: %v", tcpWriteBuf, err)
 			}
+			if v < 1 || v > maxMultipleTcpWriteBuf {
+				return nil, c.Errf("dnstap: MultipleTcpWriteBuf must be between 1 and %d (MiB units): %d", maxMultipleTcpWriteBuf, v)
+			}
+			d.MultipleTcpWriteBuf = v
 		}
 		if len(args) >= 4 {
 			qSize := args[3]
-			if v, err := strconv.Atoi(qSize); err == nil {
-				if v < 1 || v > maxMultipleQueue {
-					return nil, c.Errf("dnstap: MultipleQueue must be between 1 and %d (x10k messages): %d", maxMultipleQueue, v)
-				}
-				d.MultipleQueue = v
-			} else {
+			v, err := strconv.Atoi(qSize)
+			if err != nil {
 				return nil, c.Errf("dnstap: invalid MultipleQueue %q: %v", qSize, err)
 			}
+			if v < 1 || v > maxMultipleQueue {
+				return nil, c.Errf("dnstap: MultipleQueue must be between 1 and %d (x10k messages): %d", maxMultipleQueue, v)
+			}
+			d.MultipleQueue = v
 		}
 
 		var dio *dio

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -666,42 +666,42 @@ func optsEqual(a, b []dns.EDNS0) bool {
 	for i := range a {
 		switch aa := a[i].(type) {
 		case *dns.EDNS0_LOCAL:
-			if bb, ok := b[i].(*dns.EDNS0_LOCAL); ok {
-				if aa.Code != bb.Code {
-					return false
-				}
-				if !bytes.Equal(aa.Data, bb.Data) {
-					return false
-				}
-			} else {
+			bb, ok := b[i].(*dns.EDNS0_LOCAL)
+			if !ok {
+				return false
+			}
+			if aa.Code != bb.Code {
+				return false
+			}
+			if !bytes.Equal(aa.Data, bb.Data) {
 				return false
 			}
 		case *dns.EDNS0_NSID:
-			if bb, ok := b[i].(*dns.EDNS0_NSID); ok {
-				if aa.Nsid != bb.Nsid {
-					return false
-				}
-			} else {
+			bb, ok := b[i].(*dns.EDNS0_NSID)
+			if !ok {
+				return false
+			}
+			if aa.Nsid != bb.Nsid {
 				return false
 			}
 		case *dns.EDNS0_SUBNET:
-			if bb, ok := b[i].(*dns.EDNS0_SUBNET); ok {
-				if aa.Code != bb.Code {
-					return false
-				}
-				if aa.Family != bb.Family {
-					return false
-				}
-				if aa.SourceNetmask != bb.SourceNetmask {
-					return false
-				}
-				if aa.SourceScope != bb.SourceScope {
-					return false
-				}
-				if !aa.Address.Equal(bb.Address) {
-					return false
-				}
-			} else {
+			bb, ok := b[i].(*dns.EDNS0_SUBNET)
+			if !ok {
+				return false
+			}
+			if aa.Code != bb.Code {
+				return false
+			}
+			if aa.Family != bb.Family {
+				return false
+			}
+			if aa.SourceNetmask != bb.SourceNetmask {
+				return false
+			}
+			if aa.SourceScope != bb.SourceScope {
+				return false
+			}
+			if !aa.Address.Equal(bb.Address) {
 				return false
 			}
 

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -96,21 +96,19 @@ func setup(c *caddy.Controller) error {
 				cfgOpts = append(cfgOpts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(v[0], v[1], "")))
 				log.Warningf("Save aws_access_key in Corefile has been deprecated, please use other authentication methods instead")
 			case "aws_endpoint":
-				if c.NextArg() {
-					clientOpts = append(clientOpts, func(o *route53.Options) {
-						o.BaseEndpoint = aws.String(c.Val())
-					})
-				} else {
+				if !c.NextArg() {
 					return plugin.Error("route53", c.ArgErr())
 				}
+				clientOpts = append(clientOpts, func(o *route53.Options) {
+					o.BaseEndpoint = aws.String(c.Val())
+				})
 			case "upstream":
 				c.RemainingArgs() // eats args
 			case "credentials":
-				if c.NextArg() {
-					cfgOpts = append(cfgOpts, config.WithSharedConfigProfile(c.Val()))
-				} else {
+				if !c.NextArg() {
 					return c.ArgErr()
 				}
+				cfgOpts = append(cfgOpts, config.WithSharedConfigProfile(c.Val()))
 				if c.NextArg() {
 					sharedConfigFiles := []string{c.Val()}
 					// If AWS_SDK_LOAD_CONFIG is set also load ~/.aws/config to stay consistent
@@ -123,21 +121,20 @@ func setup(c *caddy.Controller) error {
 			case "fallthrough":
 				fall.SetZonesFromArgs(c.RemainingArgs())
 			case "refresh":
-				if c.NextArg() {
-					refreshStr := c.Val()
-					_, err := strconv.Atoi(refreshStr)
-					if err == nil {
-						refreshStr = c.Val() + "s"
-					}
-					refresh, err = time.ParseDuration(refreshStr)
-					if err != nil {
-						return plugin.Error("route53", c.Errf("Unable to parse duration: %v", err))
-					}
-					if refresh <= 0 {
-						return plugin.Error("route53", c.Errf("refresh interval must be greater than 0: %q", refreshStr))
-					}
-				} else {
+				if !c.NextArg() {
 					return plugin.Error("route53", c.ArgErr())
+				}
+				refreshStr := c.Val()
+				_, err := strconv.Atoi(refreshStr)
+				if err == nil {
+					refreshStr = c.Val() + "s"
+				}
+				refresh, err = time.ParseDuration(refreshStr)
+				if err != nil {
+					return plugin.Error("route53", c.Errf("Unable to parse duration: %v", err))
+				}
+				if refresh <= 0 {
+					return plugin.Error("route53", c.Errf("refresh interval must be greater than 0: %q", refreshStr))
 				}
 			default:
 				return plugin.Error("route53", c.Errf("unknown property %q", c.Val()))


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Simplify if/else blocks where the else clause returns, by inverting the condition and returning early. Re-enable the early-return rule.

### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?


None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.