### PR TITLE
fix(tls): use temp dir for keylog test path

### DIFF
--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTLS(t *testing.T) {
+	tmpDir := t.TempDir()
 	tests := []struct {
 		input              string
 		shouldErr          bool
@@ -25,7 +26,7 @@ func TestTLS(t *testing.T) {
 		{"tls test_cert.pem test_key.pem test_ca.pem {\nclient_auth require\n}", false, "", ""},
 		{"tls test_cert.pem test_key.pem test_ca.pem {\nclient_auth verify_if_given\n}", false, "", ""},
 		{"tls test_cert.pem test_key.pem test_ca.pem {\nclient_auth require_and_verify\n}", false, "", ""},
-		{"tls test_cert.pem test_key.pem test_ca.pem {\nkeylog tls.log\n}", false, "", ""},
+		{"tls test_cert.pem test_key.pem test_ca.pem {\nkeylog " + filepath.Join(tmpDir, "tls.log") + "\n}", false, "", ""},
 		// negative
 		{"tls test_cert.pem test_key.pem test_ca.pem {\nunknown\n}", true, "", "unknown option"},
 		// client_auth takes exactly one parameter, which must be one of known keywords.


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The keylog test case in `TestTLS` used a relative path, causing a `tls.log` file to be left in the source tree after each test run. Use `t.TempDir()` so the file is automatically cleaned up.

### 2. Which issues (if any) are related?

Missed from #7537 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.