### PR TITLE
test(dnstap): fix flaky TestReconnect

### DIFF
--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -20,13 +20,28 @@ var (
 )
 
 type MockLogger struct {
-	WarnCount int
-	WarnLog   string
+	mu        sync.Mutex
+	warnCount int
+	warnLog   string
 }
 
 func (l *MockLogger) Warningf(format string, v ...any) {
-	l.WarnCount++
-	l.WarnLog += fmt.Sprintf(format, v...)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnCount++
+	l.warnLog += fmt.Sprintf(format, v...)
+}
+
+func (l *MockLogger) WarnCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.warnCount
+}
+
+func (l *MockLogger) WarnLog() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.warnLog
 }
 
 func accept(t *testing.T, l net.Listener, count int) {
@@ -172,9 +187,10 @@ func TestReconnect(t *testing.T) {
 		// THEN
 		//		DnsTap is able to reconnect
 		//		Messages can be sent eventually
-		require.NotNil(t, dio.enc)
-		require.Equal(t, 0, len(dio.queue))
-		require.Less(t, logger.WarnCount, messageCount)
+		require.Eventually(t, func() bool {
+			return len(dio.queue) == 0
+		}, time.Second, 10*time.Millisecond, "queue should be drained by serve goroutine")
+		require.Less(t, logger.WarnCount(), messageCount)
 	})
 
 	t.Run("NotConnectedOnStart", func(t *testing.T) {
@@ -225,9 +241,10 @@ func TestReconnect(t *testing.T) {
 		// THEN
 		//		DnsTap is able to reconnect
 		//		Messages can be sent eventually
-		require.NotNil(t, dio.enc)
-		require.Equal(t, 0, len(dio.queue))
-		require.Less(t, logger.WarnCount, messageCount)
+		require.Eventually(t, func() bool {
+			return len(dio.queue) == 0
+		}, time.Second, 10*time.Millisecond, "queue should be drained by serve goroutine")
+		require.Less(t, logger.WarnCount(), messageCount)
 	})
 }
 
@@ -264,6 +281,6 @@ func TestFullQueueWriteFail(t *testing.T) {
 
 	// THEN
 	//		Dropped messages are logged
-	require.NotEqual(t, 0, logger.WarnCount)
-	require.Contains(t, logger.WarnLog, "Dropped dnstap messages")
+	require.NotEqual(t, 0, logger.WarnCount())
+	require.Contains(t, logger.WarnLog(), "Dropped dnstap messages")
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `TestReconnect` subtests checked `dio.queue` length immediately after `wg.Wait()`, but `wg.Wait()` only synchronizes with the server accept goroutine - not with the client `serve()` goroutine that drains the queue. When `serve()` was blocked in a `d.dial()` reconnection attempt (up to 10ms), the last enqueued message hadn't been dequeued yet, causing the assertion to fail intermittently.

Replace the immediate equality check with `require.Eventually`, which polls until the queue drains (up to 1s, checking every 10ms). Also make MockLogger concurrency-safe with a mutex, eliminating a data race between the serve goroutine writing warnings and the test goroutine reading them.

I also removed `require.NotNil(t, dio.enc)` as it races with the `serve()` goroutine writing `d.enc` via `d.dial()`. Reconnection is already proven by `wg.Wait()` completing successfully.

### 2. Which issues (if any) are related?

Flakiness observed in https://github.com/coredns/coredns/actions/runs/23706263785/job/69058595099?pr=7980

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.