### PR TITLE
fix: use descriptive error for unknown block options in health and log

### DIFF
--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -58,7 +58,7 @@ func parse(c *caddy.Controller) (string, time.Duration, error) {
 				}
 				dur = l
 			default:
-				return "", 0, c.ArgErr()
+				return "", 0, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
 	}

--- a/plugin/health/setup_test.go
+++ b/plugin/health/setup_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -8,24 +9,25 @@ import (
 
 func TestSetupHealth(t *testing.T) {
 	tests := []struct {
-		input     string
-		shouldErr bool
+		input              string
+		shouldErr          bool
+		expectedErrContent string
 	}{
-		{`health`, false},
-		{`health localhost:1234`, false},
+		{`health`, false, ""},
+		{`health localhost:1234`, false, ""},
 		{`health localhost:1234 {
 			lameduck 4s
-}`, false},
-		{`health bla:a`, false},
+}`, false, ""},
+		{`health bla:a`, false, ""},
 
-		{`health bla`, true},
-		{`health bla bla`, true},
+		{`health bla`, true, ""},
+		{`health bla bla`, true, ""},
 		{`health localhost:1234 {
 			lameduck a
-}`, true},
+}`, true, ""},
 		{`health localhost:1234 {
 			lamedudk 4
-} `, true},
+} `, true, "unknown property"},
 	}
 
 	for i, test := range tests {
@@ -39,6 +41,9 @@ func TestSetupHealth(t *testing.T) {
 		if err != nil {
 			if !test.shouldErr {
 				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+			}
+			if test.expectedErrContent != "" && !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain %q, got: %v", i, test.expectedErrContent, err)
 			}
 		}
 	}

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -86,7 +86,7 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 					classes[cls] = struct{}{}
 				}
 			default:
-				return nil, c.ArgErr()
+				return nil, c.Errf("unknown property '%s'", c.Val())
 			}
 		}
 		if len(classes) == 0 {

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -180,5 +181,16 @@ func TestLogParse(t *testing.T) {
 					i, j, test.expectedLogRules[j].Class, actualLogRule.Class)
 			}
 		}
+	}
+}
+
+func TestLogParseUnknownProperty(t *testing.T) {
+	c := caddy.NewTestController("dns", `log { unknown }`)
+	_, err := logParse(c)
+	if err == nil {
+		t.Fatal("expected error for unknown block option, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown property") {
+		t.Errorf("expected error to contain 'unknown property', got: %v", err)
 	}
 }


### PR DESCRIPTION
When you typo a block option in `health` or `log`, the error you get back is kinda useless:

```
Wrong argument count or unexpected line ending after 'lamedudk'
```

That's `c.ArgErr()`, which is meant for wrong arg counts -- not unknown properties. So the user has no clue what's actually wrong.

**Reproduce:**

```
health localhost:8080 {
    lamedudk 5s
}
```

or

```
log {
    clss denial
}
```

Both silently give a misleading error instead of saying "hey, that option doesn't exist".

**Fix:** swap `c.ArgErr()` for `c.Errf("unknown property '%s'", c.Val())` in the default cases of those two setup parsers, same as was done in #8119, #8120, #8121.

After fix:
```
unknown property 'lamedudk'
```