### PR TITLE
fix(file): normalize escaped owner labels in tree lookups

### DIFF
--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -181,6 +181,41 @@ func TestLookup(t *testing.T) {
 	}
 }
 
+func TestLookupDecimalEscapedOwnerName(t *testing.T) {
+	const zoneData = `campus.edu.              500 IN SOA ns1.outside.edu. root.campus.edu. 8 6048 4000 2419200 6048
+campus.edu.              500 IN NS  ns1.outside.edu.
+has\046dot.campus.edu.   500 IN A   192.0.2.2
+`
+
+	zone, err := Parse(strings.NewReader(zoneData), "campus.edu.", "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expected no error when reading zone, got %q", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{"campus.edu.": zone}, Names: []string{"campus.edu."}}}
+	ctx := context.TODO()
+
+	tc := test.Case{
+		Qname: "has\\.dot.campus.edu.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("has\\046dot.campus.edu. 500 IN A 192.0.2.2"),
+		},
+		Ns: []dns.RR{
+			test.NS("campus.edu. 500 IN NS ns1.outside.edu."),
+		},
+	}
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	_, err = fm.ServeDNS(ctx, rec, tc.Msg())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if err := test.SortAndCheck(rec.Msg, tc); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLookupNil(_t *testing.T) {
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: nil}, Names: []string{testzone}}}
 	ctx := context.TODO()

--- a/plugin/file/tree/less.go
+++ b/plugin/file/tree/less.go
@@ -25,12 +25,8 @@ func less(a, b string) int {
 			return 0
 		}
 
-		// sadly this []byte will allocate... TODO(miek): check if this is needed
-		// for a name, otherwise compare the strings.
-		ab := []byte(strings.ToLower(a[ai:aj]))
-		bb := []byte(strings.ToLower(b[bi:bj]))
-		doDDD(ab)
-		doDDD(bb)
+		ab := normalizeLabel(a[ai:aj])
+		bb := normalizeLabel(b[bi:bj])
 
 		res := bytes.Compare(ab, bb)
 		if res != 0 {
@@ -41,17 +37,29 @@ func less(a, b string) int {
 	}
 }
 
-func doDDD(b []byte) {
-	lb := len(b)
-	for i := 0; i < lb; i++ {
-		if i+3 < lb && b[i] == '\\' && isDigit(b[i+1]) && isDigit(b[i+2]) && isDigit(b[i+3]) {
-			b[i] = dddToByte(b[i:])
-			for j := i + 1; j < lb-3; j++ {
-				b[j] = b[j+3]
-			}
-			lb -= 3
+func normalizeLabel(label string) []byte {
+	// Compare canonical label bytes, not presentation-format escapes.
+	b := []byte(strings.ToLower(label))
+	lb := 0
+	for i := 0; i < len(b); i++ {
+		if b[i] != '\\' || i+1 >= len(b) {
+			b[lb] = b[i]
+			lb++
+			continue
 		}
+
+		if i+3 < len(b) && isDigit(b[i+1]) && isDigit(b[i+2]) && isDigit(b[i+3]) {
+			b[lb] = dddToByte(b[i:])
+			i += 3
+			lb++
+			continue
+		}
+
+		b[lb] = b[i+1]
+		i++
+		lb++
 	}
+	return b[:lb]
 }
 
 func isDigit(b byte) bool     { return b >= '0' && b <= '9' }

--- a/plugin/file/tree/less.go
+++ b/plugin/file/tree/less.go
@@ -40,6 +40,10 @@ func less(a, b string) int {
 func normalizeLabel(label string) []byte {
 	// Compare canonical label bytes, not presentation-format escapes.
 	b := []byte(strings.ToLower(label))
+	if bytes.IndexByte(b, '\\') < 0 {
+		return b
+	}
+
 	lb := 0
 	for i := 0; i < len(b); i++ {
 		if b[i] != '\\' || i+1 >= len(b) {

--- a/plugin/file/tree/less_test.go
+++ b/plugin/file/tree/less_test.go
@@ -98,6 +98,25 @@ func TestLess_EmptyVsEmpty(t *testing.T) {
 	}
 }
 
+func TestLess_EquivalentEscapes(t *testing.T) {
+	tests := []struct {
+		a string
+		b string
+	}{
+		{a: "has\\046dot.example.", b: "has\\.dot.example."},
+		{a: "escaped\\032space.example.", b: "escaped\\ space.example."},
+	}
+
+	for _, tc := range tests {
+		if d := less(tc.a, tc.b); d != 0 {
+			t.Fatalf("expected %q and %q to compare equal, got %d", tc.a, tc.b, d)
+		}
+		if d := less(tc.b, tc.a); d != 0 {
+			t.Fatalf("expected %q and %q to compare equal, got %d", tc.b, tc.a, d)
+		}
+	}
+}
+
 // Test that concurrent calls to Less (which calls Elem.Name) do not race or panic.
 // See issue #7561 for reference.
 func TestLess_ConcurrentNameAccess(t *testing.T) {
@@ -122,7 +141,7 @@ func TestLess_ConcurrentNameAccess(t *testing.T) {
 }
 
 func BenchmarkLess(b *testing.B) {
-	// The original less function, serving as the benchmark test baseline.
+	// A copy of the comparison loop, serving as the benchmark test baseline.
 	less0 := func(a, b string) int {
 		i := 1
 		aj := len(a)
@@ -136,10 +155,8 @@ func BenchmarkLess(b *testing.B) {
 
 			// sadly this []byte will allocate... TODO(miek): check if this is needed
 			// for a name, otherwise compare the strings.
-			ab := []byte(strings.ToLower(a[ai:aj]))
-			bb := []byte(strings.ToLower(b[bi:bj]))
-			doDDD(ab)
-			doDDD(bb)
+			ab := normalizeLabel(a[ai:aj])
+			bb := normalizeLabel(b[bi:bj])
 
 			res := bytes.Compare(ab, bb)
 			if res != 0 {

--- a/plugin/file/tree/less_test.go
+++ b/plugin/file/tree/less_test.go
@@ -105,6 +105,9 @@ func TestLess_EquivalentEscapes(t *testing.T) {
 	}{
 		{a: "has\\046dot.example.", b: "has\\.dot.example."},
 		{a: "escaped\\032space.example.", b: "escaped\\ space.example."},
+		{a: "slash\\\\back.example.", b: "slash\\092back.example."},
+		{a: "\\097.example.", b: "a.example."},
+		{a: "has\\046dot.example.", b: "has\\046dot.example."},
 	}
 
 	for _, tc := range tests {
@@ -113,6 +116,26 @@ func TestLess_EquivalentEscapes(t *testing.T) {
 		}
 		if d := less(tc.b, tc.a); d != 0 {
 			t.Fatalf("expected %q and %q to compare equal, got %d", tc.b, tc.a, d)
+		}
+	}
+}
+
+func TestLess_MixedEscapedAndPlainSortOrder(t *testing.T) {
+	names := []string{
+		"hasdot.example.",
+		"has\\.dot.example.",
+		"has.example.",
+	}
+	want := []string{
+		"has.example.",
+		"has\\.dot.example.",
+		"hasdot.example.",
+	}
+
+	sort.Sort(set(names))
+	for i := range names {
+		if names[i] != want[i] {
+			t.Fatalf("expected %q at index %d, got %q", want[i], i, names[i])
 		}
 	}
 }
@@ -141,7 +164,22 @@ func TestLess_ConcurrentNameAccess(t *testing.T) {
 }
 
 func BenchmarkLess(b *testing.B) {
-	// A copy of the comparison loop, serving as the benchmark test baseline.
+	normalizeLabel0 := func(label string) []byte {
+		b := []byte(strings.ToLower(label))
+		lb := len(b)
+		for i := 0; i < lb; i++ {
+			if i+3 < lb && b[i] == '\\' && isDigit(b[i+1]) && isDigit(b[i+2]) && isDigit(b[i+3]) {
+				b[i] = dddToByte(b[i:])
+				for j := i + 1; j < lb-3; j++ {
+					b[j] = b[j+3]
+				}
+				lb -= 3
+			}
+		}
+		return b[:lb]
+	}
+
+	// The original less function, serving as the benchmark test baseline.
 	less0 := func(a, b string) int {
 		i := 1
 		aj := len(a)
@@ -155,8 +193,8 @@ func BenchmarkLess(b *testing.B) {
 
 			// sadly this []byte will allocate... TODO(miek): check if this is needed
 			// for a name, otherwise compare the strings.
-			ab := normalizeLabel(a[ai:aj])
-			bb := normalizeLabel(b[bi:bj])
+			ab := normalizeLabel0(a[ai:aj])
+			bb := normalizeLabel0(b[bi:bj])
 
 			res := bytes.Compare(ab, bb)
 			if res != 0 {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The file plugin stores owner names in presentation form, but the tree comparator only handled decimal escapes incompletely. As a result, records loaded from names like `has\046dot.example.` could not be found by normal queries such as `has\.dot.example.`.

This change normalizes escaped label bytes before tree comparisons so RFC 1035 decimal escapes and equivalent single-character escapes compare identically. It also adds a tree-level regression test and an end-to-end file plugin lookup test for the reported case.

### 2. Which issues (if any) are related?

Fixes #8012

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.