### PR TITLE
fix: reject unknown chaos block options

### DIFF
--- a/plugin/chaos/setup.go
+++ b/plugin/chaos/setup.go
@@ -32,25 +32,30 @@ func parse(c *caddy.Controller) (string, []string, error) {
 
 	if c.Next() {
 		args := c.RemainingArgs()
+		authors := Owners
 		if len(args) == 0 {
-			return trim(chaosVersion), Owners, nil
-		}
-		if len(args) == 1 {
-			return trim(args[0]), Owners, nil
+			version = trim(chaosVersion)
+		} else if len(args) == 1 {
+			version = trim(args[0])
+		} else {
+			version = args[0]
+			authorSet := make(map[string]struct{})
+			for _, a := range args[1:] {
+				authorSet[a] = struct{}{}
+			}
+			list := make([]string, 0, len(authorSet))
+			for k := range authorSet {
+				k = trim(k) // limit size to 255 chars
+				list = append(list, k)
+			}
+			sort.Strings(list)
+			authors = list
 		}
 
-		version = args[0]
-		authors := make(map[string]struct{})
-		for _, a := range args[1:] {
-			authors[a] = struct{}{}
+		if c.NextBlock() {
+			return "", nil, c.Errf("unknown property '%s'", c.Val())
 		}
-		list := []string{}
-		for k := range authors {
-			k = trim(k) // limit size to 255 chars
-			list = append(list, k)
-		}
-		sort.Strings(list)
-		return version, list, nil
+		return version, authors, nil
 	}
 
 	return version, Owners, nil

--- a/plugin/chaos/setup_test.go
+++ b/plugin/chaos/setup_test.go
@@ -22,6 +22,11 @@ func TestSetupChaos(t *testing.T) {
 		{
 			`chaos v3 "Miek Gieben"`, false, "v3", "Miek Gieben", "",
 		},
+		{
+			`chaos v2 {
+				unknown
+			}`, true, "", "", "unknown property",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Tiny config-footgun fix. The `chaos` plugin has no documented block options, but this used to parse with no error:

```txt
.:0 {
    chaos v2 {
        unknown
    }
}
```

Before this change, the added test fails because no error is returned. Now CoreDNS rejects it with `unknown property 'unknown'`.

### 2. Which issues (if any) are related?

None found. Searched issues/PRs for chaos unknown property and plugin/chaos block. Similar parser hardening landed in #8119 and #8120.

### 3. Which documentation changes (if any) need to be made?

None. Docs already only show `chaos [VERSION] [AUTHORS...]`.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Valid chaos configs still work; invalid block keys now fail fast.

Tests:
`go test -race ./plugin/chaos`
`go test ./plugin/chaos ./test -run Chaos -count=1`