### PR TITLE
plugin/file: do not expand wildcard across a closer empty non-terminal

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -203,7 +203,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	// Haven't found the original name.
 
 	// Found wildcard.
-	if wildElem != nil {
+	if wildElem != nil && !closerENTExists(tr, qname, wildElem.Name()) {
 		// set metadata value for the wildcard record that synthesized the result
 		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
 			return wildElem.Name()
@@ -286,6 +286,33 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	}
 Out:
 	return nil, ret, nil, rcode
+}
+
+// closerENTExists reports whether there is an empty-non-terminal between the
+// wildcard's parent and qname. Per RFC 4592, such an ENT is the closest
+// encloser and the shallower wildcard does not apply to qname.
+func closerENTExists(tr *tree.Tree, qname, wildcardName string) bool {
+	// The wildcard owner is "*.<parent>"; anything with that exact prefix is not a closer encloser.
+	if len(wildcardName) < 2 || wildcardName[0] != '*' || wildcardName[1] != '.' {
+		return false
+	}
+	parent := wildcardName[2:]
+	// Walk strict ancestors of qname that are strict descendants of parent.
+	// Each ancestor is an ENT if the tree contains any name strictly below it.
+	name := qname
+	offset, end := dns.NextLabel(name, 0)
+	for !end {
+		name = name[offset:]
+		if name == parent || !dns.IsSubDomain(parent, name) {
+			return false
+		}
+		// An ENT exists at `name` iff tr.Next(name) returns a descendant of name.
+		if x, found := tr.Next(name); found && dns.IsSubDomain(name, x.Name()) {
+			return true
+		}
+		offset, end = dns.NextLabel(name, 0)
+	}
+	return false
 }
 
 // typeFromElem returns the type tp from e and adds signatures (if they exist) and do is true.

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -354,3 +354,59 @@ func TestLookupWildcardAdditional(t *testing.T) {
 		}
 	}
 }
+
+const closerENTWildcard = `; example.org test file with a wildcard and a deeper empty non-terminal
+$TTL 3600
+example.org.             IN     SOA     sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+example.org.             IN     NS      b.iana-servers.net.
+*.example.org.           IN     A       127.0.0.53
+real.deeper.example.org. IN     A       127.0.0.54
+`
+
+var closerENTWildcardTestCases = []test.Case{
+	// deeper.example.org. is an empty non-terminal (real.deeper.example.org.
+	// exists below it), so it is a closer encloser than the wildcard's parent
+	// example.org. A name under it with no record and no *.deeper.example.org.
+	// wildcard is an NXDOMAIN, not the *.example.org. wildcard.
+	{
+		Qname: "nonexistent.deeper.example.org.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600`),
+		},
+	},
+	// No closer empty non-terminal between example.org. and the queried name, so
+	// the wildcard still applies exactly as before.
+	{
+		Qname: "nonexistent.example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A(`nonexistent.example.org. 3600 IN A 127.0.0.53`)},
+		Ns:     []dns.RR{test.NS(`example.org. 3600 IN NS b.iana-servers.net.`)},
+	},
+}
+
+func TestLookupWildcardRespectsCloserEmptyNonTerminal(t *testing.T) {
+	const name = "example.org."
+	zone, err := Parse(strings.NewReader(closerENTWildcard), name, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expect no error when reading zone, got %q", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
+	ctx := context.TODO()
+
+	for _, tc := range closerENTWildcardTestCases {
+		m := tc.Msg()
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		_, err := fm.ServeDNS(ctx, rec, m)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+			return
+		}
+
+		resp := rec.Msg
+		if err := test.SortAndCheck(resp, tc); err != nil {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
### What this fixes

A query for a name that sits **below a closer empty non-terminal** was answered with a shallower wildcard record instead of `NXDOMAIN`.

Per [RFC 4592 §2.2.1](https://datatracker.ietf.org/doc/html/rfc4592#section-2.2.1), a wildcard is the source of synthesis for a name only when the wildcard owner's parent is the *closest encloser* of that name. If an empty non-terminal exists between the wildcard parent and the queried name, that empty non-terminal is the closer encloser and the shallower wildcard must not be expanded.

### Example

```
example.org.             IN SOA ...
example.org.             IN NS  b.iana-servers.net.
*.example.org.           IN A   127.0.0.53
real.deeper.example.org. IN A   127.0.0.54
```

`deeper.example.org.` is an empty non-terminal. A query for `nonexistent.deeper.example.org.` should return `NXDOMAIN` (its closest encloser is `deeper.example.org.`, and there is no `*.deeper.example.org.`), but CoreDNS returned the `*.example.org.` A record.

### Change

`Zone.Lookup` now guards wildcard expansion with `closerENTExists`, which walks the strict ancestors of the queried name between the wildcard parent and the name and reports whether any of them is an empty non-terminal.

### Test

`TestLookupWildcardRespectsCloserEmptyNonTerminal` asserts `NXDOMAIN` for a name below a closer empty non-terminal, plus a no-regression case where a plain wildcard with no closer empty non-terminal still applies. `go test ./plugin/file/...` passes.
