### PR TITLE
plugin/proxyproto: Apply an explicitly configured default policy evenwhen no allow list is present.

### DIFF
--- a/plugin/proxyproto/setup.go
+++ b/plugin/proxyproto/setup.go
@@ -25,6 +25,7 @@ func setup(c *caddy.Controller) error {
 	var (
 		allowedIPNets              []*net.IPNet
 		policy                     = proxyproto.IGNORE
+		defaultSet                 bool
 		sessionTrackingTTL         time.Duration
 		sessionTrackingMaxSessions int
 	)
@@ -44,6 +45,7 @@ func setup(c *caddy.Controller) error {
 					allowedIPNets = append(allowedIPNets, ipnet)
 				}
 			case "default":
+				defaultSet = true
 				v := c.RemainingArgs()
 				if len(v) != 1 {
 					return plugin.Error("proxyproto", c.ArgErr())
@@ -84,6 +86,9 @@ func setup(c *caddy.Controller) error {
 	}
 	config.ProxyProtoConnPolicy = func(connPolicyOptions proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
 		if len(allowedIPNets) == 0 {
+			if defaultSet {
+				return policy, nil
+			}
 			return proxyproto.USE, nil
 		}
 		h, _, _ := net.SplitHostPort(connPolicyOptions.Upstream.String())

--- a/plugin/proxyproto/setup_test.go
+++ b/plugin/proxyproto/setup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
+
 	proxyprotoLib "github.com/pires/go-proxyproto"
 )
 

--- a/plugin/proxyproto/setup_test.go
+++ b/plugin/proxyproto/setup_test.go
@@ -1,12 +1,14 @@
 package proxyproto
 
 import (
+	"net"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
+	proxyprotoLib "github.com/pires/go-proxyproto"
 )
 
 func TestSetup(t *testing.T) {
@@ -82,5 +84,34 @@ func TestSetup(t *testing.T) {
 				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
 			}
 		}
+	}
+}
+
+func TestDefaultPolicyWithoutAllow(t *testing.T) {
+	c := caddy.NewTestController(
+		"dns",
+		"proxyproto {\ndefault reject\n}",
+	)
+
+	if err := setup(c); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := dnsserver.GetConfig(c)
+
+	policy, err := cfg.ProxyProtoConnPolicy(
+		proxyprotoLib.ConnPolicyOptions{
+			Upstream: &net.TCPAddr{
+				IP:   net.ParseIP("192.0.2.1"),
+				Port: 53,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if policy != proxyprotoLib.REJECT {
+		t.Fatalf("Expected REJECT, got %v", policy)
 	}
 }


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fix the issue where explicitly configured default reject policy is ignoreed when no allo list is present

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a