### PR TITLE
plugin/file: respect closer empty non-terminals in wildcard lookup

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -100,6 +100,9 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			if wild, found := tr.Search(wildcard); found {
 				wildElem = wild
 			}
+			if x, found := tr.Next(parts); found && dns.IsSubDomain(parts, x.Name()) {
+				wildElem = nil
+			}
 
 			// Keep on searching, because maybe we hit an empty-non-terminal (which aren't
 			// stored in the tree. Only when we have match the full qname (and possible wildcard

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -266,6 +266,29 @@ func TestLookupMultiWildcard(t *testing.T) {
 	}
 }
 
+func TestLookupWildcardRespectsCloserEmptyNonTerminal(t *testing.T) {
+	const name = "example.org."
+	zone, err := Parse(strings.NewReader(exampleOrg), name, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expect no error when reading zone, got %q", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
+	req := new(dns.Msg)
+	req.SetQuestion("x.c.w.example.org.", dns.TypeTXT)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	if _, err := fm.ServeDNS(context.TODO(), rec, req); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if rec.Msg.Rcode != dns.RcodeNameError {
+		t.Fatalf("Expected NXDOMAIN below closer empty non-terminal, got rcode %d", rec.Msg.Rcode)
+	}
+	if len(rec.Msg.Answer) != 0 {
+		t.Fatalf("Expected no wildcard answer, got %v", rec.Msg.Answer)
+	}
+}
+
 const exampleOrg = `; example.org test file
 $TTL 3600
 example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The file plugin can keep a wildcard candidate while walking labels from right to left. If a closer empty non-terminal exists below the queried name, that wildcard should not be used for synthesis.

This clears the wildcard candidate when the tree has a closer name below the current search name, so a query under that empty non-terminal returns NXDOMAIN instead of a wildcard answer.

### 2. Which issues (if any) are related?

Fixes #4290.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.

Tests:
- `go test ./plugin/file -run TestLookupWildcardRespectsCloserEmptyNonTerminal -count=1`
- `go test ./plugin/file`