### PR TITLE
core: bound HTTP/3 request header size for DoH3

### DIFF
--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -26,6 +26,8 @@ import (
 const (
 	// DefaultHTTPS3MaxStreams is the default maximum number of concurrent QUIC streams per connection.
 	DefaultHTTPS3MaxStreams = 256
+	// DefaultHTTPS3MaxHeaderBytes limits HTTP/3 header memory before requests reach the DoH handler.
+	DefaultHTTPS3MaxHeaderBytes = 16 << 10 // 16 KiB
 )
 
 // ServerHTTPS3 represents a DNS-over-HTTP/3 server.
@@ -91,6 +93,7 @@ func NewServerHTTPS3(addr string, group []*Config) (*ServerHTTPS3, error) {
 		TLSConfig:       tlsConfig,
 		EnableDatagrams: true,
 		QUICConfig:      qconf,
+		MaxHeaderBytes:  DefaultHTTPS3MaxHeaderBytes,
 		// Logger: stdlog.New(&loggerAdapter{}, "", 0), TODO: Fix it
 	}
 

--- a/core/dnsserver/server_https3_test.go
+++ b/core/dnsserver/server_https3_test.go
@@ -152,6 +152,27 @@ func TestNewServerHTTPS3ZeroLimits(t *testing.T) {
 	}
 }
 
+func TestNewServerHTTPS3DefaultMaxHeaderBytes(t *testing.T) {
+	c := Config{
+		Zone:        "example.com.",
+		Transport:   "https3",
+		TLSConfig:   &tls.Config{},
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "443",
+	}
+
+	server, err := NewServerHTTPS3("127.0.0.1:443", []*Config{&c})
+	if err != nil {
+		t.Fatalf("NewServerHTTPS3() failed: %v", err)
+	}
+
+	if server.httpsServer.MaxHeaderBytes != DefaultHTTPS3MaxHeaderBytes {
+		t.Errorf("expected MaxHeaderBytes = %d, got %d",
+			DefaultHTTPS3MaxHeaderBytes,
+			server.httpsServer.MaxHeaderBytes)
+	}
+}
+
 func testConfigWithTSIGCheckPluginHTTPS3(t *testing.T, check func(*testing.T, error)) *Config {
 	t.Helper()
 


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR Set a conservative MaxHeaderBytes value on the DoH3 HTTP/3 server. This reduces memory exposure from large request headers before requests reach the DoH handler.
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a