### PR TITLE
lint(revive): fix unreachable-code violation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,7 +99,6 @@ linters:
           disabled: true
 
         - name: unreachable-code
-          disabled: true
 
         - name: unused-parameter
           disabled: true

--- a/plugin/pprof/pprof_test.go
+++ b/plugin/pprof/pprof_test.go
@@ -157,7 +157,7 @@ func TestHandlerStartupInvalidAddress(t *testing.T) {
 
 	err := h.Startup()
 	if err == nil {
-		t.Fatal("Expected error for invalid address format")
 		defer h.Shutdown()
+		t.Fatal("Expected error for invalid address format")
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Move `defer` before `t.Fatal` so it is reachable. Re-enable the `unreachable-code` rule.


### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.