### PR TITLE
lint(revive): fix indent-error-flow violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,8 @@ linters:
         - name: increment-decrement
 
         - name: indent-error-flow
-          disabled: true
+          arguments:
+            - "preserveScope"
 
         - name: range
 

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -175,20 +175,19 @@ func (z *Zone) nameFromRight(qname string, i int) (string, bool) {
 
 	n := len(qname)
 	for j := 1; j <= z.origLen; j++ {
-		if m, shot := dns.PrevLabel(qname[:n], 1); shot {
+		m, shot := dns.PrevLabel(qname[:n], 1)
+		if shot {
 			return qname, shot
-		} else {
-			n = m
 		}
+		n = m
 	}
 
 	for j := 1; j <= i; j++ {
 		m, shot := dns.PrevLabel(qname[:n], 1)
 		if shot {
 			return qname, shot
-		} else {
-			n = m
 		}
+		n = m
 	}
 	return qname[n:], false
 }

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -669,9 +669,8 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 func (k *Kubernetes) Serial(state request.Request) uint32 {
 	if !k.isMultiClusterZone(state.Zone) {
 		return uint32(k.APIConn.Modified(ModifiedInternal)) // #nosec G115 -- Unix time to SOA serial
-	} else {
-		return uint32(k.APIConn.Modified(ModifiedMultiCluster)) // #nosec G115 -- Unix time to SOA serial
 	}
+	return uint32(k.APIConn.Modified(ModifiedMultiCluster)) // #nosec G115 -- Unix time to SOA serial
 }
 
 // MinTTL returns the minimal TTL.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -237,12 +237,11 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			args := c.RemainingArgs()
 			if len(args) == 0 {
 				return nil, c.ArgErr()
-			} else {
-				var err error
-				k8s.startupTimeout, err = time.ParseDuration(args[0])
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse startup_timeout: %v, %s", args[0], err)
-				}
+			}
+			var err error
+			k8s.startupTimeout, err = time.ParseDuration(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse startup_timeout: %v, %s", args[0], err)
 			}
 		case "apiserver_qps":
 			args := c.RemainingArgs()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Remove unnecessary else blocks after return statements, outdenting the else body. Re-enable the `indent-error-flow` rule.

### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.