### PR TITLE
plugin/pkg/dnsutil: guard Join against an empty label slice

### DIFF
--- a/plugin/pkg/dnsutil/join.go
+++ b/plugin/pkg/dnsutil/join.go
@@ -10,6 +10,9 @@ import (
 // the root label it is ignored. Not other syntax checks are performed.
 func Join(labels ...string) string {
 	ll := len(labels)
+	if ll == 0 {
+		return "."
+	}
 	if labels[ll-1] == "." {
 		return strings.Join(labels[:ll-1], ".") + "."
 	}

--- a/plugin/pkg/dnsutil/join_test.go
+++ b/plugin/pkg/dnsutil/join_test.go
@@ -19,3 +19,12 @@ func TestJoin(t *testing.T) {
 		}
 	}
 }
+
+func TestJoinEmpty(t *testing.T) {
+	// Join called with no labels must not index labels[ll-1] out of range; it
+	// returns the root name. Callers on the MX/SRV path can reach Join with an
+	// empty label slice.
+	if x := Join(); x != "." {
+		t.Errorf("expected %q, got %q", ".", x)
+	}
+}


### PR DESCRIPTION
### What this fixes

`dnsutil.Join` indexed `labels[ll-1]` unconditionally, so calling it with **no labels** panicked with an index out of range. The MX/SRV target-handling path can reach `Join` with an empty label slice.

### Change

Return the root name `"."` when `Join` is called with no labels. Existing behavior for all non-empty inputs is unchanged.

### Test

`TestJoinEmpty` covers the no-argument case (it panics on the old code). `go test ./plugin/pkg/dnsutil/...` passes.
