### PR TITLE
fix(auto): keep first matching zone file for duplicate origins

### DIFF
--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -44,12 +44,14 @@ func (a Auto) Walk() error {
 		cleanPath := filepath.Clean(path)
 		if previous, ok := seen[origin]; ok && previous != cleanPath {
 			log.Warningf("Multiple zone files match origin %q: using %q instead of %q", origin, path, previous)
+			toDelete[origin] = false
+			return nil
 		}
 		seen[origin] = cleanPath
 
 		if z, ok := a.Z[origin]; ok {
 			toDelete[origin] = false
-			z.SetFile(path)
+			z.SetFile(cleanPath)
 			return nil
 		}
 

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -149,6 +149,37 @@ func TestWalkWarnsForDuplicateOrigin(t *testing.T) {
 	}
 }
 
+func TestWalkKeepsFirstMatchingFileForOrigin(t *testing.T) {
+	dir := t.TempDir()
+	zone := filepath.Join(dir, "example.org.zone")
+	backup := filepath.Join(dir, "example.org.zone.bak-20260528")
+
+	for _, path := range []string{zone, backup} {
+		if err := os.WriteFile(path, []byte(zoneContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := Auto{
+		loader: loader{
+			directory: dir,
+			re:        regexp.MustCompile(`(.*)\.zone`),
+			template:  `${1}`,
+		},
+		Zones: &Zones{},
+	}
+
+	a.Walk()
+	if got := a.Z["example.org."].File(); got != zone {
+		t.Fatalf("zone file = %q, want %q", got, zone)
+	}
+
+	a.Walk()
+	if got := a.Z["example.org."].File(); got != zone {
+		t.Fatalf("zone file after reload = %q, want %q", got, zone)
+	}
+}
+
 func createFiles(t *testing.T) (string, error) {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This is a small follow up to #8191

`auto` already warns when 2 files map to the same origin, but it still updates the loaded zone to the later file in the same walk. So a backup like `example.org.zone.bak-20260528` can sneak in as the reload source for `example.org.`. Pretty easy to hit in practice if backups live next to the real zone file.

This keeps the first matching file for an origin in a walk, and still logs the warning for the duplicate.

Repro:

```sh
go test ./plugin/auto -run TestWalkKeepsFirstMatchingFileForOrigin -count=1
```

Before this patch it fails because the zone file flips to `example.org.zone.bak-20260528`. After the patch it stays on `example.org.zone`.

### 2. Which issues (if any) are related?

Related to `#8130`.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Real file moves still work, this only stops duplicate matches from swapping the active file path.
