### PR TITLE
docs(timeouts): document DoQ read timeout

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -115,7 +115,7 @@ type Config struct {
 	// This is nil if not specified, allowing for a default to be used.
 	MaxHTTPS3Streams *int
 
-	// Timeouts for TCP, TLS and HTTPS servers.
+	// Timeouts for connection-oriented servers. Exact applicability depends on transport.
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	IdleTimeout  time.Duration

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -35,9 +35,9 @@ import (
 // graceful termination (POSIX only).
 type Server struct {
 	Addr         string        // Address we listen on
-	IdleTimeout  time.Duration // Idle timeout for TCP
-	ReadTimeout  time.Duration // Read timeout for TCP
-	WriteTimeout time.Duration // Write timeout for TCP
+	IdleTimeout  time.Duration // Idle timeout for connection-oriented transports
+	ReadTimeout  time.Duration // Read timeout for connection-oriented transports
+	WriteTimeout time.Duration // Write timeout for connection-oriented transports that support it
 
 	connPolicy                    proxyproto.ConnPolicyFunc // Proxy Protocol connection policy function
 	udpSessionTrackingTTL         time.Duration             // TTL for UDP PPv2 session tracking (0 = disabled)

--- a/plugin/timeouts/README.md
+++ b/plugin/timeouts/README.md
@@ -2,7 +2,7 @@
 
 ## Name
 
-*timeouts* - allows you to configure the server read, write and idle timeouts for the TCP, TLS, DoH and DoQ (idle only) servers.
+*timeouts* - allows you to configure the supported server read, write and idle timeouts for the TCP, TLS, DoH and DoQ servers.
 
 ## Description
 
@@ -30,6 +30,11 @@ timeouts {
 For any timeouts that are not provided, default values are used which may vary
 depending on the server type. At least one timeout must be specified otherwise
 the entire timeouts block should be omitted.
+
+The configured timeouts apply where the selected server transport supports
+them. TCP, TLS and DoH servers use the read, write and idle timeouts. DoQ
+servers use the read timeout to bound receiving a query on an opened QUIC
+stream, and the idle timeout to bound idle QUIC connections.
 
 ## Examples
 
@@ -63,12 +68,14 @@ https://. {
 }
 ~~~
 
-Start a DNS-over-QUIC server that has the idle timeout set to two minutes.
+Start a DNS-over-QUIC server that has a 10 second read timeout for receiving a
+query on an opened stream and the idle timeout set to two minutes.
 
 ~~~
 quic://.:853 {
 	tls cert.pem key.pem ca.pem
 	timeouts {
+		read 10s
 		idle 2m
 	}
 	forward . /etc/resolv.conf


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Remove stale guidance that DoQ only supports idle timeouts.

### 2. Which issues (if any) are related?

Docs update which #8231 missed.

### 3. Which documentation changes (if any) need to be made?

This is the documentation change.

### 4. Does this introduce a backward incompatible change or deprecation?

No.