### PR TITLE
chore: bump golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
-          version: v2.11.1
+          version: v2.11.4

--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -36,7 +36,7 @@ type dio struct {
 	proto              string
 	enc                *encoder
 	queue              chan *tap.Dnstap
-	dropped            uint32
+	dropped            atomic.Uint32
 	quit               chan struct{}
 	flushTimeout       time.Duration
 	tcpTimeout         time.Duration
@@ -108,7 +108,7 @@ func (d *dio) Dnstap(payload *tap.Dnstap) {
 	select {
 	case d.queue <- payload:
 	default:
-		atomic.AddUint32(&d.dropped, 1)
+		d.dropped.Add(1)
 	}
 }
 
@@ -142,7 +142,7 @@ func (d *dio) serve() {
 			return
 		case payload := <-d.queue:
 			if err := d.write(payload); err != nil {
-				atomic.AddUint32(&d.dropped, 1)
+				d.dropped.Add(1)
 				if !errors.Is(err, errNoOutput) {
 					// Redial immediately if it's not an output connection error
 					d.dial()
@@ -153,7 +153,7 @@ func (d *dio) serve() {
 				d.enc.flush()
 			}
 		case <-errorCheckTicker.C:
-			if dropped := atomic.SwapUint32(&d.dropped, 0); dropped > 0 {
+			if dropped := d.dropped.Swap(0); dropped > 0 {
 				d.logger.Warningf("Dropped dnstap messages: %d\n", dropped)
 			}
 			if d.enc == nil {

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -13,7 +13,7 @@ import (
 
 // Erratic is a plugin that returns erratic responses to each client.
 type Erratic struct {
-	q        uint64 // counter of queries
+	q        atomic.Uint64 // counter of queries
 	drop     uint64
 	delay    uint64
 	truncate uint64
@@ -29,8 +29,8 @@ func (e *Erratic) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	delay := false
 	trunc := false
 
-	queryNr := atomic.LoadUint64(&e.q)
-	atomic.AddUint64(&e.q, 1)
+	queryNr := e.q.Load()
+	e.q.Add(1)
 
 	if e.drop > 0 && queryNr%e.drop == 0 {
 		drop = true

--- a/plugin/erratic/ready.go
+++ b/plugin/erratic/ready.go
@@ -1,11 +1,9 @@
 package erratic
 
-import "sync/atomic"
-
 // Ready returns true if the number of received queries is in the range [3, 5). All other values return false.
 // To aid in testing we want to this flip between ready and not ready.
 func (e *Erratic) Ready() bool {
-	q := atomic.LoadUint64(&e.q)
+	q := e.q.Load()
 	if q >= 3 && q < 5 {
 		return true
 	}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -70,13 +70,13 @@ type dnsControl struct {
 	// modified tracks timestamp of the most recent changes
 	// It needs to be first because it is guaranteed to be 8-byte
 	// aligned ( we use sync.LoadAtomic with this )
-	modified int64
+	modified atomic.Int64
 	// multiClusterModified tracks timestamp of the most recent changes to
 	// multi cluster services
-	multiClusterModified int64
+	multiClusterModified atomic.Int64
 	// extModified tracks timestamp of the most recent changes to
 	// services with external facing IP addresses
-	extModified int64
+	extModified atomic.Int64
 
 	client    kubernetes.Interface
 	mcsClient mcsClientset.MulticlusterV1alpha1Interface
@@ -880,11 +880,11 @@ func serviceImportEquivalent(oldObj, newObj any) bool {
 func (dns *dnsControl) Modified(mode ModifiedMode) int64 {
 	switch mode {
 	case ModifiedInternal:
-		return atomic.LoadInt64(&dns.modified)
+		return dns.modified.Load()
 	case ModifiedExternal:
-		return atomic.LoadInt64(&dns.extModified)
+		return dns.extModified.Load()
 	case ModifiedMultiCluster:
-		return atomic.LoadInt64(&dns.multiClusterModified)
+		return dns.multiClusterModified.Load()
 	}
 	return -1
 }
@@ -892,19 +892,19 @@ func (dns *dnsControl) Modified(mode ModifiedMode) int64 {
 // updateModified set dns.modified to the current time.
 func (dns *dnsControl) updateModified() {
 	unix := time.Now().Unix()
-	atomic.StoreInt64(&dns.modified, unix)
+	dns.modified.Store(unix)
 }
 
 // updateMultiClusterModified set dns.modified to the current time.
 func (dns *dnsControl) updateMultiClusterModified() {
 	unix := time.Now().Unix()
-	atomic.StoreInt64(&dns.multiClusterModified, unix)
+	dns.multiClusterModified.Store(unix)
 }
 
 // updateExtModified set dns.extModified to the current time.
 func (dns *dnsControl) updateExtModified() {
 	unix := time.Now().Unix()
-	atomic.StoreInt64(&dns.extModified, unix)
+	dns.extModified.Store(unix)
 }
 
 var errObj = errors.New("obj was not of the correct type")

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -55,9 +55,9 @@ func TestDoErr(t *testing.T) {
 func TestDoDupSuppress(t *testing.T) {
 	var g Group
 	c := make(chan string)
-	var calls int32
+	var calls atomic.Int32
 	fn := func() (any, error) {
-		atomic.AddInt32(&calls, 1)
+		calls.Add(1)
 		return <-c, nil
 	}
 
@@ -77,7 +77,7 @@ func TestDoDupSuppress(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // let goroutines above block
 	c <- "bar"
 	wg.Wait()
-	if got := atomic.LoadInt32(&calls); got != 1 {
+	if got := calls.Load(); got != 1 {
 		t.Errorf("Number of calls = %d; want 1", got)
 	}
 }

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -63,7 +63,7 @@ var tagByProvider = map[string]traceTags{
 }
 
 type trace struct {
-	count uint64 // as per Go spec, needs to be first element in a struct
+	count atomic.Uint64 // as per Go spec, needs to be first element in a struct
 
 	Next                   plugin.Handler
 	Endpoint               string
@@ -155,7 +155,7 @@ func (t *trace) Name() string { return "trace" }
 func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	shouldTrace := false
 	if t.every > 0 {
-		queryNr := atomic.AddUint64(&t.count, 1)
+		queryNr := t.count.Add(1)
 		if queryNr%t.every == 0 {
 			shouldTrace = true
 		}

--- a/plugin/tsig/setup_test.go
+++ b/plugin/tsig/setup_test.go
@@ -16,9 +16,9 @@ func TestParse(t *testing.T) {
 		"name.key.":  "test-key",
 		"name2.key.": "test-key-2",
 	}
-	secretConfig := ""
+	var secretConfig strings.Builder
 	for k, s := range secrets {
-		secretConfig += fmt.Sprintf("secret %s %s\n", k, s)
+		fmt.Fprintf(&secretConfig, "secret %s %s\n", k, s)
 	}
 	secretsFile, cleanup, err := test.TempFile(".", `key "name.key." {
 	secret "test-key";
@@ -42,7 +42,7 @@ key "name2.key." {
 		expectedAllOpcodes bool
 	}{
 		{
-			input:           "tsig {\n " + secretConfig + "}",
+			input:           "tsig {\n " + secretConfig.String() + "}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  defaultQTypes,
 			expectedOpCodes: defaultOpCodes,
@@ -56,14 +56,14 @@ key "name2.key." {
 			expectedSecrets: secrets,
 		},
 		{
-			input:           "tsig example.com {\n " + secretConfig + "}",
+			input:           "tsig example.com {\n " + secretConfig.String() + "}",
 			expectedZones:   []string{"example.com."},
 			expectedQTypes:  defaultQTypes,
 			expectedOpCodes: defaultOpCodes,
 			expectedSecrets: secrets,
 		},
 		{
-			input:            "tsig {\n " + secretConfig + " require all \n}",
+			input:            "tsig {\n " + secretConfig.String() + " require all \n}",
 			expectedZones:    []string{"."},
 			expectedQTypes:   qTypes{},
 			expectedOpCodes:  defaultOpCodes,
@@ -71,28 +71,28 @@ key "name2.key." {
 			expectedSecrets:  secrets,
 		},
 		{
-			input:           "tsig {\n " + secretConfig + " require none \n}",
+			input:           "tsig {\n " + secretConfig.String() + " require none \n}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  qTypes{},
 			expectedOpCodes: defaultOpCodes,
 			expectedSecrets: secrets,
 		},
 		{
-			input:           "tsig {\n " + secretConfig + " \n require A AAAA \n}",
+			input:           "tsig {\n " + secretConfig.String() + " \n require A AAAA \n}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  qTypes{dns.TypeA: {}, dns.TypeAAAA: {}},
 			expectedOpCodes: defaultOpCodes,
 			expectedSecrets: secrets,
 		},
 		{
-			input:           "tsig {\n " + secretConfig + " \n require_opcode UPDATE NOTIFY \n}",
+			input:           "tsig {\n " + secretConfig.String() + " \n require_opcode UPDATE NOTIFY \n}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  defaultQTypes,
 			expectedOpCodes: opCodes{dns.OpcodeUpdate: {}, dns.OpcodeNotify: {}},
 			expectedSecrets: secrets,
 		},
 		{
-			input:              "tsig {\n " + secretConfig + " \n require_opcode all \n}",
+			input:              "tsig {\n " + secretConfig.String() + " \n require_opcode all \n}",
 			expectedZones:      []string{"."},
 			expectedQTypes:     defaultQTypes,
 			expectedOpCodes:    opCodes{},
@@ -100,14 +100,14 @@ key "name2.key." {
 			expectedSecrets:    secrets,
 		},
 		{
-			input:           "tsig {\n " + secretConfig + " \n require_opcode none \n}",
+			input:           "tsig {\n " + secretConfig.String() + " \n require_opcode none \n}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  defaultQTypes,
 			expectedOpCodes: opCodes{},
 			expectedSecrets: secrets,
 		},
 		{
-			input:           "tsig {\n " + secretConfig + " \n require AXFR \n require_opcode UPDATE \n}",
+			input:           "tsig {\n " + secretConfig.String() + " \n require AXFR \n require_opcode UPDATE \n}",
 			expectedZones:   []string{"."},
 			expectedQTypes:  qTypes{dns.TypeAXFR: {}},
 			expectedOpCodes: opCodes{dns.OpcodeUpdate: {}},


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fix modernize linter violations introduced by the version bump: replace `sync/atomic` free functions with typed atomic methods (`Uint64`, `Uint32`, `Int64`, `Int32`) and use `strings.Builder` instead of string concatenation in tests.

### 2. Which issues (if any) are related?

None, cleanup.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.