### PR TITLE
Enforce docker build test

### DIFF
--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -121,3 +121,13 @@ jobs:
 
       - name: Test Makefile.docker release/github-push (dry-run)
         run: make VERSION=x DOCKER=x -n release docker-push -f Makefile.docker
+
+      - name: Prepare Docker build
+        run: |
+          for arch in amd64 arm arm64 mips64le ppc64le s390x riscv64 loong64; do
+            mkdir -p build/docker/$arch
+            cp build/linux/$arch/coredns build/docker/$arch/
+          done
+
+      - name: Test Makefile.docker build
+        run: make VERSION=x DOCKER=x -f Makefile.docker docker-build


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR enforce docker-build test so that every PR will check to make sure the docker build (which reliesd on if base image, binary, etc are still correct), is actually available and working.

Note previously, we only check a dry run of docker push, but not actually build the docker image (as binary was fetched from release version on github). This PR fetch local binary build instead as there maynot be the same in different release versions of binary.

This is related #8228
### 2. Which issues (if any) are related?
#8228
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a