### PR TITLE
Allow selectively exporting all Go runtime metrics

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -55,13 +55,21 @@ This plugin can only be used once per Server Block.
 ## Syntax
 
 ~~~
-prometheus [ADDRESS]
+prometheus [ADDRESS] {
+    runtime_metrics
+}
 ~~~
 
 For each zone that you want to see metrics for.
 
 It optionally takes a bind address to which the metrics are exported; the default
 listens on `localhost:9153`. The metrics path is fixed to `/metrics`.
+
+* `runtime_metrics` exports the full Go [runtime/metrics](https://pkg.go.dev/runtime/metrics)
+  set — notably `go_cpu_classes_*` for CPU attribution (GC mark/assist/pause vs user code)
+  and `go_sched_latencies_seconds` for goroutine scheduling delay. Adds roughly 100 scalars
+  and 8 histograms. This is a process-wide latch: enabling it in any server block enables it
+  for all, and it stays enabled across reloads until restart.
 
 ## Examples
 

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"net"
 	"runtime"
+	"sync"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
@@ -10,11 +11,19 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/uniq"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 var (
 	u        = uniq.New()
 	registry = newReg()
+
+	// There is one Go runtime per process, so this is a latch: the first server
+	// block to enable runtime_metrics swaps the collector for everyone, and the
+	// swap persists across reloads until process restart.
+	runtimeMetricsOnce sync.Once
 )
 
 func init() { plugin.Register("prometheus", setup) }
@@ -96,9 +105,18 @@ func parse(c *caddy.Controller) (*Metrics, error) {
 			return met, c.ArgErr()
 		}
 
-		// Parse TLS block if present
 		for c.NextBlock() {
 			switch c.Val() {
+			case "runtime_metrics":
+				if len(c.RemainingArgs()) != 0 {
+					return nil, c.ArgErr()
+				}
+				runtimeMetricsOnce.Do(func() {
+					prometheus.Unregister(collectors.NewGoCollector())
+					prometheus.MustRegister(collectors.NewGoCollector(
+						collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
+					))
+				})
 			case "tls":
 				if met.tlsConfigPath != "" {
 					return nil, c.Err("tls block already specified")

--- a/plugin/metrics/setup_test.go
+++ b/plugin/metrics/setup_test.go
@@ -15,8 +15,17 @@ func TestPrometheusParse(t *testing.T) {
 		// oks
 		{`prometheus`, false, "localhost:9153"},
 		{`prometheus localhost:53`, false, "localhost:53"},
+		{`prometheus {
+			runtime_metrics
+		}`, false, "localhost:9153"},
+		{`prometheus localhost:53 {
+			runtime_metrics
+		}`, false, "localhost:53"},
 		// fails
 		{`prometheus {}`, true, ""},
+		{`prometheus {
+			runtime_metrics extra_arg
+		}`, true, ""},
 		{`prometheus /foo`, true, ""},
 		{`prometheus a b c`, true, ""},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

You can configure `prometheus` in a Corefile.

You can export a few additional metrics from the Go runtime (https://pkg.go.dev/runtime/metrics):
- [Go 1.20](https://go.dev/doc/go1.20) introduced `/cpu/classes/*` and friends
- [Go 1.22](https://go.dev/doc/go1.22) introduced `/sched/pauses/stopping/gc:seconds` and friends

This PR allows explicitly opting in to those additional metrics in the `prometheus` stanza

### 2. Which issues (if any) are related?

none

### 3. Which documentation changes (if any) need to be made?

The `prometheus` plugin now documents the optional `runtime_metrics` stanza, along with the hot-reload behavior (which is admittedly kind of confusing) 

### 4. Does this introduce a backward incompatible change or deprecation?

no, I intentionally scoped it behind a new stanza

I think it is worth considering whether this should be the default, but I am not confident this won't cause problems with someone's prometheus scraping setup out in the wild