### PR TITLE
plugin/erratic: apply default truncate amount of 2 for bare `truncate`

### DIFF
--- a/plugin/erratic/setup.go
+++ b/plugin/erratic/setup.go
@@ -86,6 +86,8 @@ func parseErratic(c *caddy.Controller) (*Erratic, error) {
 					return nil, c.ArgErr()
 				}
 
+				// Defaults.
+				e.truncate = 2
 				if len(args) == 0 {
 					continue
 				}

--- a/plugin/erratic/setup_test.go
+++ b/plugin/erratic/setup_test.go
@@ -51,6 +51,10 @@ func TestParseErratic(t *testing.T) {
 			drop 3
 			delay
 		}`, false, 3, 2, 0},
+		{`erratic {
+			drop 3
+			truncate
+		}`, false, 3, 0, 2},
 		// fails
 		{`erratic {
 			drop -1


### PR DESCRIPTION
## Description

The *erratic* plugin's README documents that `truncate` defaults to 2:

> `truncate`: truncate 1 per **AMOUNT** of queries, the default is 2.

and the sibling `delay` directive sets its default (`e.delay = 2`) *before* the no-args `continue`. The `truncate` case was missing this default, so a bare `truncate` left `e.truncate` at 0 and silently truncated nothing — contradicting the documented behavior and the pattern used by `delay`.

## Fix

Set the default to 2 in the `truncate` case, mirroring `delay`, and add a table test (`drop 3; truncate` → `truncate == 2`) that fails without this change.

Verified locally: the new test fails before the fix (`Expected truncate 2 but found: 0`) and passes after; `go test ./plugin/erratic/` is green and `gofmt` is clean.