### PR TITLE
plugin/transfer: collect all notify errors instead of shadowing

### DIFF
--- a/plugin/transfer/notify.go
+++ b/plugin/transfer/notify.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -25,17 +26,17 @@ func (t *Transfer) Notify(zone string) error {
 	}
 	c := notifyClient(x)
 
-	var err1 error
+	var errs error
 	for _, t := range x.to {
 		if t == "*" {
 			continue
 		}
 		if err := sendNotify(c, m, t); err != nil {
-			err1 = err
+			errs = errors.Join(errs, err)
 		}
 	}
 	log.Debugf("Sent notifies for zone %q to %v", zone, x.to)
-	return err1 // this only captures the last error
+	return errs
 }
 
 func notifyClient(x *xfr) *dns.Client {

--- a/plugin/transfer/notify_test.go
+++ b/plugin/transfer/notify_test.go
@@ -2,7 +2,10 @@ package transfer
 
 import (
 	"net"
+	"strings"
 	"testing"
+
+	"github.com/miekg/dns"
 )
 
 func TestNotifyClientSource(t *testing.T) {
@@ -23,5 +26,63 @@ func TestNotifyClientSource(t *testing.T) {
 	}
 	if !addr.IP.Equal(source) {
 		t.Fatalf("expected source address %s, got %s", source, addr.IP)
+	}
+}
+
+func TestNotifyMultipleFailures(t *testing.T) {
+	// Start two local UDP listeners returning different rcodes
+	l1, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer l1.Close()
+
+	l2, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer l2.Close()
+
+	serve := func(conn net.PacketConn, rcode int) {
+		buf := make([]byte, 512)
+		for {
+			n, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			msg := new(dns.Msg)
+			if err := msg.Unpack(buf[:n]); err != nil {
+				continue
+			}
+			msg.SetReply(msg)
+			msg.Rcode = rcode
+			out, _ := msg.Pack()
+			conn.WriteTo(out, addr)
+		}
+	}
+
+	go serve(l1, dns.RcodeServerFailure)
+	go serve(l2, dns.RcodeRefused)
+
+	tr := &Transfer{
+		xfrs: []*xfr{
+			{
+				Zones: []string{"example.com."},
+				to:    []string{l1.LocalAddr().String(), l2.LocalAddr().String()},
+			},
+		},
+	}
+
+	err = tr.Notify("example.com.")
+	if err == nil {
+		t.Fatal("expected error from Notify, got nil")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, l1.LocalAddr().String()) || !strings.Contains(errStr, "SERVFAIL") {
+		t.Errorf("expected error to contain %q and SERVFAIL, got: %v", l1.LocalAddr().String(), errStr)
+	}
+	if !strings.Contains(errStr, l2.LocalAddr().String()) || !strings.Contains(errStr, "REFUSED") {
+		t.Errorf("expected error to contain %q and REFUSED, got: %v", l2.LocalAddr().String(), errStr)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a silent error shadowing bug in the `transfer` plugin where `Notify()` only returned the error of the last upstream server if multiple notifications failed. 

## Why is it important?

As reported in #7167, if a user configures multiple `to` addresses for zone transfers and all of them fail to accept the NOTIFY message, CoreDNS only logs the error for the last IP in the configuration list. The errors from all preceding IPs are completely overwritten and silently dropped. This causes confusion during debugging, making it appear as if only the last server in the list is broken.

This PR uses the standard `errors.Join` to accumulate all errors encountered during the loop, so that `log.Warning` prints a complete report of all failing notifications.

## Related Issues
Related to #7167

## How to test this PR
Run standard tests: `go test ./plugin/transfer/...`
Alternatively, configure multiple dummy `transfer { to ... }` IP addresses that will reject the NOTIFY. You will now see the `SERVFAIL` (or timeout) errors for **all** addresses in the CoreDNS logs instead of just the last one.