### PR TITLE
fix: reject unknown trace and dnstap block options

### DIFF
--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -180,6 +180,8 @@ func parseConfig(c *caddy.Controller) ([]*Dnstap, error) {
 					}
 					d.ExtraFormat = c.Val()
 				}
+			default:
+				return nil, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
 		dnstaps = append(dnstaps, &d)

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -59,6 +59,7 @@ func TestConfig(t *testing.T) {
 		{"dnstap dnstap.sock {\nidentity\n}\n", true, []results{{endpoint: "dnstap.sock", full: false, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1, multipleQueue: 1}}},
 		{"dnstap dnstap.sock {\nversion\n}\n", true, []results{{endpoint: "dnstap.sock", full: false, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1, multipleQueue: 1}}},
 		{"dnstap dnstap.sock {\nextra\n}\n", true, []results{{endpoint: "dnstap.sock", full: false, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1, multipleQueue: 1}}},
+		{"dnstap dnstap.sock {\nidentitiy NAME\n}\n", true, []results{{endpoint: "dnstap.sock", full: false, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1, multipleQueue: 1}}},
 		// Limits and parsing for writebuffer (MiB) and queue (x10k)
 		{"dnstap dnstap.sock full 1024 2048", false, []results{{endpoint: "dnstap.sock", full: true, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1024, multipleQueue: 2048}}},
 		{"dnstap dnstap.sock full 1025 1", true, []results{{endpoint: "dnstap.sock", full: true, proto: "unix", identity: []byte(hostname), version: []byte("-"), multipleTcpWriteBuf: 1, multipleQueue: 1}}},

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -129,6 +129,8 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 				if err != nil {
 					return nil, err
 				}
+			default:
+				return nil, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
 	}

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -44,6 +44,7 @@ func TestTraceParse(t *testing.T) {
 		{"trace {\n zipkin_max_backlog_size\n}", true, "", 1, `coredns`, false, 0, 0, 0},
 		{"trace {\n zipkin_max_batch_size\n}", true, "", 1, `coredns`, false, 0, 0, 0},
 		{"trace {\n zipkin_max_batch_interval\n}", true, "", 1, `coredns`, false, 0, 0, 0},
+		{"trace {\n evrey 100\n}", true, "", 1, `coredns`, false, 0, 0, 0},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Reject unrecognized nested directives in the `trace` and `dnstap` setup parsers instead of silently consuming them. This matches the behavior used by other CoreDNS plugins and catches configuration typos during startup.

Add parser tests covering misspelled block properties for both plugins.

### 2. Which issues (if any) are related?

Inspired by #8119.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.