### PR TITLE
plugin/ready: reject unknown block properties

### DIFF
--- a/plugin/ready/setup.go
+++ b/plugin/ready/setup.go
@@ -90,7 +90,8 @@ func parse(c *caddy.Controller) (string, monitorType, error) {
 		}
 
 		for c.NextBlock() {
-			if c.Val() == "monitor" {
+			switch c.Val() {
+			case "monitor":
 				args := c.RemainingArgs()
 				if len(args) != 1 {
 					return "", "", c.ArgErr()
@@ -101,6 +102,8 @@ func parse(c *caddy.Controller) (string, monitorType, error) {
 				if err != nil {
 					return "", "", err
 				}
+			default:
+				return "", "", c.Errf("unknown property '%s'", c.Val())
 			}
 		}
 	}

--- a/plugin/ready/setup_test.go
+++ b/plugin/ready/setup_test.go
@@ -62,6 +62,13 @@ ready localhost:1234 {
 			shouldErr: true,
 		},
 		{
+			input: `
+ready {
+	monitro continuously
+}`,
+			shouldErr: true,
+		},
+		{
 			input:     `ready localhost:1234 b`,
 			shouldErr: true,
 		},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`ready` only supports `monitor` inside its block, but unknown keys were silently ignored. So a typo like this starts with default `until-ready` behavior, which is kinda rough:

```txt
.:0 {
    ready {
        monitro continuously
    }
}
```

Repro before this change: `go test ./plugin/ready` with the added case fails because no error is returned. After this change CoreDNS rejects it with `unknown property 'monitro'`.

### 2. Which issues (if any) are related?

None found. Searched issues/PRs for ready monitor / unknown property stuff.

### 3. Which documentation changes (if any) need to be made?

None. Existing docs already list `monitor` as the only block option.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Valid `ready` configs keep working; invalid block keys now fail fast.

Tests:
`go test ./plugin/ready ./plugin/health ./plugin/pprof ./plugin/https`
`go test ./test -run TestReloadMetricsHealth -count=1`