### PR TITLE
plugin/forward: Fix issue in DoH health checks used a default TLS instead of the configured CA

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -244,6 +244,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 				Timeout:   2 * time.Second,
 			}
 			f.proxies[i].SetHTTPClient(&c)
+			f.proxies[i].SetTLSConfig(f.tlsConfig)
 			f.proxies[i].SetDOHRequestOptions(f.dohMethod)
 		}
 

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -906,3 +906,30 @@ func TestSetupReadTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupDOHHealthcheckTLSConfig(t *testing.T) {
+	c := caddy.NewTestController(
+		"dns",
+		`forward . https://127.0.0.1 {
+			tls_servername dns.example
+		}`,
+	)
+
+	fs, err := parseForward(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := fs[0].
+		proxies[0].
+		GetHealthchecker().
+		GetTLSConfig()
+
+	if got.ServerName != "dns.example" {
+		t.Fatalf(
+			"Expected DoH healthcheck TLS server name %q, got %q",
+			"dns.example",
+			got.ServerName,
+		)
+	}
+}


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes issue in forward plugin where default TLS instead of configured CA was used.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a