### PR TITLE
plugin: add AAAA lookup for internal SRV and MX targets

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"strings"
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
@@ -227,7 +228,11 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 				if e1 == nil && m1 != nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
-						if _, ok := a.(*dns.CNAME); !ok {
+						if cn, ok := a.(*dns.CNAME); ok {
+							if !containsCNAME(extra, cn) {
+								extra = append(extra, a)
+							}
+						} else {
 							extra = append(extra, a)
 						}
 					}
@@ -245,7 +250,11 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
 			if e2 == nil {
 				for _, a := range addr6 {
-					if _, ok := a.(*dns.CNAME); !ok {
+					if cn, ok := a.(*dns.CNAME); ok {
+						if !containsCNAME(extra, cn) {
+							extra = append(extra, a)
+						}
+					} else {
 						extra = append(extra, a)
 					}
 				}
@@ -300,9 +309,12 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 
 				m1, e1 = b.Lookup(ctx, state, mx.Mx, dns.TypeAAAA)
 				if e1 == nil && m1 != nil {
-					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
-						if _, ok := a.(*dns.CNAME); !ok {
+						if cn, ok := a.(*dns.CNAME); ok {
+							if !containsCNAME(extra, cn) {
+								extra = append(extra, a)
+							}
+						} else {
 							extra = append(extra, a)
 						}
 					}
@@ -319,7 +331,11 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
 			if e2 == nil {
 				for _, a := range addr6 {
-					if _, ok := a.(*dns.CNAME); !ok {
+					if cn, ok := a.(*dns.CNAME); ok {
+						if !containsCNAME(extra, cn) {
+							extra = append(extra, a)
+						}
+					} else {
 						extra = append(extra, a)
 					}
 				}
@@ -573,3 +589,14 @@ func isDuplicate(m map[item]struct{}, name, addr string, port uint16) bool {
 }
 
 const hostmaster = "hostmaster"
+
+func containsCNAME(records []dns.RR, cname *dns.CNAME) bool {
+	for _, r := range records {
+		if c, ok := r.(*dns.CNAME); ok {
+			if strings.EqualFold(c.Hdr.Name, cname.Hdr.Name) && strings.EqualFold(c.Target, cname.Target) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -241,7 +241,11 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			if e1 == nil {
 				extra = append(extra, addr...)
 			}
-			// TODO(miek): AAAA as well here.
+			state2 := state.NewWithQuestion(srv.Target, dns.TypeAAAA)
+			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
+			if e2 == nil {
+				extra = append(extra, addr6...)
+			}
 
 		case dns.TypeA, dns.TypeAAAA:
 			addr := serv.Host
@@ -307,7 +311,11 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 			if e1 == nil {
 				extra = append(extra, addr...)
 			}
-			// TODO(miek): AAAA as well here.
+			state2 := state.NewWithQuestion(mx.Mx, dns.TypeAAAA)
+			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
+			if e2 == nil {
+				extra = append(extra, addr6...)
+			}
 
 		case dns.TypeA, dns.TypeAAAA:
 			addr := serv.Host

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -244,7 +244,11 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			state2 := state.NewWithQuestion(srv.Target, dns.TypeAAAA)
 			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
 			if e2 == nil {
-				extra = append(extra, addr6...)
+				for _, a := range addr6 {
+					if _, ok := a.(*dns.CNAME); !ok {
+						extra = append(extra, a)
+					}
+				}
 			}
 
 		case dns.TypeA, dns.TypeAAAA:
@@ -314,7 +318,11 @@ func MX(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 			state2 := state.NewWithQuestion(mx.Mx, dns.TypeAAAA)
 			addr6, _, e2 := AAAA(ctx, b, zone, state2, nil, opt)
 			if e2 == nil {
-				extra = append(extra, addr6...)
+				for _, a := range addr6 {
+					if _, ok := a.(*dns.CNAME); !ok {
+						extra = append(extra, a)
+					}
+				}
 			}
 
 		case dns.TypeA, dns.TypeAAAA:

--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -604,3 +604,49 @@ func TestIsDuplicate(t *testing.T) {
 		t.Fatal("expected duplicate on second insert (addr)")
 	}
 }
+
+func TestSRVInternalAAAA(t *testing.T) {
+	b := &mockBackend{
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
+			if state.Name() == "_sip._tcp.example.org." {
+				return []msg.Service{
+					{Host: "internal.example.org.", Port: 80, Priority: 10, Weight: 5, TTL: 30, Key: "/skydns/org/example/s1"},
+				}, nil
+			}
+			if state.Name() == "internal.example.org." {
+				return []msg.Service{
+					{Host: "1.2.3.4", TTL: 30, Key: "/skydns/org/example/internal"},
+					{Host: "::1", TTL: 30, Key: "/skydns/org/example/internal6"},
+				}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("_sip._tcp.example.org.", dns.TypeSRV)
+	state := request.Request{Req: req, W: &test.ResponseWriter{}}
+	recs, extra, err := SRV(context.Background(), b, "example.org.", state, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 SRV records, got %d", len(recs))
+	}
+	// With the fix, we should get 2 extra records (one A, one AAAA)
+	if len(extra) != 2 {
+		t.Fatalf("expected 2 extra records (A and AAAA), got %d", len(extra))
+	}
+	hasA := false
+	hasAAAA := false
+	for _, e := range extra {
+		if e.Header().Rrtype == dns.TypeA {
+			hasA = true
+		}
+		if e.Header().Rrtype == dns.TypeAAAA {
+			hasAAAA = true
+		}
+	}
+	if !hasA || !hasAAAA {
+		t.Fatalf("expected both A and AAAA in extra, got %v", extra)
+	}
+}

--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -760,3 +760,105 @@ func TestMXInternalAAAA(t *testing.T) {
 		t.Fatalf("expected CNAME, A and AAAA in extra, got %v", extra)
 	}
 }
+
+func TestSRVInternalIPv6Only(t *testing.T) {
+	b := &mockBackend{
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
+			if state.Name() == "_sip._tcp.example.org." {
+				return []msg.Service{
+					{Host: "alias.example.org.", Port: 80, Priority: 10, Weight: 5, TTL: 30, Key: "/skydns/org/example/s1"},
+				}, nil
+			}
+			if state.Name() == "alias.example.org." {
+				return []msg.Service{
+					{Host: "internal.example.org.", TTL: 30, Key: "/skydns/org/example/alias"},
+				}, nil
+			}
+			if state.Name() == "internal.example.org." {
+				// Only IPv6 address
+				return []msg.Service{
+					{Host: "::1", TTL: 30, Key: "/skydns/org/example/internal6"},
+				}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("_sip._tcp.example.org.", dns.TypeSRV)
+	state := request.Request{Req: req, W: &test.ResponseWriter{}}
+	recs, extra, err := SRV(context.Background(), b, "example.org.", state, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 SRV records, got %d", len(recs))
+	}
+	// We should get 2 extra records: CNAME and AAAA (since A returned nothing, but CNAME must be preserved)
+	if len(extra) != 2 {
+		t.Fatalf("expected 2 extra records (CNAME, AAAA), got %d: %v", len(extra), extra)
+	}
+	hasCNAME := false
+	hasAAAA := false
+	for _, e := range extra {
+		if e.Header().Rrtype == dns.TypeCNAME {
+			hasCNAME = true
+		}
+		if e.Header().Rrtype == dns.TypeAAAA {
+			hasAAAA = true
+		}
+	}
+	if !hasCNAME || !hasAAAA {
+		t.Fatalf("expected CNAME and AAAA in extra, got %v", extra)
+	}
+}
+
+func TestMXInternalIPv6Only(t *testing.T) {
+	b := &mockBackend{
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
+			if state.Name() == "example.org." {
+				return []msg.Service{
+					{Host: "alias.example.org.", Priority: 10, Mail: true, TTL: 30, Key: "/skydns/org/example/mx1"},
+				}, nil
+			}
+			if state.Name() == "alias.example.org." {
+				return []msg.Service{
+					{Host: "internal.example.org.", TTL: 30, Key: "/skydns/org/example/alias"},
+				}, nil
+			}
+			if state.Name() == "internal.example.org." {
+				// Only IPv6 address
+				return []msg.Service{
+					{Host: "::1", TTL: 30, Key: "/skydns/org/example/internal6"},
+				}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeMX)
+	state := request.Request{Req: req, W: &test.ResponseWriter{}}
+	recs, extra, err := MX(context.Background(), b, "example.org.", state, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 MX records, got %d", len(recs))
+	}
+	// We should get 2 extra records: CNAME and AAAA (since A returned nothing, but CNAME must be preserved)
+	if len(extra) != 2 {
+		t.Fatalf("expected 2 extra records (CNAME, AAAA), got %d: %v", len(extra), extra)
+	}
+	hasCNAME := false
+	hasAAAA := false
+	for _, e := range extra {
+		if e.Header().Rrtype == dns.TypeCNAME {
+			hasCNAME = true
+		}
+		if e.Header().Rrtype == dns.TypeAAAA {
+			hasAAAA = true
+		}
+	}
+	if !hasCNAME || !hasAAAA {
+		t.Fatalf("expected CNAME and AAAA in extra, got %v", extra)
+	}
+}

--- a/plugin/backend_lookup_test.go
+++ b/plugin/backend_lookup_test.go
@@ -650,3 +650,113 @@ func TestSRVInternalAAAA(t *testing.T) {
 		t.Fatalf("expected both A and AAAA in extra, got %v", extra)
 	}
 }
+
+func TestCNAMEInternalAAAA(t *testing.T) {
+	b := &mockBackend{
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
+			if state.Name() == "_sip._tcp.example.org." {
+				return []msg.Service{
+					{Host: "alias.example.org.", Port: 80, Priority: 10, Weight: 5, TTL: 30, Key: "/skydns/org/example/s1"},
+				}, nil
+			}
+			if state.Name() == "alias.example.org." {
+				return []msg.Service{
+					{Host: "internal.example.org.", TTL: 30, Key: "/skydns/org/example/alias"},
+				}, nil
+			}
+			if state.Name() == "internal.example.org." {
+				return []msg.Service{
+					{Host: "1.2.3.4", TTL: 30, Key: "/skydns/org/example/internal"},
+					{Host: "::1", TTL: 30, Key: "/skydns/org/example/internal6"},
+				}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("_sip._tcp.example.org.", dns.TypeSRV)
+	state := request.Request{Req: req, W: &test.ResponseWriter{}}
+	recs, extra, err := SRV(context.Background(), b, "example.org.", state, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 SRV records, got %d", len(recs))
+	}
+	// We should get 3 extra records: CNAME, A, AAAA (no duplicate CNAME)
+	if len(extra) != 3 {
+		t.Fatalf("expected 3 extra records (CNAME, A, AAAA), got %d: %v", len(extra), extra)
+	}
+	hasCNAME := false
+	hasA := false
+	hasAAAA := false
+	for _, e := range extra {
+		if e.Header().Rrtype == dns.TypeCNAME {
+			hasCNAME = true
+		}
+		if e.Header().Rrtype == dns.TypeA {
+			hasA = true
+		}
+		if e.Header().Rrtype == dns.TypeAAAA {
+			hasAAAA = true
+		}
+	}
+	if !hasCNAME || !hasA || !hasAAAA {
+		t.Fatalf("expected CNAME, A and AAAA in extra, got %v", extra)
+	}
+}
+
+func TestMXInternalAAAA(t *testing.T) {
+	b := &mockBackend{
+		mockServices: func(_ctx context.Context, state request.Request, _exact bool, _opt Options) ([]msg.Service, error) {
+			if state.Name() == "example.org." {
+				return []msg.Service{
+					{Host: "alias.example.org.", Priority: 10, Mail: true, TTL: 30, Key: "/skydns/org/example/mx1"},
+				}, nil
+			}
+			if state.Name() == "alias.example.org." {
+				return []msg.Service{
+					{Host: "internal.example.org.", TTL: 30, Key: "/skydns/org/example/alias"},
+				}, nil
+			}
+			if state.Name() == "internal.example.org." {
+				return []msg.Service{
+					{Host: "1.2.3.4", TTL: 30, Key: "/skydns/org/example/internal"},
+					{Host: "::1", TTL: 30, Key: "/skydns/org/example/internal6"},
+				}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeMX)
+	state := request.Request{Req: req, W: &test.ResponseWriter{}}
+	recs, extra, err := MX(context.Background(), b, "example.org.", state, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 MX records, got %d", len(recs))
+	}
+	// We should get 3 extra records: CNAME, A, AAAA (no duplicate CNAME)
+	if len(extra) != 3 {
+		t.Fatalf("expected 3 extra records (CNAME, A, AAAA), got %d: %v", len(extra), extra)
+	}
+	hasCNAME := false
+	hasA := false
+	hasAAAA := false
+	for _, e := range extra {
+		if e.Header().Rrtype == dns.TypeCNAME {
+			hasCNAME = true
+		}
+		if e.Header().Rrtype == dns.TypeA {
+			hasA = true
+		}
+		if e.Header().Rrtype == dns.TypeAAAA {
+			hasAAAA = true
+		}
+	}
+	if !hasCNAME || !hasA || !hasAAAA {
+		t.Fatalf("expected CNAME, A and AAAA in extra, got %v", extra)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Resolves a long-standing `TODO` in `plugin/backend_lookup.go` by adding `dns.TypeAAAA` queries alongside `dns.TypeA` queries for resolving internal `SRV` and `MX` targets in the Additional section.

## Why is it important?

When returning an `SRV` or `MX` record that points to an internal target, `backend_lookup.go` fetches the IP address of that target and appends it to the `Extra` (Additional) section as a Glue record. 
However, it previously only queried for IPv4 (`dns.TypeA`) addresses, completely ignoring IPv6. This led to incomplete responses in dual-stack environments and broken functionality in IPv6-only environments because clients were not receiving the `AAAA` glue records they expected.

This PR adds the missing `AAAA()` lookups directly after the `A()` lookups, exactly as hinted by the `// TODO(miek): AAAA as well here.` comments.

## How to test this PR

Run existing unit tests for plugins that rely on `backend_lookup.go`:
`go test ./plugin/etcd/... ./plugin/kubernetes/... ./plugin/auto/...`
All tests continue to pass correctly. 

In a real environment, query an `SRV` or `MX` record configured in a backend plugin (like `etcd`) that has both IPv4 and IPv6 addresses. Ensure that both `A` and `AAAA` records are now returned in the Additional section.