### PR TITLE
test(tls): make keylog path test portable

### DIFF
--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -2,7 +2,6 @@ package tls
 
 import (
 	"crypto/tls"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -102,8 +101,7 @@ func TestTLSKeyLog(t *testing.T) {
 
 	t.Run("Bad Path", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Chmod(tmpDir, 0000)
-		input := "tls test_cert.pem test_key.pem test_ca.pem {\nkeylog " + filepath.Join(tmpDir, "tls.log") + "\n}"
+		input := "tls test_cert.pem test_key.pem test_ca.pem {\nkeylog " + filepath.Join(tmpDir, "missing", "tls.log") + "\n}"
 		c := caddy.NewTestController("dns", input)
 		err := setup(c)
 		if err == nil {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `plugin/tls` tests can fail like:

```
--- FAIL: TestTLSKeyLog (0.02s)
    --- FAIL: TestTLSKeyLog/Bad_Path (0.02s)
        tls_test.go:110: Expected error but found none
```

Directory permission checks can be bypassed by privileged users and may behave differently on filesystems with nonstandard permission semantics. 

Make the bad-path case deterministic so TLS keylog tests remain portable.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

No, just tests.

### 4. Does this introduce a backward incompatible change or deprecation?

No.