### PR TITLE
lint(revive): fix context-as-argument violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,8 @@ linters:
         - name: blank-imports
 
         - name: context-as-argument
-          disabled: true
+          arguments:
+            - allowTypesBefore: "*testing.T"
 
         - name: context-keys-type
 

--- a/plugin/nomad/nomad.go
+++ b/plugin/nomad/nomad.go
@@ -53,15 +53,15 @@ func (n Nomad) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	svcRegistrations, _, err := fetchServiceRegistrations(n, serviceName, namespace)
 	if err != nil {
 		log.Warning(err)
-		return handleServiceLookupError(w, m, ctx, namespace)
+		return handleServiceLookupError(ctx, w, m, namespace)
 	}
 
 	if len(svcRegistrations) == 0 {
-		return handleResponseError(n, w, m, originalQName, n.ttl, ctx, namespace, err)
+		return handleResponseError(ctx, n, w, m, originalQName, n.ttl, namespace, err)
 	}
 
 	if err := addServiceResponses(m, svcRegistrations, header, state.QType(), originalQName, n.ttl); err != nil {
-		return handleResponseError(n, w, m, originalQName, n.ttl, ctx, namespace, err)
+		return handleResponseError(ctx, n, w, m, originalQName, n.ttl, namespace, err)
 	}
 
 	err = w.WriteMsg(m)
@@ -107,7 +107,7 @@ func fetchServiceRegistrations(n Nomad, serviceName, namespace string) ([]*api.S
 	return nc.Services().Get(serviceName, (&api.QueryOptions{Namespace: namespace, Filter: n.filter}))
 }
 
-func handleServiceLookupError(w dns.ResponseWriter, m *dns.Msg, ctx context.Context, namespace string) (int, error) {
+func handleServiceLookupError(ctx context.Context, w dns.ResponseWriter, m *dns.Msg, namespace string) (int, error) {
 	m.Rcode = dns.RcodeSuccess
 	err := w.WriteMsg(m)
 	requestFailedCount.WithLabelValues(metrics.WithServer(ctx), namespace).Inc()
@@ -145,7 +145,7 @@ func addServiceResponses(m *dns.Msg, svcRegistrations []*api.ServiceRegistration
 	return nil
 }
 
-func handleResponseError(n Nomad, w dns.ResponseWriter, m *dns.Msg, originalQName string, ttl uint32, ctx context.Context, namespace string, err error) (int, error) {
+func handleResponseError(ctx context.Context, n Nomad, w dns.ResponseWriter, m *dns.Msg, originalQName string, ttl uint32, namespace string, err error) (int, error) {
 	m.Rcode = dns.RcodeNameError
 	m.Answer = append(m.Answer, createSOARecord(originalQName, ttl, n.Zone))
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -71,6 +71,8 @@ func (f HandlerFunc) Name() string { return "handlerfunc" }
 func Error(name string, err error) error { return fmt.Errorf("%s/%s: %w", "plugin", name, err) }
 
 // NextOrFailure calls next.ServeDNS when next is not nil, otherwise it will return, a ServerFailure and a `no next plugin found` error.
+//
+//nolint:revive // ctx is not the first parameter to preserve the existing public API.
 func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if next != nil {
 		if span := ot.SpanFromContext(ctx); span != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Move `context.Context` to the first parameter for unexported nomad functions. Add `nolint` directive to `NextOrFailure` to preserve the existing public plugin API. Re-enable the context-as-argument rule.

### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.