### PR TITLE
docs: fix duplicated word in dnstap ServeDNS comment

### DIFF
--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -88,7 +88,7 @@ func (h *Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 
 	// The query tap message should be sent before sending the query to the
-	// forwarder. Otherwise, the tap messages will come out out of order.
+	// forwarder. Otherwise, the tap messages will come out of order.
 	h.tapQuery(ctx, w, r, rw.queryTime)
 
 	return plugin.NextOrFailure(h.Name(), h.Next, ctx, rw, r)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fixes a small typo in the dnstap plugin: the `ServeDNS` comment reads "the tap messages will come out out of order", with "out" duplicated. This changes it to "come out of order".

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None. This only touches a source comment.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
