### PR TITLE
dnstap: close replaced reconnect connections

### DIFF
--- a/plugin/dnstap/encoder.go
+++ b/plugin/dnstap/encoder.go
@@ -1,7 +1,7 @@
 package dnstap
 
 import (
-	"io"
+	"net"
 	"time"
 
 	tap "github.com/dnstap/golang-dnstap"
@@ -11,11 +11,12 @@ import (
 
 // encoder wraps a golang-framestream.Encoder.
 type encoder struct {
-	fs *fs.Encoder
+	fs   *fs.Encoder
+	conn net.Conn
 }
 
-func newEncoder(w io.Writer, timeout time.Duration) (*encoder, error) {
-	fs, err := fs.NewEncoder(w, &fs.EncoderOptions{
+func newEncoder(conn net.Conn, timeout time.Duration) (*encoder, error) {
+	fs, err := fs.NewEncoder(conn, &fs.EncoderOptions{
 		ContentType:   []byte("protobuf:dnstap.Dnstap"),
 		Bidirectional: true,
 		Timeout:       timeout,
@@ -23,7 +24,7 @@ func newEncoder(w io.Writer, timeout time.Duration) (*encoder, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &encoder{fs}, nil
+	return &encoder{fs: fs, conn: conn}, nil
 }
 
 func (e *encoder) writeMsg(msg *tap.Dnstap) error {
@@ -37,4 +38,10 @@ func (e *encoder) writeMsg(msg *tap.Dnstap) error {
 }
 
 func (e *encoder) flush() error { return e.fs.Flush() }
-func (e *encoder) close() error { return e.fs.Close() }
+func (e *encoder) close() error {
+	err := e.fs.Close()
+	if closeErr := e.conn.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/plugin/dnstap/io.go
+++ b/plugin/dnstap/io.go
@@ -92,8 +92,17 @@ func (d *dio) dial() error {
 		tcpConn.SetNoDelay(false)
 	}
 
-	d.enc, err = newEncoder(conn, d.tcpTimeout)
-	return err
+	enc, err := newEncoder(conn, d.tcpTimeout)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	if d.enc != nil {
+		d.enc.close()
+	}
+	d.enc = enc
+	return nil
 }
 
 // Connect connects to the dnstap endpoint.

--- a/plugin/dnstap/io_test.go
+++ b/plugin/dnstap/io_test.go
@@ -69,6 +69,53 @@ func accept(t *testing.T, l net.Listener, count int) {
 	}
 }
 
+func acceptUntilClosed(l net.Listener) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		server, err := l.Accept()
+		if err != nil {
+			done <- fmt.Errorf("server accept: %w", err)
+			return
+		}
+		defer server.Close()
+
+		dec, err := fs.NewDecoder(server, &fs.DecoderOptions{
+			ContentType:   []byte("protobuf:dnstap.Dnstap"),
+			Bidirectional: true,
+		})
+		if err != nil {
+			done <- fmt.Errorf("server decoder: %w", err)
+			return
+		}
+
+		if _, err := dec.Decode(); err == nil {
+			done <- fmt.Errorf("server decode unexpectedly succeeded")
+			return
+		}
+
+		if err := server.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			done <- fmt.Errorf("server read deadline: %w", err)
+			return
+		}
+
+		var b [1]byte
+		_, err = server.Read(b[:])
+		if err == nil {
+			done <- fmt.Errorf("server read unexpectedly succeeded")
+			return
+		}
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			done <- fmt.Errorf("server connection was not closed")
+			return
+		}
+
+		done <- nil
+	}()
+
+	return done
+}
+
 func TestTransport(t *testing.T) {
 	transport := [2][2]string{
 		{"tcp", ":0"},
@@ -246,6 +293,27 @@ func TestReconnect(t *testing.T) {
 		}, time.Second, 10*time.Millisecond, "queue should be drained by serve goroutine")
 		require.Less(t, logger.WarnCount(), messageCount)
 	})
+}
+
+func TestDialClosesReplacedConnection(t *testing.T) {
+	l, err := reuseport.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Cannot start listener: %s", err)
+	}
+	defer l.Close()
+
+	dio := newIO("tcp", l.Addr().String(), 1, 1)
+	dio.tcpTimeout = 100 * time.Millisecond
+
+	firstClosed := acceptUntilClosed(l)
+	require.NoError(t, dio.dial())
+
+	secondClosed := acceptUntilClosed(l)
+	require.NoError(t, dio.dial())
+	require.NoError(t, <-firstClosed)
+
+	require.NoError(t, dio.enc.close())
+	require.NoError(t, <-secondClosed)
 }
 
 func TestFullQueueWriteFail(t *testing.T) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The dnstap reconnect path can replace the active encoder after opening a new connection. `framestream.Encoder.Close` stops the stream, but does not close the `net.Conn` itself. Keep the connection with the encoder so reconnect and shutdown close both pieces of state.

This also closes the newly opened connection if encoder setup fails, and adds a reconnect test that verifies the replaced connection is actually closed.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.

Tests:
- `go test ./plugin/dnstap -run TestDialClosesReplacedConnection -count=1`
- `go test ./plugin/dnstap`