### PR TITLE
plugin/file: Fix panic on zero-valued SOA refresh

### DIFF
--- a/plugin/file/secondary.go
+++ b/plugin/file/secondary.go
@@ -152,9 +152,9 @@ Restart:
 		return nil
 	}
 	soa := z.getSOA()
-	refresh := time.Second * time.Duration(soa.Refresh)
-	retry := time.Second * time.Duration(soa.Retry)
-	expire := time.Second * time.Duration(soa.Expire)
+	refresh := time.Second * time.Duration(max(soa.Refresh, 1))
+	retry := time.Second * time.Duration(max(soa.Retry, 1))
+	expire := time.Second * time.Duration(max(soa.Expire, 1))
 
 	refreshTicker := time.NewTicker(refresh)
 	retryTicker := time.NewTicker(retry)

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -165,4 +166,24 @@ func newRequest(_zone string, _qtype uint16) request.Request {
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4097, true)
 	return request.Request{W: &test.ResponseWriter{}, Req: m}
+}
+
+func TestUpdateWithZeroSOATimers(t *testing.T) {
+	z := NewZone(testZone, "test")
+	z.SOA = test.SOA(
+		fmt.Sprintf("%s IN SOA bla. bla. 1 0 0 0 0", testZone),
+	)
+
+	updateShutdown := make(chan bool)
+	time.AfterFunc(10*time.Millisecond, func() {
+		close(updateShutdown)
+	})
+
+	if err := z.UpdateWithTransfer(
+		updateShutdown,
+		nil,
+		func(*Zone, *transfer.Transfer) error { return nil },
+	); err != nil {
+		t.Fatalf("Unexpected update error: %v", err)
+	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes panic with zero-valued SOA refresh
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a