### PR TITLE
fix(server_https): use http.LocalAddrContextKey for DoH local address and avoid blocking accept loop under PROXY protocol

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -52,9 +52,6 @@ func (l *loggerAdapter) Write(p []byte) (n int, err error) {
 // Plugins can access the original HTTP request to retrieve headers, client IP, and metadata.
 type HTTPRequestKey struct{}
 
-// connAddrKey is the context key for the per-connection local address set by ConnContext.
-type connAddrKey struct{}
-
 // NewServerHTTPS returns a new CoreDNS HTTPS server and compiles all plugins in to it.
 func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 	s, err := NewServer(addr, group)
@@ -93,9 +90,6 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 		WriteTimeout: s.WriteTimeout,
 		IdleTimeout:  s.IdleTimeout,
 		ErrorLog:     stdlog.New(&loggerAdapter{}, "", 0),
-		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-			return context.WithValue(ctx, connAddrKey{}, c.LocalAddr())
-		},
 	}
 	maxConnections := DefaultHTTPSMaxConnections
 	if len(group) > 0 && group[0] != nil && group[0].MaxHTTPSConnections != nil {
@@ -176,9 +170,9 @@ func (s *ServerHTTPS) Stop() error {
 	return nil
 }
 
-// localAddr returns the per-connection local address from context, or s.listenAddr as fallback.
+// localAddr returns the per-connection local address, or s.listenAddr as fallback.
 func (s *ServerHTTPS) localAddr(r *http.Request) net.Addr {
-	if addr, ok := r.Context().Value(connAddrKey{}).(net.Addr); ok {
+	if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 		return addr
 	}
 	return s.listenAddr

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -196,7 +196,7 @@ func TestDoHWriterLaddrFromConnContext(t *testing.T) {
 	ppDst := &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 443}
 
 	r := httptest.NewRequest(http.MethodPost, "/dns-query", io.NopCloser(bytes.NewReader(buf)))
-	ctx := context.WithValue(r.Context(), connAddrKey{}, ppDst)
+	ctx := context.WithValue(r.Context(), http.LocalAddrContextKey, ppDst)
 	r = r.WithContext(ctx)
 	w := httptest.NewRecorder()
 
@@ -230,7 +230,7 @@ func TestDoHWriterLaddrFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No connAddrKey in context; should fall back to s.listenAddr.
+	// No LocalAddrContextKey in context; should fall back to s.listenAddr.
 	r := httptest.NewRequest(http.MethodPost, "/dns-query", io.NopCloser(bytes.NewReader(buf)))
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
## What this fixes

This fixes my original PR https://github.com/coredns/coredns/pull/8005

`NewServerHTTPS` resolved the per-connection local address in a custom `http.Server.ConnContext` callback:

```go
ConnContext: func(ctx context.Context, c net.Conn) context.Context {
    return context.WithValue(ctx, connAddrKey{}, c.LocalAddr())
},
```

`ConnContext` runs **synchronously in the `http.Server` accept loop**, before the per-connection serving goroutine starts. For a plain socket `c.LocalAddr()` is cheap, but when the listener is wrapped by `go-proxyproto`, `Conn.LocalAddr()` calls `ensureHeaderProcessed()`, which reads the PROXY header off the connection (`sync.Once`). If the header has not arrived yet, that read **blocks inside the accept loop** and head-of-line-blocks acceptance of every other connection, so connections last longer than they should.

## The fix

`net/http` and `http2` already populate `http.LocalAddrContextKey` from the connection in the **per-connection serving goroutine**, not the accept loop:

| Path | Where | Source |
|------|-------|--------|
| HTTP/1.1 | `c.serve()` goroutine | `net/http` `server.go:1901` |
| HTTP/2 (stdlib bundle) | serving goroutine | `net/http` `h2_bundle.go:4552` |
| HTTP/2 (x/net) | `serverConnBaseContext` | `golang.org/x/net/http2` `server_common.go:216` |

All resolve `c.LocalAddr()` on the same `tls.Conn → … → proxyproto.Conn` chain, so the value under `http.LocalAddrContextKey` is byte-identical to what the custom callback produced — the PPv2 destination address — and it is set off the accept loop on both the HTTP/1.1 and HTTP/2 paths.

So this drops the custom `ConnContext` callback and the `connKey` type and reads the framework key directly:

```go
func (s *ServerHTTPS) localAddr(r *http.Request) net.Addr {
    if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
        return addr
    }
    return s.listenAddr
}
```

The client address is unaffected: it arrives via `r.RemoteAddr`, which the framework populates natively from `c.RemoteAddr()` on both paths.

## Testing

- `go build ./core/dnsserver/` — ok
- `go vet ./core/dnsserver/` — clean
- `gofmt` — clean
- `go test ./core/dnsserver/` — ok
- `go test -race ./core/dnsserver/` — ok

`TestDoHWriterLaddrFromConnContext` / `TestDoHWriterLaddrFallback` stash the address under `http.LocalAddrContextKey` instead of the removed custom key.
