### PR TITLE
fix(dnssec): return nil from ParseKeyFile on error

### DIFF
--- a/plugin/dnssec/dnskey.go
+++ b/plugin/dnssec/dnskey.go
@@ -71,7 +71,7 @@ func ParseKeyFile(pubFile, privFile string) (*DNSKEY, error) {
 	if s, ok := p.(ed25519.PrivateKey); ok {
 		return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: s, tag: dk.KeyTag()}, nil
 	}
-	return &DNSKEY{K: dk, D: dk.ToDS(dns.SHA256), s: nil, tag: 0}, errors.New("no private key found")
+	return nil, errors.New("no private key found")
 }
 
 // ParseKeyFromAWSSecretsManager retrieves and parses a DNSSEC key pair from AWS Secrets Manager.


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The final error return in `ParseKeyFile` returned a partially populated `*DNSKEY` (with nil signer and zero tag) alongside the error. Every other error return in the function returns nil. Align this one for consistency as callers already check `err`.

### 2. Which issues (if any) are related?

None, cleanup.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.