### PR TITLE
plugin/forward: Forward NODATA responses to Next handler

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -110,7 +110,7 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
-* `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
+* `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. Use `NOERROR` for `NODATA`-error handling. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored.
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 * `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
 

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -110,7 +110,8 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
-* `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. Use `NOERROR` for `NODATA`-error handling. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored.
+* `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
+* `next_on_nodata` If `NOERROR` is returned by the remote, but an empty answer section (`NODATA`) was provided, execute the next `forward` plugin, if configured.
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 * `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -236,11 +236,13 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			continue
 		}
 
-		// Check if we have an alternate Rcode defined, check if we match on the code
-		for _, alternateRcode := range f.nextAlternateRcodes {
-			if alternateRcode == ret.Rcode && f.Next != nil { // In case we do not have a Next handler, just continue normally
-				if _, ok := f.Next.(*Forward); ok { // Only continue if the next forwarder is also a Forworder
-					return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+		if ret.Rcode != dns.RcodeSuccess || isEmpty(ret) { // NOERROR should not call Next handler, unless it is a NODATA-error response.
+			// Check if we have an alternate Rcode defined, check if we match on the code
+			for _, alternateRcode := range f.nextAlternateRcodes {
+				if alternateRcode == ret.Rcode && f.Next != nil { // In case we do not have a Next handler, just continue normally
+					if _, ok := f.Next.(*Forward); ok { // Only continue if the next forwarder is also a Forworder
+						return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+					}
 				}
 			}
 		}
@@ -271,6 +273,19 @@ func (f *Forward) isAllowedDomain(name string) bool {
 
 	for _, ignore := range f.ignored {
 		if plugin.Name(ignore).Matches(name) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEmpty(r *dns.Msg) bool {
+	if len(r.Answer) == 0 {
+		return true
+	}
+
+	for _, r := range r.Answer {
+		if r != nil {
 			return false
 		}
 	}

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -44,6 +44,7 @@ type Forward struct {
 	ignored []string
 
 	nextAlternateRcodes []int
+	nextOnNodata        bool
 
 	tlsConfig                  *tls.Config
 	tlsServerName              string
@@ -236,13 +237,19 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			continue
 		}
 
-		if ret.Rcode != dns.RcodeSuccess || isEmpty(ret) { // NOERROR should not call Next handler, unless it is a NODATA-error response.
-			// Check if we have an alternate Rcode defined, check if we match on the code
-			for _, alternateRcode := range f.nextAlternateRcodes {
-				if alternateRcode == ret.Rcode && f.Next != nil { // In case we do not have a Next handler, just continue normally
-					if _, ok := f.Next.(*Forward); ok { // Only continue if the next forwarder is also a Forworder
-						return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
-					}
+		// Check if we have an alternate Rcode defined, check if we match on the code
+		for _, alternateRcode := range f.nextAlternateRcodes {
+			if alternateRcode == ret.Rcode && f.Next != nil { // In case we do not have a Next handler, just continue normally
+				if _, ok := f.Next.(*Forward); ok { // Only continue if the next forwarder is also a Forworder
+					return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+				}
+			}
+		}
+
+		if f.nextOnNodata && f.Next != nil {
+			if ret.Rcode == dns.RcodeSuccess && isEmpty(ret) {
+				if _, ok := f.Next.(*Forward); ok {
+					return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
 				}
 			}
 		}

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -11,8 +12,10 @@ import (
 	"github.com/coredns/caddy/caddyfile"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin/dnstap"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/proxy"
 	"github.com/coredns/coredns/plugin/pkg/transport"
+	"github.com/coredns/coredns/plugin/test"
 
 	"github.com/miekg/dns"
 	"github.com/opentracing/opentracing-go"
@@ -153,6 +156,84 @@ func TestForward_Regression_NoBusyLoop(t *testing.T) {
 			// attempts as observed via spans should be equal to the configured value.
 			if tc.maxAttempts > 0 && uint32(len(spans)) != tc.maxAttempts {
 				t.Errorf("Expected %d spans, got %d", tc.maxAttempts, len(spans))
+			}
+		})
+	}
+}
+
+func TestForward_NextOnNodata(t *testing.T) {
+	tests := []struct {
+		name         string
+		nextOnNodata bool
+	}{
+		{name: "serveEmpty", nextOnNodata: false},
+		{name: "nextNotEmpty", nextOnNodata: true},
+	}
+
+	s1 := dnstest.NewMultipleServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	s2 := dnstest.NewMultipleServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.1"))
+		w.WriteMsg(ret)
+	})
+	defer s1.Close()
+	defer s2.Close()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var config string
+			if tc.nextOnNodata {
+				config = `
+					forward . %s {
+						next_on_nodata
+					}
+					forward . %s
+					`
+			} else {
+				config = `
+					forward . %s
+					forward . %s
+					`
+			}
+			c := caddy.NewTestController("dns", fmt.Sprintf(config, s1.Addr, s2.Addr))
+			fs, err := parseForward(c)
+			if err != nil {
+				t.Errorf("Failed to create forwarder: %s", err)
+			}
+			if x := len(fs); x != 2 {
+				t.Errorf("Failed to create two forward instances")
+			}
+			f := fs[0]
+			f.Next = fs[1]
+			f.OnStartup()
+			defer f.OnShutdown()
+
+			m := new(dns.Msg)
+			m.SetQuestion("example.org.", dns.TypeA)
+			rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+			if _, err := f.ServeDNS(context.TODO(), rec, m); err != nil {
+				t.Fatal("Expected to receive reply, but didn't")
+			}
+			if x := rec.Rcode; x != dns.RcodeSuccess {
+				t.Errorf("Expected %v, got %+v instead", dns.RcodeSuccess, rec)
+			}
+			if tc.nextOnNodata {
+				if x := len(rec.Msg.Answer); x != 1 {
+					t.Errorf("Expected answer, got %d instead", x)
+				}
+				if x := rec.Msg.Answer[0].Header().Name; x != "example.org." {
+					t.Errorf("Expected %s, got %s", "example.org.", x)
+				}
+			} else {
+				if x := len(rec.Msg.Answer); x != 0 {
+					t.Errorf("Expected zero length answer, got %d instead", x)
+				}
 			}
 		})
 	}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -395,6 +395,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 
 			f.nextAlternateRcodes = append(f.nextAlternateRcodes, rc)
 		}
+	case "next_on_nodata":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.nextOnNodata = true
 	case "failfast_all_unhealthy_upstreams":
 		args := c.RemainingArgs()
 		if len(args) != 0 {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Forward can't handle NODATA-responses, which are technically error responses as well.
Using the NOERROR-case to allow forwarding to Next handler, when upstream returned `NODATA`.
Unfortunately, NODATA isn't a [real rcode](https://datatracker.ietf.org/doc/html/rfc2308#section-1), but inferred from the answer section, the plugin code has been updated to inspect NODATA-answers as well.

### 2. Which issues (if any) are related?
See coredns/alternate#24 - original PR coredns/alternate#48.
Altered the original PR to not include the magic string "NODATA", with a "-1" RCode value.

### 3. Which documentation changes (if any) need to be made?
See changes to `plugin/forward/README.md`, added new config option "next_on_nodata", which activates the new behavior.

### 4. Does this introduce a backward incompatible change or deprecation?
After discussion a new backwards-compatible change was introduced.

<details>
Current behavior for:
```
forward . a.b.c.d {
  next NOERROR
}
forward . d.e.f.0
```
would _always_ respond with the response from `d.e.f.0`.
The new behavior only uses `d.e.f.0` when `a.b.c.d` returned `NOERROR` with an empty answer set.
In some sense it is a backward incompatible change, but I'd argue that this case is rather exotic, forwarding and discarding the answer would be quite wasteful.
</details>

I've built this locally, and verified it works just like my previous patch to the alternate-plugin, which has been running here for two years unchanged.