### PR TITLE
fix(kubernetes): remove debug fmt.Println from multicluster zone validation

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -293,8 +293,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 
 	for _, multiclusterZone := range k8s.opts.multiclusterZones {
 		if !slices.Contains(k8s.Zones, multiclusterZone) {
-			fmt.Println(k8s.Zones)
-			return nil, c.Errf("is not authoritative for the multicluster zone %s", multiclusterZone)
+			return nil, c.Errf("is not authoritative for the multicluster zone %s (authoritative zones: %v)", multiclusterZone, k8s.Zones)
 		}
 	}
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`fmt.Println(k8s.Zones)` was left in `ParseStanza` by mistake when multicluster support landed (#7266). 
Every time someone misconfigures a `multicluster` zone that's not in the server block, it dumps the zones slice to stdout before returning the error. 
That's debug noise leaking into production.

The fix drops the `fmt.Println` and folds the zones list into the error message itself, so you still get the info but through the right channel.

Reproduce:

```
# Corefile
coredns.local {
    kubernetes coredns.local {
        multicluster clusterset.local
    }
}
```

Or just run the existing test and watch stdout:

```
go test ./plugin/kubernetes/ -run TestKubernetesParseMulticluster -v
# prints [coredns.local.] to stdout even though tests pass
```

### 2. Which issues (if any) are related?

None found

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No