### PR TITLE
ci: create PR instead of push autogenerated docs

### DIFF
--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -26,18 +27,13 @@ jobs:
           bash -x -e ./.github/fixup_file_mtime.sh
           make -f Makefile.doc
 
-      - name: Set up Git
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "coredns[bot]"
-          git config user.email "bot@bot.coredns.io"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
-      - name: Commit and push changes
-        run: |
-          git add .
-          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -s -m 'auto make -f Makefile.doc'
-            git push
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0
+        with:
+          commit-message: 'auto make -f Makefile.doc'
+          title: 'Update generated documentation'
+          body: 'Automated doc generation via `make -f Makefile.doc`'
+          branch: bot/make-doc
+          committer: 'coredns[bot] <bot@coredns.io>'
+          author: 'coredns[bot] <bot@coredns.io>'
+          signoff: true


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The scheduled Github Actions workflow for generating docs has been failing for quite some time: https://github.com/coredns/coredns/actions/workflows/make.doc.yml.

Replace direct push to master with `peter-evans/create-pull-request` action, since `master` is a protected branch requiring changes via pull request.

### 2. Which issues (if any) are related?

Docs previously updated manually in #7971. This is why the latest CI task succeeded, as there was no diff.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.