### PR TITLE
fix(dnssec) TestDelegationUnSigned: Potential nil pointer dereference

### DIFF
--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -169,7 +169,10 @@ func TestDelegationUnSigned(t *testing.T) {
 		}
 	}
 	if nsec == nil {
-		t.Error("Authority section should hold a NSEC record")
+		t.Fatal("Authority section should hold a NSEC record")
+	}
+	if rrsig == nil {
+		t.Fatal("Authority section should hold a RRSIG record")
 	}
 	if rrsig.TypeCovered != dns.TypeNSEC {
 		t.Errorf("RRSIG should cover type %s, got %s",


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes potential nil pointer dereference (on access to rrsig.TypeCovered) in UT TestDelegationUnSigned (in case test or called function would be modified).

### 2. Which issues (if any) are related?
no

### 3. Which documentation changes (if any) need to be made?
not need

### 4. Does this introduce a backward incompatible change or deprecation?
no