### PR TITLE
plugin/dnstap: store IPv4-mapped IPv6 addresses as 4 octets with SocketFamily INET

### DIFF
--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -123,8 +123,9 @@ func testMessage() *tap.Message {
 	return &tap.Message{
 		SocketFamily:   &inet,
 		SocketProtocol: &udp,
-		QueryAddress:   net.ParseIP("10.240.0.1"),
-		QueryPort:      &port,
+		// Explicit 4-octet form, because that's the expected dnstap message representation when SocketFamily is INET.
+		QueryAddress: net.ParseIP("10.240.0.1").To4(),
+		QueryPort:    &port,
 	}
 }
 

--- a/plugin/dnstap/msg/msg.go
+++ b/plugin/dnstap/msg/msg.go
@@ -15,31 +15,37 @@ var (
 	familyINET6 = tap.SocketFamily_INET6
 )
 
+// socketFamilyAndAddress maps an IP to the dnstap SocketFamily and the address
+// bytes to store for it. IPv4, including IPv4-mapped IPv6, is returned as a
+// 4-octet INET address; anything else as a 16-octet INET6 address, matching
+// https://github.com/dnstap/dnstap.pb/blob/main/dnstap.proto.
+func socketFamilyAndAddress(ip net.IP) (*tap.SocketFamily, []byte) {
+	if ip4 := ip.To4(); ip4 != nil {
+		return &familyINET, ip4
+	}
+	return &familyINET6, ip
+}
+
+// TODO: SetQueryAddress and SetResponseAddress each set the message-level SocketFamily (and SocketProtocol) from their own address. A dnstap Message describes a single socket whose two endpoints share one family, but calling both setters with addresses of different families leaves SocketFamily reflecting only the last call and inconsistent with the other stored address. Evaluate replacing the two setters with a single SetAddresses(t, query, response) that derives SocketFamily/SocketProtocol once for the whole socket and rejects a family mismatch.
+
 // SetQueryAddress adds the query address to the message. This also sets the SocketFamily and SocketProtocol.
 func SetQueryAddress(t *tap.Message, addr net.Addr) error {
-	t.SocketFamily = &familyINET
 	switch a := addr.(type) {
 	case *net.TCPAddr:
 		t.SocketProtocol = &protoTCP
-		t.QueryAddress = a.IP
 
 		p := uint32(a.Port) // #nosec G115 -- Port is inherently bounded (1-65535)
 		t.QueryPort = &p
 
-		if a.IP.To4() == nil {
-			t.SocketFamily = &familyINET6
-		}
+		t.SocketFamily, t.QueryAddress = socketFamilyAndAddress(a.IP)
 		return nil
 	case *net.UDPAddr:
 		t.SocketProtocol = &protoUDP
-		t.QueryAddress = a.IP
 
 		p := uint32(a.Port) // #nosec G115 -- Port is inherently bounded (1-65535)
 		t.QueryPort = &p
 
-		if a.IP.To4() == nil {
-			t.SocketFamily = &familyINET6
-		}
+		t.SocketFamily, t.QueryAddress = socketFamilyAndAddress(a.IP)
 		return nil
 	default:
 		return fmt.Errorf("unknown address type: %T", a)
@@ -48,29 +54,22 @@ func SetQueryAddress(t *tap.Message, addr net.Addr) error {
 
 // SetResponseAddress the response address to the message. This also sets the SocketFamily and SocketProtocol.
 func SetResponseAddress(t *tap.Message, addr net.Addr) error {
-	t.SocketFamily = &familyINET
 	switch a := addr.(type) {
 	case *net.TCPAddr:
 		t.SocketProtocol = &protoTCP
-		t.ResponseAddress = a.IP
 
 		p := uint32(a.Port) // #nosec G115 -- Port is inherently bounded (1-65535)
 		t.ResponsePort = &p
 
-		if a.IP.To4() == nil {
-			t.SocketFamily = &familyINET6
-		}
+		t.SocketFamily, t.ResponseAddress = socketFamilyAndAddress(a.IP)
 		return nil
 	case *net.UDPAddr:
 		t.SocketProtocol = &protoUDP
-		t.ResponseAddress = a.IP
 
 		p := uint32(a.Port) // #nosec G115 -- Port is inherently bounded (1-65535)
 		t.ResponsePort = &p
 
-		if a.IP.To4() == nil {
-			t.SocketFamily = &familyINET6
-		}
+		t.SocketFamily, t.ResponseAddress = socketFamilyAndAddress(a.IP)
 		return nil
 	default:
 		return fmt.Errorf("unknown address type: %T", a)

--- a/plugin/dnstap/msg/msg_test.go
+++ b/plugin/dnstap/msg/msg_test.go
@@ -1,0 +1,91 @@
+package msg
+
+import (
+	"net"
+	"testing"
+
+	tap "github.com/dnstap/golang-dnstap"
+)
+
+// ipv4MappedINET is the 16-byte IPv4-mapped IPv6 form of 192.0.2.1
+// (::ffff:192.0.2.1). Dual-stack listeners report IPv4 clients this way, and
+// Go's net.IP.To4 still recognizes them as IPv4.
+var ipv4MappedINET = net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 1}
+
+// An IPv4 client reported as an IPv4-mapped IPv6 address must be stored as a
+// 4-octet address with SocketFamily INET, otherwise the dnstap message parser
+// could get confused when expecting only 4 bytes but is presented with 16 bytes.
+func TestSetAddressIPv4MappedReportedAsINET(t *testing.T) {
+	assertINET := func(t *testing.T, family tap.SocketFamily, addr []byte) {
+		t.Helper()
+		if family != tap.SocketFamily_INET {
+			t.Errorf("SocketFamily = %v, want INET", family)
+		}
+		if len(addr) != 4 {
+			t.Errorf("address length = %d, want 4 octets for INET", len(addr))
+		}
+		if got := net.IP(addr).String(); got != "192.0.2.1" {
+			t.Errorf("address = %q, want %q", got, "192.0.2.1")
+		}
+	}
+
+	t.Run("query/udp", func(t *testing.T) {
+		m := new(tap.Message)
+		if err := SetQueryAddress(m, &net.UDPAddr{IP: ipv4MappedINET}); err != nil {
+			t.Fatal(err)
+		}
+		assertINET(t, m.GetSocketFamily(), m.GetQueryAddress())
+	})
+
+	t.Run("query/tcp", func(t *testing.T) {
+		m := new(tap.Message)
+		if err := SetQueryAddress(m, &net.TCPAddr{IP: ipv4MappedINET}); err != nil {
+			t.Fatal(err)
+		}
+		assertINET(t, m.GetSocketFamily(), m.GetQueryAddress())
+	})
+
+	t.Run("response/udp", func(t *testing.T) {
+		m := new(tap.Message)
+		if err := SetResponseAddress(m, &net.UDPAddr{IP: ipv4MappedINET}); err != nil {
+			t.Fatal(err)
+		}
+		assertINET(t, m.GetSocketFamily(), m.GetResponseAddress())
+	})
+
+	t.Run("response/tcp", func(t *testing.T) {
+		m := new(tap.Message)
+		if err := SetResponseAddress(m, &net.TCPAddr{IP: ipv4MappedINET}); err != nil {
+			t.Fatal(err)
+		}
+		assertINET(t, m.GetSocketFamily(), m.GetResponseAddress())
+	})
+}
+
+// Native IPv4 addresses keep SocketFamily INET and a 4-octet address.
+func TestSetAddressNativeIPv4(t *testing.T) {
+	m := new(tap.Message)
+	if err := SetQueryAddress(m, &net.UDPAddr{IP: net.IP{192, 0, 2, 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if m.GetSocketFamily() != tap.SocketFamily_INET {
+		t.Errorf("SocketFamily = %v, want INET", m.GetSocketFamily())
+	}
+	if got := len(m.GetQueryAddress()); got != 4 {
+		t.Errorf("address length = %d, want 4 octets for INET", got)
+	}
+}
+
+// Genuine IPv6 addresses keep SocketFamily INET6 and a 16-octet address.
+func TestSetAddressNativeIPv6(t *testing.T) {
+	m := new(tap.Message)
+	if err := SetQueryAddress(m, &net.UDPAddr{IP: net.ParseIP("2001:db8::1")}); err != nil {
+		t.Fatal(err)
+	}
+	if m.GetSocketFamily() != tap.SocketFamily_INET6 {
+		t.Errorf("SocketFamily = %v, want INET6", m.GetSocketFamily())
+	}
+	if got := len(m.GetQueryAddress()); got != 16 {
+		t.Errorf("address length = %d, want 16 octets for INET6", got)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`SetQueryAddress` and `SetResponseAddress` stored the address from `net.Addr` as-is. On a dual-stack listener an IPv4 client's `IP` is the 16-octet IPv4-mapped IPv6 form (`::ffff:a.b.c.d`), so the message ends up with `socket_family = INET` but a 16-octet address.

From https://github.com/dnstap/dnstap.pb/blob/main/dnstap.proto, the address width is tied to the family:

> // For SocketFamily INET, this field is 4 octets (IPv4 address).
> // For SocketFamily INET6, this field is 16 octets (IPv6 address).

A consumer that takes the width from `socket_family`, as the schema describes, reads the first 4 octets, which for the mapped form are zeros, and reports the source as `0.0.0.0`.

Some samples here. Before applying this PR, a `CLIENT_QUERY` from `127.0.0.1`:

```
Message.socket_family = INET
Message.query_address = 00000000000000000000ffff7f000001   (::ffff:127.0.0.1)
```

which a consumer (Vector) reads as:

```
"socketFamily": "INET",
"sourceAddress": "0.0.0.0",
"sourcePort": 56079
```

After, the same client:

```
Message.socket_family = INET
Message.query_address = 7f000001   (127.0.0.1)
```

and the consumer happy:

```
"socketFamily": "INET",
"sourceAddress": "127.0.0.1",
"sourcePort": 54481
```

The change adds a small `socketFamilyAndAddress` helper, shared by both setters, returning the 4-octet form with INET for IPv4 (including IPv4-mapped IPv6) and the 16-octet form with INET6 otherwise.

### 2. Which issues (if any) are related?

I ran into this while debugging the symptom downstream in Vector and there was an issue for Vector already in vectordotdev/vector#25181. 

Other relevant references:

- vectordotdev/vector#25540: the consumer-side fix in Vector (unwrap IPv4-mapped INET).
- coredns/coredns#8184 (mine): proposes a change that would allow to merge `SetQueryAddress` and `SetResponseAddress` in the current PR in a single function to ensure consistency.

### 3. Which documentation changes (if any) need to be made?

None that I can see. The behavior now matches dnstap.proto, and `plugin/dnstap/README.md` does not document the address encoding.

### 4. Does this introduce a backward incompatible change or deprecation?

I would not expect one for spec-compliant consumers. Tooling that decodes the address by its byte length (for example dnstap's own `net.IP` based formatters) rendered the old 16-octet INET value correctly and renders the new 4-octet value the same. The visible change is that consumers keying off `socket_family` now receive the 4-octet IPv4 the schema describes. 
