### PR TITLE
plugin/transfer: Fix panic in CoreDNS transfer plugin caused by empty DNS record

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -128,6 +128,9 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	batchSize := 0
 	var soa *dns.SOA
 	for records := range pchan {
+		if len(records) == 0 {
+			continue
+		}
 		if x, ok := records[0].(*dns.SOA); ok && soa == nil {
 			soa = x
 		}

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -474,3 +474,31 @@ func TestTransferLargeRecordBatching(t *testing.T) {
 		t.Errorf("expected multiple messages for large transfer, got %d", len(w.Msgs))
 	}
 }
+
+type emptyBatchTransferer struct{}
+
+func (emptyBatchTransferer) Transfer(_ string, _ uint32) (<-chan []dns.RR, error) {
+	ch := make(chan []dns.RR, 1)
+
+	ch <- []dns.RR{}
+
+	close(ch)
+	return ch, nil
+}
+
+func TestTransferEmptyBatch(t *testing.T) {
+	tr := &Transfer{
+		Transferers: []Transferer{emptyBatchTransferer{}},
+		xfrs:        []*xfr{{Zones: []string{"example.org."}, to: []string{"*"}}},
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeAXFR)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{TCP: true})
+
+	_, err := tr.ServeDNS(context.Background(), rec, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes panic in CoreDNS transfer plugin caused by empty DNS record.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a