### PR TITLE
Populating errors from all Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ GOLANG_VERSION ?= $(shell cat .go-version)
 STRIP_FLAGS?=-s -w
 LDFLAGS?=-ldflags="$(STRIP_FLAGS) -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)"
 
+.SHELLFLAGS := -e -c
+
 export GOSUMDB = sum.golang.org
 export GOTOOLCHAIN = go$(GOLANG_VERSION)
 

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -10,6 +10,8 @@ READMES:=$(subst /README.md,,$(READMES))
 PLUGINS:=$(subst plugin/,coredns-,$(PLUGINS))
 PLUGINS:=$(subst /README.md,(7),$(PLUGINS))
 
+.SHELLFLAGS := -e -c
+
 all: mmark man/coredns.1 man/corefile.5 plugins
 
 GO           ?= go

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -36,6 +36,8 @@ LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64 loong64
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~mips64le ~~g" | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
 
+.SHELLFLAGS := -e -c
+
 all:
 	@echo Use the 'release' target to download released binaries and build containers per arch, 'docker-push' to build and push a multi arch manifest.
 	echo $(DOCKER_IMAGE_LIST_VERSIONED)


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR populating errors from all Makefile, so any PR test can be fully checked correctly. See #8265 for related issue.
This can make sure release to dockerhub can also be checked before merge. (where last release issue was discovered)

### 2. Which issues (if any) are related?
#8265
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a