### PR TITLE
build: add loong64 arch support

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -87,6 +87,9 @@ else
 	    if [ "$${arch}" = "riscv64" ]; then \
 	        DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=debian:unstable-slim --build-arg=BASE=ghcr.io/go-riscv/distroless/static-unstable:nonroot"; \
 	    fi; \
+	    if [ "$${arch}" = "loong64" ]; then \
+            DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=ghcr.io/loong64/debian:trixie-slim --build-arg=BASE=ghcr.io/loong64/debian:trixie-slim"; \
+        fi; \
 	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) $${DOCKER_ARGS} build/docker/$${arch} ;\
 	done
 endif

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -32,7 +32,7 @@ DOCKER:=
 NAME:=coredns
 GITHUB:=https://github.com/coredns/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64 loong64
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~mips64le ~~g" | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -51,7 +51,7 @@ endif
 NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips riscv64
+LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips riscv64 loong64
 GOLANG_VERSION ?= $(shell cat .go-version)
 
 export GOSUMDB = sum.golang.org


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Add `loong64` (LoongArch 64-bit) architecture support to CoreDNS build and release pipeline, enabling CoreDNS to run natively on LoongArch hardware.

Changes:
- `Makefile.release`: Add `loong64` to `LINUX_ARCH` for release binary builds
- `Makefile.docker`: Add `loong64` to `LINUX_ARCH` and configure Docker build args using community-provided `ghcr.io/loong64/debian:trixie-slim` images (follows the same pattern as `riscv64` which also uses non-official base images)

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/8136

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
