### PR TITLE
lint(revive): fix unused-parameter violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,7 +102,8 @@ linters:
           disabled: true
 
         - name: unused-parameter
-          disabled: true
+          arguments:
+            - allowRegex: "^_"
 
         - name: use-any
 

--- a/core/dnsserver/quic.go
+++ b/core/dnsserver/quic.go
@@ -62,9 +62,9 @@ func AddPrefix(b []byte) (m []byte) {
 
 // These methods implement the dns.ResponseWriter interface from Go DNS.
 
-func (w *DoQWriter) TsigStatus() error     { return w.tsigStatus }
-func (w *DoQWriter) TsigTimersOnly(b bool) {}
-func (w *DoQWriter) Hijack()               {}
-func (w *DoQWriter) LocalAddr() net.Addr   { return w.localAddr }
-func (w *DoQWriter) RemoteAddr() net.Addr  { return w.remoteAddr }
-func (w *DoQWriter) Network() string       { return "" }
+func (w *DoQWriter) TsigStatus() error      { return w.tsigStatus }
+func (w *DoQWriter) TsigTimersOnly(_b bool) {}
+func (w *DoQWriter) Hijack()                {}
+func (w *DoQWriter) LocalAddr() net.Addr    { return w.localAddr }
+func (w *DoQWriter) RemoteAddr() net.Addr   { return w.remoteAddr }
+func (w *DoQWriter) Network() string        { return "" }

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-func newContext(i *caddy.Instance) caddy.Context {
+func newContext(_i *caddy.Instance) caddy.Context {
 	return &dnsContext{keysToConfigs: make(map[string]*Config)}
 }
 
@@ -52,7 +52,7 @@ var _ caddy.Context = &dnsContext{}
 // InspectServerBlocks make sure that everything checks out before
 // executing directives and otherwise prepares the directives to
 // be parsed and executed.
-func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddyfile.ServerBlock) ([]caddyfile.ServerBlock, error) {
+func (h *dnsContext) InspectServerBlocks(_sourceFile string, serverBlocks []caddyfile.ServerBlock) ([]caddyfile.ServerBlock, error) {
 	// Normalize and check all the zone names and check for duplicates
 	for ib, s := range serverBlocks {
 		// Walk the s.Keys and expand any reverse address in their proper DNS in-addr zones. If the expansions leads for

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -414,7 +414,7 @@ func (s *Server) Tracer() ot.Tracer {
 }
 
 // errorFunc responds to an DNS request with an error.
-func errorFunc(server string, w dns.ResponseWriter, r *dns.Msg, rc int) {
+func errorFunc(_server string, w dns.ResponseWriter, r *dns.Msg, rc int) {
 	state := request.Request{W: w, Req: r}
 
 	answer := new(dns.Msg)

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -106,7 +106,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 	}
 
 	if s.Tracer() != nil {
-		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp any) bool {
+		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, _method string, _req, _resp any) bool {
 			return parentSpanCtx != nil
 		}
 		serverOpts = append(serverOpts, grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))))
@@ -129,7 +129,7 @@ func (s *ServergRPC) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServergRPC) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServergRPC) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServergRPC) Listen() (net.Listener, error) {
@@ -242,7 +242,7 @@ func (r *gRPCresponse) Write(b []byte) (int, error) {
 
 func (r *gRPCresponse) Close() error              { return nil }
 func (r *gRPCresponse) TsigStatus() error         { return r.tsigStatus }
-func (r *gRPCresponse) TsigTimersOnly(b bool)     {}
+func (r *gRPCresponse) TsigTimersOnly(_b bool)    {}
 func (r *gRPCresponse) Hijack()                   {}
 func (r *gRPCresponse) LocalAddr() net.Addr       { return r.localAddr }
 func (r *gRPCresponse) RemoteAddr() net.Addr      { return r.remoteAddr }

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -129,7 +129,7 @@ func (s *ServerHTTPS) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServerHTTPS) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServerHTTPS) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Listen() (net.Listener, error) {

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -132,7 +132,7 @@ func (s *ServerHTTPS3) ServePacket(pc net.PacketConn) error {
 
 // Listen function not used in HTTP/3, but defined for compatibility
 func (s *ServerHTTPS3) Listen() (net.Listener, error) { return nil, nil }
-func (s *ServerHTTPS3) Serve(l net.Listener) error    { return nil }
+func (s *ServerHTTPS3) Serve(_l net.Listener) error   { return nil }
 
 // OnStartupComplete lists the sites served by this server
 // and any relevant information, assuming Quiet is false.

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -163,7 +163,7 @@ func testConfigWithPlugin(p *contextCapturingPlugin) *Config {
 		ListenHosts: []string{"127.0.0.1"},
 		Port:        "443",
 	}
-	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
+	c.AddPlugin(func(_next plugin.Handler) plugin.Handler { return p })
 	return c
 }
 

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -286,7 +286,7 @@ func (s *ServerQUIC) Stop() error {
 }
 
 // Serve implements caddy.TCPServer interface.
-func (s *ServerQUIC) Serve(l net.Listener) error { return nil }
+func (s *ServerQUIC) Serve(_l net.Listener) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerQUIC) Listen() (net.Listener, error) { return nil, nil }

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -17,7 +17,7 @@ import (
 
 type testPlugin struct{}
 
-func (tp testPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (tp testPlugin) ServeDNS(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 	return 0, nil
 }
 
@@ -30,7 +30,7 @@ type blockingPlugin struct {
 
 func (b *blockingPlugin) Name() string { return "blocking" }
 
-func (b *blockingPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (b *blockingPlugin) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	// Respond immediately to avoid waiting in dns.Exchange
 	m := new(dns.Msg)
 	m.SetRcodeFormatError(r)
@@ -51,7 +51,7 @@ func testConfig(transport string, p plugin.Handler) *Config {
 		Stacktrace:  false,
 	}
 
-	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
+	c.AddPlugin(func(_next plugin.Handler) plugin.Handler { return p })
 	return c
 }
 

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -73,7 +73,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 }
 
 // ServePacket implements caddy.UDPServer interface.
-func (s *ServerTLS) ServePacket(p net.PacketConn) error { return nil }
+func (s *ServerTLS) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerTLS) Listen() (net.Listener, error) {

--- a/plugin/any/any_test.go
+++ b/plugin/any/any_test.go
@@ -46,7 +46,7 @@ func TestAnyNonANYQuery(t *testing.T) {
 
 			nextCalled := false
 			a := &Any{
-				Next: test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+				Next: test.HandlerFunc(func(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 					nextCalled = true
 					return 0, nil
 				}),

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -109,7 +109,7 @@ func TestAutoPathNoAnswer(t *testing.T) {
 // nextHandler returns a Handler that returns an answer for the question in the
 // request per the domain->answer map. On success an RR will be returned: "qname 3600 IN A 127.0.0.53"
 func nextHandler(mm map[string]int) test.Handler {
-	return test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		rcode, ok := mm[r.Question[0].Name]
 		if !ok {
 			return dns.RcodeServerFailure, nil

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -41,7 +41,7 @@ type Azure struct {
 }
 
 // New validates the input DNS zones and initializes the Azure struct.
-func New(ctx context.Context, publicClient publicdns.RecordSetsClient, privateClient privatedns.RecordSetsClient, keys map[string][]string, accessMap map[string]string) (*Azure, error) {
+func New(_ctx context.Context, publicClient publicdns.RecordSetsClient, privateClient privatedns.RecordSetsClient, keys map[string][]string, accessMap map[string]string) (*Azure, error) {
 	zones := make(map[string][]*zone, len(keys))
 	names := make([]string, 0, len(keys))
 	var private bool

--- a/plugin/azure/azure_test.go
+++ b/plugin/azure/azure_test.go
@@ -48,7 +48,7 @@ func testZones() zones {
 }
 
 func testHandler() test.HandlerFunc {
-	return func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -327,7 +327,7 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 }
 
 // CNAME returns CNAME records from the backend or an error.
-func CNAME(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+func CNAME(ctx context.Context, b ServiceBackend, _zone string, state request.Request, opt Options) (records []dns.RR, err error) {
 	services, err := b.Services(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
@@ -410,7 +410,7 @@ func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 }
 
 // PTR returns the PTR records from the backend, only services that have a domain name as host are included.
-func PTR(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+func PTR(ctx context.Context, b ServiceBackend, _zone string, state request.Request, opt Options) (records []dns.RR, err error) {
 	services, err := b.Reverse(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 }
 
 // SOA returns a SOA record from the backend.
-func SOA(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) ([]dns.RR, error) {
+func SOA(_ctx context.Context, b ServiceBackend, zone string, state request.Request, _opt Options) ([]dns.RR, error) {
 	minTTL := b.MinTTL(state)
 	ttl := min(minTTL, uint32(300))
 

--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -26,14 +26,14 @@ type mockBackend struct {
 	serial       uint32
 }
 
-func (m *mockBackend) Serial(state request.Request) uint32 {
+func (m *mockBackend) Serial(_state request.Request) uint32 {
 	if m.serial == 0 {
 		return uint32(time.Now().Unix())
 	}
 	return m.serial
 }
 
-func (m *mockBackend) MinTTL(state request.Request) uint32 {
+func (m *mockBackend) MinTTL(_state request.Request) uint32 {
 	if m.minTTL == 0 {
 		return 30
 	}
@@ -52,7 +52,7 @@ func (m *mockBackend) Lookup(ctx context.Context, state request.Request, name st
 	return m.mockLookup(ctx, state, name, typ)
 }
 
-func (m *mockBackend) IsNameError(err error) bool {
+func (m *mockBackend) IsNameError(_err error) bool {
 	return false
 }
 
@@ -63,7 +63,7 @@ func (m *mockBackend) Records(ctx context.Context, state request.Request, exact 
 func TestNSStateReset(t *testing.T) {
 	// Create a mock backend that always returns error
 	mock := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return nil, fmt.Errorf("mock error")
 		},
 	}
@@ -99,7 +99,7 @@ func TestNSStateReset(t *testing.T) {
 
 func TestARecords_Dedup(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "1.2.3.4", TTL: 60},
 				{Host: "1.2.3.4", TTL: 60},
@@ -127,7 +127,7 @@ func TestARecords_Dedup(t *testing.T) {
 
 func TestAAAARecords_Dedup(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "::1", TTL: 60},
 				{Host: "::1", TTL: 60},
@@ -155,7 +155,7 @@ func TestAAAARecords_Dedup(t *testing.T) {
 
 func TestTXTWithInternalCNAME(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			switch state.QName() {
 			case "txt.example.org.":
 				return []msg.Service{{Host: "target.example.org.", TTL: 50}}, nil
@@ -189,7 +189,7 @@ func TestTXTWithInternalCNAME(t *testing.T) {
 
 func TestCNAMEHostIsNameAndIpIgnored(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "target.example.org.", TTL: 50},
 				{Host: "1.2.3.4", TTL: 50},
@@ -223,7 +223,7 @@ func TestCNAMEChainLimitAndLoop(t *testing.T) {
 		chain[names[i]] = names[i+1]
 	}
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			if nxt, ok := chain[state.QName()]; ok {
 				return []msg.Service{{Host: nxt, TTL: 10}}, nil
 			}
@@ -245,7 +245,7 @@ func TestCNAMEChainLimitAndLoop(t *testing.T) {
 
 	// Now create a direct loop: qname CNAME qname should be ignored
 	b2 := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{{Host: state.QName(), TTL: 10}}, nil
 		},
 	}
@@ -263,10 +263,10 @@ func TestCNAMEChainLimitAndLoop(t *testing.T) {
 
 func TestAWithExternalCNAMELookupTruncated(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{{Host: "alias.external."}}, nil
 		},
-		mockLookup: func(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+		mockLookup: func(_ctx context.Context, _state request.Request, name string, typ uint16) (*dns.Msg, error) {
 			if name != "alias.external." || typ != dns.TypeA {
 				t.Fatalf("unexpected mockLookup: %s %d", name, typ)
 			}
@@ -303,7 +303,7 @@ func TestAAAAWithInternalCNAMEChain(t *testing.T) {
 	names := []string{"c0.example.org.", "c1.example.org.", "final.example.org."}
 	chain := map[string]string{names[0]: names[1], names[1]: names[2]}
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			if nxt, ok := chain[state.QName()]; ok {
 				return []msg.Service{{Host: nxt, TTL: 10}}, nil
 			}
@@ -339,10 +339,10 @@ func TestAAAAWithInternalCNAMEChain(t *testing.T) {
 
 func TestAAAAWithExternalCNAMELookupTruncated(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{{Host: "alias.external."}}, nil
 		},
-		mockLookup: func(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+		mockLookup: func(_ctx context.Context, _state request.Request, name string, typ uint16) (*dns.Msg, error) {
 			if name != "alias.external." || typ != dns.TypeAAAA {
 				t.Fatalf("unexpected mockLookup: %s %d", name, typ)
 			}
@@ -376,7 +376,7 @@ func TestAAAAWithExternalCNAMELookupTruncated(t *testing.T) {
 
 func TestPTRDomainOnly(t *testing.T) {
 	b := &mockBackend{
-		mockReverse: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockReverse: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "name.example.org.", TTL: 20},
 				{Host: "1.2.3.4", TTL: 20},
@@ -400,7 +400,7 @@ func TestPTRDomainOnly(t *testing.T) {
 
 func TestNSSuccess(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "1.2.3.4", TTL: 30, Key: "/skydns/org/example/ns1"},
 				{Host: "::1", TTL: 30, Key: "/skydns/org/example/ns2"},
@@ -426,13 +426,13 @@ func TestSRVAddressesAndExternalLookup(t *testing.T) {
 	// First service is IP host -> produces SRV + extra address; second is CNAME target -> triggers external lookup
 	lookedUp := false
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "1.2.3.4", Port: 80, Priority: 10, Weight: 5, TTL: 30, Key: "/skydns/org/example/s1"},
 				{Host: "alias.external.", Port: 80, Priority: 10, Weight: 5, TTL: 30, Key: "/skydns/org/example/s2"},
 			}, nil
 		},
-		mockLookup: func(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+		mockLookup: func(_ctx context.Context, _state request.Request, name string, typ uint16) (*dns.Msg, error) {
 			if name == "alias.external." && (typ == dns.TypeA || typ == dns.TypeAAAA) {
 				lookedUp = true
 				m := new(dns.Msg)
@@ -467,13 +467,13 @@ func TestSRVAddressesAndExternalLookup(t *testing.T) {
 func TestMXInternalAndExternalTargets(t *testing.T) {
 	lookedUp := false
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, _state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			return []msg.Service{
 				{Host: "1.2.3.4", Mail: true, Priority: 10, TTL: 60, Key: "/skydns/org/example/mx1"},
 				{Host: "alias.external.", Mail: true, Priority: 20, TTL: 60, Key: "/skydns/org/example/mx2"},
 			}, nil
 		},
-		mockLookup: func(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+		mockLookup: func(_ctx context.Context, _state request.Request, name string, typ uint16) (*dns.Msg, error) {
 			if name == "alias.external." && (typ == dns.TypeA || typ == dns.TypeAAAA) {
 				lookedUp = true
 				m := new(dns.Msg)
@@ -549,7 +549,7 @@ func TestBackendError(t *testing.T) {
 
 func TestCheckForApex(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			if state.QName() == "apex.dns.example.org." {
 				return []msg.Service{{Host: "1.2.3.4", TTL: 10}}, nil
 			}
@@ -570,7 +570,7 @@ func TestCheckForApex(t *testing.T) {
 
 func TestCheckForApexFallback(t *testing.T) {
 	b := &mockBackend{
-		mockServices: func(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error) {
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
 			if state.QName() == "apex.dns.example.org." {
 				return nil, dns.ErrRcode
 			}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -618,7 +618,7 @@ func BenchmarkCacheResponse(b *testing.B) {
 }
 
 func BackendHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response = true
@@ -633,7 +633,7 @@ func BackendHandler() plugin.Handler {
 }
 
 func nxDomainBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true
@@ -647,7 +647,7 @@ func nxDomainBackend(ttl int) plugin.Handler {
 }
 
 func ttlBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true
@@ -659,7 +659,7 @@ func ttlBackend(ttl int) plugin.Handler {
 }
 
 func servFailBackend(ttl int) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Response, m.RecursionAvailable = true, true

--- a/plugin/cache/dnssec_test.go
+++ b/plugin/cache/dnssec_test.go
@@ -65,7 +65,7 @@ func TestResponseWithDNSSEC(t *testing.T) {
 }
 
 func dnssecHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)
 		state := request.Request{W: &test.ResponseWriter{}, Req: r}

--- a/plugin/cache/error_test.go
+++ b/plugin/cache/error_test.go
@@ -28,7 +28,7 @@ func TestFormErr(t *testing.T) {
 
 // formErrHandler is a fake plugin implementation which returns a FORMERR for a reply.
 func formErrHandler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.net.", dns.TypeA)
 		m.Rcode = dns.RcodeFormatError

--- a/plugin/cache/prefetch_test.go
+++ b/plugin/cache/prefetch_test.go
@@ -214,7 +214,7 @@ type verification struct {
 // 127.0.0.1 and is incremented on every request.
 func prefetchHandler(qname string, ttl int, fetchc chan struct{}) plugin.Handler {
 	i := 0
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		i++
 		m := new(dns.Msg)
 		m.SetQuestion(qname, dns.TypeA)

--- a/plugin/cache/spoof_test.go
+++ b/plugin/cache/spoof_test.go
@@ -58,7 +58,7 @@ func TestResponse(t *testing.T) {
 // spoofHandler is a fake plugin implementation which returns a single A records for example.org. The qname in the
 // question section is set to example.NET (i.e. they *don't* match).
 func spoofHandler(response bool) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.net.", dns.TypeA)
 		m.Response = response
@@ -71,7 +71,7 @@ func spoofHandler(response bool) plugin.Handler {
 // spoofHandlerType is a fake plugin implementation which returns a single MX records for example.org. The qtype in the
 // question section is set to A.
 func spoofHandlerType() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.org.", dns.TypeA)
 		m.Response = true

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -47,7 +47,7 @@ type zones map[string][]*zone
 // that each domain name/zone id pair does exist, and returns a new *CloudDNS.
 // In addition to this, upstream is passed for doing recursive queries against CNAMEs.
 // Returns error if it cannot verify any given domain name/zone id pair.
-func New(ctx context.Context, c gcpDNS, keys map[string][]string, up *upstream.Upstream) (*CloudDNS, error) {
+func New(_ctx context.Context, c gcpDNS, keys map[string][]string, up *upstream.Upstream) (*CloudDNS, error) {
 	zones := make(map[string][]*zone, len(keys))
 	zoneNames := make([]string, 0, len(keys))
 	for dnsName, hostedZoneDetails := range keys {

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -22,11 +22,11 @@ type fakeGCPClient struct {
 	*gcp.Service
 }
 
-func (c fakeGCPClient) zoneExists(projectName, hostedZoneName string) error {
+func (c fakeGCPClient) zoneExists(_projectName, _hostedZoneName string) error {
 	return nil
 }
 
-func (c fakeGCPClient) listRRSets(ctx context.Context, projectName, hostedZoneName string) (*gcp.ResourceRecordSetsListResponse, error) {
+func (c fakeGCPClient) listRRSets(_ctx context.Context, projectName, hostedZoneName string) (*gcp.ResourceRecordSetsListResponse, error) {
 	if projectName == "bad-project" || hostedZoneName == "bad-zone" {
 		return nil, errors.New("the 'parameters.managedZone' resource named 'bad-zone' does not exist")
 	}
@@ -148,7 +148,7 @@ func TestCloudDNS(t *testing.T) {
 	}
 	r.Fall = fall.Zero
 	r.Fall.SetZonesFromArgs([]string{"gov."})
-	r.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	r.Next = test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/clouddns/setup_test.go
+++ b/plugin/clouddns/setup_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSetupCloudDNS(t *testing.T) {
-	f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
+	f = func(_ctx context.Context, _opt option.ClientOption) (gcpDNS, error) {
 		return fakeGCPClient{}, nil
 	}
 

--- a/plugin/erratic/autopath.go
+++ b/plugin/erratic/autopath.go
@@ -3,6 +3,6 @@ package erratic
 import "github.com/coredns/coredns/request"
 
 // AutoPath implements the AutoPathFunc call from the autopath plugin.
-func (e *Erratic) AutoPath(state request.Request) []string {
+func (e *Erratic) AutoPath(_state request.Request) []string {
 	return []string{"a.example.org.", "b.example.org.", ""}
 }

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -23,7 +23,7 @@ type Erratic struct {
 }
 
 // ServeDNS implements the plugin.Handler interface.
-func (e *Erratic) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (e *Erratic) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 	drop := false
 	delay := false

--- a/plugin/erratic/setup.go
+++ b/plugin/erratic/setup.go
@@ -18,7 +18,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("erratic", err)
 	}
 
-	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+	dnsserver.GetConfig(c).AddPlugin(func(_next plugin.Handler) plugin.Handler {
 		return e
 	})
 

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -320,7 +320,7 @@ func TestShowFirst(t *testing.T) {
 }
 
 func genErrorHandler(rcode int, err error) plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		return rcode, err
 	})
 }

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -45,7 +45,7 @@ type Etcd struct {
 }
 
 // Services implements the ServiceBackend interface.
-func (e *Etcd) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
+func (e *Etcd) Services(ctx context.Context, state request.Request, exact bool, _opt plugin.Options) (services []msg.Service, err error) {
 	services, err = e.Records(ctx, state, exact)
 	if err != nil {
 		return

--- a/plugin/etcd/xfr.go
+++ b/plugin/etcd/xfr.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Serial returns the serial number to use.
-func (e *Etcd) Serial(state request.Request) uint32 {
+func (e *Etcd) Serial(_state request.Request) uint32 {
 	return uint32(time.Now().Unix()) // #nosec G115 -- Unix time to SOA serial, Year 2106 problem accepted
 }
 
 // MinTTL returns the minimal TTL.
-func (e *Etcd) MinTTL(state request.Request) uint32 {
+func (e *Etcd) MinTTL(_state request.Request) uint32 {
 	return 30
 }

--- a/plugin/file/delete_test.go
+++ b/plugin/file/delete_test.go
@@ -29,7 +29,7 @@ type treebuf struct {
 	*bytes.Buffer
 }
 
-func (t *treebuf) printFunc(e *tree.Elem, rrs map[uint16][]dns.RR) error {
+func (t *treebuf) printFunc(_e *tree.Elem, rrs map[uint16][]dns.RR) error {
 	fmt.Fprintf(t.Buffer, "%v\n", rrs) // should be fixed order in new go versions.
 	return nil
 }

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -181,7 +181,7 @@ func TestLookup(t *testing.T) {
 	}
 }
 
-func TestLookupNil(t *testing.T) {
+func TestLookupNil(_t *testing.T) {
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: nil}, Names: []string{testzone}}}
 	ctx := context.TODO()
 

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -138,7 +138,7 @@ func TestIsNotify(t *testing.T) {
 	}
 }
 
-func newRequest(zone string, qtype uint16) request.Request {
+func newRequest(_zone string, _qtype uint16) request.Request {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4097, true)

--- a/plugin/file/zone_test.go
+++ b/plugin/file/zone_test.go
@@ -137,7 +137,7 @@ func TestInsertPreservesSRVCase(t *testing.T) {
 	}
 
 	found := false
-	err = z.Walk(func(elem *tree.Elem, rrsets map[uint16][]dns.RR) error {
+	err = z.Walk(func(_elem *tree.Elem, rrsets map[uint16][]dns.RR) error {
 		for _, rrs := range rrsets {
 			for _, rr := range rrs {
 				if srvRR, ok := rr.(*dns.SRV); ok {

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -84,14 +84,14 @@ func TestSetTapPlugin(t *testing.T) {
 
 type mockResponseWriter struct{}
 
-func (m *mockResponseWriter) LocalAddr() net.Addr         { return nil }
-func (m *mockResponseWriter) RemoteAddr() net.Addr        { return nil }
-func (m *mockResponseWriter) WriteMsg(msg *dns.Msg) error { return nil }
-func (m *mockResponseWriter) Write([]byte) (int, error)   { return 0, nil }
-func (m *mockResponseWriter) Close() error                { return nil }
-func (m *mockResponseWriter) TsigStatus() error           { return nil }
-func (m *mockResponseWriter) TsigTimersOnly(bool)         {}
-func (m *mockResponseWriter) Hijack()                     {}
+func (m *mockResponseWriter) LocalAddr() net.Addr          { return nil }
+func (m *mockResponseWriter) RemoteAddr() net.Addr         { return nil }
+func (m *mockResponseWriter) WriteMsg(_msg *dns.Msg) error { return nil }
+func (m *mockResponseWriter) Write([]byte) (int, error)    { return 0, nil }
+func (m *mockResponseWriter) Close() error                 { return nil }
+func (m *mockResponseWriter) TsigStatus() error            { return nil }
+func (m *mockResponseWriter) TsigTimersOnly(bool)          {}
+func (m *mockResponseWriter) Hijack()                      {}
 
 // TestForward_Regression_NoBusyLoop ensures that ServeDNS does not perform
 // an unbounded number of upstream connect attempts for a single request when

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -177,7 +177,7 @@ func TestHealthMaxFails(t *testing.T) {
 	defaultTimeout = 10 * time.Millisecond
 	//,hcInterval = 10 * time.Millisecond
 
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s := dnstest.NewServer(func(_w dns.ResponseWriter, _r *dns.Msg) {
 		// timeout
 	})
 	defer s.Close()
@@ -280,7 +280,7 @@ func TestHealthDomain(t *testing.T) {
 
 func TestAllUpstreamsDown(t *testing.T) {
 	qs := uint32(0)
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s := dnstest.NewServer(func(_w dns.ResponseWriter, r *dns.Msg) {
 		// count non-healthcheck queries
 		if r.Question[0].Name != "." {
 			atomic.AddUint32(&qs, 1)
@@ -289,7 +289,7 @@ func TestAllUpstreamsDown(t *testing.T) {
 	})
 	defer s.Close()
 
-	s1 := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s1 := dnstest.NewServer(func(_w dns.ResponseWriter, r *dns.Msg) {
 		// count non-healthcheck queries
 		if r.Question[0].Name != "." {
 			atomic.AddUint32(&qs, 1)

--- a/plugin/grpc/grpc_test.go
+++ b/plugin/grpc/grpc_test.go
@@ -115,7 +115,7 @@ type deadlineCheckingClient struct {
 	err          error
 }
 
-func (c *deadlineCheckingClient) Query(ctx context.Context, in *pb.DnsPacket, opts ...grpcgo.CallOption) (*pb.DnsPacket, error) {
+func (c *deadlineCheckingClient) Query(ctx context.Context, _in *pb.DnsPacket, _opts ...grpcgo.CallOption) (*pb.DnsPacket, error) {
 	if dl, ok := ctx.Deadline(); ok {
 		c.sawDeadline = true
 		c.lastDeadline = dl

--- a/plugin/grpc/proxy_test.go
+++ b/plugin/grpc/proxy_test.go
@@ -94,7 +94,7 @@ type testServiceClient struct {
 	err       error
 }
 
-func (m testServiceClient) Query(ctx context.Context, in *pb.DnsPacket, opts ...grpc.CallOption) (*pb.DnsPacket, error) {
+func (m testServiceClient) Query(_ctx context.Context, _in *pb.DnsPacket, _opts ...grpc.CallOption) (*pb.DnsPacket, error) {
 	return m.dnsPacket, m.err
 }
 
@@ -137,7 +137,7 @@ type grpcDnsServiceServer struct {
 	pb.UnimplementedDnsServiceServer
 }
 
-func (*grpcDnsServiceServer) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket, error) {
+func (*grpcDnsServiceServer) Query(_ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket, error) {
 	msg := &dns.Msg{}
 	msg.Unpack(in.GetMsg())
 	answer := new(dns.Msg)

--- a/plugin/header/header_test.go
+++ b/plugin/header/header_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHeaderResponseRules(t *testing.T) {
 	wr := dnstest.NewRecorder(&test.ResponseWriter{})
-	next := plugin.HandlerFunc(func(ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
+	next := plugin.HandlerFunc(func(_ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
 		writer.WriteMsg(msg)
 		return dns.RcodeSuccess, nil
 	})
@@ -83,7 +83,7 @@ func TestHeaderResponseRules(t *testing.T) {
 
 func TestHeaderQueryRules(t *testing.T) {
 	wr := dnstest.NewRecorder(&test.ResponseWriter{})
-	next := plugin.HandlerFunc(func(ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
+	next := plugin.HandlerFunc(func(_ctx context.Context, writer dns.ResponseWriter, msg *dns.Msg) (int, error) {
 		writer.WriteMsg(msg)
 		return dns.RcodeSuccess, nil
 	})

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -57,7 +57,7 @@ func (h *health) OnStartup() error {
 	h.mux = http.NewServeMux()
 	h.nlSetup = true
 
-	h.mux.HandleFunc(h.healthURI.Path, func(w http.ResponseWriter, r *http.Request) {
+	h.mux.HandleFunc(h.healthURI.Path, func(w http.ResponseWriter, _r *http.Request) {
 		// We're always healthy.
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, http.StatusText(http.StatusOK))

--- a/plugin/health/overloaded_test.go
+++ b/plugin/health/overloaded_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_health_overloaded_cancellation(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _r *http.Request) {
 		time.Sleep(1 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -288,10 +288,10 @@ func (external) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (external) SvcIndexReverse(string) []*object.Service  { return nil }
 func (external) Modified(kubernetes.ModifiedMode) int64    { return 0 }
 
-func (external) SvcImportIndex(s string) []*object.ServiceImport                    { return nil }
-func (external) ServiceImportList() []*object.ServiceImport                         { return nil }
-func (external) McEpIndex(s string) []*object.MultiClusterEndpoints                 { return nil }
-func (external) MultiClusterEndpointsList(s string) []*object.MultiClusterEndpoints { return nil }
+func (external) SvcImportIndex(_s string) []*object.ServiceImport                    { return nil }
+func (external) ServiceImportList() []*object.ServiceImport                          { return nil }
+func (external) McEpIndex(_s string) []*object.MultiClusterEndpoints                 { return nil }
+func (external) MultiClusterEndpointsList(_s string) []*object.MultiClusterEndpoints { return nil }
 
 func (external) EpIndex(s string) []*object.Endpoints {
 	return epIndexExternal[s]
@@ -304,9 +304,9 @@ func (external) EndpointsList() []*object.Endpoints {
 	}
 	return eps
 }
-func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
-func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
-func (external) PodIndex(string) []*object.Pod                                     { return nil }
+func (external) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) { return nil, nil }
+func (external) SvcIndex(s string) []*object.Service                                 { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                       { return nil }
 
 func (external) SvcExtIndexReverse(ip string) (result []*object.Service) {
 	for _, svcs := range svcIndexExternal {
@@ -423,7 +423,7 @@ func (external) ServiceList() []*object.Service {
 	return svcs
 }
 
-func externalAddress(state request.Request, headless bool) []dns.RR {
+func externalAddress(_state request.Request, _headless bool) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
 }

--- a/plugin/kubernetes/autopath_test.go
+++ b/plugin/kubernetes/autopath_test.go
@@ -23,25 +23,25 @@ var (
 // Mock API connector for testing
 type mockAPIConnector struct{}
 
-func (m *mockAPIConnector) PodIndex(ip string) []*object.Pod {
+func (m *mockAPIConnector) PodIndex(_ip string) []*object.Pod {
 	return []*object.Pod{mockPod}
 }
 
 // Minimal implementation of other required methods
-func (m *mockAPIConnector) ServiceList() []*object.Service                     { return nil }
-func (m *mockAPIConnector) EndpointsList() []*object.Endpoints                 { return nil }
-func (m *mockAPIConnector) ServiceImportList() []*object.ServiceImport         { return nil }
-func (m *mockAPIConnector) SvcIndex(s string) []*object.Service                { return nil }
-func (m *mockAPIConnector) SvcIndexReverse(s string) []*object.Service         { return nil }
-func (m *mockAPIConnector) SvcExtIndexReverse(s string) []*object.Service      { return nil }
-func (m *mockAPIConnector) SvcImportIndex(s string) []*object.ServiceImport    { return nil }
-func (m *mockAPIConnector) EpIndex(s string) []*object.Endpoints               { return nil }
-func (m *mockAPIConnector) EpIndexReverse(s string) []*object.Endpoints        { return nil }
-func (m *mockAPIConnector) McEpIndex(s string) []*object.MultiClusterEndpoints { return nil }
-func (m *mockAPIConnector) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (m *mockAPIConnector) ServiceList() []*object.Service                      { return nil }
+func (m *mockAPIConnector) EndpointsList() []*object.Endpoints                  { return nil }
+func (m *mockAPIConnector) ServiceImportList() []*object.ServiceImport          { return nil }
+func (m *mockAPIConnector) SvcIndex(_s string) []*object.Service                { return nil }
+func (m *mockAPIConnector) SvcIndexReverse(_s string) []*object.Service         { return nil }
+func (m *mockAPIConnector) SvcExtIndexReverse(_s string) []*object.Service      { return nil }
+func (m *mockAPIConnector) SvcImportIndex(_s string) []*object.ServiceImport    { return nil }
+func (m *mockAPIConnector) EpIndex(_s string) []*object.Endpoints               { return nil }
+func (m *mockAPIConnector) EpIndexReverse(_s string) []*object.Endpoints        { return nil }
+func (m *mockAPIConnector) McEpIndex(_s string) []*object.MultiClusterEndpoints { return nil }
+func (m *mockAPIConnector) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return nil, nil
 }
-func (m *mockAPIConnector) GetNamespaceByName(name string) (*object.Namespace, error) {
+func (m *mockAPIConnector) GetNamespaceByName(_name string) (*object.Namespace, error) {
 	return nil, nil
 }
 func (m *mockAPIConnector) Run()                        {}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -665,8 +665,8 @@ func (dns *dnsControl) GetNamespaceByName(name string) (*object.Namespace, error
 	return ns, nil
 }
 
-func (dns *dnsControl) Add(obj any)               { dns.updateModified() }
-func (dns *dnsControl) Delete(obj any)            { dns.updateModified() }
+func (dns *dnsControl) Add(_obj any)              { dns.updateModified() }
+func (dns *dnsControl) Delete(_obj any)           { dns.updateModified() }
 func (dns *dnsControl) Update(oldObj, newObj any) { dns.detectChanges(oldObj, newObj) }
 
 // detectChanges detects changes in objects, and updates the modified timestamp

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -241,7 +241,7 @@ func createClusterIPSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 	}, meta.CreateOptions{})
 }
 
-func createHeadlessSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+func createHeadlessSvc(suffix int, client kubernetes.Interface, _ip net.IP) {
 	ctx := context.TODO()
 	client.CoreV1().Services("testns").Create(ctx, &api.Service{
 		ObjectMeta: meta.ObjectMeta{
@@ -254,7 +254,7 @@ func createHeadlessSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 	}, meta.CreateOptions{})
 }
 
-func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
+func createExternalSvc(suffix int, client kubernetes.Interface, _ip net.IP) {
 	ctx := context.TODO()
 	client.CoreV1().Services("testns").Create(ctx, &api.Service{
 		ObjectMeta: meta.ObjectMeta{
@@ -273,7 +273,7 @@ func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 	}, meta.CreateOptions{})
 }
 
-func createMultiClusterHeadlessSvc(suffix int, mcsClient mcsClientset.MulticlusterV1alpha1Interface, ip net.IP) {
+func createMultiClusterHeadlessSvc(suffix int, mcsClient mcsClientset.MulticlusterV1alpha1Interface, _ip net.IP) {
 	ctx := context.TODO()
 	mcsClient.ServiceImports("testns").Create(ctx, &mcs.ServiceImport{
 		ObjectMeta: meta.ObjectMeta{

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -111,9 +111,9 @@ func (external) EndpointsList() []*object.Endpoints {
 	}
 	return eps
 }
-func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
-func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
-func (external) PodIndex(string) []*object.Pod                                     { return nil }
+func (external) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) { return nil, nil }
+func (external) SvcIndex(s string) []*object.Service                                 { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                       { return nil }
 
 func (external) GetNamespaceByName(name string) (*object.Namespace, error) {
 	return &object.Namespace{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -1133,7 +1133,7 @@ func (APIConnServeTest) EndpointsList() []*object.Endpoints {
 	return eps
 }
 
-func (APIConnServeTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnServeTest) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",
@@ -1161,7 +1161,7 @@ type Upstub struct {
 }
 
 // Lookup returns a set response
-func (t *Upstub) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (t *Upstub) Lookup(_ctx context.Context, _state request.Request, _name string, _typ uint16) (*dns.Msg, error) {
 	var answer []dns.RR
 	// if query type is not CNAME, remove any CNAME with same name as qname from the answer
 	if t.Qtype != dns.TypeCNAME {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -97,7 +97,7 @@ var (
 )
 
 // Services implements the ServiceBackend interface.
-func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (svcs []msg.Service, err error) {
+func (k *Kubernetes) Services(ctx context.Context, state request.Request, _exact bool, _opt plugin.Options) (svcs []msg.Service, err error) {
 	// We're looking again at types, which we've already done in ServeDNS, but there are some types k8s just can't answer.
 	switch state.QType() {
 	case dns.TypeTXT:
@@ -329,7 +329,7 @@ func (k *Kubernetes) InitKubeCache(ctx context.Context) (onStart func() error, o
 }
 
 // Records looks up services in kubernetes.
-func (k *Kubernetes) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
+func (k *Kubernetes) Records(_ctx context.Context, state request.Request, _exact bool) ([]msg.Service, error) {
 	multicluster := k.isMultiClusterZone(state.Zone)
 	r, e := parseRequest(state.Name(), state.Zone, multicluster)
 	if e != nil {
@@ -675,7 +675,7 @@ func (k *Kubernetes) Serial(state request.Request) uint32 {
 }
 
 // MinTTL returns the minimal TTL.
-func (k *Kubernetes) MinTTL(state request.Request) uint32 { return k.ttl }
+func (k *Kubernetes) MinTTL(_state request.Request) uint32 { return k.ttl }
 
 func (k *Kubernetes) isMultiClusterZone(zone string) bool {
 	z := plugin.Zones(k.opts.multiclusterZones).Matches(zone)

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -330,7 +330,7 @@ func (APIConnServiceTest) McEpIndex(string) []*object.MultiClusterEndpoints {
 	return eps
 }
 
-func (APIConnServiceTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnServiceTest) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -94,11 +94,11 @@ func (APIConnTest) EpIndexReverse(ip string) []*object.Endpoints {
 	return eps
 }
 
-func (APIConnTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnTest) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return &api.Node{}, nil
 }
 
-func (APIConnTest) GetNamespaceByName(name string) (*object.Namespace, error) {
+func (APIConnTest) GetNamespaceByName(_name string) (*object.Namespace, error) {
 	return nil, fmt.Errorf("namespace not found")
 }
 

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -167,16 +167,16 @@ func (e *Endpoints) DeepCopyObject() runtime.Object {
 func (e *Endpoints) GetNamespace() string { return e.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (e *Endpoints) SetNamespace(namespace string) {}
+func (e *Endpoints) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (e *Endpoints) GetName() string { return e.Name }
 
 // SetName implements the metav1.Object interface.
-func (e *Endpoints) SetName(name string) {}
+func (e *Endpoints) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (e *Endpoints) GetResourceVersion() string { return e.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (e *Endpoints) SetResourceVersion(version string) {}
+func (e *Endpoints) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/object/multicluster_endpoint.go
+++ b/plugin/kubernetes/object/multicluster_endpoint.go
@@ -49,16 +49,16 @@ func (e *MultiClusterEndpoints) DeepCopyObject() runtime.Object {
 func (e *MultiClusterEndpoints) GetNamespace() string { return e.Endpoints.GetNamespace() }
 
 // SetNamespace implements the metav1.Object interface.
-func (e *MultiClusterEndpoints) SetNamespace(namespace string) {}
+func (e *MultiClusterEndpoints) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (e *MultiClusterEndpoints) GetName() string { return e.Endpoints.GetName() }
 
 // SetName implements the metav1.Object interface.
-func (e *MultiClusterEndpoints) SetName(name string) {}
+func (e *MultiClusterEndpoints) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (e *MultiClusterEndpoints) GetResourceVersion() string { return e.Endpoints.GetResourceVersion() }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (e *MultiClusterEndpoints) SetResourceVersion(version string) {}
+func (e *MultiClusterEndpoints) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/object/namespace.go
+++ b/plugin/kubernetes/object/namespace.go
@@ -46,16 +46,16 @@ func (n *Namespace) DeepCopyObject() runtime.Object {
 func (n *Namespace) GetNamespace() string { return "" }
 
 // SetNamespace implements the metav1.Object interface.
-func (n *Namespace) SetNamespace(namespace string) {}
+func (n *Namespace) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (n *Namespace) GetName() string { return n.Name }
 
 // SetName implements the metav1.Object interface.
-func (n *Namespace) SetName(name string) {}
+func (n *Namespace) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (n *Namespace) GetResourceVersion() string { return n.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (n *Namespace) SetResourceVersion(version string) {}
+func (n *Namespace) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/object/object.go
+++ b/plugin/kubernetes/object/object.go
@@ -38,37 +38,37 @@ func (e *Empty) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKin
 func (e *Empty) GetGenerateName() string { return "" }
 
 // SetGenerateName implements the metav1.Object interface.
-func (e *Empty) SetGenerateName(name string) {}
+func (e *Empty) SetGenerateName(_name string) {}
 
 // GetUID implements the metav1.Object interface.
 func (e *Empty) GetUID() types.UID { return "" }
 
 // SetUID implements the metav1.Object interface.
-func (e *Empty) SetUID(uid types.UID) {}
+func (e *Empty) SetUID(_uid types.UID) {}
 
 // GetGeneration implements the metav1.Object interface.
 func (e *Empty) GetGeneration() int64 { return 0 }
 
 // SetGeneration implements the metav1.Object interface.
-func (e *Empty) SetGeneration(generation int64) {}
+func (e *Empty) SetGeneration(_generation int64) {}
 
 // GetSelfLink implements the metav1.Object interface.
 func (e *Empty) GetSelfLink() string { return "" }
 
 // SetSelfLink implements the metav1.Object interface.
-func (e *Empty) SetSelfLink(selfLink string) {}
+func (e *Empty) SetSelfLink(_selfLink string) {}
 
 // GetCreationTimestamp implements the metav1.Object interface.
 func (e *Empty) GetCreationTimestamp() v1.Time { return v1.Time{} }
 
 // SetCreationTimestamp implements the metav1.Object interface.
-func (e *Empty) SetCreationTimestamp(timestamp v1.Time) {}
+func (e *Empty) SetCreationTimestamp(_timestamp v1.Time) {}
 
 // GetDeletionTimestamp implements the metav1.Object interface.
 func (e *Empty) GetDeletionTimestamp() *v1.Time { return &v1.Time{} }
 
 // SetDeletionTimestamp implements the metav1.Object interface.
-func (e *Empty) SetDeletionTimestamp(timestamp *v1.Time) {}
+func (e *Empty) SetDeletionTimestamp(_timestamp *v1.Time) {}
 
 // GetDeletionGracePeriodSeconds implements the metav1.Object interface.
 func (e *Empty) GetDeletionGracePeriodSeconds() *int64 { return nil }
@@ -80,19 +80,19 @@ func (e *Empty) SetDeletionGracePeriodSeconds(*int64) {}
 func (e *Empty) GetLabels() map[string]string { return nil }
 
 // SetLabels implements the metav1.Object interface.
-func (e *Empty) SetLabels(labels map[string]string) {}
+func (e *Empty) SetLabels(_labels map[string]string) {}
 
 // GetAnnotations implements the metav1.Object interface.
 func (e *Empty) GetAnnotations() map[string]string { return nil }
 
 // SetAnnotations implements the metav1.Object interface.
-func (e *Empty) SetAnnotations(annotations map[string]string) {}
+func (e *Empty) SetAnnotations(_annotations map[string]string) {}
 
 // GetFinalizers implements the metav1.Object interface.
 func (e *Empty) GetFinalizers() []string { return nil }
 
 // SetFinalizers implements the metav1.Object interface.
-func (e *Empty) SetFinalizers(finalizers []string) {}
+func (e *Empty) SetFinalizers(_finalizers []string) {}
 
 // GetOwnerReferences implements the metav1.Object interface.
 func (e *Empty) GetOwnerReferences() []v1.OwnerReference { return nil }
@@ -104,10 +104,10 @@ func (e *Empty) SetOwnerReferences([]v1.OwnerReference) {}
 func (e *Empty) GetZZZ_DeprecatedClusterName() string { return "" }
 
 // SetZZZ_DeprecatedClusterName implements the metav1.Object interface.
-func (e *Empty) SetZZZ_DeprecatedClusterName(clusterName string) {}
+func (e *Empty) SetZZZ_DeprecatedClusterName(_clusterName string) {}
 
 // GetManagedFields implements the metav1.Object interface.
 func (e *Empty) GetManagedFields() []v1.ManagedFieldsEntry { return nil }
 
 // SetManagedFields implements the metav1.Object interface.
-func (e *Empty) SetManagedFields(managedFields []v1.ManagedFieldsEntry) {}
+func (e *Empty) SetManagedFields(_managedFields []v1.ManagedFieldsEntry) {}

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -65,16 +65,16 @@ func (p *Pod) DeepCopyObject() runtime.Object {
 func (p *Pod) GetNamespace() string { return p.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (p *Pod) SetNamespace(namespace string) {}
+func (p *Pod) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (p *Pod) GetName() string { return p.Name }
 
 // SetName implements the metav1.Object interface.
-func (p *Pod) SetName(name string) {}
+func (p *Pod) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (p *Pod) GetResourceVersion() string { return p.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (p *Pod) SetResourceVersion(version string) {}
+func (p *Pod) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -105,16 +105,16 @@ func (s *Service) DeepCopyObject() runtime.Object {
 func (s *Service) GetNamespace() string { return s.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (s *Service) SetNamespace(namespace string) {}
+func (s *Service) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (s *Service) GetName() string { return s.Name }
 
 // SetName implements the metav1.Object interface.
-func (s *Service) SetName(name string) {}
+func (s *Service) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (s *Service) GetResourceVersion() string { return s.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (s *Service) SetResourceVersion(version string) {}
+func (s *Service) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/object/serviceimport.go
+++ b/plugin/kubernetes/object/serviceimport.go
@@ -80,16 +80,16 @@ func (s *ServiceImport) DeepCopyObject() runtime.Object {
 func (s *ServiceImport) GetNamespace() string { return s.Namespace }
 
 // SetNamespace implements the metav1.Object interface.
-func (s *ServiceImport) SetNamespace(namespace string) {}
+func (s *ServiceImport) SetNamespace(_namespace string) {}
 
 // GetName implements the metav1.Object interface.
 func (s *ServiceImport) GetName() string { return s.Name }
 
 // SetName implements the metav1.Object interface.
-func (s *ServiceImport) SetName(name string) {}
+func (s *ServiceImport) SetName(_name string) {}
 
 // GetResourceVersion implements the metav1.Object interface.
 func (s *ServiceImport) GetResourceVersion() string { return s.Version }
 
 // SetResourceVersion implements the metav1.Object interface.
-func (s *ServiceImport) SetResourceVersion(version string) {}
+func (s *ServiceImport) SetResourceVersion(_version string) {}

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Reverse implements the ServiceBackend interface.
-func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
+func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, _opt plugin.Options) ([]msg.Service, error) {
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
 		_, e := k.Records(ctx, state, exact)
@@ -27,7 +27,7 @@ func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact b
 
 // serviceRecordForIP gets a service record with a cluster ip matching the ip argument
 // If a service cluster ip does not match, it checks all endpoints
-func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
+func (k *Kubernetes) serviceRecordForIP(ip, _name string) []msg.Service {
 	// First check services with cluster ips
 	for _, service := range k.APIConn.SvcIndexReverse(ip) {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -137,7 +137,7 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
 	return nil
 }
 
-func (APIConnReverseTest) GetNodeByName(ctx context.Context, name string) (*api.Node, error) {
+func (APIConnReverseTest) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -196,7 +196,7 @@ func countRecords(result []dns.RR) (cname int, address int, mx int, sorted bool)
 }
 
 func handler() plugin.Handler {
-	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		w.WriteMsg(r)
 		return dns.RcodeSuccess, nil
 	})

--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -12,7 +12,7 @@ import (
 
 type testProvider map[string]Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _state request.Request) context.Context {
 	for k, v := range tp {
 		SetValueFunc(ctx, k, v)
 	}
@@ -23,7 +23,7 @@ type testHandler struct{ ctx context.Context }
 
 func (m *testHandler) Name() string { return "test" }
 
-func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *testHandler) ServeDNS(ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 	m.ctx = ctx
 	return 0, nil
 }

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -224,7 +224,7 @@ func getTLSClient(clientCertName bool) *http.Client {
 					caCertPool.AppendCertsFromPEM(cert)
 					return caCertPool
 				}(),
-				GetClientCertificate: func(req *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				GetClientCertificate: func(_req *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 					return &clientCertficate, nil
 				},
 			},
@@ -523,7 +523,7 @@ func TestMetricsHTTPTimeout(t *testing.T) {
 	}
 }
 
-func TestMustRegister_DuplicateOK(t *testing.T) {
+func TestMustRegister_DuplicateOK(_t *testing.T) {
 	met := New("localhost:0")
 	met.Reg = prometheus.NewRegistry()
 

--- a/plugin/minimal/minimal_test.go
+++ b/plugin/minimal/minimal_test.go
@@ -19,7 +19,7 @@ type testHandler struct {
 
 func (t *testHandler) Name() string { return "test-handler" }
 
-func (t *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (t *testHandler) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	d := new(dns.Msg)
 	d.SetReply(r)
 	if t.Response != nil {

--- a/plugin/pkg/dnstest/recorder_test.go
+++ b/plugin/pkg/dnstest/recorder_test.go
@@ -8,7 +8,7 @@ import (
 
 type responseWriter struct{ dns.ResponseWriter }
 
-func (r *responseWriter) WriteMsg(m *dns.Msg) error     { return nil }
+func (r *responseWriter) WriteMsg(_m *dns.Msg) error    { return nil }
 func (r *responseWriter) Write(buf []byte) (int, error) { return len(buf), nil }
 
 func TestNewRecorder(t *testing.T) {

--- a/plugin/pkg/log/listener_test.go
+++ b/plugin/pkg/log/listener_test.go
@@ -80,42 +80,42 @@ func (l *mockListener) Name() string {
 	return l.name
 }
 
-func (l *mockListener) Debug(plugin string, v ...any) {
+func (l *mockListener) Debug(_plugin string, _v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Debugf(plugin string, format string, v ...any) {
+func (l *mockListener) Debugf(_plugin string, _format string, _v ...any) {
 	log(debug, l.name+" mocked debug")
 }
 
-func (l *mockListener) Info(plugin string, v ...any) {
+func (l *mockListener) Info(_plugin string, _v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Infof(plugin string, format string, v ...any) {
+func (l *mockListener) Infof(_plugin string, _format string, _v ...any) {
 	log(info, l.name+" mocked info")
 }
 
-func (l *mockListener) Warning(plugin string, v ...any) {
+func (l *mockListener) Warning(_plugin string, _v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Warningf(plugin string, format string, v ...any) {
+func (l *mockListener) Warningf(_plugin string, _format string, _v ...any) {
 	log(warning, l.name+" mocked warning")
 }
 
-func (l *mockListener) Error(plugin string, v ...any) {
+func (l *mockListener) Error(_plugin string, _v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Errorf(plugin string, format string, v ...any) {
+func (l *mockListener) Errorf(_plugin string, _format string, _v ...any) {
 	log(err, l.name+" mocked error")
 }
 
-func (l *mockListener) Fatal(plugin string, v ...any) {
+func (l *mockListener) Fatal(_plugin string, _v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }
 
-func (l *mockListener) Fatalf(plugin string, format string, v ...any) {
+func (l *mockListener) Fatalf(_plugin string, _format string, _v ...any) {
 	log(fatal, l.name+" mocked fatal")
 }

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -103,7 +103,7 @@ func (t *Transport) Dial(proto string) (*persistConn, bool, error) {
 }
 
 // Connect selects an upstream, sends the request and waits for a response.
-func (p *Proxy) Connect(ctx context.Context, state request.Request, opts Options) (*dns.Msg, error) {
+func (p *Proxy) Connect(_ctx context.Context, state request.Request, opts Options) (*dns.Msg, error) {
 	start := time.Now()
 
 	var proto string

--- a/plugin/pkg/proxy/health_test.go
+++ b/plugin/pkg/proxy/health_test.go
@@ -103,7 +103,7 @@ func TestHealthNoRecursion(t *testing.T) {
 }
 
 func TestHealthTimeout(t *testing.T) {
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+	s := dnstest.NewServer(func(_w dns.ResponseWriter, _r *dns.Msg) {
 		// timeout
 	})
 	defer s.Close()

--- a/plugin/pkg/rand/rand_test.go
+++ b/plugin/pkg/rand/rand_test.go
@@ -170,7 +170,7 @@ func TestConcurrentMixedOperations(t *testing.T) {
 	// Mix of Int() and Perm() operations running concurrently
 	for i := range numGoroutines {
 		wg.Add(1)
-		go func(id int) {
+		go func(_id int) {
 			defer wg.Done()
 			for j := range numOperations {
 				if j%2 == 0 {

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -308,7 +308,7 @@ func BenchmarkParseFormat(b *testing.B) {
 
 type testProvider map[string]metadata.Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _state request.Request) context.Context {
 	for k, v := range tp {
 		metadata.SetValueFunc(ctx, k, v)
 	}
@@ -319,7 +319,7 @@ type testHandler struct{ ctx context.Context }
 
 func (m *testHandler) Name() string { return "test" }
 
-func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *testHandler) ServeDNS(ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 	m.ctx = ctx
 	return 0, nil
 }

--- a/plugin/pkg/reuseport/listen_reuseport.go
+++ b/plugin/pkg/reuseport/listen_reuseport.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func control(network, address string, c syscall.RawConn) error {
+func control(_network, _address string, c syscall.RawConn) error {
 	c.Control(func(fd uintptr) {
 		const maxInt = int(^uint(0) >> 1)
 		if fd > uintptr(maxInt) {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -42,7 +42,7 @@ type mockHandler struct {
 	returnErr error
 }
 
-func (m *mockHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *mockHandler) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if m.writeMsg {
 		resp := new(dns.Msg)
 		resp.SetReply(r)

--- a/plugin/pprof/pprof_test.go
+++ b/plugin/pprof/pprof_test.go
@@ -127,7 +127,7 @@ func TestHandlerPprofRedirect(t *testing.T) {
 
 	// Create a client that doesn't follow redirects
 	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(_req *http.Request, _via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}

--- a/plugin/rewrite/class.go
+++ b/plugin/rewrite/class.go
@@ -30,7 +30,7 @@ func newClassRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the current request.
-func (rule *classRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *classRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.fromClass > 0 && rule.toClass > 0 {
 		if state.Req.Question[0].Qclass == rule.fromClass {
 			state.Req.Question[0].Qclass = rule.toClass

--- a/plugin/rewrite/cname_target_test.go
+++ b/plugin/rewrite/cname_target_test.go
@@ -17,7 +17,7 @@ import (
 
 type MockedUpstream struct{}
 
-func (u *MockedUpstream) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (u *MockedUpstream) Lookup(_ctx context.Context, state request.Request, _name string, _typ uint16) (*dns.Msg, error) {
 	m := new(dns.Msg)
 	m.SetReply(state.Req)
 	m.Authoritative = true
@@ -235,14 +235,14 @@ func doTestCNameTargetTests(t *testing.T, rules []Rule) {
 // nilUpstream returns a nil message to simulate an upstream failure path.
 type nilUpstream struct{}
 
-func (f *nilUpstream) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (f *nilUpstream) Lookup(_ctx context.Context, _state request.Request, _name string, _typ uint16) (*dns.Msg, error) {
 	return nil, nil
 }
 
 // errUpstream returns a nil message with an error to simulate an upstream failure path.
 type errUpstream struct{}
 
-func (f *errUpstream) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (f *errUpstream) Lookup(_ctx context.Context, _state request.Request, _name string, _typ uint16) (*dns.Msg, error) {
 	return nil, errors.New("upstream failure")
 }
 

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -90,7 +90,7 @@ func unsetEdns0Option(opt *dns.OPT, code uint16) {
 }
 
 // Rewrite will alter the request EDNS0 NSID option
-func (rule *edns0NsidRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0NsidRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	if rule.action == Unset {
@@ -129,7 +129,7 @@ func (rule *edns0NsidRule) Rewrite(ctx context.Context, state request.Request) (
 func (rule *edns0NsidRule) Mode() string { return rule.mode }
 
 // Rewrite will alter the request EDNS0 local options.
-func (rule *edns0LocalRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0LocalRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	if rule.action == Unset {
@@ -433,7 +433,7 @@ func (rule *edns0SubnetRule) fillEcsData(state request.Request, ecs *dns.EDNS0_S
 }
 
 // Rewrite will alter the request EDNS0 subnet option.
-func (rule *edns0SubnetRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *edns0SubnetRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	o := setupEdns0Opt(state.Req)
 
 	if rule.action == Unset {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -96,7 +96,7 @@ type nameRewriterResponseRule struct {
 	stringRewriter
 }
 
-func (r *nameRewriterResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *nameRewriterResponseRule) RewriteResponse(_res *dns.Msg, rr dns.RR) {
 	rr.Header().Name = r.rewriteString(rr.Header().Name)
 }
 
@@ -105,7 +105,7 @@ type valueRewriterResponseRule struct {
 	stringRewriter
 }
 
-func (r *valueRewriterResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *valueRewriterResponseRule) RewriteResponse(_res *dns.Msg, rr dns.RR) {
 	value := getRecordValueForRewrite(rr)
 	if value != "" {
 		new := r.rewriteString(value)
@@ -186,7 +186,7 @@ func newExactNameRule(nextAction string, orig, replacement string, answers Respo
 	}
 }
 
-func (rule *exactNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactNameRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.from == state.Name() {
 		state.Req.Question[0].Name = rule.replacement
 		return rule.responseRuleFor(state)
@@ -207,7 +207,7 @@ func newPrefixNameRule(nextAction string, auto bool, prefix, replacement string,
 	}
 }
 
-func (rule *prefixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixNameRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if after, ok := strings.CutPrefix(state.Name(), rule.prefix); ok {
 		state.Req.Question[0].Name = rule.replacement + after
 		return rule.responseRuleFor(state)
@@ -239,7 +239,7 @@ func newSuffixNameRule(nextAction string, auto bool, suffix, replacement string,
 	}
 }
 
-func (rule *suffixNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixNameRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if before, ok := strings.CutSuffix(state.Name(), rule.suffix); ok {
 		state.Req.Question[0].Name = before + rule.replacement
 		return rule.responseRuleFor(state)
@@ -261,7 +261,7 @@ func newSubstringNameRule(nextAction string, auto bool, substring, replacement s
 	}
 }
 
-func (rule *substringNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringNameRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if strings.Contains(state.Name(), rule.substring) {
 		state.Req.Question[0].Name = strings.ReplaceAll(state.Name(), rule.substring, rule.replacement)
 		return rule.responseRuleFor(state)
@@ -283,7 +283,7 @@ func newRegexNameRule(nextAction string, auto bool, pattern *regexp.Regexp, repl
 	}
 }
 
-func (rule *regexNameRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexNameRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	regexGroups := rule.pattern.FindStringSubmatch(state.Name())
 	if len(regexGroups) == 0 {
 		return nil, RewriteIgnored

--- a/plugin/rewrite/rcode.go
+++ b/plugin/rewrite/rcode.go
@@ -18,7 +18,7 @@ type rcodeResponseRule struct {
 	new int
 }
 
-func (r *rcodeResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *rcodeResponseRule) RewriteResponse(res *dns.Msg, _rr dns.RR) {
 	if r.old == res.Rcode {
 		res.Rcode = r.new
 	}
@@ -73,29 +73,29 @@ type regexRCodeRule struct {
 
 // Rewrite rewrites the current request based upon exact match of the name
 // in the question section of the request.
-func (rule *exactRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactRCodeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(rule.From == state.Name())
 }
 
 // Rewrite rewrites the current request when the name begins with the matching string.
-func (rule *prefixRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixRCodeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasPrefix(state.Name(), rule.Prefix))
 }
 
 // Rewrite rewrites the current request when the name ends with the matching string.
-func (rule *suffixRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixRCodeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasSuffix(state.Name(), rule.Suffix))
 }
 
 // Rewrite rewrites the current request based upon partial match of the
 // name in the question section of the request.
-func (rule *substringRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringRCodeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.Contains(state.Name(), rule.Substring))
 }
 
 // Rewrite rewrites the current request when the name in the question
 // section of the request matches a regular expression.
-func (rule *regexRCodeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexRCodeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(len(rule.Pattern.FindStringSubmatch(state.Name())) != 0)
 }
 

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func msgPrinter(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func msgPrinter(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	if len(r.Answer) == 0 {
 		r.Answer = []dns.RR{
 			test.A(fmt.Sprintf("%s  5   IN  A  10.0.0.1", r.Question[0].Name)),
@@ -714,7 +714,7 @@ func optsEqual(a, b []dns.EDNS0) bool {
 
 type testProvider map[string]metadata.Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, _state request.Request) context.Context {
 	for k, v := range tp {
 		metadata.SetValueFunc(ctx, k, v)
 	}

--- a/plugin/rewrite/ttl.go
+++ b/plugin/rewrite/ttl.go
@@ -18,7 +18,7 @@ type ttlResponseRule struct {
 	maxTTL uint32
 }
 
-func (r *ttlResponseRule) RewriteResponse(res *dns.Msg, rr dns.RR) {
+func (r *ttlResponseRule) RewriteResponse(_res *dns.Msg, rr dns.RR) {
 	if rr.Header().Ttl < r.minTTL {
 		rr.Header().Ttl = r.minTTL
 	} else if rr.Header().Ttl > r.maxTTL {
@@ -75,29 +75,29 @@ type regexTTLRule struct {
 
 // Rewrite rewrites the current request based upon exact match of the name
 // in the question section of the request.
-func (rule *exactTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *exactTTLRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(rule.From == state.Name())
 }
 
 // Rewrite rewrites the current request when the name begins with the matching string.
-func (rule *prefixTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *prefixTTLRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasPrefix(state.Name(), rule.Prefix))
 }
 
 // Rewrite rewrites the current request when the name ends with the matching string.
-func (rule *suffixTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *suffixTTLRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.HasSuffix(state.Name(), rule.Suffix))
 }
 
 // Rewrite rewrites the current request based upon partial match of the
 // name in the question section of the request.
-func (rule *substringTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *substringTTLRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(strings.Contains(state.Name(), rule.Substring))
 }
 
 // Rewrite rewrites the current request when the name in the question
 // section of the request matches a regular expression.
-func (rule *regexTTLRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *regexTTLRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	return rule.responseRule(len(rule.Pattern.FindStringSubmatch(state.Name())) != 0)
 }
 

--- a/plugin/rewrite/type.go
+++ b/plugin/rewrite/type.go
@@ -30,7 +30,7 @@ func newTypeRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the current request.
-func (rule *typeRule) Rewrite(ctx context.Context, state request.Request) (ResponseRules, Result) {
+func (rule *typeRule) Rewrite(_ctx context.Context, state request.Request) (ResponseRules, Result) {
 	if rule.fromType > 0 && rule.toType > 0 {
 		if state.QType() == rule.fromType {
 			state.Req.Question[0].Qtype = rule.toType

--- a/plugin/root/root_test.go
+++ b/plugin/root/root_test.go
@@ -97,6 +97,6 @@ func getTempDirPath() (string, error) {
 	return tempDir, nil
 }
 
-func getInaccessiblePath(file string) string {
+func getInaccessiblePath(_file string) string {
 	return filepath.Join("C:", "file\x00name") // null byte in filename is not allowed on Windows AND unix
 }

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -22,11 +22,11 @@ type fakeRoute53 struct {
 	route53Client
 }
 
-func (fakeRoute53) ListHostedZonesByName(_ context.Context, input *route53.ListHostedZonesByNameInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error) {
+func (fakeRoute53) ListHostedZonesByName(_ context.Context, _input *route53.ListHostedZonesByNameInput, _optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error) {
 	return nil, nil
 }
 
-func (fakeRoute53) ListResourceRecordSets(_ context.Context, in *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+func (fakeRoute53) ListResourceRecordSets(_ context.Context, in *route53.ListResourceRecordSetsInput, _optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
 	if aws.ToString(in.HostedZoneId) == "0987654321" {
 		return nil, errors.New("bad. zone is bad")
 	}
@@ -91,7 +91,7 @@ func TestRoute53(t *testing.T) {
 	}
 	r.Fall = fall.Zero
 	r.Fall.SetZonesFromArgs([]string{"gov."})
-	r.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	r.Next = test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := crequest.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/sign/nsec.go
+++ b/plugin/sign/nsec.go
@@ -10,7 +10,7 @@ import (
 )
 
 // names returns the elements of the zone in nsec order.
-func names(origin string, z *file.Zone) []string {
+func names(_origin string, z *file.Zone) []string {
 	// There will also be apex records other than NS and SOA (who are kept separate), as we
 	// are adding DNSKEY and CDS/CDNSKEY records in the apex *before* we sign.
 	n := []string{}

--- a/plugin/template/cname_test.go
+++ b/plugin/template/cname_test.go
@@ -68,7 +68,7 @@ type Upstub struct {
 }
 
 // Lookup returns a set response
-func (t *Upstub) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+func (t *Upstub) Lookup(_ctx context.Context, _state request.Request, _name string, _typ uint16) (*dns.Msg, error) {
 	var answer []dns.RR
 	// if query type is not CNAME, remove any CNAME with same name as qname from the answer
 	if t.Qtype != dns.TypeCNAME {

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -170,7 +170,7 @@ func TestHandler(t *testing.T) {
 			tmpl:         rcodeServfailTemplate,
 			qname:        "test.invalid.",
 			expectedCode: dns.RcodeServerFailure,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},
@@ -190,7 +190,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `template: answer:1:26: executing "answer" at <index .Match 2>: error calling index: index out of range: 2`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},
@@ -202,7 +202,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},
@@ -214,7 +214,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},
@@ -226,7 +226,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},
@@ -295,7 +295,7 @@ func TestHandler(t *testing.T) {
 			qname:        "test.example.",
 			expectedCode: dns.RcodeServerFailure,
 			expectedErr:  "template: answer:1:26: executing \"answer\" at <parseInt \"gg\" 16 8>: error calling parseInt: strconv.ParseUint: parsing \"gg\": invalid syntax",
-			verifyResponse: func(r *dns.Msg) error {
+			verifyResponse: func(_r *dns.Msg) error {
 				return nil
 			},
 		},

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -325,7 +325,7 @@ func SortAndCheck(resp *dns.Msg, tc Case) error {
 
 // ErrorHandler returns a Handler that returns ServerFailure error when called.
 func ErrorHandler() Handler {
-	return HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)
 		m.SetRcode(r, dns.RcodeServerFailure)
 		w.WriteMsg(m)
@@ -335,7 +335,7 @@ func ErrorHandler() Handler {
 
 // NextHandler returns a Handler that returns rcode and err.
 func NextHandler(rcode int, err error) Handler {
-	return HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return HandlerFunc(func(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		return rcode, err
 	})
 }

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -43,7 +43,7 @@ func (t *ResponseWriter) RemoteAddr() net.Addr {
 func (t *ResponseWriter) Network() string { return "" }
 
 // WriteMsg implements dns.ResponseWriter interface.
-func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { return nil }
+func (t *ResponseWriter) WriteMsg(_m *dns.Msg) error { return nil }
 
 // Write implements dns.ResponseWriter interface.
 func (t *ResponseWriter) Write(buf []byte) (int, error) { return len(buf), nil }

--- a/plugin/transfer/select_test.go
+++ b/plugin/transfer/select_test.go
@@ -16,14 +16,14 @@ type (
 	t2 struct{}
 )
 
-func (t t1) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+func (t t1) Transfer(zone string, _serial uint32) (<-chan []dns.RR, error) {
 	const z = "example.org."
 	if zone != z {
 		return nil, ErrNotAuthoritative
 	}
 	return nil, errors.New(z)
 }
-func (t t2) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+func (t t2) Transfer(zone string, _serial uint32) (<-chan []dns.RR, error) {
 	const z = "sub.example.org."
 	if zone != z {
 		return nil, ErrNotAuthoritative

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -57,7 +57,7 @@ type terminatingPlugin struct{}
 func (*terminatingPlugin) Name() string { return "testplugin" }
 
 // ServeDNS implements plugin.Handler that returns NXDOMAIN for all requests.
-func (*terminatingPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (*terminatingPlugin) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	m := new(dns.Msg)
 	m.SetRcode(r, dns.RcodeNameError)
 	w.WriteMsg(m)
@@ -284,7 +284,7 @@ type errWriter struct {
 	test.ResponseWriter
 }
 
-func (e *errWriter) WriteMsg(m *dns.Msg) error { return fmt.Errorf("write error") }
+func (e *errWriter) WriteMsg(_m *dns.Msg) error { return fmt.Errorf("write error") }
 
 // blockingTransferer produces many records into the channel and signals when done.
 type blockingTransferer struct {
@@ -293,10 +293,10 @@ type blockingTransferer struct {
 }
 
 func (b *blockingTransferer) Name() string { return "blockingtransferer" }
-func (b *blockingTransferer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (b *blockingTransferer) ServeDNS(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 	return 0, nil
 }
-func (b *blockingTransferer) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+func (b *blockingTransferer) Transfer(zone string, _serial uint32) (<-chan []dns.RR, error) {
 	if zone != b.Zone {
 		return nil, ErrNotAuthoritative
 	}
@@ -343,7 +343,7 @@ func TestTransferDrainsProducerOnClientError(t *testing.T) {
 type nopHandler struct{}
 
 func (nopHandler) Name() string { return "nop" }
-func (nopHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (nopHandler) ServeDNS(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 	return dns.RcodeSuccess, nil
 }
 

--- a/plugin/tsig/tsig_test.go
+++ b/plugin/tsig/tsig_test.go
@@ -307,7 +307,7 @@ func TestServeDNSTsigErrors(t *testing.T) {
 }
 
 func testHandler() test.HandlerFunc {
-	return func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		state := request.Request{W: w, Req: r}
 		qname := state.Name()
 		m := new(dns.Msg)

--- a/plugin/view/metadata.go
+++ b/plugin/view/metadata.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Metadata implements the metadata.Provider interface.
-func (v *View) Metadata(ctx context.Context, state request.Request) context.Context {
+func (v *View) Metadata(ctx context.Context, _state request.Request) context.Context {
 	metadata.SetValueFunc(ctx, "view/name", func() string {
 		return v.viewName
 	})

--- a/plugin/whoami/setup.go
+++ b/plugin/whoami/setup.go
@@ -14,7 +14,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("whoami", c.ArgErr())
 	}
 
-	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+	dnsserver.GetConfig(c).AddPlugin(func(_next plugin.Handler) plugin.Handler {
 		return Whoami{}
 	})
 

--- a/plugin/whoami/whoami.go
+++ b/plugin/whoami/whoami.go
@@ -19,7 +19,7 @@ const name = "whoami"
 type Whoami struct{}
 
 // ServeDNS implements the plugin.Handler interface.
-func (wh Whoami) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (wh Whoami) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 
 	a := new(dns.Msg)

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -145,7 +145,7 @@ type benchmarkResponseWriter struct{}
 
 func (b *benchmarkResponseWriter) LocalAddr() net.Addr         { return nil }
 func (b *benchmarkResponseWriter) RemoteAddr() net.Addr        { return nil }
-func (b *benchmarkResponseWriter) WriteMsg(m *dns.Msg) error   { return nil }
+func (b *benchmarkResponseWriter) WriteMsg(_m *dns.Msg) error  { return nil }
 func (b *benchmarkResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
 func (b *benchmarkResponseWriter) Close() error                { return nil }
 func (b *benchmarkResponseWriter) TsigStatus() error           { return nil }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Prefix unused function parameters with `_` to satisfy the `unused-parameter` revive rule. This is a mechanical change across 95 files. Re-enable the `unused-parameter` rule.

### 2. Which issues (if any) are related?

Draft until #7973 merged.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.