### PR TITLE
plugin/hosts: fall through unsupported query types

### DIFF
--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -50,6 +50,10 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	case dns.TypeAAAA:
 		ips := h.LookupStaticHostV6(qname)
 		answers = aaaa(qname, h.options.ttl, ips)
+	default:
+		if h.Fall.Through(qname) {
+			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
+		}
 	}
 
 	// Only on NXDOMAIN we will fallthrough.

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -57,6 +57,35 @@ func TestLookupA(t *testing.T) {
 	}
 }
 
+func TestFallthroughUnsupportedType(t *testing.T) {
+	h := Hosts{
+		Next: test.NextHandler(dns.RcodeRefused, nil),
+		Hostsfile: &Hostsfile{
+			Origins: []string{"."},
+			hmap:    newMap(),
+			inline:  newMap(),
+			options: newOptions(),
+		},
+		Fall: fall.Root,
+	}
+	h.hmap = h.parse(strings.NewReader(hostsExample))
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeTXT)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	rcode, err := h.ServeDNS(context.Background(), rec, m)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if rcode != dns.RcodeRefused {
+		t.Fatalf("Expected fallthrough rcode %d, got %d", dns.RcodeRefused, rcode)
+	}
+	if rec.Msg != nil {
+		t.Fatalf("Expected no response from hosts after fallthrough, got %#v", rec.Msg)
+	}
+}
+
 var hostsTestCases = []test.Case{
 	{
 		Qname: "example.org.", Qtype: dns.TypeA,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `hosts` plugin currently falls through only when a name does not exist in the hosts data. If the name exists but the query type is not handled by the plugin, such as TXT, the plugin returns an empty authoritative response instead of falling through.

This makes `fallthrough` ineffective for unsupported query types when the same name has an A or AAAA entry in `hosts`.

This PR falls through for query types that `hosts` does not answer when `fallthrough` is configured. Existing behavior for A, AAAA, and PTR lookups is unchanged.

### 2. Which issues (if any) are related?

Fixes #6672.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.