### PR TITLE
core/dnsserver: propagate HTTPRequestValidateFunc to all configs

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -275,6 +275,10 @@ func propagateConfigParams(configs []*Config) {
 		c.WriteTimeout = c.firstConfigInBlock.WriteTimeout
 		c.IdleTimeout = c.firstConfigInBlock.IdleTimeout
 		c.TsigSecret = c.firstConfigInBlock.TsigSecret
+
+		// Propagate HTTPRequestValidateFunc so that custom path validators work in
+		// multi-transport blocks. Otherwise HTTPS 404s on non-"/dns-query" paths.
+		c.HTTPRequestValidateFunc = c.firstConfigInBlock.HTTPRequestValidateFunc
 	}
 }
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`Config.HTTPRequestValidateFunc` exists for external plugins to hook into, but it
doesn't actually work when a server block has more than one transport.

Plugin setup only runs for the first key of a server block (caddy skips
`ServerBlockKeyIndex > 0`), so `dnsserver.GetConfig(c)` always returns the first
key's `*Config`, and that is the only config a plugin can set the validator on.

But, `NewServerHTTPS` reads the validator from the configs in its own
listener group — i.e. the config belonging to the `https://` key, which never
received it. In a block such as:

    . https://.:8443 tls://.:8853 {
        external_plugin_with_validator
    }

the HTTPS server always finds a nil validator, falls back to the default
`/dns-query` path check, and then returns 404 for any custom path the plugin
intended to accept. Single-key blocks (`https://.:443 { ... }`) happen to work,
which is why this was probably not already fixed.

This PR fixes it by adding `HTTPRequestValidateFunc` to the fields that
`propagateConfigParams` copies from `firstConfigInBlock` to all other configs in
the block, alongside the existing propagation of `Plugin`, `TLSConfig`,
timeouts, etc.

### 2. Which issues (if any) are related?

Similar, but not directly related; #5703 (fixed by #5707), where `TLSConfig` was not correctly propagated to the other configs in a server block.

### 3. Which documentation changes (if any) need to be made?

None I'm aware of

### 4. Does this introduce a backward incompatible change or deprecation?

No.