### PR TITLE
fix: reject invalid any and local config

### DIFF
--- a/plugin/any/setup.go
+++ b/plugin/any/setup.go
@@ -9,6 +9,14 @@ import (
 func init() { plugin.Register("any", setup) }
 
 func setup(c *caddy.Controller) error {
+	c.Next() // 'any'
+	if c.NextArg() {
+		return plugin.Error("any", c.ArgErr())
+	}
+	if c.NextBlock() {
+		return plugin.Error("any", c.Errf("unknown property '%s'", c.Val()))
+	}
+
 	a := Any{}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/local/setup.go
+++ b/plugin/local/setup.go
@@ -9,6 +9,14 @@ import (
 func init() { plugin.Register("local", setup) }
 
 func setup(c *caddy.Controller) error {
+	c.Next() // 'local'
+	if c.NextArg() {
+		return plugin.Error("local", c.ArgErr())
+	}
+	if c.NextBlock() {
+		return plugin.Error("local", c.Errf("unknown property '%s'", c.Val()))
+	}
+
 	l := Local{}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/local/setup_test.go
+++ b/plugin/local/setup_test.go
@@ -1,4 +1,4 @@
-package any
+package local
 
 import (
 	"testing"
@@ -8,27 +8,26 @@ import (
 )
 
 func TestSetup(t *testing.T) {
-	c := caddy.NewTestController("dns", `any`)
+	c := caddy.NewTestController("dns", `local`)
 	if err := setup(c); err != nil {
-		t.Fatalf("Expected no errors, but got: %v", err)
+		t.Fatalf("expected no errors, but got: %v", err)
 	}
 
-	// Check that the plugin was added to the config
 	cfg := dnsserver.GetConfig(c)
 	if len(cfg.Plugin) == 0 {
-		t.Error("Expected plugin to be added to config")
+		t.Fatal("expected plugin to be added to config")
 	}
 }
 
 func TestSetupRejectsArgs(t *testing.T) {
-	c := caddy.NewTestController("dns", `any example.org`)
+	c := caddy.NewTestController("dns", `local example.org`)
 	if err := setup(c); err == nil {
 		t.Fatal("expected error for unexpected argument, got nil")
 	}
 }
 
 func TestSetupRejectsBlockOptions(t *testing.T) {
-	c := caddy.NewTestController("dns", `any { foo }`)
+	c := caddy.NewTestController("dns", `local { foo }`)
 	if err := setup(c); err == nil {
 		t.Fatal("expected error for unexpected block option, got nil")
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`any` and `local` were accepting junk config instead of failing fast.

Repro before this patch:
```txt
. {
    any example.org
    local { foo }
}
```

Both cases are reachable in normal startup config parsing, no weird setup needed. They should error, but they slipped through. This patch makes both plugins validate args/block content, and adds tests.

### 2. Which issues (if any) are related?

No direct issue found. Kinda the same lane as #8120, #8121, #8119 and #8128.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Only for invalid config. Valid configs stay the same.
