### PR TITLE
Test: populating build test failure

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -114,16 +114,10 @@ jobs:
         run: sudo apt-get install make curl
 
       - name: Test Makefile.release release
-        run: |
-          set -xe
-          make GITHUB_ACCESS_TOKEN=x release -f Makefile.release
+        run: make GITHUB_ACCESS_TOKEN=x release -f Makefile.release
 
       - name: Test Makefile.release release/github-push (dry-run)
-        run: |
-          set -xe
-          make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
+        run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
 
       - name: Test Makefile.docker release/github-push (dry-run)
-        run: |
-          set -xe
-          make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker
+        run: make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -114,10 +114,16 @@ jobs:
         run: sudo apt-get install make curl
 
       - name: Test Makefile.release release
-        run: make GITHUB_ACCESS_TOKEN=x release -f Makefile.release
+        run: |
+          set -xe
+          make GITHUB_ACCESS_TOKEN=x release -f Makefile.release
 
       - name: Test Makefile.release release/github-push (dry-run)
-        run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
+        run: |
+          set -xe
+          make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release
 
       - name: Test Makefile.docker release/github-push (dry-run)
-        run: make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker
+        run: |
+          set -xe
+          make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker

--- a/Makefile.release
+++ b/Makefile.release
@@ -54,6 +54,8 @@ GITHUB:=coredns
 LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x mips riscv64 loong64
 GOLANG_VERSION ?= $(shell cat .go-version)
 
+.SHELLFLAGS := -e -c
+
 export GOSUMDB = sum.golang.org
 export GOTOOLCHAIN = go$(GOLANG_VERSION)
 


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The current build test won't populating the failure caused issue undetected:

See https://github.com/coredns/coredns/issues/8228#issuecomment-4931425842

### 2. Which issues (if any) are related?
#8228
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a