### PR TITLE
fix(trace): correct Zipkin v2 endpoint docs

### DIFF
--- a/man/coredns-trace.7
+++ b/man/coredns-trace.7
@@ -28,7 +28,7 @@ trace [ENDPOINT\-TYPE] [ENDPOINT]
 Defaults to \fB\fCzipkin\fR.
 .IP \(bu 4
 \fBENDPOINT\fP is the tracing destination, and defaults to \fB\fClocalhost:9411\fR. For Zipkin, if
-\fBENDPOINT\fP does not begin with \fB\fChttp\fR, then it will be transformed to \fB\fChttp://ENDPOINT/api/v1/spans\fR.
+\fBENDPOINT\fP does not begin with \fB\fChttp\fR, then it will be transformed to \fB\fChttp://ENDPOINT/api/v2/spans\fR.
 
 
 .PP
@@ -128,7 +128,7 @@ the standard Zipkin URL you can do something like:
 .RS
 
 .nf
-trace http://tracinghost:9411/zipkin/api/v1/spans
+trace http://tracinghost:9411/zipkin/api/v2/spans
 
 .fi
 .RE
@@ -173,4 +173,3 @@ plugin is also enabled:
 .SH "SEE ALSO"
 .PP
 See the \fIdebug\fP plugin for more information about debug logging.
-

--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -20,7 +20,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT]
 * **ENDPOINT-TYPE** is the type of tracing destination. Currently only `zipkin` and `datadog` are supported.
   Defaults to `zipkin`.
 * **ENDPOINT** is the tracing destination, and defaults to `localhost:9411`. For Zipkin, if
-  **ENDPOINT** does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v1/spans`.
+  **ENDPOINT** does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v2/spans`.
 
 With this form, all queries will be traced.
 
@@ -82,7 +82,7 @@ If for some reason you are using an API reverse proxy or something and need to r
 the standard Zipkin URL you can do something like:
 
 ~~~
-trace http://tracinghost:9411/zipkin/api/v1/spans
+trace http://tracinghost:9411/zipkin/api/v2/spans
 ~~~
 
 Using DataDog:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
The `trace` docs still point Zipkin users at `/api/v1/spans`, but the code and tests use `/api/v2/spans`.
So the docs are out of sync, and a user following them can end up with a dead-end config. This updates the README and generated man page to match actual behavior. Small fix, but it clears up a real footgun.

Repro on current `master`:
1. Open `plugin/trace/README.md` or `man/coredns-trace.7` and note `/api/v1/spans`.
2. Open `plugin/trace/setup.go` and `plugin/trace/setup_test.go` and note `/api/v2/spans`.
3. The same README also says Zipkin v1 is unsupported since CoreDNS 1.7.1, so yeah, the docs contradict themselves a bit.

### 2. Which issues (if any) are related?
No direct issue found.
Related history: #4180, #5460

### 3. Which documentation changes (if any) need to be made?
Included here.

### 4. Does this introduce a backward incompatible change or deprecation?
No. Docs only, no runtime change.
