### PR TITLE
plugin/cache: allow cache TTLs above default 3600s

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -242,7 +242,7 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	buf, _ := dw.Msg.Pack()
 
 	mt, _ := response.Typify(dw.Msg, time.Now().UTC())
-	age := dnsutil.MinimalTTL(dw.Msg, mt)
+	age := dnsutil.MinimalTTL(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
 
 	w.Header().Set("Content-Type", doh.MimeType)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", uint32(age.Seconds())))

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -242,7 +242,7 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	buf, _ := dw.Msg.Pack()
 
 	mt, _ := response.Typify(dw.Msg, time.Now().UTC())
-	age := dnsutil.MinimalTTL(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
+	age := dnsutil.MinimalTTLWithMaximum(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
 
 	w.Header().Set("Content-Type", doh.MimeType)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", uint32(age.Seconds())))

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -213,7 +213,7 @@ func (s *ServerHTTPS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	buf, _ := dw.Msg.Pack()
 	mt, _ := response.Typify(dw.Msg, time.Now().UTC())
-	age := dnsutil.MinimalTTL(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
+	age := dnsutil.MinimalTTLWithMaximum(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
 
 	w.Header().Set("Content-Type", doh.MimeType)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", uint32(age.Seconds())))

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -213,7 +213,7 @@ func (s *ServerHTTPS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	buf, _ := dw.Msg.Pack()
 	mt, _ := response.Typify(dw.Msg, time.Now().UTC())
-	age := dnsutil.MinimalTTL(dw.Msg, mt)
+	age := dnsutil.MinimalTTL(dw.Msg, mt, dnsutil.MaximumDefaultTTL)
 
 	w.Header().Set("Content-Type", doh.MimeType)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", uint32(age.Seconds())))

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -224,12 +224,12 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	var duration time.Duration
 	switch mt {
 	case response.NameError, response.NoData:
-		msgTTL := dnsutil.MinimalTTL(res, mt, w.nttl)
+		msgTTL := dnsutil.MinimalTTLWithMaximum(res, mt, w.nttl)
 		duration = computeTTL(msgTTL, w.minnttl, w.nttl)
 	case response.ServerError:
 		duration = w.failttl
 	default:
-		msgTTL := dnsutil.MinimalTTL(res, mt, w.pttl)
+		msgTTL := dnsutil.MinimalTTLWithMaximum(res, mt, w.pttl)
 		duration = computeTTL(msgTTL, w.minpttl, w.pttl)
 	}
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -221,14 +221,15 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// key returns empty string for anything we don't want to cache.
 	hasKey, key := key(w.state.Name(), res, mt, w.do, w.cd)
 
-	msgTTL := dnsutil.MinimalTTL(res, mt)
 	var duration time.Duration
 	switch mt {
 	case response.NameError, response.NoData:
+		msgTTL := dnsutil.MinimalTTL(res, mt, w.nttl)
 		duration = computeTTL(msgTTL, w.minnttl, w.nttl)
 	case response.ServerError:
 		duration = w.failttl
 	default:
+		msgTTL := dnsutil.MinimalTTL(res, mt, w.pttl)
 		duration = computeTTL(msgTTL, w.minpttl, w.pttl)
 	}
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -362,6 +362,27 @@ func TestCacheZeroTTL(t *testing.T) {
 	}
 }
 
+func TestCacheHonorsConfiguredPositiveMaxTTLAboveDefault(t *testing.T) {
+	c := New()
+	c.pttl = 2 * time.Hour
+	c.minpttl = 0
+	c.Next = ttlBackend(24 * 60 * 60)
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	c.ServeDNS(context.TODO(), rec, req)
+
+	if rec.Msg == nil || len(rec.Msg.Answer) == 0 {
+		t.Fatalf("expected answer, got %+v", rec.Msg)
+	}
+
+	if got, want := rec.Msg.Answer[0].Header().Ttl, uint32(7200); got != want {
+		t.Fatalf("expected TTL %d, got %d", want, got)
+	}
+}
+
 func TestCacheServfailTTL0(t *testing.T) {
 	c := New()
 	c.minpttl = minTTL

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -8,9 +8,14 @@ import (
 	"github.com/miekg/dns"
 )
 
-// MinimalTTL scans the DNS message and returns the lowest TTL found,
+// MinimalTTL scans the message returns the lowest TTL found taking into the response.Type of the message.
+func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
+	return MinimalTTLWithMaximum(m, mt, MaximumDefaultTTL)
+}
+
+// MinimalTTLWithMaximum scans the DNS message and returns the lowest TTL found,
 // constrained by maximumTTL and the response type.
-func MinimalTTL(m *dns.Msg, mt response.Type, maximumTTL time.Duration) time.Duration {
+func MinimalTTLWithMaximum(m *dns.Msg, mt response.Type, maximumTTL time.Duration) time.Duration {
 	if mt != response.NoError && mt != response.NameError && mt != response.NoData {
 		return MinimalDefaultTTL
 	}

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -8,8 +8,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-// MinimalTTL scans the message returns the lowest TTL found taking into the response.Type of the message.
-func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
+// MinimalTTL scans the DNS message and returns the lowest TTL found,
+// constrained by maximumTTL and the response type.
+func MinimalTTL(m *dns.Msg, mt response.Type, maximumTTL time.Duration) time.Duration {
 	if mt != response.NoError && mt != response.NameError && mt != response.NoData {
 		return MinimalDefaultTTL
 	}
@@ -20,7 +21,7 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 		return MinimalDefaultTTL
 	}
 
-	minTTL := MaximumDefaulTTL
+	minTTL := maximumTTL
 	for _, r := range m.Answer {
 		if r.Header().Ttl < uint32(minTTL.Seconds()) {
 			minTTL = time.Duration(r.Header().Ttl) * time.Second

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -25,7 +25,7 @@ func TestMinimalTTL(t *testing.T) {
 	if mt != response.NoData {
 		t.Fatalf("Expected type to be response.NoData, got %s", mt)
 	}
-	dur := MinimalTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
+	dur := MinimalTTL(m, mt, MaximumDefaultTTL) // minTTL on msg is 3600 (neg. ttl on SOA)
 	if dur != 1800*time.Second {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
@@ -35,7 +35,7 @@ func TestMinimalTTL(t *testing.T) {
 	if mt != response.NameError {
 		t.Fatalf("Expected type to be response.NameError, got %s", mt)
 	}
-	dur = MinimalTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
+	dur = MinimalTTL(m, mt, MaximumDefaultTTL) // minTTL on msg is 3600 (neg. ttl on SOA)
 	if dur != 1800*time.Second {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
@@ -63,7 +63,7 @@ func BenchmarkMinimalTTL(b *testing.B) {
 	mt, _ := response.Typify(m, utc)
 
 	for b.Loop() {
-		dur := MinimalTTL(m, mt)
+		dur := MinimalTTL(m, mt, MaximumDefaultTTL)
 		if dur != 1000*time.Second {
 			b.Fatalf("Wrong MinimalTTL %d, expected %d", dur, 1000*time.Second)
 		}

--- a/plugin/pkg/dnsutil/ttl_test.go
+++ b/plugin/pkg/dnsutil/ttl_test.go
@@ -25,7 +25,7 @@ func TestMinimalTTL(t *testing.T) {
 	if mt != response.NoData {
 		t.Fatalf("Expected type to be response.NoData, got %s", mt)
 	}
-	dur := MinimalTTL(m, mt, MaximumDefaultTTL) // minTTL on msg is 3600 (neg. ttl on SOA)
+	dur := MinimalTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
 	if dur != 1800*time.Second {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
@@ -35,7 +35,7 @@ func TestMinimalTTL(t *testing.T) {
 	if mt != response.NameError {
 		t.Fatalf("Expected type to be response.NameError, got %s", mt)
 	}
-	dur = MinimalTTL(m, mt, MaximumDefaultTTL) // minTTL on msg is 3600 (neg. ttl on SOA)
+	dur = MinimalTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
 	if dur != 1800*time.Second {
 		t.Fatalf("Expected minttl duration to be %d, got %d", 1800, dur)
 	}
@@ -63,7 +63,7 @@ func BenchmarkMinimalTTL(b *testing.B) {
 	mt, _ := response.Typify(m, utc)
 
 	for b.Loop() {
-		dur := MinimalTTL(m, mt, MaximumDefaultTTL)
+		dur := MinimalTTL(m, mt)
 		if dur != 1000*time.Second {
 			b.Fatalf("Wrong MinimalTTL %d, expected %d", dur, 1000*time.Second)
 		}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This change allows the cache plugin to honor configured maximum TTL values above the default 3600s limit. Default behavior remains unchanged 
### 2. Which issues (if any) are related?
This PR fixes #7846
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a