### PR TITLE
Fix data race in xfr.go

### DIFF
--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -19,8 +19,12 @@ func (f File) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
 // Transfer transfers a zone with serial in the returned channel and implements IXFR fallback, by just
 // sending a single SOA record.
 func (z *Zone) Transfer(serial uint32) (<-chan []dns.RR, error) {
-	// get soa and apex
-	apex, err := z.ApexIfDefined()
+	// Snapshot apex and tree under one read lock so the goroutine walks the
+	// same generation the SOA came from, even if TransferIn swaps them mid-AXFR.
+	z.RLock()
+	apex, err := z.apexIfDefinedLocked()
+	t := z.Tree
+	z.RUnlock()
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +39,7 @@ func (z *Zone) Transfer(serial uint32) (<-chan []dns.RR, error) {
 		}
 
 		ch <- apex
-		z.Walk(func(e *tree.Elem, _ map[uint16][]dns.RR) error { ch <- e.All(); return nil })
+		t.Walk(func(e *tree.Elem, _ map[uint16][]dns.RR) error { ch <- e.All(); return nil })
 		ch <- []dns.RR{apex[0]}
 
 		close(ch)

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -146,6 +146,11 @@ func (z *Zone) SetFile(path string) {
 func (z *Zone) ApexIfDefined() ([]dns.RR, error) {
 	z.RLock()
 	defer z.RUnlock()
+	return z.apexIfDefinedLocked()
+}
+
+// apexIfDefinedLocked is ApexIfDefined without locking; caller must hold z's read lock.
+func (z *Zone) apexIfDefinedLocked() ([]dns.RR, error) {
 	if z.SOA == nil {
 		return nil, fmt.Errorf("no SOA")
 	}

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -290,7 +290,7 @@ func TestSecondaryZoneNotify(t *testing.T) {
 		if len(r.Answer) != 0 {
 			break
 		}
-		time.Sleep(1000 * time.Microsecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if len(r.Answer) == 0 {
 		t.Fatalf("Expected answer section")
@@ -323,7 +323,7 @@ www    IN A    127.0.0.1
 		if len(r.Answer) != 0 {
 			break
 		}
-		time.Sleep(1000 * time.Microsecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if len(r.Answer) != 1 {
 		t.Fatalf("Expected one RR in answer section got %d", len(r.Answer))


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fixes a data race in xfr.go

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/8038

```
go test -race -run '^TestSecondaryZoneNotify$' -count=200 -cpu=2,4 ./test/
```
pretty reliably triggers a race for me on master, and with this fix it reliably passes
```
$ go test -race -run '^TestSecondaryZoneNotify$' -count=200 -cpu=2,4 ./test/
ok      github.com/coredns/coredns/test 80.972s
```

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

none