### PR TITLE
Change base image for mips64le

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -90,8 +90,11 @@ else
 	        DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=debian:unstable-slim --build-arg=BASE=ghcr.io/go-riscv/distroless/static-unstable:nonroot"; \
 	    fi; \
 	    if [ "$${arch}" = "loong64" ]; then \
-            DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=ghcr.io/loong64/debian:trixie-slim --build-arg=BASE=ghcr.io/loong64/debian:trixie-slim"; \
-        fi; \
+	        DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=ghcr.io/loong64/debian:trixie-slim --build-arg=BASE=ghcr.io/loong64/debian:trixie-slim"; \
+	    fi; \
+	    if [ "$${arch}" = "mips64le" ]; then \
+	        DOCKER_ARGS="--build-arg=DEBIAN_IMAGE=debian:unstable-slim --build-arg=BASE=mips64le/debian:unstable-slim"; \
+	    fi; \
 	    DOCKER_BUILDKIT=1 docker build --platform=$${arch} -t $(DOCKER_IMAGE_NAME):$${arch}-$(VERSION) $${DOCKER_ARGS} build/docker/$${arch} ;\
 	done
 endif


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Since mips64le does not have a distroless image anymore, have to change the base image.

This is still part of #8228. However, since it only involved container image and not rebuild binary, shoud be ok with existing one.

### 2. Which issues (if any) are related?
#8228
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a