### PR TITLE
feat(bind): add support for ipv4 and ipv6 keywords in bind directive

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -23,6 +23,12 @@ type Config struct {
 	// defaults to a single empty string that denote the wildcard address
 	ListenHosts []string
 
+	// ListenNetProtos maps listen hosts to their network protocol suffix.
+	// "4" forces IPv4-only, "6" forces IPv6-only. Hosts not in the map
+	// use the default dual-stack behaviour. Set by the bind plugin when
+	// the ipv4 or ipv6 keyword is used.
+	ListenNetProtos map[string]string
+
 	// The port to listen on.
 	Port string
 

--- a/core/dnsserver/ipnet_test.go
+++ b/core/dnsserver/ipnet_test.go
@@ -1,0 +1,33 @@
+package dnsserver
+
+import "testing"
+
+func TestServerNet(t *testing.T) {
+	tests := []struct {
+		netProto string
+		proto    string
+		expected string
+	}{
+		// Dual-stack (default)
+		{"", "tcp", "tcp"},
+		{"", "udp", "udp"},
+
+		// IPv4-only
+		{"4", "tcp", "tcp4"},
+		{"4", "udp", "udp4"},
+
+		// IPv6-only
+		{"6", "tcp", "tcp6"},
+		{"6", "udp", "udp6"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.proto+"_proto"+tc.netProto, func(t *testing.T) {
+			s := &Server{netProto: tc.netProto}
+			got := s.net(tc.proto)
+			if got != tc.expected {
+				t.Errorf("Server{netProto: %q}.net(%q) = %q, want %q", tc.netProto, tc.proto, got, tc.expected)
+			}
+		})
+	}
+}

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -265,6 +265,7 @@ func propagateConfigParams(configs []*Config) {
 	for _, c := range configs {
 		c.Plugin = c.firstConfigInBlock.Plugin
 		c.ListenHosts = c.firstConfigInBlock.ListenHosts
+		c.ListenNetProtos = c.firstConfigInBlock.ListenNetProtos
 		c.Debug = c.firstConfigInBlock.Debug
 		c.Stacktrace = c.firstConfigInBlock.Stacktrace
 		c.NumSockets = c.firstConfigInBlock.NumSockets

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -39,6 +39,8 @@ type Server struct {
 	ReadTimeout  time.Duration // Read timeout for TCP
 	WriteTimeout time.Duration // Write timeout for TCP
 
+	netProto string // IP version suffix: "4" for IPv4-only, "6" for IPv6-only, "" for dual-stack
+
 	connPolicy                    proxyproto.ConnPolicyFunc // Proxy Protocol connection policy function
 	udpSessionTrackingTTL         time.Duration             // TTL for UDP PPv2 session tracking (0 = disabled)
 	udpSessionTrackingMaxSessions int                       // LRU cap for UDP session tracking (0 = default)
@@ -76,6 +78,15 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		ReadTimeout:  3 * time.Second,
 		WriteTimeout: 5 * time.Second,
 		tsigSecret:   make(map[string]string),
+	}
+
+	// Look up the per-address network protocol suffix set by the bind
+	// plugin's ipv4/ipv6 keywords.
+	if len(group) > 0 && group[0].ListenNetProtos != nil {
+		if parts := strings.SplitN(addr, "://", 2); len(parts) == 2 {
+			host, _, _ := net.SplitHostPort(parts[1])
+			s.netProto = group[0].ListenNetProtos[host]
+		}
 	}
 
 	for _, site := range group {
@@ -190,9 +201,17 @@ func (s *Server) ServePacket(p net.PacketConn) error {
 	return s.server[udp].ActivateAndServe()
 }
 
+// net returns the network string for the given base protocol (e.g. "tcp" or
+// "udp"), qualified with the IP version suffix when the server is configured
+// for single-stack operation via the bind plugin's ipv4/ipv6 keywords.
+func (s *Server) net(proto string) string {
+	return proto + s.netProto
+}
+
 // Listen implements caddy.TCPServer interface.
 func (s *Server) Listen() (net.Listener, error) {
-	l, err := reuseport.Listen("tcp", s.Addr[len(transport.DNS+"://"):])
+	addr := s.Addr[len(transport.DNS+"://"):]
+	l, err := reuseport.Listen(s.net("tcp"), addr)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +228,8 @@ func (s *Server) WrapListener(ln net.Listener) net.Listener {
 
 // ListenPacket implements caddy.UDPServer interface.
 func (s *Server) ListenPacket() (net.PacketConn, error) {
-	p, err := reuseport.ListenPacket("udp", s.Addr[len(transport.DNS+"://"):])
+	addr := s.Addr[len(transport.DNS+"://"):]
+	p, err := reuseport.ListenPacket(s.net("udp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -133,7 +133,8 @@ func (s *ServergRPC) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServergRPC) Listen() (net.Listener, error) {
-	l, err := reuseport.Listen("tcp", s.Addr[len(transport.GRPC+"://"):])
+	addr := s.Addr[len(transport.GRPC+"://"):]
+	l, err := reuseport.Listen(s.net("tcp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -140,7 +140,8 @@ func (s *ServerHTTPS) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Listen() (net.Listener, error) {
-	l, err := reuseport.Listen("tcp", s.Addr[len(transport.HTTPS+"://"):])
+	addr := s.Addr[len(transport.HTTPS+"://"):]
+	l, err := reuseport.Listen(s.net("tcp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -112,7 +112,8 @@ var _ caddy.GracefulServer = &ServerHTTPS3{}
 
 // ListenPacket opens the UDP socket for QUIC.
 func (s *ServerHTTPS3) ListenPacket() (net.PacketConn, error) {
-	p, err := reuseport.ListenPacket("udp", s.Addr[len(transport.HTTPS3+"://"):])
+	addr := s.Addr[len(transport.HTTPS3+"://"):]
+	p, err := reuseport.ListenPacket(s.net("udp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -242,7 +242,8 @@ func (s *ServerQUIC) serveQUICStream(stream *quic.Stream, conn *quic.Conn) {
 
 // ListenPacket implements caddy.UDPServer interface.
 func (s *ServerQUIC) ListenPacket() (net.PacketConn, error) {
-	p, err := reuseport.ListenPacket("udp", s.Addr[len(transport.QUIC+"://"):])
+	addr := s.Addr[len(transport.QUIC+"://"):]
+	p, err := reuseport.ListenPacket(s.net("udp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -77,7 +77,8 @@ func (s *ServerTLS) ServePacket(_p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerTLS) Listen() (net.Listener, error) {
-	l, err := reuseport.Listen("tcp", s.Addr[len(transport.TLS+"://"):])
+	addr := s.Addr[len(transport.TLS+"://"):]
+	l, err := reuseport.Listen(s.net("tcp"), addr)
 	if err != nil {
 		return nil, err
 	}

--- a/man/coredns-bind.7
+++ b/man/coredns-bind.7
@@ -27,7 +27,7 @@ In its basic form, a simple bind uses this syntax:
 .RS
 
 .nf
-bind ADDRESS|IFACE  ...
+bind ADDRESS|IFACE|ipv4|ipv6  ...
 
 .fi
 .RE
@@ -50,7 +50,16 @@ bind ADDRESS|IFACE ... {
 \fBADDRESS|IFACE\fP is an IP address or interface name to bind to.
 When several addresses are provided a listener will be opened on each of the addresses. Please read the \fIDescription\fP for more details.
 .IP \(bu 4
+\fBipv4\fP is a shorthand for \fB\fC0.0.0.0\fR that ensures the listener uses an IPv4-only socket.
+.IP \(bu 4
+\fBipv6\fP is a shorthand for \fB\fC::\fR that ensures the listener uses an IPv6-only socket.
+.IP \(bu 4
 \fB\fCexcept\fR, excludes interfaces or IP addresses to bind to. \fB\fCexcept\fR option only excludes addresses for the current \fB\fCbind\fR directive if multiple \fB\fCbind\fR directives are used in the same server block.
+
+.PP
+Note: By default, Go creates dual-stack sockets, which means that binding to \fB\fC0.0.0.0\fR or \fB\fC::\fR will
+listen on both IPv4 and IPv6. Use the \fB\fCipv4\fR or \fB\fCipv6\fR keywords instead to restrict listening to a
+single address family. The keywords can be combined with other addresses in the same \fB\fCbind\fR directive.
 
 .SH "EXAMPLES"
 
@@ -123,6 +132,48 @@ You can exclude some addresses by their IP or interface name (The following will
     bind lo {
         except 127.0.0.1
     }
+}
+
+.fi
+.RE
+
+.PP
+To bind to IPv4 only:
+
+.PP
+.RS
+
+.nf
+\&. {
+    bind ipv4
+}
+
+.fi
+.RE
+
+.PP
+To bind to IPv6 only:
+
+.PP
+.RS
+
+.nf
+\&. {
+    bind ipv6
+}
+
+.fi
+.RE
+
+.PP
+To bind to specific addresses and all IPv6 addresses:
+
+.PP
+.RS
+
+.nf
+\&. {
+    bind 127.0.0.1 127.0.0.2 ipv6
 }
 
 .fi

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -20,7 +20,7 @@ If the given argument is an interface name, and that interface has several IP ad
 In its basic form, a simple bind uses this syntax:
 
 ~~~ txt
-bind ADDRESS|IFACE  ...
+bind ADDRESS|IFACE|ipv4|ipv6  ...
 ~~~
 
 You can also exclude some addresses with their IP address or interface name in expanded syntax:
@@ -35,7 +35,13 @@ bind ADDRESS|IFACE ... {
 
 * **ADDRESS|IFACE** is an IP address or interface name to bind to.
 When several addresses are provided a listener will be opened on each of the addresses. Please read the *Description* for more details.
+* **ipv4** is a shorthand for `0.0.0.0` that ensures the listener uses an IPv4-only socket.
+* **ipv6** is a shorthand for `::` that ensures the listener uses an IPv6-only socket.
 * `except`, excludes interfaces or IP addresses to bind to. `except` option only excludes addresses for the current `bind` directive if multiple `bind` directives are used in the same server block.
+
+Note: By default, Go creates dual-stack sockets, which means that binding to `0.0.0.0` or `::` will
+listen on both IPv4 and IPv6. Use the `ipv4` or `ipv6` keywords instead to restrict listening to a
+single address family. The keywords can be combined with other addresses in the same `bind` directive.
 ## Examples
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):
@@ -79,6 +85,30 @@ You can exclude some addresses by their IP or interface name (The following will
     bind lo {
         except 127.0.0.1
     }
+}
+~~~
+
+To bind to IPv4 only:
+
+~~~ corefile
+. {
+    bind ipv4
+}
+~~~
+
+To bind to IPv6 only:
+
+~~~ corefile
+. {
+    bind ipv6
+}
+~~~
+
+To bind to specific addresses and all IPv6 addresses:
+
+~~~ corefile
+. {
+    bind 127.0.0.1 127.0.0.2 ipv6
 }
 ~~~
 

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -16,6 +16,7 @@ func setup(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
 	// addresses will be consolidated over all BIND directives available in that BlocServer
 	all := []string{}
+	netProtos := map[string]string{}
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		log.Warning(plugin.Error("bind", fmt.Errorf("failed to get interfaces list, cannot bind by interface name: %s", err)))
@@ -27,7 +28,24 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("bind", err)
 		}
 
-		ips, err := listIP(b.addrs, ifaces)
+		// Handle ipv4/ipv6 keywords: expand to the corresponding wildcard
+		// address and record the protocol suffix so the listener creates a
+		// single-stack socket.
+		var addrs []string
+		for _, a := range b.addrs {
+			switch a {
+			case "ipv4":
+				addrs = append(addrs, "0.0.0.0")
+				netProtos["0.0.0.0"] = "4"
+			case "ipv6":
+				addrs = append(addrs, "::")
+				netProtos["::"] = "6"
+			default:
+				addrs = append(addrs, a)
+			}
+		}
+
+		ips, err := listIP(addrs, ifaces)
 		if err != nil {
 			return plugin.Error("bind", err)
 		}
@@ -45,6 +63,9 @@ func setup(c *caddy.Controller) error {
 	}
 
 	config.ListenHosts = all
+	if len(netProtos) > 0 {
+		config.ListenNetProtos = netProtos
+	}
 	return nil
 }
 

--- a/plugin/bind/setup_test.go
+++ b/plugin/bind/setup_test.go
@@ -16,18 +16,27 @@ func TestSetup(t *testing.T) {
 	}
 
 	for i, test := range []struct {
-		config   string
-		expected []string
-		failing  bool
+		config        string
+		expected      []string
+		expectedProto map[string]string
+		failing       bool
 	}{
-		{`bind 1.2.3.4`, []string{"1.2.3.4"}, false},
-		{`bind`, nil, true},
-		{`bind 1.2.3.invalid`, nil, true},
-		{`bind 1.2.3.4 ::5`, []string{"1.2.3.4", "::5"}, false},
-		{`bind ::1 1.2.3.4 ::5 127.9.9.0`, []string{"::1", "1.2.3.4", "::5", "127.9.9.0"}, false},
-		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, true},
-		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, false},
-		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, false},
+		{`bind 1.2.3.4`, []string{"1.2.3.4"}, nil, false},
+		{`bind`, nil, nil, true},
+		{`bind 1.2.3.invalid`, nil, nil, true},
+		{`bind 1.2.3.4 ::5`, []string{"1.2.3.4", "::5"}, nil, false},
+		{`bind ::1 1.2.3.4 ::5 127.9.9.0`, []string{"::1", "1.2.3.4", "::5", "127.9.9.0"}, nil, false},
+		{`bind ::1 1.2.3.4 ::5 127.9.9.0 noone`, nil, nil, true},
+		{`bind 1.2.3.4 lo`, []string{"1.2.3.4", "127.0.0.1", "::1"}, nil, false},
+		{"bind lo {\nexcept 127.0.0.1\n}\n", []string{"::1"}, nil, false},
+		// ipv4/ipv6 keywords
+		{`bind ipv4`, []string{"0.0.0.0"}, map[string]string{"0.0.0.0": "4"}, false},
+		{`bind ipv6`, []string{"::"}, map[string]string{"::": "6"}, false},
+		{`bind 127.0.0.1 127.0.0.2 ipv6`, []string{"127.0.0.1", "127.0.0.2", "::"}, map[string]string{"::": "6"}, false},
+		{`bind ipv4 ::1`, []string{"0.0.0.0", "::1"}, map[string]string{"0.0.0.0": "4"}, false},
+		// 0.0.0.0 without keyword stays dual-stack (no proto entry)
+		{`bind 0.0.0.0`, []string{"0.0.0.0"}, nil, false},
+		{`bind ::`, []string{"::"}, nil, false},
 	} {
 		c := caddy.NewTestController("dns", test.config)
 		err := setup(c)
@@ -49,6 +58,15 @@ func TestSetup(t *testing.T) {
 			if got, want := cfg.ListenHosts[i], v; got != want {
 				t.Errorf("Test %d : expected the config's ListenHost to be %s, was %s", i, want, got)
 			}
+		}
+		if test.expectedProto != nil {
+			for host, wantProto := range test.expectedProto {
+				if gotProto := cfg.ListenNetProtos[host]; gotProto != wantProto {
+					t.Errorf("Test %d : expected ListenNetProtos[%q] = %q, got %q", i, host, wantProto, gotProto)
+				}
+			}
+		} else if len(cfg.ListenNetProtos) > 0 {
+			t.Errorf("Test %d : expected no ListenNetProtos, got %v", i, cfg.ListenNetProtos)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Due to Go's `net.Listen` behavior ([golang/go#48723](https://github.com/golang/go/issues/48723)), binding to `0.0.0.0` or `::` creates a dual-stack socket that listens on **both** IPv4 and IPv6. There is currently no way to restrict CoreDNS to a single address family.

#### Solution

Add `ipv4` and `ipv6` as keywords in the `bind` directive. These are aliases for `0.0.0.0` and `::` respectively, but they force the listener to use a single-stack socket (`tcp4`/`udp4` or `tcp6`/`udp6`).

The keywords can be used standalone or combined with other addresses:

```corefile
. {
    bind ipv4
}
```
```corefile
. {
    bind 127.0.0.1 ipv6
}
```

### 2. Which issues (if any) are related?

fixes #7275

### 3. Which documentation changes (if any) need to be made?

Documentation has been updated as part of this PR:

- **`plugin/bind/README.md`**keywords.
- **`man/coredns-bind.7`**

### 4. Does this introduce a backward incompatible change or deprecation?

Existing configurations are **not affected**. Using `::` or `0.0.0.0` directly continues to create dual-stack sockets as before.

**With `bind 127.0.0.1 ::`** (existing behavior, unchanged — `::` creates a dual-stack socket):
```
udp   UNCONN 0      0          127.0.0.1:1053       0.0.0.0:*
udp   UNCONN 0      0                  *:1053             *:*      ← dual-stack
tcp   LISTEN 0      4096       127.0.0.1:1053       0.0.0.0:*
tcp   LISTEN 0      4096               *:1053             *:*      ← dual-stack
```

**With `bind 127.0.0.1 ipv6`** (new — `ipv6` creates an IPv6-only socket):
```
udp   UNCONN 0      0          127.0.0.1:1053       0.0.0.0:*
udp   UNCONN 0      0               [::]:1053          [::]:*      ← IPv6 only
tcp   LISTEN 0      4096       127.0.0.1:1053       0.0.0.0:*
tcp   LISTEN 0      4096            [::]:1053          [::]:*      ← IPv6 only
```

The difference: `*:1053` (dual-stack) vs `[::]:1053` (IPv6-only).