### PR TITLE
fix(test): deduplicate TSIG test helpers

### DIFF
--- a/core/dnsserver/server_grpc_test.go
+++ b/core/dnsserver/server_grpc_test.go
@@ -16,43 +16,6 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-type tsigStatusCheckPlugin struct {
-	t      *testing.T
-	check  func(*testing.T, error)
-	called *bool
-}
-
-func (p tsigStatusCheckPlugin) Name() string { return "tsig-status-check" }
-
-func (p tsigStatusCheckPlugin) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	p.t.Helper()
-	if p.called != nil {
-		*p.called = true
-	}
-	p.check(p.t, w.TsigStatus())
-
-	m := new(dns.Msg)
-	m.SetReply(r)
-	if err := w.WriteMsg(m); err != nil {
-		p.t.Fatalf("WriteMsg() failed: %v", err)
-	}
-	return dns.RcodeSuccess, nil
-}
-
-func mustPackSignedTSIGQuery(t *testing.T, keyName, secret string, tsigTime int64) []byte {
-	t.Helper()
-
-	m := new(dns.Msg)
-	m.SetQuestion("example.com.", dns.TypeA)
-	m.SetTsig(keyName, dns.HmacSHA256, 300, tsigTime)
-
-	wire, _, err := dns.TsigGenerate(m, secret, "", false)
-	if err != nil {
-		t.Fatalf("dns.TsigGenerate() failed: %v", err)
-	}
-	return wire
-}
-
 func TestNewServergRPC(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -504,12 +467,12 @@ func TestServergRPC_Query_TSIGBadSigSetsTsigStatus(t *testing.T) {
 	const clientSecret = "MTIzNDU2Nzg5MDEyMzQ1Ng=="
 	const serverSecret = "QUJDREVGR0hJSktMTU5PUA=="
 
-	called := false
+	called := make(chan struct{}, 1)
 
 	server, err := NewServergRPC("127.0.0.1:0", []*Config{
 		testConfig("grpc", tsigStatusCheckPlugin{
 			t:      t,
-			called: &called,
+			called: called,
 			check: func(t *testing.T, got error) {
 				t.Helper()
 				if got == nil {
@@ -546,7 +509,9 @@ func TestServergRPC_Query_TSIGBadSigSetsTsigStatus(t *testing.T) {
 		t.Fatalf("Query() failed: %v", err)
 	}
 
-	if !called {
+	select {
+	case <-called:
+	default:
 		t.Fatal("ServeDNS() was not called")
 	}
 }
@@ -555,12 +520,12 @@ func TestServergRPC_Query_TSIGBadTimeSetsTsigStatus(t *testing.T) {
 	const keyName = "tsig-key."
 	const secret = "MTIzNDU2Nzg5MDEyMzQ1Ng=="
 
-	called := false
+	called := make(chan struct{}, 1)
 
 	server, err := NewServergRPC("127.0.0.1:0", []*Config{
 		testConfig("grpc", tsigStatusCheckPlugin{
 			t:      t,
-			called: &called,
+			called: called,
 			check: func(t *testing.T, got error) {
 				t.Helper()
 				if !errors.Is(got, dns.ErrTime) {
@@ -591,7 +556,9 @@ func TestServergRPC_Query_TSIGBadTimeSetsTsigStatus(t *testing.T) {
 		t.Fatalf("Query() failed: %v", err)
 	}
 
-	if !called {
+	select {
+	case <-called:
+	default:
 		t.Fatal("ServeDNS() was not called")
 	}
 }
@@ -600,12 +567,12 @@ func TestServergRPC_Query_TSIGValidLeavesTsigStatusNil(t *testing.T) {
 	const keyName = "tsig-key."
 	const secret = "MTIzNDU2Nzg5MDEyMzQ1Ng=="
 
-	called := false
+	called := make(chan struct{}, 1)
 
 	server, err := NewServergRPC("127.0.0.1:0", []*Config{
 		testConfig("grpc", tsigStatusCheckPlugin{
 			t:      t,
-			called: &called,
+			called: called,
 			check: func(t *testing.T, got error) {
 				t.Helper()
 				if got != nil {
@@ -636,7 +603,9 @@ func TestServergRPC_Query_TSIGValidLeavesTsigStatusNil(t *testing.T) {
 		t.Fatalf("Query() failed: %v", err)
 	}
 
-	if !called {
+	select {
+	case <-called:
+	default:
 		t.Fatal("ServeDNS() was not called")
 	}
 

--- a/core/dnsserver/server_quic_test.go
+++ b/core/dnsserver/server_quic_test.go
@@ -19,44 +19,6 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-type tsigStatusCheckPlugin struct {
-	t      *testing.T
-	check  func(*testing.T, error)
-	called chan struct{}
-}
-
-func (p tsigStatusCheckPlugin) Name() string { return "tsig-status-check" }
-
-func (p tsigStatusCheckPlugin) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	p.t.Helper()
-	if p.called != nil {
-		p.called <- struct{}{}
-	}
-	p.check(p.t, w.TsigStatus())
-
-	m := new(dns.Msg)
-	m.SetReply(r)
-	if err := w.WriteMsg(m); err != nil {
-		p.t.Fatalf("WriteMsg() failed: %v", err)
-	}
-	return dns.RcodeSuccess, nil
-}
-
-func mustPackSignedTSIGQuery(t *testing.T, keyName, secret string, tsigTime int64) []byte {
-	t.Helper()
-
-	m := new(dns.Msg)
-	m.SetQuestion("example.com.", dns.TypeA)
-	m.Id = 0
-	m.SetTsig(keyName, dns.HmacSHA256, 300, tsigTime)
-
-	wire, _, err := dns.TsigGenerate(m, secret, "", false)
-	if err != nil {
-		t.Fatalf("dns.TsigGenerate() failed: %v", err)
-	}
-	return wire
-}
-
 func TestNewServerQUIC(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/core/dnsserver/tsig_test.go
+++ b/core/dnsserver/tsig_test.go
@@ -1,0 +1,46 @@
+package dnsserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+type tsigStatusCheckPlugin struct {
+	t      *testing.T
+	check  func(*testing.T, error)
+	called chan struct{}
+}
+
+func (p tsigStatusCheckPlugin) Name() string { return "tsig-status-check" }
+
+func (p tsigStatusCheckPlugin) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	p.t.Helper()
+	if p.called != nil {
+		p.called <- struct{}{}
+	}
+	p.check(p.t, w.TsigStatus())
+
+	m := new(dns.Msg)
+	m.SetReply(r)
+	if err := w.WriteMsg(m); err != nil {
+		p.t.Fatalf("WriteMsg() failed: %v", err)
+	}
+	return dns.RcodeSuccess, nil
+}
+
+func mustPackSignedTSIGQuery(t *testing.T, keyName, secret string, tsigTime int64) []byte {
+	t.Helper()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.Id = 0
+	m.SetTsig(keyName, dns.HmacSHA256, 300, tsigTime)
+
+	wire, _, err := dns.TsigGenerate(m, secret, "", false)
+	if err != nil {
+		t.Fatalf("dns.TsigGenerate() failed: %v", err)
+	}
+	return wire
+}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Extract `tsigStatusCheckPlugin` and `mustPackSignedTSIGQuery` into a shared `tsig_test.go` to fix compilation errors caused by duplicate type definitions across gRPC and QUIC server tests.

Unify the called field type to chan struct{} for both gRPC and QUIC tests for consistency.

### 2. Which issues (if any) are related?

Surfaced after merging #8006 and #8007, without rebasing in between. See CI logs from `master`: https://github.com/coredns/coredns/actions/runs/23975694959/job/69932281671

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.