### PR TITLE
plugin/rewrite: normalize exact CNAME rewrite targets

### DIFF
--- a/plugin/rewrite/cname_target.go
+++ b/plugin/rewrite/cname_target.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
@@ -138,6 +139,10 @@ func newCNAMERule(nextAction string, args ...string) (Rule, error) {
 		paramFromTarget, paramToTarget = strings.ToLower(args[0]), strings.ToLower(args[1])
 	} else {
 		return nil, fmt.Errorf("too few (%d) arguments for a cname rule", len(args))
+	}
+	if rewriteType == ExactMatch {
+		paramFromTarget = plugin.Name(paramFromTarget).Normalize()
+		paramToTarget = plugin.Name(paramToTarget).Normalize()
 	}
 	rule := cnameTargetRule{
 		rewriteType:     rewriteType,

--- a/plugin/rewrite/cname_target_test.go
+++ b/plugin/rewrite/cname_target_test.go
@@ -76,7 +76,7 @@ func TestCNameTargetRewrite(t *testing.T) {
 		args         []string
 		expectedType reflect.Type
 	}{
-		{[]string{"continue", "cname", "exact", "def.example.com.", "xyz.example.com."}, reflect.TypeFor[*cnameTargetRule]()},
+		{[]string{"continue", "cname", "exact", "def.example.com", "xyz.example.com"}, reflect.TypeFor[*cnameTargetRule]()},
 		{[]string{"continue", "cname", "prefix", "chat.openai.com", "bard.google.com"}, reflect.TypeFor[*cnameTargetRule]()},
 		{[]string{"continue", "cname", "suffix", "uvw.", "xyz."}, reflect.TypeFor[*cnameTargetRule]()},
 		{[]string{"continue", "cname", "substring", "efgh", "zzzz.www"}, reflect.TypeFor[*cnameTargetRule]()},
@@ -295,5 +295,22 @@ func TestNewCNAMERuleLargeRegex(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "too long") {
 		t.Errorf("Expected 'too long' error, got: %v", err)
+	}
+}
+
+func TestNewCNAMERuleNormalization(t *testing.T) {
+	rule, err := newCNAMERule("stop", "exact", "newyork.foo.com", "vpce-123.amazonaws.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cnameRule, ok := rule.(*cnameTargetRule)
+	if !ok {
+		t.Fatalf("expected *cnameTargetRule, got %T", rule)
+	}
+	if cnameRule.paramFromTarget != "newyork.foo.com." {
+		t.Errorf("expected fromTarget to be normalized to 'newyork.foo.com.', got %q", cnameRule.paramFromTarget)
+	}
+	if cnameRule.paramToTarget != "vpce-123.amazonaws.com." {
+		t.Errorf("expected toTarget to be normalized to 'vpce-123.amazonaws.com.', got %q", cnameRule.paramToTarget)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Resolves #6922 by fixing two issues in the CNAME target rewrite logic (`plugin/rewrite/cname_target.go`):

1. **Missing name normalization for ExactMatch rules**: When a user configures a rule like `rewrite cname exact newyork.foo.com vpce-123...` (without a trailing dot), the rewrite rule previously matched literally against `newyork.foo.com.` (with a trailing dot) from the DNS message target. This caused `ExactMatch` rules to silently fail to apply. This PR calls `plugin.Name().Normalize()` when creating `ExactMatch` rules to ensure proper comparison.

## How to test this PR

Run existing unit tests in `plugin/rewrite`:
`go test ./plugin/rewrite/...`

The test case in `cname_target_test.go` was updated to omit trailing dots in the configuration arguments to verify that the normalization works correctly and correctly overrides the CNAME target.

Fixes #6922