### PR TITLE
plugin/dns64: add filter_a option and EDE transparency signals

### DIFF
--- a/plugin/dns64/README.md
+++ b/plugin/dns64/README.md
@@ -13,6 +13,8 @@ The synthesis is *only* performed **if the query came in via IPv6**.
 
 This translation is for IPv6-only networks that have [NAT64](https://en.wikipedia.org/wiki/NAT64).
 
+Synthesised responses carry [RFC 8914](https://tools.ietf.org/html/rfc8914) Extended DNS Error code 29 ("Synthesized") so EDNS-aware clients can tell that the AAAA was produced by DNS64 rather than served from upstream. Per RFC 6891 the plugin only attaches the OPT record (and therefore the EDE) when the incoming client query already carried OPT.
+
 ## Syntax
 
 ~~~
@@ -28,12 +30,44 @@ dns64 [PREFIX] {
     [translate_all]
     prefix PREFIX
     [allow_ipv4]
+    [filter_a]
 }
 ~~~
 
 * `prefix` specifies any local IPv6 prefix to use, instead of the well known prefix (64:ff9b::/96)
-* `translate_all` translates all queries, including responses that have AAAA results.
+* `translate_all` runs synthesis for every AAAA query this plugin intercepts. Real AAAA records from the upstream response are **discarded** and replaced by AAAAs synthesised from the A records of the same name. Use this when clients must always reach a host through the DNS64 prefix — for example because the prefix itself is the routing target of a gateway or subnet router.
 * `allow_ipv4` Allow translating queries if they come in over IPv4, default is IPv6 only translation.
+* `filter_a` suppresses client-facing A responses for queries eligible for DNS64, replying with `NOERROR` and an empty answer section. This steers clients onto the synthesised AAAA path without them ever seeing the underlying A record. The response includes:
+    - An SOA for the queried name's enclosing zone, placed in the authority section so downstream resolvers can negative-cache the NODATA per [RFC 2308](https://tools.ietf.org/html/rfc2308). The SOA is harvested via a single internal SOA lookup (cheaply amortised when a `cache` plugin is in the chain). If the lookup fails or returns no SOA, the response is served without one rather than failing.
+    - [RFC 8914](https://tools.ietf.org/html/rfc8914) Extended DNS Error code 17 ("Filtered"), attached only when the client's query carried OPT (RFC 6891); non-EDNS clients see plain `NOERROR`/NODATA.
+
+  The plugin's own internal A lookup during synthesis is exempt, so AAAA responses continue to be synthesised normally.
+
+  `filter_a` only intercepts queries of type `A`. `ANY` queries are out of scope and will reach upstream unchanged — if upstream returns A records in the `ANY` response the client will see them. Combine with the [`any`](https://coredns.io/plugins/any/) plugin in the same server block (it implements [RFC 8482](https://tools.ietf.org/html/rfc8482) and responds to `ANY` with HINFO) if you need `ANY` traffic covered as well.
+
+### How `translate_all` and `filter_a` interact
+
+The two options are independent and can each be used on their own. They affect different query types:
+
+* `translate_all` changes how **AAAA** queries are answered (always synthesise vs. prefer real AAAA).
+* `filter_a` changes how **A** queries are answered (suppress with NODATA + EDE 17 vs. pass through).
+
+Client-visible behaviour for the four combinations:
+
+| `translate_all` | `filter_a` | Client sees for A | Client sees for AAAA |
+|:---:|:---:|---|---|
+| off | off | real A record | real AAAA if present, otherwise synthesised from A |
+| off | **on**  | NODATA + EDE 17 "Filtered" | real AAAA if present, otherwise synthesised from A |
+| **on**  | off | real A record | always synthesised (real AAAA discarded) |
+| **on**  | **on**  | NODATA + EDE 17 "Filtered" | always synthesised (real AAAA discarded) |
+
+Pick based on what you want to enforce:
+
+* Want clients to **prefer** IPv6 but still use a host's real IPv6 when it exists, and never fall back to IPv4? Use `filter_a` without `translate_all`.
+* Want clients to always route through your DNS64 prefix regardless of what's upstream? Use `translate_all`, and add `filter_a` if you also want to block the v4 fallback.
+* Want only synthesis, unchanged client-visible A records? Leave `filter_a` off.
+
+**Edge case with `translate_all`**: because `translate_all` discards the upstream AAAA and rebuilds the answer from the A lookup alone, a name that has only a real AAAA and no A will yield an empty synthesised answer. Adding `filter_a` compounds this: that name becomes unresolvable for the client on both A and AAAA. In DNS64/NAT64 deployments this is usually fine (v4-only hosts are the targets), but in mixed deployments you may want to scope the dns64 block to zones where every name has A records.
 
 ## Examples
 
@@ -85,11 +119,36 @@ This may cause unwanted IPv6 dns64 traffic when a dualstack client would normall
 }
 ~~~
 
+Prefer IPv6 everywhere: suppress A responses so dual-stack clients don't fall back to v4, but keep serving real AAAA records when the upstream has them (only synthesise when there is no AAAA).
+
+~~~ corefile
+. {
+    dns64 {
+        filter_a
+    }
+    forward . 1.1.1.1
+}
+~~~
+
+Force every eligible AAAA through the DNS64 prefix and block the v4 fallback. Useful when the prefix is the routing target (for example a NAT64 gateway or any transition mechanism that steers IPv6 traffic bearing the prefix to a specific router). Adding the `any` plugin short-circuits `ANY` queries with RFC 8482 HINFO, keeping v4 closed on that path too.
+
+~~~ corefile
+. {
+    dns64 {
+        translate_all
+        filter_a
+    }
+    any
+    forward . 1.1.1.1
+}
+~~~
+
 ## Metrics
 
 If monitoring is enabled (via the _prometheus_ plugin) then the following metrics are exported:
 
 - `coredns_dns64_requests_translated_total{server}` - counter of DNS requests translated
+- `coredns_dns64_requests_filtered_total{server}` - counter of client A queries suppressed by `filter_a`
 
 The `server` label is explained in the _prometheus_ plugin documentation.
 

--- a/plugin/dns64/dns64.go
+++ b/plugin/dns64/dns64.go
@@ -29,13 +29,82 @@ type DNS64 struct {
 	Prefix       *net.IPNet
 	TranslateAll bool // Not comply with 5.1.1
 	AllowIPv4    bool
+	FilterA      bool
 	Upstream     UpstreamInt
+}
+
+// dns64InternalKey marks contexts that belong to a query the dns64 plugin
+// spawned itself (via upstream.Lookup) while handling a client query — either
+// DoDNS64's A lookup for synthesis or filter_a's SOA lookup for negative
+// caching. When set, ServeDNS must not apply filter_a to the re-entered
+// query, otherwise the plugin would shadow its own internal work.
+type dns64InternalKey struct{}
+
+// pickSOA returns the first SOA record from msg, searching the Answer section
+// first (covers the zone-apex case) and then the Authority section (the common
+// NODATA-for-SOA-at-non-apex case). Returns nil if no SOA is present.
+func pickSOA(msg *dns.Msg) dns.RR {
+	for _, rr := range msg.Answer {
+		if rr.Header().Rrtype == dns.TypeSOA {
+			return rr
+		}
+	}
+	for _, rr := range msg.Ns {
+		if rr.Header().Rrtype == dns.TypeSOA {
+			return rr
+		}
+	}
+	return nil
+}
+
+// addEDE attaches an RFC 8914 Extended DNS Error option to msg's EDNS0 record,
+// creating the record (with a 4096-byte UDP size, advertising the server's
+// capacity per RFC 6891 §6.2.3) if none is present, or preserving the existing
+// OPT and appending the EDE option to it.
+func addEDE(msg *dns.Msg, code uint16, reason string) {
+	opt := msg.IsEdns0()
+	if opt == nil {
+		msg.SetEdns0(4096, false)
+		opt = msg.IsEdns0()
+	}
+	opt.Option = append(opt.Option, &dns.EDNS0_EDE{InfoCode: code, ExtraText: reason})
 }
 
 // ServeDNS implements the plugin.Handler interface.
 func (d *DNS64) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	// filter_a: suppress client A responses with NOERROR/NODATA + EDE 17
+	// "Filtered". Queries the plugin itself re-entered the chain for (marked
+	// via dns64InternalKey) are exempt so synthesis and the SOA lookup below
+	// keep working.
+	if d.shouldFilterA(ctx, &state) {
+		reply := new(dns.Msg)
+		reply.SetReply(r)
+		// RFC 2308 §5: a NODATA response should carry the enclosing zone's SOA
+		// in the authority section so downstream resolvers can negative-cache it.
+		// Issue an internal SOA query for the queried name — the recursor typically
+		// returns the zone SOA either in Answer (if the name is a zone apex) or
+		// in Authority (the common case). The dns64InternalKey marker prevents us
+		// from looping on our own filter.
+		lookupCtx := context.WithValue(ctx, dns64InternalKey{}, true)
+		if soaResp, err := d.Upstream.Lookup(lookupCtx, state, state.Name(), dns.TypeSOA); err == nil && soaResp != nil {
+			if soa := pickSOA(soaResp); soa != nil {
+				reply.Ns = append(reply.Ns, soa)
+			}
+		}
+		// RFC 6891 §6.1.1: only include OPT (and therefore EDE) when the client
+		// sent OPT.
+		if r.IsEdns0() != nil {
+			addEDE(reply, dns.ExtendedErrorCodeFiltered, "dns64 filter_a: A records suppressed")
+		}
+		RequestsFilteredCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
+		w.WriteMsg(reply)
+		return dns.RcodeSuccess, nil
+	}
+
 	// Don't proxy if we don't need to.
-	if !d.requestShouldIntercept(&request.Request{W: w, Req: r}) {
+	if !d.requestShouldIntercept(&state) {
 		return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
 	}
 
@@ -67,6 +136,24 @@ func (d *DNS64) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 // Name implements the Handler interface.
 func (d *DNS64) Name() string { return "dns64" }
+
+// shouldFilterA returns true if the request is a network-origin client A query
+// that should be suppressed per the filter_a option. Queries the plugin itself
+// spawned via upstream.Lookup (marked via dns64InternalKey) are always passed
+// through so synthesis and the SOA lookup keep working. filter_a only applies
+// to qtype A — ANY queries are left to the `any` plugin per RFC 8482.
+func (d *DNS64) shouldFilterA(ctx context.Context, req *request.Request) bool {
+	if !d.FilterA {
+		return false
+	}
+	if v, _ := ctx.Value(dns64InternalKey{}).(bool); v {
+		return false
+	}
+	if !d.AllowIPv4 && req.Family() == 1 {
+		return false
+	}
+	return req.QType() == dns.TypeA && req.QClass() == dns.ClassINET
+}
 
 // requestShouldIntercept returns true if the request represents one that is eligible
 // for DNS64 rewriting:
@@ -118,6 +205,7 @@ func (d *DNS64) responseShouldDNS64(origResponse *dns.Msg) bool {
 // and synthesizes the answer. Returns the response message, or error on internal failure.
 func (d *DNS64) DoDNS64(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, origResponse *dns.Msg) (*dns.Msg, error) {
 	req := request.Request{W: w, Req: r} // req is unused
+	ctx = context.WithValue(ctx, dns64InternalKey{}, true)
 	resp, err := d.Upstream.Lookup(ctx, req, req.Name(), dns.TypeA)
 	if err != nil {
 		return nil, err
@@ -172,6 +260,12 @@ func (d *DNS64) Synthesize(origReq, origResponse, resp *dns.Msg) *dns.Msg {
 			},
 			AAAA: aaaa,
 		})
+	}
+
+	// RFC 8914 EDE code 29 "Synthesized": tell EDNS-aware clients this AAAA was synthesised.
+	// Only emit OPT/EDE when the client query carried OPT (RFC 6891).
+	if origReq.IsEdns0() != nil {
+		addEDE(&ret, dns.ExtendedErrorCodeSynthesized, "DNS64 synthesised this response from A records")
 	}
 	return &ret
 }

--- a/plugin/dns64/dns64_test.go
+++ b/plugin/dns64/dns64_test.go
@@ -497,7 +497,7 @@ func TestDNS64(t *testing.T) {
 			d := DNS64{
 				Next:     &fakeHandler{t, tc.initResp},
 				Prefix:   pfx,
-				Upstream: &fakeUpstream{t, tc.req.Question[0].Name, tc.aResp},
+				Upstream: &fakeUpstream{t: t, qname: tc.req.Question[0].Name, resp: tc.aResp},
 			}
 
 			rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
@@ -537,20 +537,301 @@ func (fh *fakeHandler) Name() string {
 type fakeUpstream struct {
 	t     *testing.T
 	qname string
-	resp  *dns.Msg
+	resp  *dns.Msg // A-query response
+	soa   *dns.Msg // optional SOA-query response; nil means "no SOA found"
+}
+
+// TestSynthesizeEDE asserts that synthesised AAAA responses carry EDE code 29
+// ("Synthesized") when the client's query included OPT, and that we do not add
+// OPT (or EDE) when the client did not opt into EDNS.
+func TestSynthesizeEDE(t *testing.T) {
+	_, pfx, _ := net.ParseCIDR("64:ff9b::/96")
+
+	aResp := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 43, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+		Answer:   []dns.RR{test.A("v4only.example. 60 IN A 192.0.2.42")},
+	}
+	emptyAAAA := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 42, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
+		Ns:       []dns.RR{test.SOA("v4only.example. 70 IN SOA foo bar 1 1 1 1 1")},
+	}
+	newDNS64 := func() *DNS64 {
+		return &DNS64{
+			Next:     &fakeHandler{t, emptyAAAA},
+			Prefix:   pfx,
+			Upstream: &fakeUpstream{t: t, qname: "v4only.example.", resp: aResp},
+		}
+	}
+
+	t.Run("EDNS-aware AAAA query gets EDE 29 Synthesized", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}}}
+		req.SetEdns0(4096, false)
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		opt := rec.Msg.IsEdns0()
+		if opt == nil {
+			t.Fatal("expected OPT with EDE, got no OPT")
+		}
+		found := false
+		for _, o := range opt.Option {
+			if ede, ok := o.(*dns.EDNS0_EDE); ok && ede.InfoCode == dns.ExtendedErrorCodeSynthesized {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected EDE InfoCode %d (Synthesized), got %#v", dns.ExtendedErrorCodeSynthesized, opt.Option)
+		}
+	})
+
+	t.Run("non-EDNS AAAA query stays non-EDNS", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rec.Msg.IsEdns0() != nil {
+			t.Fatal("response must not include OPT when the query had no OPT")
+		}
+	})
+}
+
+// TestFilterA covers the filter_a option. Subtests assert:
+//   - external A queries → NOERROR/NODATA + EDE 17 (when EDNS present).
+//   - AAAA queries still synthesise (internal A lookup bypasses the filter
+//     via dns64InternalKey).
+//   - internal A lookups carrying dns64InternalKey are passed through.
+//   - RFC 6891: no OPT in query → no OPT in response.
+//   - RFC 2308: the internal SOA lookup populates the authority section, from
+//     either Answer (zone apex) or Ns (non-apex), with a graceful fallback
+//     when the lookup returns no SOA.
+//   - non-INET class is not filtered.
+func TestFilterA(t *testing.T) {
+	_, pfx, _ := net.ParseCIDR("64:ff9b::/96")
+
+	aResp := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 43, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+		Answer:   []dns.RR{test.A("v4only.example. 60 IN A 192.0.2.42")},
+	}
+	emptyAAAA := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: 42, Response: true, Rcode: dns.RcodeSuccess},
+		Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}},
+		Ns:       []dns.RR{test.SOA("v4only.example. 70 IN SOA foo bar 1 1 1 1 1")},
+	}
+
+	newDNS64 := func() *DNS64 {
+		return &DNS64{
+			Next:         &fakeHandler{t, emptyAAAA},
+			Prefix:       pfx,
+			AllowIPv4:    true,
+			FilterA:      true,
+			TranslateAll: true,
+			Upstream:     &fakeUpstream{t: t, qname: "v4only.example.", resp: aResp},
+		}
+	}
+
+	t.Run("external A suppressed with EDE 17", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		req.SetEdns0(4096, false) // EDE is only emitted when the client signalled EDNS.
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "127.0.0.1"})
+
+		rc, err := d.ServeDNS(context.Background(), rec, req)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rc != dns.RcodeSuccess {
+			t.Fatalf("rcode: want NOERROR, got %s", dns.RcodeToString[rc])
+		}
+		if len(rec.Msg.Answer) != 0 {
+			t.Fatalf("answer section: want empty, got %v", rec.Msg.Answer)
+		}
+		opt := rec.Msg.IsEdns0()
+		if opt == nil {
+			t.Fatal("expected OPT record carrying EDE, got none")
+		}
+		found := false
+		for _, o := range opt.Option {
+			if ede, ok := o.(*dns.EDNS0_EDE); ok && ede.InfoCode == dns.ExtendedErrorCodeFiltered {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected EDE InfoCode %d (Filtered) in options, got %#v", dns.ExtendedErrorCodeFiltered, opt.Option)
+		}
+	})
+
+	t.Run("AAAA still synthesised when filter_a is set", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+
+		rc, err := d.ServeDNS(context.Background(), rec, req)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rc != dns.RcodeSuccess {
+			t.Fatalf("rcode: want NOERROR, got %s", dns.RcodeToString[rc])
+		}
+		if len(rec.Msg.Answer) != 1 {
+			t.Fatalf("want 1 synthesised AAAA, got %v", rec.Msg.Answer)
+		}
+		aaaa, ok := rec.Msg.Answer[0].(*dns.AAAA)
+		if !ok {
+			t.Fatalf("want AAAA RR, got %T", rec.Msg.Answer[0])
+		}
+		want := net.ParseIP("64:ff9b::192.0.2.42")
+		if !aaaa.AAAA.Equal(want) {
+			t.Fatalf("want %s, got %s", want, aaaa.AAAA)
+		}
+	})
+
+	t.Run("internal A lookup bypasses filter_a", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+
+		// Marked exactly as DoDNS64 does before re-entering the chain.
+		ctx := context.WithValue(context.Background(), dns64InternalKey{}, true)
+
+		// fakeHandler's reply is empty-AAAA — not useful here. Swap for the A
+		// response so we can assert the internal call passes through.
+		d.Next = &fakeHandler{t, aResp}
+
+		if _, err := d.ServeDNS(ctx, rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if len(rec.Msg.Answer) != 1 || rec.Msg.Answer[0].Header().Rrtype != dns.TypeA {
+			t.Fatalf("internal A lookup should have passed through to next with an A record, got %v", rec.Msg.Answer)
+		}
+	})
+
+	t.Run("no OPT in query means no OPT in response", func(t *testing.T) {
+		// RFC 6891 forbids OPT in a response when the query had no OPT.
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "127.0.0.1"})
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rec.Msg.IsEdns0() != nil {
+			t.Fatal("response must not include OPT when the query had no OPT")
+		}
+	})
+
+	t.Run("SOA from Authority section is included for RFC 2308 negative caching", func(t *testing.T) {
+		d := newDNS64()
+		// Upstream returns NODATA for SOA-at-non-apex with the zone's SOA in Ns.
+		d.Upstream = &fakeUpstream{
+			t:     t,
+			qname: "v4only.example.",
+			soa: &dns.Msg{
+				MsgHdr: dns.MsgHdr{Response: true, Rcode: dns.RcodeSuccess},
+				Ns:     []dns.RR{test.SOA("example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 900 1209600 86400")},
+			},
+		}
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		req.SetEdns0(4096, false)
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "127.0.0.1"})
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if len(rec.Msg.Ns) != 1 {
+			t.Fatalf("want 1 SOA in authority section, got %d: %v", len(rec.Msg.Ns), rec.Msg.Ns)
+		}
+		soa, ok := rec.Msg.Ns[0].(*dns.SOA)
+		if !ok {
+			t.Fatalf("want SOA RR in authority section, got %T", rec.Msg.Ns[0])
+		}
+		if soa.Hdr.Name != "example." {
+			t.Fatalf("want SOA name example., got %s", soa.Hdr.Name)
+		}
+	})
+
+	t.Run("SOA from Answer section is included when the queried name is a zone apex", func(t *testing.T) {
+		d := newDNS64()
+		d.Upstream = &fakeUpstream{
+			t:     t,
+			qname: "apex.example.",
+			soa: &dns.Msg{
+				MsgHdr: dns.MsgHdr{Response: true, Rcode: dns.RcodeSuccess},
+				Answer: []dns.RR{test.SOA("apex.example. 3600 IN SOA ns.apex.example. hostmaster.apex.example. 1 7200 900 1209600 86400")},
+			},
+		}
+		req := &dns.Msg{Question: []dns.Question{{Name: "apex.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		req.SetEdns0(4096, false)
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "127.0.0.1"})
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if len(rec.Msg.Ns) != 1 {
+			t.Fatalf("want 1 SOA in authority section, got %d", len(rec.Msg.Ns))
+		}
+	})
+
+	t.Run("SOA lookup failure falls back to NODATA without SOA", func(t *testing.T) {
+		d := newDNS64()
+		// Upstream returns an empty message for SOA (no Answer, no Ns). Production
+		// code treats this as "no SOA" and returns NODATA without Ns — it does
+		// not SERVFAIL.
+		d.Upstream = &fakeUpstream{t: t, qname: "v4only.example.", resp: aResp /* soa unset → empty SOA response */}
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "127.0.0.1"})
+		rc, err := d.ServeDNS(context.Background(), rec, req)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if rc != dns.RcodeSuccess {
+			t.Fatalf("want NOERROR, got %s", dns.RcodeToString[rc])
+		}
+		if len(rec.Msg.Ns) != 0 {
+			t.Fatalf("want no SOA when upstream didn't return one, got %v", rec.Msg.Ns)
+		}
+	})
+
+	t.Run("non-INET A class is not filtered", func(t *testing.T) {
+		d := newDNS64()
+		req := &dns.Msg{Question: []dns.Question{{Name: "v4only.example.", Qtype: dns.TypeA, Qclass: dns.ClassCHAOS}}}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+		// With filter_a skipped and not an AAAA, we just defer to Next.
+		d.Next = &fakeHandler{t, aResp}
+		if _, err := d.ServeDNS(context.Background(), rec, req); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		// Presence of the A answer from fakeHandler proves filter_a didn't fire.
+		if len(rec.Msg.Answer) != 1 {
+			t.Fatalf("class CHAOS A should pass through unfiltered, got %v", rec.Msg.Answer)
+		}
+	})
 }
 
 func (fu *fakeUpstream) Lookup(_ context.Context, _ request.Request, name string, typ uint16) (*dns.Msg, error) {
 	if fu.qname == "" {
-		fu.t.Fatalf("Unexpected A lookup for %s", name)
+		fu.t.Fatalf("Unexpected lookup for %s", name)
 	}
 	if name != fu.qname {
-		fu.t.Fatalf("Wrong A lookup for %s, expected %s", name, fu.qname)
+		fu.t.Fatalf("Wrong lookup for %s, expected %s", name, fu.qname)
 	}
 
-	if typ != dns.TypeA {
-		fu.t.Fatalf("Wrong lookup type %d, expected %d", typ, dns.TypeA)
+	switch typ {
+	case dns.TypeA:
+		return fu.resp, nil
+	case dns.TypeSOA:
+		// filter_a issues an SOA lookup to populate the authority section for
+		// RFC 2308 negative caching. Tests that don't set soa get a synthetic
+		// empty response — the production code treats that as "no SOA found"
+		// and returns NODATA without a SOA, which is the correct fallback.
+		if fu.soa != nil {
+			return fu.soa, nil
+		}
+		return &dns.Msg{}, nil
 	}
-
-	return fu.resp, nil
+	fu.t.Fatalf("Wrong lookup type %d", typ)
+	return nil, nil // unreachable (t.Fatalf halts the goroutine); required by the compiler
 }

--- a/plugin/dns64/metrics.go
+++ b/plugin/dns64/metrics.go
@@ -15,4 +15,13 @@ var (
 		Name:      "requests_translated_total",
 		Help:      "Counter of DNS requests translated by dns64.",
 	}, []string{"server"})
+
+	// RequestsFilteredCount is the number of client A queries suppressed by
+	// the filter_a option.
+	RequestsFilteredCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: pluginName,
+		Name:      "requests_filtered_total",
+		Help:      "Counter of client A queries suppressed by the dns64 filter_a option.",
+	}, []string{"server"})
 )

--- a/plugin/dns64/setup.go
+++ b/plugin/dns64/setup.go
@@ -65,6 +65,8 @@ func dns64Parse(c *caddy.Controller) (*DNS64, error) {
 				dns64.TranslateAll = true
 			case "allow_ipv4":
 				dns64.AllowIPv4 = true
+			case "filter_a":
+				dns64.FilterA = true
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())
 			}

--- a/plugin/dns64/setup_test.go
+++ b/plugin/dns64/setup_test.go
@@ -12,17 +12,20 @@ func TestSetupDns64(t *testing.T) {
 		shouldErr      bool
 		wantPrefix     string
 		wantAllowIpv4  bool
+		wantFilterA    bool
 	}{
 		{
 			`dns64`,
 			false,
 			"64:ff9b::/96",
 			false,
+			false,
 		},
 		{
 			`dns64 64:dead::/96`,
 			false,
 			"64:dead::/96",
+			false,
 			false,
 		},
 		{
@@ -32,11 +35,13 @@ func TestSetupDns64(t *testing.T) {
 			false,
 			"64:ff9b::/96",
 			false,
+			false,
 		},
 		{
 			`dns64`,
 			false,
 			"64:ff9b::/96",
+			false,
 			false,
 		},
 		{
@@ -45,6 +50,7 @@ func TestSetupDns64(t *testing.T) {
 			}`,
 			false,
 			"64:ff9b::/96",
+			false,
 			false,
 		},
 		{
@@ -54,6 +60,7 @@ func TestSetupDns64(t *testing.T) {
 			false,
 			"64:ff9b::/32",
 			false,
+			false,
 		},
 		{
 			`dns64 {
@@ -61,6 +68,7 @@ func TestSetupDns64(t *testing.T) {
 			}`,
 			true,
 			"64:ff9b::/52",
+			false,
 			false,
 		},
 		{
@@ -70,6 +78,7 @@ func TestSetupDns64(t *testing.T) {
 			true,
 			"64:ff9b::/104",
 			false,
+			false,
 		},
 		{
 			`dns64 {
@@ -78,6 +87,7 @@ func TestSetupDns64(t *testing.T) {
 			true,
 			"8.8.9.9/24",
 			false,
+			false,
 		},
 		{
 			`dns64 {
@@ -85,6 +95,7 @@ func TestSetupDns64(t *testing.T) {
 			}`,
 			false,
 			"64:ff9b::/96",
+			false,
 			false,
 		},
 		{
@@ -94,6 +105,7 @@ func TestSetupDns64(t *testing.T) {
 			false,
 			"2002:ac12:b083::/96",
 			false,
+			false,
 		},
 		{
 			`dns64 {
@@ -101,6 +113,7 @@ func TestSetupDns64(t *testing.T) {
 			}`,
 			false,
 			"2002:c0a8:a88a::/48",
+			false,
 			false,
 		},
 		{
@@ -110,11 +123,13 @@ func TestSetupDns64(t *testing.T) {
 			true,
 			"64:ff9b::/96",
 			false,
+			false,
 		},
 		{
 			`dns64 foobar`,
 			true,
 			"64:ff9b::/96",
+			false,
 			false,
 		},
 		{
@@ -124,6 +139,7 @@ func TestSetupDns64(t *testing.T) {
 			true,
 			"64:ff9b::/96",
 			false,
+			false,
 		},
 		{
 			`dns64 {
@@ -131,6 +147,26 @@ func TestSetupDns64(t *testing.T) {
 			}`,
 			false,
 			"64:ff9b::/96",
+			true,
+			false,
+		},
+		{
+			`dns64 {
+				filter_a
+			}`,
+			false,
+			"64:ff9b::/96",
+			false,
+			true,
+		},
+		{
+			`dns64 {
+				allow_ipv4
+				filter_a
+			}`,
+			false,
+			"64:ff9b::/96",
+			true,
 			true,
 		},
 	}
@@ -146,7 +182,10 @@ func TestSetupDns64(t *testing.T) {
 				t.Errorf("Test %d expected prefix %s, got %v", i+1, test.wantPrefix, dns64.Prefix.String())
 			}
 			if dns64.AllowIPv4 != test.wantAllowIpv4 {
-				t.Errorf("Test %d expected prefix %v, got %v", i+1, test.wantAllowIpv4, dns64.AllowIPv4)
+				t.Errorf("Test %d expected allow_ipv4 %v, got %v", i+1, test.wantAllowIpv4, dns64.AllowIPv4)
+			}
+			if dns64.FilterA != test.wantFilterA {
+				t.Errorf("Test %d expected filter_a %v, got %v", i+1, test.wantFilterA, dns64.FilterA)
 			}
 		}
 	}

--- a/test/dns64_filter_a_test.go
+++ b/test/dns64_filter_a_test.go
@@ -1,0 +1,124 @@
+package test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+// TestDNS64FilterA exercises the `filter_a` dns64 option end-to-end against a
+// real zone file (so the internal SOA lookup that filter_a issues for RFC 2308
+// negative caching can resolve). It asserts:
+//   - A queries return NOERROR/NODATA with the zone's SOA in the authority
+//     section and EDE 17 "Filtered".
+//   - AAAA queries are still synthesised from the zone's A records, with
+//     EDE 29 "Synthesized".
+func TestDNS64FilterA(t *testing.T) {
+	zoneFile, rm, err := test.TempFile(".", `$ORIGIN example.
+@	3600 IN	SOA ns.example. hostmaster.example. 1 7200 900 1209600 3600
+	3600 IN NS ns.example.
+v4only	60   IN A 192.0.2.42
+ns	3600 IN A 192.0.2.1
+`)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `.:0 {
+		file ` + zoneFile + ` example
+		dns64 {
+			prefix 64:ff9b::/96
+			translate_all
+			allow_ipv4
+			filter_a
+		}
+	}`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	// A query: NOERROR + empty answer + EDE 17.
+	m := new(dns.Msg)
+	m.SetQuestion("v4only.example.", dns.TypeA)
+	m.SetEdns0(4096, false)
+
+	resp, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("A exchange failed: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("A query: want NOERROR, got %s", dns.RcodeToString[resp.Rcode])
+	}
+	if len(resp.Answer) != 0 {
+		t.Fatalf("A query: want empty answer, got %v", resp.Answer)
+	}
+	// RFC 2308: NODATA should carry an SOA in the authority section so
+	// downstream resolvers can negative-cache it. filter_a issues an internal
+	// SOA query for the queried name; the `file` plugin answers with the zone
+	// SOA in the Authority section (NODATA for SOA at a non-apex name).
+	foundSOA := false
+	for _, rr := range resp.Ns {
+		if _, ok := rr.(*dns.SOA); ok {
+			foundSOA = true
+		}
+	}
+	if !foundSOA {
+		t.Fatalf("A query: expected SOA in authority section for negative caching, got %v", resp.Ns)
+	}
+	opt := resp.IsEdns0()
+	if opt == nil {
+		t.Fatal("A query: expected OPT record carrying EDE, got none")
+	}
+	foundEDE := false
+	for _, o := range opt.Option {
+		if ede, ok := o.(*dns.EDNS0_EDE); ok && ede.InfoCode == dns.ExtendedErrorCodeFiltered {
+			foundEDE = true
+		}
+	}
+	if !foundEDE {
+		t.Fatalf("A query: expected EDE code %d (Filtered), got %#v", dns.ExtendedErrorCodeFiltered, opt.Option)
+	}
+
+	// AAAA query: synthesised AAAA from the zone's A record, with EDE 29 Synthesized.
+	m = new(dns.Msg)
+	m.SetQuestion("v4only.example.", dns.TypeAAAA)
+	m.SetEdns0(4096, false)
+	resp, err = dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("AAAA exchange failed: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("AAAA query: want NOERROR, got %s", dns.RcodeToString[resp.Rcode])
+	}
+	if len(resp.Answer) == 0 {
+		t.Fatal("AAAA query: want synthesised AAAA, got empty — filter_a is shadowing dns64's own internal A lookup")
+	}
+	aaaa, ok := resp.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("AAAA query: want AAAA RR, got %T", resp.Answer[0])
+	}
+	want := net.ParseIP("64:ff9b::192.0.2.42")
+	if !aaaa.AAAA.Equal(want) {
+		t.Fatalf("AAAA query: want %s, got %s", want, aaaa.AAAA)
+	}
+	opt = resp.IsEdns0()
+	if opt == nil {
+		t.Fatal("AAAA query: expected OPT record carrying EDE 29 Synthesized, got none")
+	}
+	foundSyn := false
+	for _, o := range opt.Option {
+		if ede, ok := o.(*dns.EDNS0_EDE); ok && ede.InfoCode == dns.ExtendedErrorCodeSynthesized {
+			foundSyn = true
+		}
+	}
+	if !foundSyn {
+		t.Fatalf("AAAA query: expected EDE code %d (Synthesized), got %#v", dns.ExtendedErrorCodeSynthesized, opt.Option)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Two related improvements to `plugin/dns64`, sharing a small set of helpers and one plugin-private context key.

**`filter_a` option.** Today, operators running DNS64 for v6-preferred deployments have no plugin-native way to stop clients from seeing A records alongside their synthesised AAAAs. The usual workarounds (layering `template IN A . { rcode NOERROR }` above `dns64`) don't compose cleanly — `dns64`'s internal A lookup re-enters the plugin chain and gets swallowed by the same template. This PR adds an opt-in `filter_a` option that short-circuits client A queries (class IN, type A) with NOERROR + empty answer, steering clients onto the synthesised AAAA path without exposing the underlying v4. The response includes:

- The enclosing zone's SOA in the authority section, so downstream resolvers can negative-cache per RFC 2308 §5. The SOA is harvested via a single internal `upstream.Lookup` for type SOA at the queried name (`pickSOA` checks Answer then Authority). If the lookup fails, the response is served without an SOA rather than SERVFAIL-ing.
- RFC 8914 Extended DNS Error code 17 ("Filtered") on the OPT — only when the client's query carried OPT (RFC 6891 §6.1.1).

`filter_a` intercepts only qtype A and leaves qtype ANY alone; the README recommends pairing with the [`any`](https://coredns.io/plugins/any/) plugin (RFC 8482) when ANY traffic also needs covering.

**Deployments this helps** include any setup where the DNS64 prefix *is* the routing target — NAT64 gateways, IPv6-only networks built on NAT64/464XLAT, Tailscale 4via6 subnet routers, and similar transition mechanisms. In all of these, letting clients see the real A record bypasses the transition router entirely; `filter_a` closes that gap.

**EDE 29 on synthesis.** While adding the EDE 17 plumbing it became obvious that the existing synthesis path was silent about its own work — no EDE 29 ("Synthesized") despite RFC 8914 defining it specifically for DNS64. `Synthesize` now emits EDE 29 on the same RFC 6891 gate (client OPT present). This is adjacent to but independent of `filter_a`; happy to split into two commits if reviewers prefer — the hunk is small and self-contained.

The two behaviours share:
- A `dns64InternalKey` context value (unexported zero-sized struct) that marks queries the plugin spawned itself via `upstream.Lookup`. `shouldFilterA` checks it so filter_a doesn't cannibalise its own SOA lookup or `DoDNS64`'s A lookup. The key is local to this plugin.
- A small `addEDE` helper that appends EDE to the response's OPT (preserving any existing OPT; creating one at 4096-byte UDP size per RFC 6891 §6.2.3 when absent).
- A new `coredns_dns64_requests_filtered_total{server}` metric, symmetric with the existing `coredns_dns64_requests_translated_total`.

**Pre-existing behaviour, unchanged:** `Synthesize` still copies the internal A lookup's OPT into the client response via `ret.Extra = resp.Extra`; our `addEDE` appends to that inherited OPT. The OPT logically belongs to the server, not the upstream — but cleaning that up is out of scope for this PR.

**Test coverage:**
- `plugin/dns64/dns64_test.go` — `TestFilterA` with 8 subtests (EDE 17 with EDNS; no OPT when query lacks OPT; AAAA synthesis keeps working with filter_a set; internal-key bypass; SOA from Authority; SOA from Answer at zone apex; SOA lookup failure fallback; non-INET class passthrough). `TestSynthesizeEDE` covers EDE 29 with and without client EDNS.
- `plugin/dns64/setup_test.go` — `filter_a` parsing (alone and combined with `allow_ipv4`); cases rewritten to named-field struct literals in the same diff.
- `test/dns64_filter_a_test.go` — end-to-end against a real zone served by the `file` plugin: A → NODATA + SOA + EDE 17; AAAA → synthesised + EDE 29.

Full `go test ./...` passes.

### 2. Which issues (if any) are related?

None that I'm aware of. Happy to link discussion if anyone can point at prior interest in v6-preferred DNS64 behaviour, EDE 29 signalling, or RFC 2308 negative caching in synthesised responses.

### 3. Which documentation changes (if any) need to be made?

All in-plugin, in `plugin/dns64/README.md`:

- Syntax block gains `filter_a`.
- Description notes that synthesised responses carry EDE 29 (gated on client OPT).
- Option descriptions for `translate_all` (tightened wording: the fact that real upstream AAAAs are *discarded* was previously understated) and `filter_a` (full behaviour, SOA/EDE details, RFC 2308/6891/8914 references, ANY limitation + `any`-plugin pointer).
- New "How `translate_all` and `filter_a` interact" subsection with a 2×2 matrix of client-visible behaviour and guidance on picking the right combination, including the compounded edge case (`translate_all` + AAAA-only name → empty answer, worsened by `filter_a`).
- Two new examples — `filter_a` alone (prefer-v6) and `filter_a` + `translate_all` + `any` (force-via-prefix).
- Metrics section gains `coredns_dns64_requests_filtered_total{server}`.

No changes to top-level docs or site content outside the plugin directory.

### 4. Does this introduce a backward incompatible change or deprecation?

**No.**

- `filter_a` is a new keyword, defaulting off. Existing Corefiles parse and behave identically.
- EDE 29 on synthesis is emitted only when the client's query carried OPT (RFC 6891 §6.1.1), so non-EDNS traffic sees byte-for-byte the same response as before. EDNS-aware traffic gains an informational EDE option; no existing OPT options are removed or overwritten (we append).
- No changes to public Go API surface beyond the new exported `FilterA` struct field, which existing consumers don't set and therefore ignore.
- The new `coredns_dns64_requests_filtered_total` metric is additive; the existing `coredns_dns64_requests_translated_total` is unchanged.