### PR TITLE
fix(azure): apply `access` mode to every zone in the same block

### DIFF
--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -67,18 +67,17 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 
 	var fall fall.F
 	var access string
-	var resourceGroup string
-	var zoneName string
 
 	for c.Next() {
 		args := c.RemainingArgs()
+		var currentZoneKeys []string
 
 		for i := range args {
 			parts := strings.SplitN(args[i], ":", 2)
 			if len(parts) != 2 {
 				return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
 			}
-			resourceGroup, zoneName = parts[0], parts[1]
+			resourceGroup, zoneName := parts[0], parts[1]
 			if resourceGroup == "" || zoneName == "" {
 				return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid resource group/zone: %q", args[i])
 			}
@@ -88,6 +87,7 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 
 			resourceGroupSet[resourceGroup+zoneName] = struct{}{}
 			accessMap[resourceGroup+zoneName] = "public"
+			currentZoneKeys = append(currentZoneKeys, resourceGroup+zoneName)
 			resourceGroupMapping[resourceGroup] = append(resourceGroupMapping[resourceGroup], zoneName)
 		}
 
@@ -131,7 +131,9 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 				if access != "public" && access != "private" {
 					return env, resourceGroupMapping, accessMap, fall, c.Errf("invalid access value: can be public/private, found: %s", access)
 				}
-				accessMap[resourceGroup+zoneName] = access
+				for _, k := range currentZoneKeys {
+					accessMap[k] = access
+				}
 			default:
 				return env, resourceGroupMapping, accessMap, fall, c.Errf("unknown property: %q", c.Val())
 			}

--- a/plugin/azure/setup_test.go
+++ b/plugin/azure/setup_test.go
@@ -8,64 +8,88 @@ import (
 
 func TestSetup(t *testing.T) {
 	tests := []struct {
-		body          string
-		expectedError bool
+		body           string
+		expectedError  bool
+		expectedAccess map[string]string
 	}{
-		{`azure`, false},
-		{`azure :`, true},
-		{`azure resource_set:zone`, false},
+		{`azure`, false, nil},
+		{`azure :`, true, nil},
+		{`azure resource_set:zone`, false, nil},
 		{`azure resource_set:zone {
     tenant
-}`, true},
+}`, true, nil},
 		{`azure resource_set:zone {
     tenant abc
-}`, false},
+}`, false, nil},
 		{`azure resource_set:zone {
     client
-}`, true},
+}`, true, nil},
 		{`azure resource_set:zone {
     client abc
-}`, false},
+}`, false, nil},
 		{`azure resource_set:zone {
     subscription
-}`, true},
+}`, true, nil},
 		{`azure resource_set:zone {
     subscription abc
-}`, false},
+}`, false, nil},
 		{`azure resource_set:zone {
     foo
-}`, true},
+}`, true, nil},
 		{`azure resource_set:zone {
     tenant tenant_id
     client client_id
     secret client_secret
     subscription subscription_id
     access public
-}`, false},
+}`, false, nil},
 		{`azure resource_set:zone {
     fallthrough
-}`, false},
+}`, false, nil},
 		{`azure resource_set:zone {
 		environment AZUREPUBLICCLOUD
-	}`, false},
+	}`, false, nil},
 		{`azure resource_set:zone resource_set:zone {
 			fallthrough
-		}`, true},
+		}`, true, nil},
 		{`azure resource_set:zone,zone2 {
 			access private
-		}`, false},
+		}`, false, nil},
 		{`azure resource-set:zone {
 			access public
-		}`, false},
+		}`, false, nil},
 		{`azure resource-set:zone {
 			access foo
-		}`, true},
+		}`, true, nil},
+		{`azure rg:zone1 rg:zone2 {
+			access private
+		}`, false, map[string]string{"rgzone1": "private", "rgzone2": "private"}},
+		{`azure rg:zone1 {
+			access private
+		}
+		azure rg:zone2 {
+		}`, false, map[string]string{"rgzone1": "private", "rgzone2": "public"}},
+		{`azure rg:zone1 rg:zone2 {
+		}`, false, map[string]string{"rgzone1": "public", "rgzone2": "public"}},
 	}
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.body)
-		if _, _, _, _, err := parse(c); (err == nil) == test.expectedError {
+		_, _, accessMap, _, err := parse(c)
+		if (err == nil) == test.expectedError {
 			t.Fatalf("Unexpected errors: %v in test: %d\n\t%s", err, i, test.body)
+		}
+		if test.expectedAccess == nil {
+			continue
+		}
+		if len(accessMap) != len(test.expectedAccess) {
+			t.Fatalf("Test %d: accessMap size mismatch: got %d (%v), want %d (%v)\n\t%s",
+				i, len(accessMap), accessMap, len(test.expectedAccess), test.expectedAccess, test.body)
+		}
+		for k, want := range test.expectedAccess {
+			if got := accessMap[k]; got != want {
+				t.Fatalf("Test %d: accessMap[%q] = %q, want %q\n\t%s", i, k, got, want, test.body)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`access private` was silently honored only for the last zone in an `azure RG:ZONE` block. The earlier zones retained the default `public` mode and were queried against the wrong Azure API, returning empty or stale data without any error or warning. This affects the canonical multi-zone example shown in the README.

The cause was a pair of function-scoped `resourceGroup`/`zoneName` variables that the args loop overwrites on each iteration. The `access` handler then keyed `accessMap` by whatever value happened to be left behind. The per-zone `accessMap` that has existed since the directive was introduced makes the intended behavior unambiguous: each zone declared in the block should carry its own access setting.

Scope the parser variables to the args loop so the misuse cannot recur, track the zones declared in the current `azure` directive, and apply `access` to all of them. The existing tests only checked that `parse()` did not error, which is why this defect went unnoticed. The new cases assert `accessMap` contents directly.

### 2. Which issues (if any) are related?

None that I know of.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

I don't think so unless some system is relying on the buggy behavior.