### PR TITLE
Test: Fix flaky health test

### DIFF
--- a/plugin/pkg/proxy/health_test.go
+++ b/plugin/pkg/proxy/health_test.go
@@ -104,8 +104,8 @@ func TestHealthHTTPS(t *testing.T) {
 
 	hc := NewHealthChecker("TestHealthHTTPS", transport.HTTPS, true, ".")
 	hc.SetTLSConfig(s.Client().Transport.(*http.Transport).TLSClientConfig)
-	hc.SetReadTimeout(10 * time.Millisecond)
-	hc.SetWriteTimeout(10 * time.Millisecond)
+	hc.SetReadTimeout(1 * time.Second)
+	hc.SetWriteTimeout(1 * time.Second)
 
 	p := NewProxy("TestHealthHTTPS", s.URL, transport.HTTPS)
 	p.readTimeout = 10 * time.Millisecond


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes flaky health test. The timeout introduced in TestHealthHTTPS actually are too aggressive and not related to the Health test itself.

See https://github.com/coredns/coredns/actions/runs/28897275817/job/85724936090?pr=8237

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a