### PR TITLE
plugin/rewrite: do not clamp the OPT record TTL in ttl rewrite

### DIFF
--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -323,6 +323,11 @@ If a range is supplied, the TTL value is set to `MIN` if it is below, or set to 
 The TTL value is left unchanged if it is already inside the provided range.
 The ranges can be unbounded on either side.
 
+A TTL rewrite applies to all records in the answer, authority and additional sections
+of a matching response. The EDNS0 OPT pseudo-record is never rewritten: its header TTL
+field does not hold a TTL but encodes EDNS0 metadata (extended RCODE, version and flags
+such as the DNSSEC DO bit), which would be corrupted by rewriting.
+
 TTL examples with ranges:
 ```
 # rewrite TTL to be between 30s and 300s

--- a/plugin/rewrite/ttl.go
+++ b/plugin/rewrite/ttl.go
@@ -19,6 +19,12 @@ type ttlResponseRule struct {
 }
 
 func (r *ttlResponseRule) RewriteResponse(_res *dns.Msg, rr dns.RR) {
+	// The OPT pseudo-record does not carry an actual TTL: its header TTL field
+	// encodes EDNS0 metadata (version, extended RCODE and flags such as the DO
+	// bit). Clamping it would corrupt the EDNS0 header, so leave it untouched.
+	if rr.Header().Rrtype == dns.TypeOPT {
+		return
+	}
 	if rr.Header().Ttl < r.minTTL {
 		rr.Header().Ttl = r.minTTL
 	} else if rr.Header().Ttl > r.maxTTL {

--- a/plugin/rewrite/ttl_test.go
+++ b/plugin/rewrite/ttl_test.go
@@ -158,6 +158,50 @@ func doTTLTests(t *testing.T, rules []Rule) {
 	}
 }
 
+func TestTTLRewriteDoesNotCorruptOPT(t *testing.T) {
+	// A ttl rewrite rule must only clamp the TTL of real resource records.
+	// The OPT pseudo-record carries EDNS0 metadata (version, extended RCODE and
+	// flags such as DO) in its header TTL field, so clamping it corrupts the
+	// EDNS0 header of the response.
+	rule, err := newRule("stop", "ttl", "example.org.", "3600")
+	if err != nil {
+		t.Fatalf("unable to create ttl rule: %s", err)
+	}
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	m.Question[0].Qclass = dns.ClassINET
+	// Request advertises DNSSEC OK; the echoing handler replies with the same OPT.
+	m.SetEdns0(4096, true)
+
+	rw := Rewrite{
+		Next:  plugin.HandlerFunc(msgPrinter),
+		Rules: []Rule{rule},
+	}
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	rw.ServeDNS(context.TODO(), rec, m)
+	resp := rec.Msg
+
+	// Sanity check: the ttl rule fired and clamped the real answer records.
+	if len(resp.Answer) == 0 {
+		t.Fatalf("expected an answer, got %q", resp)
+	}
+	if got := resp.Answer[0].Header().Ttl; got != 3600 {
+		t.Fatalf("expected answer TTL to be clamped to 3600, got %d", got)
+	}
+
+	opt := resp.IsEdns0()
+	if opt == nil {
+		t.Fatalf("expected an OPT record in the response, got none")
+	}
+	if !opt.Do() {
+		t.Errorf("DO bit was cleared by the ttl rewrite; OPT header TTL field is now %d", opt.Hdr.Ttl)
+	}
+	if opt.Version() != 0 {
+		t.Errorf("EDNS0 version was corrupted by the ttl rewrite: got %d, want 0", opt.Version())
+	}
+}
+
 func TestNewTTLRuleLargeRegex(t *testing.T) {
 	largeRegex := strings.Repeat("a", maxRegexpLen+1)
 	_, err := newTTLRule("stop", "regex", largeRegex, "300")


### PR DESCRIPTION
A `ttl` rewrite rule installs a response rule that clamps the header TTL of every record in the answer, authority **and additional** sections. The additional section normally contains the EDNS0 OPT pseudo-record, whose header TTL field is not an actual TTL — per RFC 6891 §6.1.3 it encodes the EDNS version, extended RCODE and flags (including the DO bit).

As a result any `ttl` rewrite corrupts the EDNS0 header of responses that carry an OPT record:

- `rewrite ttl example.org. 3600` clears the **DO bit** of a DNSSEC-aware response — the OPT TTL field is `0x8000 = 32768` (DO set), which is above `3600`, so it is clamped down and the DO bit is lost;
- a minimum-TTL rule such as `rewrite ttl example.org. 30-` raises an OPT whose TTL field was `0`, setting reserved Z-flag bits.

`ResponseReverter.WriteMsg` applies the response rules over `res.Extra`, and `plugin/pkg/edns` only validates the *request* OPT, so the corrupted OPT is written straight to the client with no compensating fixup.

This skips OPT records when applying the ttl response rule, so only real resource records are clamped. Added a regression test (`TestTTLRewriteDoesNotCorruptOPT`) that drives the full `ServeDNS` → `ResponseReverter` path and fails before the fix.

*Disclosure: this bug was found and the fix drafted with the assistance of Claude (an AI tool); all changes were reviewed and verified by me.*
