### PR TITLE
plugin/dane: New plugin to simplify TLSA record setup

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -46,6 +46,7 @@ var Directives = []string{
 	"acl",
 	"header",
 	"dnssec",
+	"dane",
 	"autopath",
 	"minimal",
 	"template",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/cancel"
 	_ "github.com/coredns/coredns/plugin/chaos"
 	_ "github.com/coredns/coredns/plugin/clouddns"
+	_ "github.com/coredns/coredns/plugin/dane"
 	_ "github.com/coredns/coredns/plugin/debug"
 	_ "github.com/coredns/coredns/plugin/dns64"
 	_ "github.com/coredns/coredns/plugin/dnssec"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -55,6 +55,7 @@ rewrite:rewrite
 acl:acl
 header:header
 dnssec:dnssec
+dane:dane
 autopath:autopath
 minimal:minimal
 template:template

--- a/plugin/dane/README.md
+++ b/plugin/dane/README.md
@@ -1,0 +1,39 @@
+
+# dane
+
+## Name
+
+*dane* - generates TLSA responses from certificate files.
+
+## Description
+
+*dane* simplifies rotating TLS certificates that are served over DNS.
+An upstream plugin such as *file* can return a dummy value in certificate association data
+which is then replaced by the real value computed from the PEM certificate file.
+
+## Syntax
+
+~~~ txt
+dane [ZONES...] {
+    file KEY PATH
+}
+~~~
+
+* **ZONES** zones that should have their responses rewritten. If empty, the zones from the
+configuration block are used.
+* `file` indicates that the **KEY** association data should be replaced by association data
+computed from **FILE**. This directive can be specified more than once.
+
+## Examples
+
+Respond to `_25._tcp.example.org` with a TLSA response using data from `fullchain.pem`
+~~~ txt
+example.org {
+    records {
+        _25._tcp 60 IN TLSA 2 0 1 EE
+    }
+    dane {
+        file EE fullchain.pem
+    }
+}
+~~~

--- a/plugin/dane/dane.go
+++ b/plugin/dane/dane.go
@@ -1,0 +1,101 @@
+package dane
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/response"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Dane is a plugin that automatically generates TLSA records from certificate files
+type Dane struct {
+	Next         plugin.Handler
+	Zones        []string
+	Certificates map[string][]string
+}
+
+var (
+	ErrInvalidUpstreamResponse = errors.New("invalid upstream response")
+	ErrUnsupportedMatchingType = errors.New("unsupported matching type")
+)
+
+// ResponseWriter replaces "dummy" TLSA responses with real certificate contents
+type ResponseWriter struct {
+	dns.ResponseWriter
+	d *Dane
+}
+
+func certIndex(usage, selector, matching uint8) (uint, error) {
+	if usage > 3 || selector > 1 || matching > 2 {
+		return 0, ErrInvalidUpstreamResponse
+	}
+	if matching == 0 {
+		return 0, ErrUnsupportedMatchingType
+	}
+	if usage > 1 {
+		usage -= 2
+	}
+	return uint(usage) | (uint(selector) << 1) | (uint(matching-1) << 2), nil
+}
+
+// WriteMsg implements the dns.ResponseWriter interface.
+func (d *ResponseWriter) WriteMsg(res *dns.Msg) error {
+	mt, _ := response.Typify(res, time.Now().UTC())
+	if mt != response.NoError {
+		return d.ResponseWriter.WriteMsg(res)
+	}
+
+	var resCopy *dns.Msg
+	for i, rr := range res.Answer {
+		if rr.Header().Rrtype != dns.TypeTLSA {
+			continue
+		}
+		tlsaRr := rr.(*dns.TLSA)
+		replacements, ok := d.d.Certificates[tlsaRr.Certificate]
+		if !ok {
+			continue
+		}
+		idx, err := certIndex(tlsaRr.Usage, tlsaRr.Selector, tlsaRr.MatchingType)
+		if err != nil {
+			return err
+		}
+		if resCopy == nil {
+			resCopy = res.Copy()
+		}
+		tgtRr := resCopy.Answer[i].(*dns.TLSA)
+		tgtRr.Certificate = replacements[idx]
+	}
+	if resCopy != nil {
+		return d.ResponseWriter.WriteMsg(resCopy)
+	}
+	return d.ResponseWriter.WriteMsg(res)
+}
+
+// Write implements the dns.ResponseWriter interface.
+func (d *ResponseWriter) Write(buf []byte) (int, error) {
+	log.Warning("Dane called with Write: not rewriting reply")
+	n, err := d.ResponseWriter.Write(buf)
+	return n, err
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (d *Dane) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	zone := plugin.Zones(d.Zones).Matches(state.Name())
+	if zone == "" {
+		return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
+	}
+
+	drr := &ResponseWriter{w, d}
+	return plugin.NextOrFailure(d.Name(), d.Next, ctx, drr, r)
+}
+
+// Name implements the Handler interface.
+func (d *Dane) Name() string { return "dane" }

--- a/plugin/dane/dane_test.go
+++ b/plugin/dane/dane_test.go
@@ -1,0 +1,95 @@
+package dane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/file"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+const dbMiekNL = `
+$TTL    30M
+$ORIGIN miek.nl.
+@       IN      SOA     linode.atoom.net. miek.miek.nl. (
+                             1282630057 ; Serial
+                             4H         ; Refresh
+                             1H         ; Retry
+                             7D         ; Expire
+                             4H )       ; Negative Cache TTL
+                        A 1.1.1.1
+_25._tcp                TLSA    3 1 1 01
+_26._tcp                TLSA    2 0 1 01
+_27._tcp                TLSA    2 0 1 96BCEC06264976F37460779ACF28C5A7CFE8A3C0AAE11A8FFCEE05C0BDDF08C6
+_27._tcp                TXT     "asdf"
+`
+
+var dnsTestCases = []test.Case{
+	{
+		Qname: "_25._tcp.miek.nl.", Qtype: dns.TypeTLSA,
+		Answer: []dns.RR{
+			test.TLSA("_25._tcp.miek.nl.	1800	IN	TLSA	3 1 1 F4"),
+		},
+	},
+	{
+		Qname: "_26._tcp.miek.nl.", Qtype: dns.TypeTLSA,
+		Answer: []dns.RR{
+			test.TLSA("_26._tcp.miek.nl.	1800	IN	TLSA	2 0 1 F1"),
+		},
+	},
+	{
+		Qname: "_27._tcp.miek.nl.", Qtype: dns.TypeTLSA,
+		Answer: []dns.RR{
+			test.TLSA("_27._tcp.miek.nl.	1800	IN	TLSA	2 0 1 96BCEC06264976F37460779ACF28C5A7CFE8A3C0AAE11A8FFCEE05C0BDDF08C6"),
+		},
+	},
+	{
+		Qname: "_27._tcp.miek.nl.", Qtype: dns.TypeTXT,
+		Answer: []dns.RR{
+			test.TXT("_27._tcp.miek.nl.	1800	IN	TXT     \"asdf\""),
+		},
+	},
+	{
+		Qname: "miek.nl.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("miek.nl.	1800	IN	A	1.1.1.1"),
+		},
+	},
+}
+
+func TestDane_Replacement(t *testing.T) {
+	zone, err := file.Parse(strings.NewReader(dbMiekNL), "miek.nl.", "stdin", 0)
+	if err != nil {
+		return
+	}
+	fm := file.File{Next: test.ErrorHandler(), Zones: file.Zones{Z: map[string]*file.Zone{"miek.nl.": zone}, Names: []string{"miek.nl."}}}
+
+	d := Dane{
+		Next:  fm,
+		Zones: []string{"miek.nl."},
+		Certificates: map[string][]string{
+			"01": {
+				"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8",
+			},
+		},
+	}
+
+	for _, tc := range dnsTestCases {
+		m := tc.Msg()
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		_, err := d.ServeDNS(context.TODO(), rec, m)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+			return
+		}
+
+		if err := test.SortAndCheck(rec.Msg, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/plugin/dane/setup.go
+++ b/plugin/dane/setup.go
@@ -1,0 +1,137 @@
+package dane
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+)
+
+func init() { plugin.Register("dane", setup) }
+
+func setup(c *caddy.Controller) error {
+	d, err := daneParse(c)
+	if err != nil {
+		return plugin.Error("dane", err)
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		d.Next = next
+		return d
+	})
+
+	return nil
+}
+
+func fillRecordFromBlock(block *pem.Block, usage uint8, target []string) error {
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("unable to parse certificate: %s", err)
+	}
+	pk, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		return fmt.Errorf("unable to serialize certificate public key: %s", err)
+	}
+	hash256 := sha256.Sum256(block.Bytes)
+	idx, _ := certIndex(usage, 0, 1)
+	target[idx] = hex.EncodeToString(hash256[:])
+	hash512 := sha512.Sum512(block.Bytes)
+	idx, _ = certIndex(usage, 0, 2)
+	target[idx] = hex.EncodeToString(hash512[:])
+	hash256 = sha256.Sum256(pk)
+	idx, _ = certIndex(usage, 1, 1)
+	target[idx] = hex.EncodeToString(hash256[:])
+	hash512 = sha512.Sum512(pk)
+	idx, _ = certIndex(usage, 1, 2)
+	target[idx] = hex.EncodeToString(hash512[:])
+	return nil
+}
+
+func generateRecords(fileName string) ([]string, error) {
+	reader, err := os.Open(filepath.Clean(fileName))
+	if err != nil {
+		return nil, plugin.Error("dane", err)
+	}
+	defer reader.Close()
+	bytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, plugin.Error("dane", err)
+	}
+	var first *pem.Block
+	var last *pem.Block
+	for {
+		var block *pem.Block
+		block, bytes = pem.Decode(bytes)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if first == nil {
+			first = block
+		}
+		last = block
+	}
+	if first == nil {
+		return nil, plugin.Error("dane", errors.New("no certificates found in file"))
+	}
+	records := make([]string, 8)
+	err = fillRecordFromBlock(first, 1, records)
+	if err != nil {
+		return nil, plugin.Error("dane", err)
+	}
+	err = fillRecordFromBlock(last, 0, records)
+	if err != nil {
+		return nil, plugin.Error("dane", err)
+	}
+	return records, nil
+}
+
+func daneParse(c *caddy.Controller) (*Dane, error) {
+	config := dnsserver.GetConfig(c)
+
+	d := &Dane{
+		Certificates: make(map[string][]string),
+	}
+
+	if c.Next() {
+		d.Zones = plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
+
+		for c.NextBlock() {
+			switch x := c.Val(); x {
+			case "file":
+				if !c.NextArg() {
+					return nil, c.ArgErr()
+				}
+				key := c.Val()
+				if !c.NextArg() {
+					return nil, c.ArgErr()
+				}
+				fileName := c.Val()
+
+				if !filepath.IsAbs(fileName) && config.Root != "" {
+					fileName = filepath.Join(config.Root, fileName)
+				}
+				var err error
+				d.Certificates[key], err = generateRecords(fileName)
+				if err != nil {
+					return nil, err
+				}
+			default:
+				return nil, c.Errf("unknown property '%s'", x)
+			}
+		}
+	}
+	return d, nil
+}

--- a/plugin/dane/setup_test.go
+++ b/plugin/dane/setup_test.go
@@ -1,0 +1,99 @@
+package dane
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coredns/caddy"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDane_Setup(t *testing.T) {
+	if err := os.WriteFile("fullchain.pem", []byte(fullchain), 0644); err != nil {
+		t.Fatalf("Failed to write certificate chain file: %s", err)
+	}
+	defer func() { os.Remove("fullchain.pem") }()
+
+	c := caddy.NewTestController("dns", config)
+	d, e := daneParse(c)
+	if e != nil {
+		t.Errorf("unexpected error: %s", e)
+	}
+	require.Equal(t, map[string][]string{
+		"01": {
+			"96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6",
+			"aeb1fd7410e83bc96f5da3c6a7c2c1bb836d1fa5cb86e708515890e428a8770b",
+			"0b9fa5a59eed715c26c1020c711b4f6ec42d58b0015e14337a39dad301c5afc3",
+			"cbbc559b44d524d6a132bdac672744da3407f12aae5d5f722c5f6c7913871c75",
+			"3b40f27e828323f5b91f8909883a78a21c86551761f27b38029faaec14af5b7aa96fb9f9cc93ee201b5eb1d0fef17b290747e8b839d2e49a8f36c5ebf3c7c910",
+			"e18f3d6ccbc578f025c3c7c29ed7bffe1b8eef5b1f839c17298dcf218303d2a63e305f6c1f489691774a18bad836035e5af2de1fc42a3a26cfe9e530f92e3855",
+			"86db73fc5893c3ea76db8e7d72dc8fb568d71ca8d7cbf75ac0660221ff39f8ebf7f8de906a45be19e9b743f24eda845dc3bdf36d095c237400caea9ec0a2f5dd",
+			"7d779dd26d37ca5a72fd05f1b815a06078c8e09777697c651fbe012c8d2894e048fcfe24160ee1562602240b6bef44e00f2b7340c84546d6110842bbdeb484a7",
+		},
+	}, d.Certificates)
+}
+
+const config = `dane example.com {
+    file 01 fullchain.pem
+`
+
+const fullchain = `
+-----BEGIN CERTIFICATE-----
+MIIEVzCCAj+gAwIBAgIRAKp18eYrjwoiCWbTi7/UuqEwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjQwMzEzMDAwMDAw
+WhcNMjcwMzEyMjM1OTU5WjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
+RW5jcnlwdDELMAkGA1UEAxMCRTcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARB6AST
+CFh/vjcwDMCgQer+VtqEkz7JANurZxLP+U9TCeioL6sp5Z8VRvRbYk4P1INBmbef
+QHJFHCxcSjKmwtvGBWpl/9ra8HW0QDsUaJW2qOJqceJ0ZVFT3hbUHifBM/2jgfgw
+gfUwDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcD
+ATASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSuSJ7chx1EoG/aouVgdAR4
+wpwAgDAfBgNVHSMEGDAWgBR5tFnme7bl5AFzgAiIyBpY9umbbjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAKGFmh0dHA6Ly94MS5pLmxlbmNyLm9yZy8wEwYDVR0g
+BAwwCjAIBgZngQwBAgEwJwYDVR0fBCAwHjAcoBqgGIYWaHR0cDovL3gxLmMubGVu
+Y3Iub3JnLzANBgkqhkiG9w0BAQsFAAOCAgEAjx66fDdLk5ywFn3CzA1w1qfylHUD
+aEf0QZpXcJseddJGSfbUUOvbNR9N/QQ16K1lXl4VFyhmGXDT5Kdfcr0RvIIVrNxF
+h4lqHtRRCP6RBRstqbZ2zURgqakn/Xip0iaQL0IdfHBZr396FgknniRYFckKORPG
+yM3QKnd66gtMst8I5nkRQlAg/Jb+Gc3egIvuGKWboE1G89NTsN9LTDD3PLj0dUMr
+OIuqVjLB8pEC6yk9enrlrqjXQgkLEYhXzq7dLafv5Vkig6Gl0nuuqjqfp0Q1bi1o
+yVNAlXe6aUXw92CcghC9bNsKEO1+M52YY5+ofIXlS/SEQbvVYYBLZ5yeiglV6t3S
+M6H+vTG0aP9YHzLn/KVOHzGQfXDP7qM5tkf+7diZe7o2fw6O7IvN6fsQXEQQj8TJ
+UXJxv2/uJhcuy/tSDgXwHM8Uk34WNbRT7zGTGkQRX0gsbjAea/jYAoWv0ZvQRwpq
+Pe79D/i7Cep8qWnA+7AE/3B3S/3dEEYmc0lpe1366A/6GEgk3ktr9PEoQrLChs6I
+tu3wnNLB2euC8IKGLQFpGtOO/2/hiAKjyajaBP25w1jF0Wl8Bbqne3uZ2q1GyPFJ
+YRmT7/OXpmOH/FVLtwS+8ng1cAmpCujPwteJZNcDG0sF2n/sc0+SQf49fdyUK0ty
++VUwFj9tmWxyR/M=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----
+`

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -117,6 +117,9 @@ func SVCB(rr string) *dns.SVCB { r, _ := dns.NewRR(rr); return r.(*dns.SVCB) }
 // HTTPS returns an HTTPS record from rr. It panics on errors.
 func HTTPS(rr string) *dns.HTTPS { r, _ := dns.NewRR(rr); return r.(*dns.HTTPS) }
 
+// TLSA returns an TLSA record from rr. It panics on errors.
+func TLSA(rr string) *dns.TLSA { r, _ := dns.NewRR(rr); return r.(*dns.TLSA) }
+
 // OPT returns an OPT record with UDP buffer size set to bufsize and the DO bit set to do.
 func OPT(bufsize int, do bool) *dns.OPT {
 	o := new(dns.OPT)
@@ -283,6 +286,20 @@ func Section(tc Case, sec sect, rr []dns.RR) error {
 			}
 			if x.String() != tt.String() {
 				return fmt.Errorf("RR %d should have value %q, but has %q", i, tt.String(), x.String())
+			}
+		case *dns.TLSA:
+			tt := section[i].(*dns.TLSA)
+			if x.Selector != tt.Selector {
+				return fmt.Errorf("RR %d should have a Selector of %d, but has %d", i, tt.Selector, x.Selector)
+			}
+			if x.MatchingType != tt.MatchingType {
+				return fmt.Errorf("RR %d should have a MatchingType of %d, but has %d", i, tt.MatchingType, x.MatchingType)
+			}
+			if x.Usage != tt.Usage {
+				return fmt.Errorf("RR %d should have a Usage of %d, but has %d", i, tt.Usage, x.Usage)
+			}
+			if x.Certificate != tt.Certificate {
+				return fmt.Errorf("RR %d should have a Certificate of %s, but has %s", i, tt.Certificate, x.Certificate)
 			}
 		}
 	}


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?
A plugin to simplify DANE setup by generating records directly from the certificate files instead of having to rely on ad hoc scripts to rewrite zone files on certificate renewals.
### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
New plugin documentation (included in this PR)
### 4. Does this introduce a backward incompatible change or deprecation?
No