### PR TITLE
plugin/transfer: accept scoped IPv6 targets

### DIFF
--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -113,13 +113,13 @@ func HostPort(s, defaultPort string) (string, error) {
 		port = defaultPort
 	}
 	if err != nil {
-		if net.ParseIP(s) == nil {
+		if net.ParseIP(stripZone(s)) == nil {
 			return "", fmt.Errorf("must specify an IP address: `%s'", s)
 		}
 		return net.JoinHostPort(s, port), nil
 	}
 
-	if net.ParseIP(addr) == nil {
+	if net.ParseIP(stripZone(addr)) == nil {
 		return "", fmt.Errorf("must specify an IP address: `%s'", addr)
 	}
 	return net.JoinHostPort(addr, port), nil

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -103,6 +103,8 @@ func TestParseHostPort(t *testing.T) {
 		{"8.8.8.8:", "8.8.8.8:53", false},
 		{"8.8.8.8::53", "", true},
 		{"resolv.conf", "", true},
+		{"fe80::1%ens3", "[fe80::1%ens3]:53", false},
+		{"[fd01::1%ens3]:153", "[fd01::1%ens3]:153", false},
 	}
 
 	for i, tc := range tests {

--- a/plugin/transfer/setup_test.go
+++ b/plugin/transfer/setup_test.go
@@ -14,7 +14,7 @@ func TestParse(t *testing.T) {
 		exp       *Transfer
 	}{
 		{`transfer example.net example.org {
-			to 1.2.3.4 5.6.7.8:1053 [1::2]:34
+			to 1.2.3.4 5.6.7.8:1053 [1::2]:34 [fe80::1%eth0]:53
 		 }
          transfer example.com example.edu {
             to * 1.2.3.4
@@ -24,7 +24,7 @@ func TestParse(t *testing.T) {
 			&Transfer{
 				xfrs: []*xfr{{
 					Zones: []string{"example.net.", "example.org."},
-					to:    []string{"1.2.3.4:53", "5.6.7.8:1053", "[1::2]:34"},
+					to:    []string{"1.2.3.4:53", "5.6.7.8:1053", "[1::2]:34", "[fe80::1%eth0]:53"},
 				}, {
 					Zones: []string{"example.com.", "example.edu."},
 					to:    []string{"*", "1.2.3.4:53"},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`transfer` rejects scoped IPv6 targets like `fe80::1%eth0`, which is a bit of a papercut. `forward` and resolv.conf parsing already accept scoped IPv6, but `parse.HostPort()` did not.

This reuses the existing zone stripping logic before IP validation, so scoped IPv6 targets are accepted and normalized, plain IPv4 and IPv6 behavior stays the same. Added parser and `transfer` regression tests too.

Repro:

```corefile
example.org {
    transfer {
        to fe80::1%eth0
    }
}
```

Before:

```text
must specify an IP address: `fe80::1%eth0`
```

After:

accepted, normalized to `[fe80::1%eth0]:53`

### 2. Which issues (if any) are related?

Related to #7248.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
