### PR TITLE
plugin/forward: Fix UDP forwarding so a malformed upstream datagram wont block valid ones later

### DIFF
--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -198,6 +198,10 @@ func (p *Proxy) lookupDNS(_ctx context.Context, state request.Request, opts Opti
 				break
 			}
 
+			if _, isDNSErr := err.(*dns.Error); isDNSErr && p.transport.transportTypeFromConn(pc) == typeUDP {
+				continue
+			}
+
 			pc.c.Close() // not giving it back
 			if err == io.EOF && cached {
 				return nil, localAddr, proto, ErrCachedClosed

--- a/plugin/pkg/proxy/connect.go
+++ b/plugin/pkg/proxy/connect.go
@@ -186,6 +186,12 @@ func (p *Proxy) lookupDNS(_ctx context.Context, state request.Request, opts Opti
 	for {
 		ret, err = pc.c.ReadMsg()
 		if err != nil {
+			if p.transport.transportTypeFromConn(pc) == typeUDP &&
+				((ret == nil && errors.Is(err, dns.ErrShortRead)) ||
+					(ret != nil && ret.Id != state.Req.Id)) {
+				continue
+			}
+
 			if ret != nil && (state.Req.Id == ret.Id) && p.transport.transportTypeFromConn(pc) == typeUDP && shouldTruncateResponse(err) {
 				// For UDP, if the error is an overflow, we probably have an upstream misbehaving in some way.
 				// (e.g. sending >512 byte responses without an eDNS0 OPT RR).
@@ -196,10 +202,6 @@ func (p *Proxy) lookupDNS(_ctx context.Context, state request.Request, opts Opti
 				// Truncate the response.
 				ret = truncateResponse(ret)
 				break
-			}
-
-			if _, isDNSErr := err.(*dns.Error); isDNSErr && p.transport.transportTypeFromConn(pc) == typeUDP {
-				continue
 			}
 
 			pc.c.Close() // not giving it back

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -267,5 +268,88 @@ func TestShouldTruncateResponse(t *testing.T) {
 				t.Errorf("For testname '%v', expected %v but got %v", tc.testname, tc.expected, result)
 			}
 		})
+	}
+}
+
+func TestProxyMalformedUDPThenValid(t *testing.T) {
+	serverResult := make(chan error, 1)
+
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// Ensure the malformed packet's partial ID cannot match the query ID.
+		badID := r.Id + 1
+
+		malformed := []byte{
+			byte(badID >> 8),
+			byte(badID),
+			0x00,
+		}
+
+		if _, err := w.Write(malformed); err != nil {
+			serverResult <- err
+			return
+		}
+
+		// Immediately send a completely valid response for the same query.
+		reply := new(dns.Msg)
+		reply.SetReply(r)
+		reply.Answer = append(
+			reply.Answer,
+			test.A("variant.example. IN A 192.0.2.55"),
+		)
+
+		if err := w.WriteMsg(reply); err != nil {
+			serverResult <- err
+			return
+		}
+
+		serverResult <- nil
+	})
+	defer s.Close()
+
+	p := NewProxy(
+		"TestProxyMalformedUDPThenValid",
+		s.Addr,
+		transport.DNS,
+	)
+	p.readTimeout = time.Second
+	p.Start(5 * time.Second)
+	defer p.Stop()
+
+	q := new(dns.Msg)
+	q.SetQuestion("variant.example.", dns.TypeA)
+
+	req := request.Request{
+		Req: q,
+		W:   &test.ResponseWriter{},
+	}
+
+	resp, _, _, err := p.Connect(
+		context.Background(),
+		req,
+		Options{PreferUDP: true},
+	)
+
+	if serverErr := <-serverResult; serverErr != nil {
+		t.Fatalf("upstream failed to send responses: %v", serverErr)
+	}
+
+	// Expected: ignore the malformed UDP datagram and read the valid response.
+	if err != nil {
+		t.Fatalf(
+			"valid response after malformed UDP datagram was not accepted: %v",
+			err,
+		)
+	}
+
+	if resp == nil {
+		t.Fatal("expected valid response, got nil")
+	}
+
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected one answer, got %d", len(resp.Answer))
+	}
+
+	if got := resp.Answer[0].String(); !strings.Contains(got, "192.0.2.55") {
+		t.Fatalf("expected 192.0.2.55, got %q", got)
 	}
 }

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -272,84 +272,121 @@ func TestShouldTruncateResponse(t *testing.T) {
 }
 
 func TestProxyMalformedUDPThenValid(t *testing.T) {
-	serverResult := make(chan error, 1)
+	tests := []struct {
+		name      string
+		malformed func(*dns.Msg) []byte
+	}{
+		{
+			name: "short packet without complete header",
+			malformed: func(r *dns.Msg) []byte {
+				badID := r.Id + 1
 
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
-		// Ensure the malformed packet's partial ID cannot match the query ID.
-		badID := r.Id + 1
+				return []byte{
+					byte(badID >> 8),
+					byte(badID),
+					0x00,
+				}
+			},
+		},
+		{
+			name: "partial malformed response with mismatched ID",
+			malformed: func(r *dns.Msg) []byte {
+				badID := r.Id + 1
 
-		malformed := []byte{
-			byte(badID >> 8),
-			byte(badID),
-			0x00,
-		}
-
-		if _, err := w.Write(malformed); err != nil {
-			serverResult <- err
-			return
-		}
-
-		// Immediately send a completely valid response for the same query.
-		reply := new(dns.Msg)
-		reply.SetReply(r)
-		reply.Answer = append(
-			reply.Answer,
-			test.A("variant.example. IN A 192.0.2.55"),
-		)
-
-		if err := w.WriteMsg(reply); err != nil {
-			serverResult <- err
-			return
-		}
-
-		serverResult <- nil
-	})
-	defer s.Close()
-
-	p := NewProxy(
-		"TestProxyMalformedUDPThenValid",
-		s.Addr,
-		transport.DNS,
-	)
-	p.readTimeout = time.Second
-	p.Start(5 * time.Second)
-	defer p.Stop()
-
-	q := new(dns.Msg)
-	q.SetQuestion("variant.example.", dns.TypeA)
-
-	req := request.Request{
-		Req: q,
-		W:   &test.ResponseWriter{},
+				// Complete DNS header claiming one question, but with the
+				// question body missing. ReadMsg returns a partial message
+				// containing badID together with an unpacking error.
+				return []byte{
+					byte(badID >> 8),
+					byte(badID),
+					0x81,
+					0x80,
+					0x00,
+					0x01,
+					0x00,
+					0x00,
+					0x00,
+					0x00,
+					0x00,
+					0x00,
+				}
+			},
+		},
 	}
 
-	resp, _, _, err := p.Connect(
-		context.Background(),
-		req,
-		Options{PreferUDP: true},
-	)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serverResult := make(chan error, 1)
 
-	if serverErr := <-serverResult; serverErr != nil {
-		t.Fatalf("upstream failed to send responses: %v", serverErr)
-	}
+			s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+				if _, err := w.Write(tc.malformed(r)); err != nil {
+					serverResult <- err
+					return
+				}
 
-	// Expected: ignore the malformed UDP datagram and read the valid response.
-	if err != nil {
-		t.Fatalf(
-			"valid response after malformed UDP datagram was not accepted: %v",
-			err,
-		)
-	}
+				// Immediately send a completely valid response for the same query.
+				reply := new(dns.Msg)
+				reply.SetReply(r)
+				reply.Answer = append(
+					reply.Answer,
+					test.A("variant.example. IN A 192.0.2.55"),
+				)
 
-	if resp == nil {
-		t.Fatal("expected valid response, got nil")
-	}
+				if err := w.WriteMsg(reply); err != nil {
+					serverResult <- err
+					return
+				}
 
-	if len(resp.Answer) != 1 {
-		t.Fatalf("expected one answer, got %d", len(resp.Answer))
-	}
+				serverResult <- nil
+			})
+			defer s.Close()
 
-	if got := resp.Answer[0].String(); !strings.Contains(got, "192.0.2.55") {
-		t.Fatalf("expected 192.0.2.55, got %q", got)
+			p := NewProxy(
+				"TestProxyMalformedUDPThenValid",
+				s.Addr,
+				transport.DNS,
+			)
+			p.readTimeout = time.Second
+			p.Start(5 * time.Second)
+			defer p.Stop()
+
+			q := new(dns.Msg)
+			q.SetQuestion("variant.example.", dns.TypeA)
+
+			req := request.Request{
+				Req: q,
+				W:   &test.ResponseWriter{},
+			}
+
+			resp, _, _, err := p.Connect(
+				context.Background(),
+				req,
+				Options{PreferUDP: true},
+			)
+
+			if serverErr := <-serverResult; serverErr != nil {
+				t.Fatalf("upstream failed to send responses: %v", serverErr)
+			}
+
+			// Expected: ignore the malformed UDP datagram and read the valid response.
+			if err != nil {
+				t.Fatalf(
+					"valid response after malformed UDP datagram was not accepted: %v",
+					err,
+				)
+			}
+
+			if resp == nil {
+				t.Fatal("expected valid response, got nil")
+			}
+
+			if len(resp.Answer) != 1 {
+				t.Fatalf("expected one answer, got %d", len(resp.Answer))
+			}
+
+			if got := resp.Answer[0].String(); !strings.Contains(got, "192.0.2.55") {
+				t.Fatalf("expected 192.0.2.55, got %q", got)
+			}
+		})
 	}
 }

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -293,8 +293,8 @@ func TestProxyMalformedUDPThenValid(t *testing.T) {
 			malformed: func(r *dns.Msg) []byte {
 				badID := r.Id + 1
 
-				// Complete DNS header claiming one question, but with the
-				// question body missing. ReadMsg returns a partial message
+				// Complete DNS header claiming one question, followed by an
+				// incomplete one-byte label. ReadMsg returns a partial message
 				// containing badID together with an unpacking error.
 				return []byte{
 					byte(badID >> 8),
@@ -309,6 +309,7 @@ func TestProxyMalformedUDPThenValid(t *testing.T) {
 					0x00,
 					0x00,
 					0x00,
+					0x01,
 				}
 			},
 		},


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes UDP forwarding so a malformed upstream datagram does not prevent CoreDNS from accepting a subsequent valid response before the existing read deadline.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a