### PR TITLE
test(forward): restore defaultTimeout

### DIFF
--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestHealth(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	i := uint32(0)
 	q := uint32(0)
@@ -53,7 +55,9 @@ func TestHealth(t *testing.T) {
 }
 
 func TestHealthTCP(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	i := uint32(0)
 	q := uint32(0)
@@ -92,7 +96,9 @@ func TestHealthTCP(t *testing.T) {
 }
 
 func TestHealthNoRecursion(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	i := uint32(0)
 	q := uint32(0)
@@ -131,7 +137,9 @@ func TestHealthNoRecursion(t *testing.T) {
 }
 
 func TestHealthTimeout(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	i := uint32(0)
 	q := uint32(0)
@@ -174,7 +182,9 @@ func TestHealthTimeout(t *testing.T) {
 }
 
 func TestHealthMaxFails(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 	//,hcInterval = 10 * time.Millisecond
 
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
@@ -205,7 +215,9 @@ func TestHealthMaxFails(t *testing.T) {
 }
 
 func TestHealthNoMaxFails(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	i := uint32(0)
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
@@ -240,7 +252,9 @@ func TestHealthNoMaxFails(t *testing.T) {
 }
 
 func TestHealthDomain(t *testing.T) {
+	origTimeout := defaultTimeout
 	defaultTimeout = 10 * time.Millisecond
+	defer func() { defaultTimeout = origTimeout }()
 
 	hcDomain := "example.org."
 	i := uint32(0)


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Health tests mutate the package-level `defaultTimeout` to 10ms without restoring it, poisoning subsequent tests. On slow CI runners, this causes `TestFailover` to fail because the deadline expires before all upstream proxies can be tried. Save and restore the original value via defer in all 7 test functions.


### 2. Which issues (if any) are related?

See https://github.com/coredns/coredns/actions/runs/23705450875/job/69056468811?pr=7980 for example

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.