### PR TITLE
dnsutil: handle empty label list in Join

### DIFF
--- a/plugin/pkg/dnsutil/join.go
+++ b/plugin/pkg/dnsutil/join.go
@@ -10,6 +10,9 @@ import (
 // the root label it is ignored. Not other syntax checks are performed.
 func Join(labels ...string) string {
 	ll := len(labels)
+	if ll == 0 {
+		return "."
+	}
 	if labels[ll-1] == "." {
 		return strings.Join(labels[:ll-1], ".") + "."
 	}

--- a/plugin/pkg/dnsutil/join_test.go
+++ b/plugin/pkg/dnsutil/join_test.go
@@ -11,6 +11,7 @@ func TestJoin(t *testing.T) {
 		{[]string{"example", "."}, "example."},
 		{[]string{"example", "org."}, "example.org."}, // technically we should not be called like this.
 		{[]string{"."}, "."},
+		{nil, "."},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
Make `dnsutil.Join` handle an empty label list.

Right now `Join` computes `len(labels)` and then indexes `labels[ll-1]`, so `Join()` panics before it can build a name. Returning `"."` keeps the behavior consistent with the existing root-label case.

This adds a table test for nil input.

Tests:
- `go test ./plugin/pkg/dnsutil`