### PR TITLE
plugin/transfer: configure notify source address

### DIFF
--- a/plugin/transfer/README.md
+++ b/plugin/transfer/README.md
@@ -22,6 +22,7 @@ use this plugin.
 ~~~
 transfer [ZONE...] {
   to ADDRESS...
+  source ADDRESS
 }
 ~~~
 
@@ -34,6 +35,10 @@ transfer [ZONE...] {
     addresses. Zone change notifications are sent to all **ADDRESS** that are an IP address or
     an IP address and port e.g. `1.2.3.4`, `12:34::56`, `1.2.3.4:5300`, `[12:34::56]:5300`.
     `to` may be specified multiple times.
+
+ *  `source` **ADDRESS** is the local IP address to use when sending zone change
+    notifications to the configured `to` addresses. It does not change which
+    clients are allowed to request AXFR or IXFR transfers.
 
 You can use the _acl_ plugin to further restrict hosts permitted to receive a zone transfer.
 See example below.
@@ -52,6 +57,17 @@ Use in conjunction with the _acl_ plugin to restrict access to subnet 10.1.0.0/1
   }
   transfer {
     to *
+  }
+...
+```
+
+Send NOTIFY messages from a specific local address.
+
+```
+...
+  transfer {
+    to 2001:db8::1
+    source 2001:db8::53
   }
 ...
 ```

--- a/plugin/transfer/notify.go
+++ b/plugin/transfer/notify.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 
@@ -16,13 +17,13 @@ func (t *Transfer) Notify(zone string) error {
 
 	m := new(dns.Msg)
 	m.SetNotify(zone)
-	c := new(dns.Client)
 
 	x := longestMatch(t.xfrs, zone)
 	if x == nil {
 		// return without error if there is no matching zone
 		return nil
 	}
+	c := notifyClient(x)
 
 	var err1 error
 	for _, t := range x.to {
@@ -35,6 +36,14 @@ func (t *Transfer) Notify(zone string) error {
 	}
 	log.Debugf("Sent notifies for zone %q to %v", zone, x.to)
 	return err1 // this only captures the last error
+}
+
+func notifyClient(x *xfr) *dns.Client {
+	c := new(dns.Client)
+	if x != nil && x.source != nil {
+		c.Dialer = &net.Dialer{LocalAddr: &net.UDPAddr{IP: x.source}}
+	}
+	return c
 }
 
 func sendNotify(c *dns.Client, m *dns.Msg, s string) error {

--- a/plugin/transfer/notify_test.go
+++ b/plugin/transfer/notify_test.go
@@ -1,0 +1,27 @@
+package transfer
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNotifyClientSource(t *testing.T) {
+	c := notifyClient(&xfr{})
+	if c.Dialer != nil {
+		t.Fatalf("expected no dialer without a source address, got %#v", c.Dialer)
+	}
+
+	source := net.ParseIP("2001:db8::53")
+	c = notifyClient(&xfr{source: source})
+	if c.Dialer == nil {
+		t.Fatal("expected dialer for source address")
+	}
+
+	addr, ok := c.Dialer.LocalAddr.(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("expected UDP local address, got %T", c.Dialer.LocalAddr)
+	}
+	if !addr.IP.Equal(source) {
+		t.Fatalf("expected source address %s, got %s", source, addr.IP)
+	}
+}

--- a/plugin/transfer/setup.go
+++ b/plugin/transfer/setup.go
@@ -1,6 +1,8 @@
 package transfer
 
 import (
+	"net"
+
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
@@ -68,6 +70,19 @@ func parseTransfer(c *caddy.Controller) (*Transfer, error) {
 					}
 					x.to = append(x.to, normalized)
 				}
+			case "source":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				if x.source != nil {
+					return nil, plugin.Error("transfer", c.Err("source already specified"))
+				}
+				ip := net.ParseIP(args[0])
+				if ip == nil {
+					return nil, plugin.Error("transfer", c.Errf("invalid source address %q", args[0]))
+				}
+				x.source = ip
 			default:
 				return nil, plugin.Error("transfer", c.Errf("unknown property %q", c.Val()))
 			}

--- a/plugin/transfer/setup_test.go
+++ b/plugin/transfer/setup_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"net"
 	"testing"
 
 	"github.com/coredns/caddy"
@@ -15,6 +16,7 @@ func TestParse(t *testing.T) {
 	}{
 		{`transfer example.net example.org {
 			to 1.2.3.4 5.6.7.8:1053 [1::2]:34 [fe80::1%eth0]:53
+			source 2001:db8::53
 		 }
          transfer example.com example.edu {
             to * 1.2.3.4
@@ -23,8 +25,9 @@ func TestParse(t *testing.T) {
 			false,
 			&Transfer{
 				xfrs: []*xfr{{
-					Zones: []string{"example.net.", "example.org."},
-					to:    []string{"1.2.3.4:53", "5.6.7.8:1053", "[1::2]:34", "[fe80::1%eth0]:53"},
+					Zones:  []string{"example.net.", "example.org."},
+					to:     []string{"1.2.3.4:53", "5.6.7.8:1053", "[1::2]:34", "[fe80::1%eth0]:53"},
+					source: net.ParseIP("2001:db8::53"),
 				}, {
 					Zones: []string{"example.com.", "example.edu."},
 					to:    []string{"*", "1.2.3.4:53"},
@@ -40,6 +43,23 @@ func TestParse(t *testing.T) {
 		},
 		{`transfer example.net example.org {
            invalid option
+		 }`,
+			nil,
+			true,
+			nil,
+		},
+		{`transfer example.net example.org {
+			to 1.2.3.4
+			source example.org
+		 }`,
+			nil,
+			true,
+			nil,
+		},
+		{`transfer example.net example.org {
+			to 1.2.3.4
+			source 192.0.2.53
+			source 2001:db8::53
 		 }`,
 			nil,
 			true,
@@ -109,8 +129,18 @@ func TestParse(t *testing.T) {
 					t.Errorf("Test %d expected %v in 'to', got %v", i, tc.exp.xfrs[j].to[k], to)
 				}
 			}
+			if !sameIP(tc.exp.xfrs[j].source, x.source) {
+				t.Errorf("Test %d expected source %v, got %v", i, tc.exp.xfrs[j].source, x.source)
+			}
 		}
 	}
+}
+
+func sameIP(a, b net.IP) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(b)
 }
 
 func TestSetup(t *testing.T) {

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -23,8 +23,9 @@ type Transfer struct {
 }
 
 type xfr struct {
-	Zones []string
-	to    []string
+	Zones  []string
+	to     []string
+	source net.IP
 }
 
 // Transferer may be implemented by plugins to enable zone transfers


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This adds a `source ADDRESS` option to the `transfer` plugin. When configured, outgoing NOTIFY messages are sent with that local IP address via `dns.Client.Dialer.LocalAddr`.

This is useful on hosts with multiple local addresses, especially IPv6 hosts where the kernel-selected source address may not be the address accepted by a secondary DNS provider.

The default behavior is unchanged when `source` is not configured. This only affects outgoing NOTIFY messages and does not change AXFR/IXFR request handling or the existing `to` behavior.

### 2. Which issues (if any) are related?

Fixes #7248.

### 3. Which documentation changes (if any) need to be made?

The `plugin/transfer` README is updated with the new `source` syntax and an example.

### 4. Does this introduce a backward incompatible change or deprecation?

No.