### PR TITLE
hygiene(core/dnsserver): sanitize DoH/DoH3 request parse errors

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -189,7 +189,8 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	msg, raw, err := doh.RequestToMsgWire(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		clog.Debugf("DoH request could not be parsed: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
 		s.countResponse(http.StatusBadRequest)
 		return
 	}

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/doh"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	cproxyproto "github.com/coredns/coredns/plugin/pkg/proxyproto"
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
@@ -178,7 +179,8 @@ func (s *ServerHTTPS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	msg, raw, err := doh.RequestToMsgWire(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		clog.Debugf("DoH3 request could not be parsed: %v", err)
+		http.Error(w, "invalid request", http.StatusBadRequest)
 		s.countResponse(http.StatusBadRequest)
 		return
 	}

--- a/core/dnsserver/server_https3_test.go
+++ b/core/dnsserver/server_https3_test.go
@@ -347,3 +347,38 @@ func TestServeHTTP3AcceptsValidTSIG(t *testing.T) {
 		t.Fatalf("expected NOERROR response from plugin, got %s", dns.RcodeToString[resp.Rcode])
 	}
 }
+
+func TestServeHTTP3DoesNotLeakBodyReadError(t *testing.T) {
+	c := Config{
+		Zone:        "example.com.",
+		Transport:   "https",
+		TLSConfig:   &tls.Config{},
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "443",
+	}
+	s, err := NewServerHTTPS3("127.0.0.1:443", []*Config{&c})
+	if err != nil {
+		t.Fatal("could not create HTTPS3 server:", err)
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/dns-query", errReader{})
+	r.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+
+	s.ServeHTTP(w, r)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(body)); got != "invalid request" {
+		t.Fatalf("expected sanitized body %q, got %q", "invalid request", got)
+	}
+}

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -581,5 +582,46 @@ func TestDoHWriterTsigStatusReturnsStoredStatus(t *testing.T) {
 	dw := &DoHWriter{tsigStatus: dns.ErrSecret}
 	if dw.TsigStatus() != dns.ErrSecret {
 		t.Fatal("expected TsigStatus to return stored tsigStatus")
+	}
+}
+
+type errReader struct{}
+
+const leakyBodyReadError = "read tcp 10.0.0.1:5443->10.0.0.2:48418: i/o timeout"
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New(leakyBodyReadError) }
+
+func TestServeHTTPDoesNotLeakBodyReadError(t *testing.T) {
+	c := Config{
+		Zone:        "example.com.",
+		Transport:   "https",
+		TLSConfig:   &tls.Config{},
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "443",
+	}
+	s, err := NewServerHTTPS("127.0.0.1:443", []*Config{&c})
+	if err != nil {
+		t.Fatal("could not create HTTPS server:", err)
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/dns-query", errReader{})
+	r.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+
+	s.ServeHTTP(w, r)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(body)); got != "invalid request" {
+		t.Fatalf("expected sanitized body %q, got %q", "invalid request", got)
 	}
 }


### PR DESCRIPTION
## Problem

The DoH (`server_https.go`) and DoH3 (`server_https3.go`) handlers echo the raw parse error into the HTTP 400 body:

```go
msg, raw, err := doh.RequestToMsgWire(r)
if err != nil {
    http.Error(w, err.Error(), http.StatusBadRequest)
```

When a body read fails mid-stream (client `ReadTimeout`, connection reset), `io.ReadAll(http.MaxBytesReader(...))` returns a `*net.OpError` whose text embeds the server's own socket. e.g.: 
```
read tcp 10.0.0.1:5443->10.0.0.2:48418: i/o timeout
```
 This discloses the server's internal bind address/port to any unauthenticated caller. Low severity, but no reason to reflect it.

DoH/DoH3 are the only affected transports: UDP/TCP hand `miekg/dns.Server` an already-unpacked `*dns.Msg` (malformed input → dropped or FormErr RCODE, no text channel), and DoQ already logs the error and closes with a numeric code instead of echoing it.

## Change

- Log the error at debug level (`clog.Debugf`); return a generic `"invalid request"` body, matching the fixed-string 404/500 responses in the same handlers and the DoQ approach.
- `plugin/pkg/doh` error strings left untouched, so `doh` tests and the client-side `ResponseToMsg` path keep full detail.
- Tests assert the 400 body no longer contains the raw error or an internal address.

## Testing

`go test ./core/dnsserver/` — all pass, including the new `TestServeHTTP{,3}DoesNotLeakBodyReadError` cases.