### PR TITLE
Automate registry.k8s.io promotion PR creation on CoreDNS release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,7 +75,7 @@ jobs:
           IMAGE_DIGEST: ${{ steps.image.outputs.image_digest }}
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python3 - <<'PY'
           import pathlib
           import re
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,7 +117,7 @@ jobs:
           token: ${{ secrets.K8S_IO_PROMOTION_TOKEN }}
           branch: bot/promote-coredns-${{ steps.image.outputs.image_tag }}
           base: main
-          commit-message: 'registry.k8s.io: promote coredns ${{ env.RELEASE }} (requires K8S_IO_PROMOTION_TOKEN)'
+          commit-message: 'registry.k8s.io: promote coredns ${{ env.RELEASE }}'
           title: 'Promote coredns to ${{ env.RELEASE }}'
           body: |
             CoreDNS ${{ env.RELEASE }} release is available - https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
           IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "Unable to resolve digest for coredns/coredns:${IMAGE_TAG}. Check docker-release job success and potential Docker Hub propagation delay."
+            echo "Unable to resolve digest for coredns/coredns:${IMAGE_TAG}. Check docker-release job success and potential Docker Hub propagation delay (5-10 minutes), then re-run the workflow."
             echo "${INSPECT_OUTPUT}"
             exit 1
           fi
@@ -96,7 +96,7 @@ jobs:
 
           digest_lines = list(digest_line_pattern.finditer(data))
           if not digest_lines:
-              raise SystemExit("unable to find digest map entries in images.yaml")
+              raise SystemExit("Unable to find digest map entries in images.yaml")
 
           insert_at = digest_lines[-1].end()
           updated = data[:insert_at] + entry + data[insert_at:]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
           IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}; check docker-release success and potential Docker Hub propagation delay"
+            echo "Unable to resolve digest for coredns/coredns:${IMAGE_TAG}. Check docker-release job success and potential Docker Hub propagation delay."
             echo "${INSPECT_OUTPUT}"
             exit 1
           fi
@@ -85,7 +85,7 @@ jobs:
           data = path.read_text()
           entry = f'    "{digest}": ["{release}"]\n'
           if entry in data:
-              print("manifest already contains current release and digest")
+              print("Manifest already contains current release and digest")
               raise SystemExit(0)
 
           digest_key_pattern = r'^\s+"sha256:[0-9a-f]{64}": '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,8 @@ jobs:
           INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
           IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "Failed to resolve digest for coredns/coredns:${IMAGE_TAG}. Ensure docker-release job completed successfully. If so, Docker Hub may still be propagating the image (typically 5-10 minutes). Wait and re-run this workflow."
+            echo "Failed to resolve digest for coredns/coredns:${IMAGE_TAG}."
+            echo "Ensure docker-release job completed successfully; Docker Hub propagation can take 5-10 minutes before digest lookup succeeds."
             echo "${INSPECT_OUTPUT}"
             exit 1
           fi
@@ -89,8 +90,9 @@ jobs:
               raise SystemExit(0)
 
           digest_key_pattern = r'^\s+"sha256:[0-9a-f]{64}": '
+          version_pattern = r'v[0-9]+\.[0-9]+\.[0-9]+'
           release_line_pattern = re.compile(rf'{digest_key_pattern}\["{re.escape(release)}"\]\n', re.MULTILINE)
-          digest_line_pattern = re.compile(rf'{digest_key_pattern}\["v[0-9]+\.[0-9]+\.[0-9]+"\]\n', re.MULTILINE)
+          digest_line_pattern = re.compile(rf'{digest_key_pattern}\["{version_pattern}"\]\n', re.MULTILINE)
 
           data = release_line_pattern.sub("", data)
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,9 +58,11 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_TAG="${RELEASE:1}"
-          IMAGE_DIGEST="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} | awk '/Digest:/ {print $2; exit}')"
+          INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
+          IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}"
+            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}; image may not be available yet"
+            echo "${INSPECT_OUTPUT}"
             exit 1
           fi
           echo "image_tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
@@ -86,10 +88,13 @@ jobs:
               print("manifest already contains current release and digest")
               raise SystemExit(0)
 
-          tag_pattern = re.compile(rf'^\s+"sha256:[0-9a-f]{{64}}": \["{re.escape(release)}"\]\n', re.MULTILINE)
-          data = tag_pattern.sub("", data)
+          digest_key_pattern = r'^\s+"sha256:[0-9a-f]{64}": '
+          release_line_pattern = re.compile(rf'{digest_key_pattern}\["{re.escape(release)}"\]\n', re.MULTILINE)
+          digest_line_pattern = re.compile(rf'{digest_key_pattern}\["v[0-9]+\.[0-9]+\.[0-9]+"\]\n', re.MULTILINE)
 
-          digest_lines = list(re.finditer(r'^\s+"sha256:[0-9a-f]{64}": \["v[0-9]+\.[0-9]+\.[0-9]+"\]\n', data, re.MULTILINE))
+          data = release_line_pattern.sub("", data)
+
+          digest_lines = list(digest_line_pattern.finditer(data))
           if not digest_lines:
               raise SystemExit("unable to find digest map entries in images.yaml")
 
@@ -115,7 +120,7 @@ jobs:
           commit-message: 'registry.k8s.io: promote coredns ${{ env.RELEASE }} (requires K8S_IO_PROMOTION_TOKEN)'
           title: 'Promote coredns to ${{ env.RELEASE }}'
           body: |
-            Coredns ${{ env.RELEASE }} release is available - https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE }}
+            CoreDNS ${{ env.RELEASE }} release is available - https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE }}
 
             ```
              ❯ docker buildx imagetools inspect coredns/coredns:${{ steps.image.outputs.image_tag }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,3 +35,93 @@ jobs:
         env:
           DOCKER_LOGIN: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  registry-k8s-io-promotion:
+    name: registry.k8s.io promotion
+    runs-on: ubuntu-latest
+    needs:
+      - docker-release
+    env:
+      RELEASE: ${{ github.event.inputs.release || github.event.release.tag_name }}
+    steps:
+      - name: Checkout kubernetes/k8s.io
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          repository: kubernetes/k8s.io
+          ref: main
+          token: ${{ secrets.K8S_IO_PROMOTION_TOKEN }}
+          path: k8s-io
+          persist-credentials: false
+
+      - name: Resolve image digest
+        id: image
+        run: |
+          set -euo pipefail
+          IMAGE_TAG="${RELEASE:1}"
+          IMAGE_DIGEST="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} | awk '/Digest:/ {print $2; exit}')"
+          if [[ -z "${IMAGE_DIGEST}" ]]; then
+            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}"
+            exit 1
+          fi
+          echo "image_tag=${IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "image_digest=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update k8s.io image promotion manifest
+        id: manifest
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import pathlib
+          import re
+
+          release = "${{ env.RELEASE }}"
+          digest = "${{ env.IMAGE_DIGEST }}"
+          path = pathlib.Path("k8s-io/registry.k8s.io/images/k8s-staging-coredns/images.yaml")
+
+          data = path.read_text()
+          entry = f'    "{digest}": ["{release}"]\n'
+          if entry in data:
+              print("manifest already contains current release and digest")
+              raise SystemExit(0)
+
+          tag_pattern = re.compile(rf'^\s+"sha256:[0-9a-f]{{64}}": \["{re.escape(release)}"\]\n', re.MULTILINE)
+          data = tag_pattern.sub("", data)
+
+          digest_lines = list(re.finditer(r'^\s+"sha256:[0-9a-f]{64}": \["v[0-9]+\.[0-9]+\.[0-9]+"\]\n', data, re.MULTILINE))
+          if not digest_lines:
+              raise SystemExit("unable to find digest map entries in images.yaml")
+
+          insert_at = digest_lines[-1].end()
+          updated = data[:insert_at] + entry + data[insert_at:]
+          path.write_text(updated)
+          PY
+
+          if git -C k8s-io diff --quiet -- registry.k8s.io/images/k8s-staging-coredns/images.yaml; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create promotion PR
+        if: steps.manifest.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          path: k8s-io
+          token: ${{ secrets.K8S_IO_PROMOTION_TOKEN }}
+          branch: bot/promote-coredns-${{ steps.image.outputs.image_tag }}
+          base: main
+          commit-message: 'registry.k8s.io: promote coredns ${{ env.RELEASE }} (requires K8S_IO_PROMOTION_TOKEN)'
+          title: 'Promote coredns to ${{ env.RELEASE }}'
+          body: |
+            Coredns ${{ env.RELEASE }} release is available - https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE }}
+
+            ```
+             ❯ docker buildx imagetools inspect coredns/coredns:${{ steps.image.outputs.image_tag }}
+            Digest: ${{ steps.image.outputs.image_digest }}
+            ```
+
+            Required repository settings/secrets for this automation:
+            - `K8S_IO_PROMOTION_TOKEN`: token with permission to push a branch to `kubernetes/k8s.io` and open pull requests.
+          signoff: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
           IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "Unable to resolve digest for coredns/coredns:${IMAGE_TAG}. Check docker-release job success and potential Docker Hub propagation delay (5-10 minutes), then re-run the workflow."
+            echo "Failed to resolve digest for coredns/coredns:${IMAGE_TAG}. Ensure docker-release job completed successfully. If so, Docker Hub may still be propagating the image (typically 5-10 minutes). Wait and re-run this workflow."
             echo "${INSPECT_OUTPUT}"
             exit 1
           fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           INSPECT_OUTPUT="$(docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG} 2>&1 || true)"
           IMAGE_DIGEST="$(printf '%s\n' "${INSPECT_OUTPUT}" | awk '/Digest:/ {print $2; exit}')"
           if [[ -z "${IMAGE_DIGEST}" ]]; then
-            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}; image may not be available yet"
+            echo "unable to resolve digest for coredns/coredns:${IMAGE_TAG}; check docker-release success and potential Docker Hub propagation delay"
             echo "${INSPECT_OUTPUT}"
             exit 1
           fi


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This automates a PR for k8's registry promotion. This today relies on a human to do.

### 2. Which issues (if any) are related?
Fixes #8183 

### 3. Which documentation changes (if any) need to be made?
Not sure here ...

### 4. Does this introduce a backward incompatible change or deprecation?
No - It does not change coredns itself ...

Release publishing currently pushes CoreDNS images to Docker Hub but still relies on a manual follow-up PR to `kubernetes/k8s.io` for `registry.k8s.io` promotion. This change extends the release workflow to generate that promotion PR automatically from the released tag and resolved image digest.

- **Workflow extension (`.github/workflows/docker.yml`)**
  - Adds `registry-k8s-io-promotion` job, gated on `docker-release`.
  - Reuses release tag from `release.published` / `workflow_dispatch` input to drive promotion data.

- **Digest resolution + manifest update**
  - Resolves the multi-arch digest for `coredns/coredns:${RELEASE#v}` via `docker buildx imagetools inspect`.
  - Checks out `kubernetes/k8s.io`, updates `registry.k8s.io/images/k8s-staging-coredns/images.yaml`, and ensures:
    - any stale mapping for the same CoreDNS tag is removed
    - the new `sha256`→`vX.Y.Z` mapping is inserted

- **Automated cross-repo PR creation**
  - Uses `peter-evans/create-pull-request` to open a promotion PR against `kubernetes/k8s.io:main`.
  - PR body includes release link, resolved digest, and required repo configuration note:
    - `K8S_IO_PROMOTION_TOKEN` (must allow branch push + PR creation on `kubernetes/k8s.io`).
    - **This will need a maintainer to add and test ... I can not ...**

```yaml
  registry-k8s-io-promotion:
    needs: [docker-release]
    ...
    - name: Resolve image digest
      run: docker buildx imagetools inspect coredns/coredns:${IMAGE_TAG}
    - name: Create promotion PR
      uses: peter-evans/create-pull-request@v8
```