### PR TITLE
lint(revive): fix unnecessary-stmt violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,6 @@ linters:
           disabled: true
 
         - name: unnecessary-stmt
-          disabled: true
 
         - name: unreachable-code
           disabled: true

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -65,7 +65,6 @@ func roundRobin(in []dns.RR) []dns.RR {
 func roundRobinShuffle(records []dns.RR) {
 	switch l := len(records); l {
 	case 0, 1:
-		break
 	case 2:
 		if dns.Id()%2 == 0 {
 			records[0], records[1] = records[1], records[0]

--- a/plugin/ready/setup.go
+++ b/plugin/ready/setup.go
@@ -90,8 +90,7 @@ func parse(c *caddy.Controller) (string, monitorType, error) {
 		}
 
 		for c.NextBlock() {
-			switch c.Val() {
-			case "monitor":
+			if c.Val() == "monitor" {
 				args := c.RemainingArgs()
 				if len(args) != 1 {
 					return "", "", c.ArgErr()

--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -69,50 +69,53 @@ func (r *cnameTargetRule) getFromAndToTarget(inputCName string) (from string, to
 
 func (r *cnameTargetRuleWithReqState) RewriteResponse(res *dns.Msg, rr dns.RR) {
 	// logic to rewrite the cname target of dns response
-	switch rr.Header().Rrtype {
-	case dns.TypeCNAME:
-		// rename the target of the cname response
-		if cname, ok := rr.(*dns.CNAME); ok {
-			fromTarget, toTarget := r.rule.getFromAndToTarget(cname.Target)
-			if cname.Target == fromTarget {
-				// create upstream request with the new target with the same qtype
-				r.state.Req.Question[0].Name = toTarget
-				// upRes can be nil if the internal query path didn't write a response
-				// (e.g. a plugin returned a success rcode without writing, dropped the query,
-				// or the context was canceled). Guard upRes before dereferencing.
-				upRes, err := r.rule.Upstream.Lookup(r.ctx, r.state, toTarget, r.state.Req.Question[0].Qtype)
-				if err != nil {
-					log.Errorf("upstream lookup failed: %v", err)
-					return
-				}
-				if upRes == nil {
-					log.Errorf("upstream lookup returned nil")
-					return
-				}
+	if rr.Header().Rrtype != dns.TypeCNAME {
+		return
+	}
+	// rename the target of the cname response
+	cname, ok := rr.(*dns.CNAME)
+	if !ok {
+		return
+	}
+	fromTarget, toTarget := r.rule.getFromAndToTarget(cname.Target)
+	if cname.Target != fromTarget {
+		return
+	}
+	// create upstream request with the new target with the same qtype
+	r.state.Req.Question[0].Name = toTarget
+	// upRes can be nil if the internal query path didn't write a response
+	// (e.g. a plugin returned a success rcode without writing, dropped the query,
+	// or the context was canceled). Guard upRes before dereferencing.
+	upRes, err := r.rule.Upstream.Lookup(r.ctx, r.state, toTarget, r.state.Req.Question[0].Qtype)
+	if err != nil {
+		log.Errorf("upstream lookup failed: %v", err)
+		return
+	}
+	if upRes == nil {
+		log.Errorf("upstream lookup returned nil")
+		return
+	}
 
-				var newAnswer []dns.RR
-				// iterate over first upstream response
-				// add the cname record to the new answer
-				for _, rr := range res.Answer {
-					if cname, ok := rr.(*dns.CNAME); ok {
-						// preserve CNAME records until the rewrite target
-						newAnswer = append(newAnswer, rr)
-						if cname.Target == fromTarget {
-							// change the target name in the response
-							cname.Target = toTarget
-							break
-						}
-					}
-				}
-				// add the upstream response to the new answer
-				newAnswer = append(newAnswer, upRes.Answer...)
-				res.Answer = newAnswer
-				// if not propagated, the truncated response might get cached,
-				// and it will be impossible to resolve the full response
-				res.Truncated = upRes.Truncated
+	var newAnswer []dns.RR
+	// iterate over first upstream response
+	// add the cname record to the new answer
+	for _, rr := range res.Answer {
+		if cname, ok := rr.(*dns.CNAME); ok {
+			// preserve CNAME records until the rewrite target
+			newAnswer = append(newAnswer, rr)
+			if cname.Target == fromTarget {
+				// change the target name in the response
+				cname.Target = toTarget
+				break
 			}
 		}
 	}
+	// add the upstream response to the new answer
+	newAnswer = append(newAnswer, upRes.Answer...)
+	res.Answer = newAnswer
+	// if not propagated, the truncated response might get cached,
+	// and it will be impossible to resolve the full response
+	res.Truncated = upRes.Truncated
 }
 
 func newCNAMERule(nextAction string, args ...string) (Rule, error) {

--- a/plugin/sign/signer.go
+++ b/plugin/sign/signer.go
@@ -133,8 +133,7 @@ func resign(rd io.Reader, now time.Time) (why error) {
 	i := 0
 
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
-		switch x := rr.(type) {
-		case *dns.RRSIG:
+		if x, ok := rr.(*dns.RRSIG); ok {
 			if x.TypeCovered != dns.TypeSOA {
 				continue
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Remove unnecessary break in switch case, and replace single-case switch statements with equivalent if statements. Re-enable the `unnecessary-stmt` rule.

### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.