### PR TITLE
fix(dnssec): add defensive nil checks

### DIFF
--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -48,6 +48,9 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 
 	mt, _ := response.Typify(req, time.Now().UTC()) // TODO(miek): need opt record here?
 	if mt == response.Delegation {
+		if len(req.Ns) == 0 {
+			return req
+		}
 		// We either sign DS or NSEC of DS.
 		ttl := req.Ns[0].Header().Ttl
 
@@ -68,7 +71,7 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 	}
 
 	if mt == response.NameError || mt == response.NoData {
-		if req.Ns[0].Header().Rrtype != dns.TypeSOA || len(req.Ns) > 1 {
+		if len(req.Ns) != 1 || req.Ns[0].Header().Rrtype != dns.TypeSOA {
 			return req
 		}
 


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add length checks for `req.Ns` before accessing `req.Ns[0]` in the Delegation and NameError/NoData code paths of `Sign()`.

Currently `response.Typify` guarantees `len(req.Ns) >= 1` for these response types. It requires SOA or NS records in the authority section to classify a response as such, so this cannot be triggered in practice. The guards are added as defense-in-depth in case Typify's classification logic changes in the future.

### 2. Which issues (if any) are related?

Fixes #7991 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.