### PR TITLE
fix(dnssec): avoid caching empty signing results

### DIFF
--- a/plugin/dnssec/cache_test.go
+++ b/plugin/dnssec/cache_test.go
@@ -59,6 +59,22 @@ func TestCacheNotValidExpired(t *testing.T) {
 	}
 }
 
+func TestCacheEmptySigsNotCached(t *testing.T) {
+	c := cache.New[[]dns.RR](defaultCap)
+	m := testMsg()
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	k := hash(m.Answer)
+
+	// Create a Dnssec instance with no keys; sign() will produce no signatures.
+	d := New([]string{"miek.nl."}, []*DNSKEY{}, false, nil, c)
+	d.Sign(state, time.Now().UTC(), server)
+
+	_, ok := d.get(k, server)
+	if ok {
+		t.Errorf("Empty signatures should not be cached")
+	}
+}
+
 func TestCacheNotValidYet(t *testing.T) {
 	fPriv, rmPriv, _ := test.TempFile(".", privKey)
 	fPub, rmPub, _ := test.TempFile(".", pubKey)

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -140,7 +140,9 @@ func (d Dnssec) sign(rrs []dns.RR, signerName string, ttl, incep, expir uint32, 
 			}
 			sigs = append(sigs, sig)
 		}
-		d.set(k, sigs)
+		if len(sigs) > 0 {
+			d.set(k, sigs)
+		}
 		return sigs, nil
 	})
 	return sigs.([]dns.RR), err


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Don't cache the result of `sign()` when no signatures were produced. This can happen when `d.keys` is empty (misconfiguration) or when splitkeys mode filters out all applicable keys. Previously, `nil` sigs were cached and never evicted by `periodicClean`, polluting the cache with useless entries and inflating cache hit metrics.

### 2. Which issues (if any) are related?

Fixes #7992

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.