### PR TITLE
ci: limit push trigger to master branch

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -1,5 +1,9 @@
 name: Go Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 permissions:
   contents: read
 


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The `go.test` workflow triggered on both `push` and `pull_request` events, causing duplicate runs on every PR. Restrict push to the `master` branch so PRs only run the `pull_request` event.

### 2. Which issues (if any) are related?

None, cleanup.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
