### PR TITLE
plugin/file: fix data race between lookups and reload/transfer

### DIFF
--- a/plugin/file/closest.go
+++ b/plugin/file/closest.go
@@ -6,11 +6,13 @@ import (
 	"github.com/miekg/dns"
 )
 
-// ClosestEncloser returns the closest encloser for qname.
-func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
+// ClosestEncloser returns the closest encloser for qname. It searches tr, which
+// the caller pins from a single zone snapshot so the lookup stays consistent
+// even if a reload or transfer swaps the zone's tree concurrently.
+func (z *Zone) ClosestEncloser(tr *tree.Tree, qname string) (*tree.Elem, bool) {
 	offset, end := dns.NextLabel(qname, 0)
 	for !end {
-		elem, _ := z.Search(qname)
+		elem, _ := tr.Search(qname)
 		if elem != nil {
 			return elem, true
 		}
@@ -19,5 +21,5 @@ func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
 		offset, end = dns.NextLabel(qname, 0)
 	}
 
-	return z.Search(z.origin)
+	return tr.Search(z.origin)
 }

--- a/plugin/file/closest.go
+++ b/plugin/file/closest.go
@@ -6,10 +6,16 @@ import (
 	"github.com/miekg/dns"
 )
 
-// ClosestEncloser returns the closest encloser for qname. It searches tr, which
-// the caller pins from a single zone snapshot so the lookup stays consistent
-// even if a reload or transfer swaps the zone's tree concurrently.
-func (z *Zone) ClosestEncloser(tr *tree.Tree, qname string) (*tree.Elem, bool) {
+// ClosestEncloser returns the closest encloser for qname.
+func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
+	_, tr := z.snapshot()
+	return z.closestEncloser(tr, qname)
+}
+
+// closestEncloser returns the closest encloser for qname. It searches tr,
+// which the caller pins from a single zone snapshot so the lookup stays
+// consistent even if a reload or transfer swaps the zone's tree concurrently.
+func (z *Zone) closestEncloser(tr *tree.Tree, qname string) (*tree.Elem, bool) {
 	offset, end := dns.NextLabel(qname, 0)
 	for !end {
 		elem, _ := tr.Search(qname)

--- a/plugin/file/closest_test.go
+++ b/plugin/file/closest_test.go
@@ -25,7 +25,7 @@ func TestClosestEncloser(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		ce, _ := z.ClosestEncloser(z.Tree, tc.in)
+		ce, _ := z.ClosestEncloser(tc.in)
 		if ce == nil {
 			if z.origin != tc.out {
 				t.Errorf("Expected ce to be %s for %s, got %s", tc.out, tc.in, ce.Name())

--- a/plugin/file/closest_test.go
+++ b/plugin/file/closest_test.go
@@ -25,7 +25,7 @@ func TestClosestEncloser(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		ce, _ := z.ClosestEncloser(tc.in)
+		ce, _ := z.ClosestEncloser(z.Tree, tc.in)
 		if ce == nil {
 			if z.origin != tc.out {
 				t.Errorf("Expected ce to be %s for %s, got %s", tc.out, tc.in, ce.Name())

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -262,7 +262,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			goto Out
 		}
 
-		ce, found := z.ClosestEncloser(tr, qname)
+		ce, found := z.closestEncloser(tr, qname)
 
 		// wildcard denial only for NXDOMAIN
 		if found {

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -484,7 +484,6 @@ func (z *Zone) doLookup(ctx context.Context, state request.Request, target strin
 func (z *Zone) additionalProcessing(tr *tree.Tree, answer []dns.RR, do bool) (extra []dns.RR) {
 	var lookup map[string]struct{}
 
-
 	for _, rr := range answer {
 		name := ""
 		switch x := rr.(type) {

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -131,7 +131,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 					rcode = Success
 				} else {
 					ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
-					answer, ns, extra, rcode = z.externalLookup(ctx, state, tr, elem, []dns.RR{cname})
+					answer, ns, extra, rcode = z.externalLookup(ctx, state, ap, tr, elem, []dns.RR{cname})
 				}
 
 				if do {
@@ -163,7 +163,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	if found && shot {
 		if rrs := elem.Type(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
-			return z.externalLookup(ctx, state, tr, elem, rrs)
+			return z.externalLookup(ctx, state, ap, tr, elem, rrs)
 		}
 
 		rrs := elem.Type(qtype)
@@ -180,7 +180,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 		// Additional section processing for MX, SRV. Check response and see if any of the names are in bailiwick -
 		// if so add IP addresses to the additional section.
-		additional := z.additionalProcessing(rrs, do)
+		additional := z.additionalProcessing(tr, rrs, do)
 
 		if do {
 			sigs := elem.Type(dns.TypeRRSIG)
@@ -206,7 +206,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 		if rrs := wildElem.TypeForWildcard(dns.TypeCNAME, qname); len(rrs) > 0 && qtype != dns.TypeCNAME {
 			ctx = context.WithValue(ctx, dnsserver.LoopKey{}, loop+1)
-			return z.externalLookup(ctx, state, tr, wildElem, rrs)
+			return z.externalLookup(ctx, state, ap, tr, wildElem, rrs)
 		}
 
 		rrs := wildElem.TypeForWildcard(qtype, qname)
@@ -224,7 +224,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 		// Additional section processing for MX, SRV, SVCB, HTTPS. Check response
 		// and see if any of the names are in bailiwick - if so add IP addresses
 		// to the additional section. This mirrors the non-wildcard path above.
-		additional := z.additionalProcessing(rrs, do)
+		additional := z.additionalProcessing(tr, rrs, do)
 
 		auth := ap.ns(do)
 		if do {
@@ -262,7 +262,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			goto Out
 		}
 
-		ce, found := z.ClosestEncloser(qname)
+		ce, found := z.ClosestEncloser(tr, qname)
 
 		// wildcard denial only for NXDOMAIN
 		if found {
@@ -343,18 +343,18 @@ func (a Apex) ns(do bool) []dns.RR {
 // authority returns the records for the authority section of a response with
 // the given result: the SOA for negative answers (NXDOMAIN/NODATA), as
 // required by RFC 2308, and the NS records otherwise.
-func (z *Zone) authority(do bool, result Result) []dns.RR {
+func (a Apex) authority(do bool, result Result) []dns.RR {
 	if result == NameError || result == NoData {
-		return z.soa(do)
+		return a.soa(do)
 	}
-	return z.ns(do)
+	return a.ns(do)
 }
 
 // externalLookup adds signatures and tries to resolve CNAMEs that point to
 // external names. It also runs additional-section processing on the resolved
 // answer so in-bailiwick SRV/MX/SVCB/HTTPS targets get their A/AAAA glue, like
 // the direct path.
-func (z *Zone) externalLookup(ctx context.Context, state request.Request, tr *tree.Tree, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
+func (z *Zone) externalLookup(ctx context.Context, state request.Request, ap Apex, tr *tree.Tree, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
 	qtype := state.QType()
 	do := state.Do()
 
@@ -372,7 +372,7 @@ func (z *Zone) externalLookup(ctx context.Context, state request.Request, tr *tr
 	if elem == nil || (qtype == dns.TypeNS || qtype == dns.TypeSOA && targetName == z.origin) {
 		lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
 		rrs = append(rrs, lookupRRs...)
-		return rrs, z.authority(do, result), z.additionalProcessing(rrs, do), result
+		return rrs, ap.authority(do, result), z.additionalProcessing(tr, rrs, do), result
 	}
 
 	i := 0
@@ -395,12 +395,12 @@ Redo:
 		if elem == nil || (qtype == dns.TypeNS || qtype == dns.TypeSOA && targetName == z.origin) {
 			lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
 			rrs = append(rrs, lookupRRs...)
-			return rrs, z.authority(do, result), z.additionalProcessing(rrs, do), result
+			return rrs, ap.authority(do, result), z.additionalProcessing(tr, rrs, do), result
 		}
 
 		i++
 		if i > 8 {
-			return rrs, z.ns(do), z.additionalProcessing(rrs, do), Success
+			return rrs, ap.ns(do), z.additionalProcessing(tr, rrs, do), Success
 		}
 
 		goto Redo
@@ -417,7 +417,7 @@ Redo:
 		}
 	}
 
-	return rrs, z.ns(do), z.additionalProcessing(rrs, do), Success
+	return rrs, ap.ns(do), z.additionalProcessing(tr, rrs, do), Success
 }
 
 // findDelegation returns the first zone cut between the zone apex and qname.
@@ -481,8 +481,9 @@ func (z *Zone) doLookup(ctx context.Context, state request.Request, target strin
 // additionalProcessing checks the current answer section and retrieves A or AAAA records
 // (and possible SIGs) to need to be put in the additional section. A target referenced by
 // more than one record is only resolved once.
-func (z *Zone) additionalProcessing(answer []dns.RR, do bool) (extra []dns.RR) {
+func (z *Zone) additionalProcessing(tr *tree.Tree, answer []dns.RR, do bool) (extra []dns.RR) {
 	var lookup map[string]struct{}
+
 
 	for _, rr := range answer {
 		name := ""
@@ -514,7 +515,7 @@ func (z *Zone) additionalProcessing(answer []dns.RR, do bool) (extra []dns.RR) {
 		}
 		lookup[target] = struct{}{}
 
-		elem, _ := z.Search(name)
+		elem, _ := tr.Search(name)
 		if elem == nil {
 			continue
 		}

--- a/plugin/file/lookup_race_test.go
+++ b/plugin/file/lookup_race_test.go
@@ -52,9 +52,7 @@ func TestLookupReloadRace(t *testing.T) {
 
 	// Writer: keep swapping the zone's data generation until told to stop.
 	var writer sync.WaitGroup
-	writer.Add(1)
-	go func() {
-		defer writer.Done()
+	writer.Go(func() {
 		i := 0
 		for {
 			select {
@@ -66,22 +64,20 @@ func TestLookupReloadRace(t *testing.T) {
 			zone.setData(g.Apex, g.Tree)
 			i++
 		}
-	}()
+	})
 
 	// Readers: hammer the lookup paths that use the helpers.
 	var readers sync.WaitGroup
 	for _, q := range queries {
-		readers.Add(1)
-		go func(qname string, qtype uint16, do bool) {
-			defer readers.Done()
+		readers.Go(func() {
 			m := new(dns.Msg)
-			m.SetQuestion(qname, qtype)
-			m.SetEdns0(4096, do)
+			m.SetQuestion(q.qname, q.qtype)
+			m.SetEdns0(4096, q.do)
 			state := request.Request{W: &test.ResponseWriter{}, Req: m}
-			for j := 0; j < 3000; j++ {
-				zone.Lookup(ctx, state, qname)
+			for range 3000 {
+				zone.Lookup(ctx, state, q.qname)
 			}
-		}(q.qname, q.qtype, q.do)
+		})
 	}
 
 	readers.Wait()

--- a/plugin/file/lookup_race_test.go
+++ b/plugin/file/lookup_race_test.go
@@ -1,0 +1,90 @@
+package file
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// TestLookupReloadRace exercises the query-time helpers that resolve in-zone
+// CNAME chains (externalLookup), additional-section targets
+// (additionalProcessing) and the DNSSEC closest encloser (ClosestEncloser)
+// concurrently with a reload/transfer that swaps the zone's Apex and tree via
+// setData. Before the fix these helpers read z.Tree/z.Apex directly instead of
+// the generation pinned by Lookup's snapshot, racing the swap. Run with -race.
+func TestLookupReloadRace(t *testing.T) {
+	zone, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expected no error when reading zone, got %q", err)
+	}
+
+	// Pre-parse a few generations to swap in from the writer goroutine.
+	gens := make([]*Zone, 4)
+	for i := range gens {
+		z, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
+		if err != nil {
+			t.Fatalf("Expected no error when reading zone, got %q", err)
+		}
+		gens[i] = z
+	}
+
+	ctx := context.TODO()
+	// Names that reach each helper: an in-zone CNAME, an SRV/MX with an in-zone
+	// target, and a non-existent name (with DO set) for the NXDOMAIN path.
+	queries := []struct {
+		qname string
+		qtype uint16
+		do    bool
+	}{
+		{"www.miek.nl.", dns.TypeA, false},   // externalLookup
+		{"srv.miek.nl.", dns.TypeSRV, false}, // additionalProcessing
+		{"mx.miek.nl.", dns.TypeMX, false},   // additionalProcessing
+		{"nx.miek.nl.", dns.TypeA, true},     // ClosestEncloser (NXDOMAIN + DO)
+	}
+
+	stop := make(chan struct{})
+
+	// Writer: keep swapping the zone's data generation until told to stop.
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			g := gens[i%len(gens)]
+			zone.setData(g.Apex, g.Tree)
+			i++
+		}
+	}()
+
+	// Readers: hammer the lookup paths that use the helpers.
+	var readers sync.WaitGroup
+	for _, q := range queries {
+		readers.Add(1)
+		go func(qname string, qtype uint16, do bool) {
+			defer readers.Done()
+			m := new(dns.Msg)
+			m.SetQuestion(qname, qtype)
+			m.SetEdns0(4096, do)
+			state := request.Request{W: &test.ResponseWriter{}, Req: m}
+			for j := 0; j < 3000; j++ {
+				zone.Lookup(ctx, state, qname)
+			}
+		}(q.qname, q.qtype, q.do)
+	}
+
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The file plugin embeds the zone's radix tree and swaps it, together with the apex records, on every reload and on secondary zone transfers, holding z.Lock() while it does so. Zone.Lookup pins one generation of that data up front through snapshot() under the read lock, but three helpers it calls later had drifted off that pinned copy: externalLookup (following in-zone CNAME chains and building the NS/authority section), additionalProcessing (MX/SRV/SVCB/HTTPS additional records) and ClosestEncloser (the DNSSEC NXDOMAIN closest encloser). Since Zone has no Search of its own, z.Search read the live z.Tree field at call time, and z.ns/z.soa/z.authority read the embedded z.Apex, so any query reaching those paths raced the reload/transfer swap that setData performs under the write lock. I noticed it while tracing how the pinned generation flows through the CNAME path and found it stopped at the helper boundary. This threads the already-pinned tree and apex into the three helpers so a single request stays on one generation, which also clears the race the detector reports. I added a regression test that drives those paths against a concurrent setData and fails under -race before the change.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None. Behavior is unchanged for valid queries.

### 4. Does this introduce a backward incompatible change or deprecation?

No. The exported ClosestEncloser(qname) signature is unchanged; it now takes its own snapshot and delegates to a private closestEncloser(tr, qname) helper, which Lookup calls with the snapshot it already holds. Query results are unchanged.

