### PR TITLE
core/dnsserver: add Config.UDPDecorateWriterFunc for external plugins

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -53,8 +53,10 @@ type Config struct {
 	// If this function is not nil it is called once per Server in ServePacket
 	// (so each UDP listening socket gets its own decorator under multisocket)
 	// and its result is installed as the underlying dns.Server's
-	// DecorateWriter. Plain dns:// UDP listeners only. Although this isn't
-	// referenced in-tree, external plugins may depend on it.
+	// DecorateWriter. Plain dns:// UDP listeners only. When several server
+	// blocks sharing a listener set it, the last one in config order wins.
+	// Although this isn't referenced in-tree, external plugins may depend
+	// on it.
 	UDPDecorateWriterFunc func(*Server) dns.DecorateWriter
 
 	// FilterFuncs is used to further filter access

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"github.com/miekg/dns"
 	"github.com/pires/go-proxyproto"
 )
 
@@ -48,6 +49,13 @@ type Config struct {
 	// HTTP requests. Although this isn't referenced in-tree, external plugins
 	// may depend on it.
 	HTTPRequestValidateFunc func(*http.Request) bool
+
+	// If this function is not nil it is called once per Server in ServePacket
+	// (so each UDP listening socket gets its own decorator under multisocket)
+	// and its result is installed as the underlying dns.Server's
+	// DecorateWriter. Plain dns:// UDP listeners only. Although this isn't
+	// referenced in-tree, external plugins may depend on it.
+	UDPDecorateWriterFunc func(*Server) dns.DecorateWriter
 
 	// FilterFuncs is used to further filter access
 	// to this handler. E.g. to limit access to a reverse zone

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -279,6 +279,10 @@ func propagateConfigParams(configs []*Config) {
 		// Propagate HTTPRequestValidateFunc so that custom path validators work in
 		// multi-transport blocks. Otherwise HTTPS 404s on non-"/dns-query" paths.
 		c.HTTPRequestValidateFunc = c.firstConfigInBlock.HTTPRequestValidateFunc
+
+		// Propagate UDPDecorateWriterFunc so a decorator configured once in a
+		// server block applies to the block's UDP listener(s).
+		c.UDPDecorateWriterFunc = c.firstConfigInBlock.UDPDecorateWriterFunc
 	}
 }
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -179,12 +179,25 @@ func (s *Server) Serve(l net.Listener) error {
 // ServePacket starts the server with an existing packetconn. It blocks until the server stops.
 // This implements caddy.UDPServer interface.
 func (s *Server) ServePacket(p net.PacketConn) error {
+	// Use a custom writer decorator if one was configured.
+	var f func(*Server) dns.DecorateWriter
+	for _, z := range s.zones {
+		for _, conf := range z {
+			if conf.UDPDecorateWriterFunc != nil {
+				f = conf.UDPDecorateWriterFunc
+			}
+		}
+	}
+	var dw dns.DecorateWriter
+	if f != nil {
+		dw = f(s)
+	}
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		ctx := context.WithValue(context.Background(), Key{}, s)
 		ctx = context.WithValue(ctx, LoopKey{}, 0)
 		s.ServeDNS(ctx, w, r)
-	}), TsigSecret: s.tsigSecret}
+	}), TsigSecret: s.tsigSecret, DecorateWriter: dw}
 	s.m.Unlock()
 
 	return s.server[udp].ActivateAndServe()

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -55,6 +55,11 @@ type Server struct {
 
 	tsigSecret map[string]string
 
+	// udpDecorateWriterFunc is selected in NewServer from the group configs in
+	// stable order (last one set wins), so the choice is deterministic when
+	// several server blocks share a listener. See Config.UDPDecorateWriterFunc.
+	udpDecorateWriterFunc func(*Server) dns.DecorateWriter
+
 	// Ensure Stop is idempotent when invoked concurrently (e.g., during reload and SIGTERM).
 	stopOnce sync.Once
 	stopErr  error
@@ -101,6 +106,10 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 
 		// copy tsig secrets
 		maps.Copy(s.tsigSecret, site.TsigSecret)
+
+		if site.UDPDecorateWriterFunc != nil {
+			s.udpDecorateWriterFunc = site.UDPDecorateWriterFunc
+		}
 
 		// compile custom plugin for everything
 		var stack plugin.Handler
@@ -180,17 +189,9 @@ func (s *Server) Serve(l net.Listener) error {
 // This implements caddy.UDPServer interface.
 func (s *Server) ServePacket(p net.PacketConn) error {
 	// Use a custom writer decorator if one was configured.
-	var f func(*Server) dns.DecorateWriter
-	for _, z := range s.zones {
-		for _, conf := range z {
-			if conf.UDPDecorateWriterFunc != nil {
-				f = conf.UDPDecorateWriterFunc
-			}
-		}
-	}
 	var dw dns.DecorateWriter
-	if f != nil {
-		dw = f(s)
+	if s.udpDecorateWriterFunc != nil {
+		dw = s.udpDecorateWriterFunc(s)
 	}
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -107,10 +107,6 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		// copy tsig secrets
 		maps.Copy(s.tsigSecret, site.TsigSecret)
 
-		if site.UDPDecorateWriterFunc != nil {
-			s.udpDecorateWriterFunc = site.UDPDecorateWriterFunc
-		}
-
 		// compile custom plugin for everything
 		var stack plugin.Handler
 		for i := len(site.Plugin) - 1; i >= 0; i-- {
@@ -146,6 +142,9 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		}
 		if site.ProxyProtoUDPSessionTrackingMaxSessions > 0 {
 			s.udpSessionTrackingMaxSessions = site.ProxyProtoUDPSessionTrackingMaxSessions
+		}
+		if site.UDPDecorateWriterFunc != nil {
+			s.udpDecorateWriterFunc = site.UDPDecorateWriterFunc
 		}
 	}
 

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -178,5 +179,63 @@ func BenchmarkCoreServeDNS(b *testing.B) {
 
 	for b.Loop() {
 		s.ServeDNS(ctx, w, m)
+	}
+}
+
+// recordingWriter counts the packed frames the decorated writer receives
+// before forwarding them to the real writer. The decorator mints a fresh
+// wrapper per packet; the frames counter is shared across them.
+type recordingWriter struct {
+	dns.Writer
+	frames *atomic.Int64
+}
+
+func (rw *recordingWriter) Write(b []byte) (int, error) {
+	rw.frames.Add(1)
+	return rw.Writer.Write(b)
+}
+
+func TestUDPDecorateWriterFunc(t *testing.T) {
+	cfg := testConfig("dns", test.ErrorHandler())
+
+	frames := new(atomic.Int64)
+	var gotServer atomic.Pointer[Server]
+	var calls atomic.Int64
+	cfg.UDPDecorateWriterFunc = func(srv *Server) dns.DecorateWriter {
+		calls.Add(1)
+		gotServer.Store(srv)
+		return func(w dns.Writer) dns.Writer {
+			return &recordingWriter{Writer: w, frames: frames}
+		}
+	}
+
+	s, err := NewServer("127.0.0.1:0", []*Config{cfg})
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket failed: %v", err)
+	}
+	defer pc.Close()
+
+	go s.ServePacket(pc)
+	defer s.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	if _, err := dns.Exchange(m, pc.LocalAddr().String()); err != nil {
+		t.Fatalf("dns.Exchange failed: %v", err)
+	}
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected UDPDecorateWriterFunc to be called once per socket, got %d", n)
+	}
+	if gotServer.Load() != s {
+		t.Errorf("expected UDPDecorateWriterFunc to receive the serving *Server")
+	}
+	if frames.Load() == 0 {
+		t.Errorf("expected the decorated writer to observe the response write")
 	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Allow external plugins to install a `dns.DecorateWriter` (this is something `miekg/dns Server` exposes, but coredns doesn't have plumbing to configure it) on plain-UDP servers, e.g. for per-socket write disciplines or overload protection.

The field is called once per Server in `ServePacket`, so each socket gets its own decorator under multisocket


### 2. Which issues (if any) are related?

none

### 3. Which documentation changes (if any) need to be made?

n/a, this new field has comments and can be referenced by plugins, but it won't (on its own) influence any existing plugins

### 4. Does this introduce a backward incompatible change or deprecation?

no