### PR TITLE
plugin/file: canonicalize escape form in owner names

### DIFF
--- a/plugin/file/escape_test.go
+++ b/plugin/file/escape_test.go
@@ -1,0 +1,69 @@
+package file
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+const dbEscapeOwner = `campus.edu.              500 IN SOA ns1.outside.edu. root.campus.edu. 8 6048 4000 2419200 6048
+campus.edu.              500 IN NS  ns1.outside.edu.
+has\046dot.campus.edu.   500 IN A   192.0.2.2
+`
+
+// TestLookupOwnerNameWithDecimalEscape covers RFC 1035 §5.1 \DDD escape
+// notation in owner names. The miekg/dns parser preserves whichever text
+// form the zone file used (\046 vs \.), but incoming queries arrive as
+// the canonical wire-unpacked form (\.). Without normalization the two
+// strings don't compare equal and the record is silently unreachable.
+func TestLookupOwnerNameWithDecimalEscape(t *testing.T) {
+	const origin = "campus.edu."
+	zone, err := Parse(strings.NewReader(dbEscapeOwner), origin, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{origin: zone}, Names: []string{origin}}}
+	ctx := context.TODO()
+
+	// The wire form of the owner name is h-a-s-.-d-o-t (one label,
+	// seven bytes), which UnpackDomainName turns into "has\.dot".
+	tc := test.Case{
+		Qname: `has\.dot.campus.edu.`, Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A(`has\.dot.campus.edu.	500	IN	A	192.0.2.2`),
+		},
+		Ns: []dns.RR{
+			test.NS(`campus.edu.	500	IN	NS	ns1.outside.edu.`),
+		},
+	}
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	if _, err := fm.ServeDNS(ctx, rec, tc.Msg()); err != nil {
+		t.Fatalf("ServeDNS: %v", err)
+	}
+	if err := test.SortAndCheck(rec.Msg, tc); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCanonicalEscape(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`has\046dot.campus.edu.`, `has\.dot.campus.edu.`},
+		{`has\.dot.campus.edu.`, `has\.dot.campus.edu.`},
+		{`plain.campus.edu.`, `plain.campus.edu.`},
+		{`a\009b.campus.edu.`, `a\009b.campus.edu.`}, // tab stays \DDD (unprintable)
+	}
+	for _, tc := range cases {
+		if got := canonicalEscape(tc.in); got != tc.want {
+			t.Errorf("canonicalEscape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -81,7 +81,7 @@ func (z *Zone) CopyWithoutApex() *Zone {
 func (z *Zone) Insert(r dns.RR) error {
 	// r.Header().Name = strings.ToLower(r.Header().Name)
 	if r.Header().Rrtype != dns.TypeSRV {
-		r.Header().Name = strings.ToLower(r.Header().Name)
+		r.Header().Name = strings.ToLower(canonicalEscape(r.Header().Name))
 	}
 
 	switch h := r.Header().Rrtype; h {
@@ -211,4 +211,28 @@ func (z *Zone) getSOA() *dns.SOA {
 	z.RLock()
 	defer z.RUnlock()
 	return z.SOA
+}
+
+// canonicalEscape normalizes the escape representation of name. RFC 1035
+// §5.1 lets the same byte be written as \DDD (decimal) or \c (literal
+// character), and miekg/dns's zone parser preserves whichever form
+// appeared in the input. Wire format has no such freedom, so packing
+// then unpacking yields the canonical text representation that incoming
+// queries use. Without this, an owner name written as has\046dot.example.
+// in a zone file is stored under that literal string and never matches a
+// query for has\.dot.example., which is how the wire form unpacks.
+func canonicalEscape(name string) string {
+	if !strings.ContainsRune(name, '\\') {
+		return name
+	}
+	buf := make([]byte, len(name)+1)
+	off, err := dns.PackDomainName(name, buf, 0, nil, false)
+	if err != nil {
+		return name
+	}
+	out, _, err := dns.UnpackDomainName(buf[:off], 0)
+	if err != nil {
+		return name
+	}
+	return out
 }


### PR DESCRIPTION
Fixes #8012.

The `file` plugin's `Zone.Insert` lower-cases the owner name but otherwise stores it as the parser handed it over. miekg/dns preserves whichever text form the zone file used for an escape — `\046` for the user, `\.` for the value the wire-side query produces — so an owner written as `has\046dot.campus.edu.` ends up in the tree under that literal string while the query comes in as `has\.dot.campus.edu.`. The strings don't compare equal and the record is silently NXDOMAIN.

Pack-then-unpack the name on Insert. `dns.PackDomainName` + `dns.UnpackDomainName` round-trips through wire format, which is the canonical representation, so both spellings land at the same key. Gated on `strings.ContainsRune(name, '\\')` so the common case is a single string scan.

Regression test in `plugin/file/escape_test.go` parses the issue's zone, queries for the canonical owner, and asserts the A record is returned. Also a small unit test on `canonicalEscape` covering decimal, literal-char, plain, and unprintable cases.

Fixes #8012