### PR TITLE
chore(deps): downgrade dd-trace-go to v2.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.30
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.13
-	github.com/DataDog/dd-trace-go/v2 v2.9.1
+	github.com/DataDog/dd-trace-go/v2 v2.8.2
 	github.com/apparentlymart/go-cidr v1.1.1
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/DataDog/datadog-agent/pkg/version v0.77.0 h1:fxpMWuoaRHS5vHzCNHftvJ6w
 github.com/DataDog/datadog-agent/pkg/version v0.77.0/go.mod h1:h9eJjfeTHlYYv+kzq6n3rQ07qXGirdCCacn1Ryu4TFQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/dd-trace-go/v2 v2.9.1 h1:N2aqlWS0nAG5o+ETVyvz3gtboZbfemaD8Q/VumStGRY=
-github.com/DataDog/dd-trace-go/v2 v2.9.1/go.mod h1:SdMkCESSBc2knx56Xol2pO7jhMDPi7MxyNj6vRYMW48=
+github.com/DataDog/dd-trace-go/v2 v2.8.2 h1:ZqF2M7j5DPG7PxkJpLIjF4L62LU/QnI86oOSAZjQC/U=
+github.com/DataDog/dd-trace-go/v2 v2.8.2/go.mod h1:o+fhXzd1mPT4Ji5YYcqIjORnNKWcS6m2eW4xqdJplRA=
 github.com/DataDog/go-libddwaf/v4 v4.9.0 h1:a788e37iuH7sR9uIYHkulvTnp2FkXTiZ3yY/kuaHgZE=
 github.com/DataDog/go-libddwaf/v4 v4.9.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

[dd-trace-go](https://github.com/DataDog/dd-trace-go) versions >=2.9.0 do not compile without warnings on non-64-bit architectures. The build fails like:

```bash
 CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -tags="grpcnotrace" -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=adba3b3" -o build/linux/arm/coredns
# github.com/DataDog/dd-trace-go/v2/ddtrace/tracer/internal
../../go/pkg/mod/github.com/!data!dog/dd-trace-go/v2@v2.9.0/ddtrace/tracer/internal/span_attributes.go:55:19: invalid argument: index 28 out of bounds [0:1]
../../go/pkg/mod/github.com/!data!dog/dd-trace-go/v2@v2.9.0/ddtrace/tracer/internal/span_attributes.go:56:19: unsafe.Sizeof(SpanAttributes{}) - 56 (constant -28 of type uintptr) overflows uintptr
```

Version bumps in CoreDNS:

- 2.8.2 to 2.9.0: https://github.com/coredns/coredns/pull/8218
- 2.9.0 to 2.9.1: https://github.com/coredns/coredns/pull/8248

Same problem occurs with 2.9.0.

This PR downgrades the dependency to v2.8.2 until upstream fixes the issue.

### 2. Which issues (if any) are related?

Relates to CoreDNS v1.14.5 release as described in https://github.com/coredns/coredns/issues/8228#issuecomment-4931425842

Upstream issue:  https://github.com/DataDog/dd-trace-go/issues/4984

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.