### PR TITLE
ci: run plugin tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# DNSSEC key material must keep LF; CRLF breaks miekg/dns private-key parsing.
+*.private text eol=lf
+*.key text eol=lf

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -59,7 +59,10 @@ jobs:
 
   test-plugins:
     name: Test Plugins
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -76,6 +79,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
+        shell: bash
         run: ( cd plugin; go test -race ./... )
 
   test-e2e:

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -151,6 +151,11 @@ func TestWalkWarnsForDuplicateOrigin(t *testing.T) {
 
 func TestWalkKeepsFirstMatchingFileForOrigin(t *testing.T) {
 	dir := t.TempDir()
+	// Match Walk: it stores paths after EvalSymlinks.
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	zone := filepath.Join(dir, "example.org.zone")
 	backup := filepath.Join(dir, "example.org.zone.bak-20260528")
 

--- a/plugin/autopath/setup_test.go
+++ b/plugin/autopath/setup_test.go
@@ -30,10 +30,10 @@ func TestSetupAutoPath(t *testing.T) {
 		{`autopath example.org @kubernetes`, false, "example.org.", "kubernetes", nil, ""},
 		{`autopath 10.0.0.0/8 @kubernetes`, false, "10.in-addr.arpa.", "kubernetes", nil, ""},
 		{`autopath ` + resolv, false, "", "", []string{"bar.com.", "baz.com.", ""}, ""},
-		// negative
-		{`autopath kubernetes`, true, "", "", nil, "open kubernetes: no such file or directory"},
+		// negative (OS error text differs; match the portable prefix)
+		{`autopath kubernetes`, true, "", "", nil, "open kubernetes:"},
 		{`autopath`, true, "", "", nil, "no resolv-conf"},
-		{`autopath ""`, true, "", "", nil, "no such file"},
+		{`autopath ""`, true, "", "", nil, "failed to parse"},
 	}
 
 	for i, test := range tests {

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -83,26 +83,8 @@ func TestZoneReloadSOAChange(t *testing.T) {
 func TestZoneReloadByMtime(t *testing.T) {
 	// Test 1: Basic mtime trigger - file modification should trigger reload
 	t.Run("BasicMtimeTrigger", func(t *testing.T) {
-		fileName, rm, err := test.TempFile(".", reloadZoneTest)
-		if err != nil {
-			t.Fatalf("Failed to create zone: %s", err)
-		}
-		defer rm()
-
-		reader, err := os.Open(fileName)
-		if err != nil {
-			t.Fatalf("Failed to open zone: %s", err)
-		}
-		z, err := Parse(reader, "miek.nl", fileName, 0)
-		if err != nil {
-			t.Fatalf("Failed to parse zone: %s", err)
-		}
-		reader.Close()
-
-		// Enable mtime-based reload
-		z.ReloadInterval = 10 * time.Millisecond
-		z.ReloadByMtime = true
-		z.Reload(&transfer.Transfer{})
+		z, fileName, cleanup := prepareMtimeZone(t, reloadZoneTest)
+		defer cleanup()
 
 		// Wait for initial load to complete
 		time.Sleep(20 * time.Millisecond)
@@ -136,26 +118,8 @@ func TestZoneReloadByMtime(t *testing.T) {
 
 	// Test 2: No reload when mtime unchanged
 	t.Run("NoReloadWhenMtimeUnchanged", func(t *testing.T) {
-		fileName, rm, err := test.TempFile(".", reloadZoneTest)
-		if err != nil {
-			t.Fatalf("Failed to create zone: %s", err)
-		}
-		defer rm()
-
-		reader, err := os.Open(fileName)
-		if err != nil {
-			t.Fatalf("Failed to open zone: %s", err)
-		}
-		z, err := Parse(reader, "miek.nl", fileName, 0)
-		if err != nil {
-			t.Fatalf("Failed to parse zone: %s", err)
-		}
-		reader.Close()
-
-		// Enable mtime-based reload
-		z.ReloadInterval = 10 * time.Millisecond
-		z.ReloadByMtime = true
-		z.Reload(&transfer.Transfer{})
+		z, _, cleanup := prepareMtimeZone(t, reloadZoneTest)
+		defer cleanup()
 
 		// Wait for initial load
 		time.Sleep(20 * time.Millisecond)
@@ -193,26 +157,8 @@ func TestZoneReloadByMtime(t *testing.T) {
 
 	// Test 3: Content verification after reload
 	t.Run("ContentVerificationAfterReload", func(t *testing.T) {
-		fileName, rm, err := test.TempFile(".", reloadZoneTest)
-		if err != nil {
-			t.Fatalf("Failed to create zone: %s", err)
-		}
-		defer rm()
-
-		reader, err := os.Open(fileName)
-		if err != nil {
-			t.Fatalf("Failed to open zone: %s", err)
-		}
-		z, err := Parse(reader, "miek.nl", fileName, 0)
-		if err != nil {
-			t.Fatalf("Failed to parse zone: %s", err)
-		}
-		reader.Close()
-
-		// Enable mtime-based reload
-		z.ReloadInterval = 10 * time.Millisecond
-		z.ReloadByMtime = true
-		z.Reload(&transfer.Transfer{})
+		z, fileName, cleanup := prepareMtimeZone(t, reloadZoneTest)
+		defer cleanup()
 
 		ctx := context.TODO()
 
@@ -266,26 +212,8 @@ func TestZoneReloadByMtime(t *testing.T) {
 
 	// Test 4: File deleted/missing during reload
 	t.Run("FileMissingDuringReload", func(t *testing.T) {
-		fileName, rm, err := test.TempFile(".", reloadZoneTest)
-		if err != nil {
-			t.Fatalf("Failed to create zone: %s", err)
-		}
-		defer rm()
-
-		reader, err := os.Open(fileName)
-		if err != nil {
-			t.Fatalf("Failed to open zone: %s", err)
-		}
-		z, err := Parse(reader, "miek.nl", fileName, 0)
-		if err != nil {
-			t.Fatalf("Failed to parse zone: %s", err)
-		}
-		reader.Close()
-
-		// Enable mtime-based reload
-		z.ReloadInterval = 10 * time.Millisecond
-		z.ReloadByMtime = true
-		z.Reload(&transfer.Transfer{})
+		z, fileName, cleanup := prepareMtimeZone(t, reloadZoneTest)
+		defer cleanup()
 
 		// Wait for initial load
 		time.Sleep(20 * time.Millisecond)
@@ -325,6 +253,45 @@ func TestZoneReloadByMtime(t *testing.T) {
 			t.Fatalf("Zone should still serve queries after file deletion, got result %d", res)
 		}
 	})
+}
+
+// prepareMtimeZone creates a zone with mtime-based reload enabled.
+func prepareMtimeZone(t *testing.T, content string) (*Zone, string, func()) {
+	t.Helper()
+	fileName, rm, err := test.TempFile(".", content)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+
+	reader, err := os.Open(fileName)
+	if err != nil {
+		rm()
+		t.Fatalf("Failed to open zone: %s", err)
+	}
+	z, err := Parse(reader, "miek.nl", fileName, 0)
+	reader.Close()
+	if err != nil {
+		rm()
+		t.Fatalf("Failed to parse zone: %s", err)
+	}
+
+	fi, err := os.Stat(fileName)
+	if err != nil {
+		rm()
+		t.Fatalf("Failed to stat zone: %s", err)
+	}
+
+	z.ReloadInterval = 10 * time.Millisecond
+	z.ReloadByMtime = true
+	// Parse does not set file_mtime unless ReloadByMtime is already enabled.
+	// Seed it so the reload loop only opens the file when mtime changes.
+	z.file_mtime = fi.ModTime()
+	z.Reload(&transfer.Transfer{})
+
+	return z, fileName, func() {
+		z.OnShutdown()
+		rm()
+	}
 }
 
 const reloadZoneTest = `miek.nl.		1627	IN	SOA	linode.atoom.net. miek.miek.nl. 1460175181 14400 3600 604800 14400

--- a/plugin/file/tree/print_test.go
+++ b/plugin/file/tree/print_test.go
@@ -72,11 +72,16 @@ func TestPrint(t *testing.T) {
 
 	f, err := os.CreateTemp(t.TempDir(), "print_test_tmp")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	//Redirect the printed results to a tmp file for later comparison
+	// Redirect Print output to a temp file, then restore stdout and close
+	// the handle so TempDir cleanup can remove it on Windows.
+	stdout := os.Stdout
 	os.Stdout = f
+	t.Cleanup(func() {
+		os.Stdout = stdout
+		f.Close()
+	})
 
 	tree.Print()
 	/**
@@ -85,12 +90,12 @@ func TestPrint(t *testing.T) {
 	  server3.example.com.
 	*/
 
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
 	buf := make([]byte, 256)
-	f.Seek(0, 0)
-	_, err = f.Read(buf)
-	if err != nil {
-		f.Close()
-		t.Error(err)
+	if _, err := f.Read(buf); err != nil {
+		t.Fatal(err)
 	}
 	height := strings.Count(string(buf), ". \n")
 	//Compare the height of the print with the actual height of the tree

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -290,6 +291,12 @@ nameserver 10.10.255.253`), 0666); err != nil {
 	}
 	defer os.Remove(emptyResolv)
 
+	// Portable stand-in for /dev/null: a resolv.conf with no nameserver lines.
+	nullResolv := filepath.Join(t.TempDir(), "null.conf")
+	if err := os.WriteFile(nullResolv, nil, 0666); err != nil {
+		t.Fatalf("Failed to write null.conf file: %s", err)
+	}
+
 	tests := []struct {
 		input         string
 		shouldErr     bool
@@ -299,7 +306,7 @@ nameserver 10.10.255.253`), 0666); err != nil {
 		// pass
 		{`forward . ` + resolv, false, "", []string{"10.10.255.252:53", "10.10.255.253:53"}},
 		// fail
-		{`forward . /dev/null`, true, "no valid upstream addresses found", nil},
+		{`forward . ` + nullResolv, true, "no valid upstream addresses found", nil},
 		// IPV6 with local zone
 		{`forward . ` + resolvIPV6, false, "", []string{"[0388:d254:7aec:6892:9f7f:e93b:5806:1b0f]:53"}},
 		// pass when empty forward file is found

--- a/plugin/geoip/setup_test.go
+++ b/plugin/geoip/setup_test.go
@@ -64,7 +64,7 @@ func TestGeoIPParse(t *testing.T) {
 		{true, fmt.Sprintf("%s 1 2 3", pluginName), "Wrong argument count", 0},
 		{true, fmt.Sprintf("%s { }", pluginName), "Error during parsing", 0},
 		{true, fmt.Sprintf("%s /dbpath { city }", pluginName), "unknown property \"city\"", 0},
-		{true, fmt.Sprintf("%s /invalidPath\n", pluginName), "failed to open database file: open /invalidPath: no such file or directory", 0},
+		{true, fmt.Sprintf("%s /invalidPath\n", pluginName), "failed to open database file: open /invalidPath:", 0},
 		{true, fmt.Sprintf("%s %s\n", pluginName, unknownDBPath), "reader does not support the \"UnknownDbType\" database type", 0},
 	}
 

--- a/plugin/grpc/proxy_test.go
+++ b/plugin/grpc/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"path"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -99,6 +100,10 @@ func (m testServiceClient) Query(_ctx context.Context, _in *pb.DnsPacket, _opts 
 }
 
 func TestProxyUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix domain sockets are not supported on windows")
+	}
+
 	tdir := t.TempDir()
 
 	fd := path.Join(tdir, "test.grpc")

--- a/plugin/pkg/proxy/proxy_test.go
+++ b/plugin/pkg/proxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -221,6 +222,7 @@ func TestCoreDNSOverflow(t *testing.T) {
 		response, _, _, err := p.Connect(context.Background(), request, options)
 		if err != nil {
 			t.Errorf("Failed to connect to testdnsserver: %s", err)
+			return
 		}
 
 		if response.Truncated != expectTruncated {
@@ -228,14 +230,17 @@ func TestCoreDNSOverflow(t *testing.T) {
 		}
 	}
 
-	// Test PreferUDP, expect truncated response
-	testConnection("PreferUDP", Options{PreferUDP: true}, true)
+	// Oversized UDP replies are truncated on Unix; Windows surfaces WSAEMSGSIZE instead.
+	if runtime.GOOS != "windows" {
+		// Test PreferUDP, expect truncated response
+		testConnection("PreferUDP", Options{PreferUDP: true}, true)
+
+		// Test No options specified, expect truncated response
+		testConnection("NoOptionsSpecified", Options{}, true)
+	}
 
 	// Test ForceTCP, expect no truncated response
 	testConnection("ForceTCP", Options{ForceTCP: true}, false)
-
-	// Test No options specified, expect truncated response
-	testConnection("NoOptionsSpecified", Options{}, true)
 
 	// Test both TCP and UDP provided, expect no truncated response
 	testConnection("BothTCPAndUDP", Options{PreferUDP: true, ForceTCP: true}, false)

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"crypto/tls"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -51,6 +52,12 @@ func TestTLS(t *testing.T) {
 			if !strings.Contains(err.Error(), test.expectedErrContent) {
 				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
 			}
+		}
+
+		// setup registers OnShutdown to close KeyLogWriter, but tests never shut down.
+		// Close explicitly so t.TempDir cleanup can remove the file on Windows.
+		if err == nil {
+			closeKeyLogWriter(t, dnsserver.GetConfig(c))
 		}
 	}
 }
@@ -121,5 +128,22 @@ func TestTLSKeyLog(t *testing.T) {
 		if cfg.TLSConfig.KeyLogWriter == nil {
 			t.Fatal("KeyLogWriter is not set")
 		}
+		// setup registers OnShutdown to close KeyLogWriter, but tests never shut down.
+		// Close explicitly so t.TempDir cleanup can remove the file on Windows.
+		closeKeyLogWriter(t, cfg)
+	})
+}
+
+func closeKeyLogWriter(t *testing.T, cfg *dnsserver.Config) {
+	t.Helper()
+	if cfg.TLSConfig == nil {
+		return
+	}
+	closer, ok := cfg.TLSConfig.KeyLogWriter.(io.Closer)
+	if !ok {
+		return
+	}
+	t.Cleanup(func() {
+		closer.Close()
 	})
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Plugin package tests previously ran only on Linux, so Windows-specific failures were never caught. Run them in CI and make the affected tests portable across platforms.

Full list of CI errors we fix in this commit:

<details>
<code>
Run ( cd plugin; go test -race ./... )
go: downloading github.com/stretchr/testify v1.11.1
go: downloading github.com/kylelemons/godebug v1.1.0
ok  	github.com/coredns/coredns/plugin	1.058s
ok  	github.com/coredns/coredns/plugin/acl	1.065s
ok  	github.com/coredns/coredns/plugin/any	1.076s
--- FAIL: TestWalkKeepsFirstMatchingFileForOrigin (0.01s)
    walk_test.go:174: zone file = "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\TestWalkKeepsFirstMatchingFileForOrigin2317918538\\001\\example.org.zone", want "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestWalkKeepsFirstMatchingFileForOrigin2317918538\\001\\example.org.zone"
FAIL
FAIL	github.com/coredns/coredns/plugin/auto	0.352s
--- FAIL: TestSetupAutoPath (0.00s)
    setup_test.go:53: Test 4: Expected error to contain: open kubernetes: no such file or directory, found error: failed to parse "kubernetes": open kubernetes: The system cannot find the file specified., input: autopath kubernetes
    setup_test.go:53: Test 6: Expected error to contain: no such file, found error: failed to parse "": open : The system cannot find the file specified., input: autopath ""
FAIL
FAIL	github.com/coredns/coredns/plugin/autopath	0.111s
ok  	github.com/coredns/coredns/plugin/azure	1.133s
ok  	github.com/coredns/coredns/plugin/bind	1.042s
ok  	github.com/coredns/coredns/plugin/bufsize	1.055s
ok  	github.com/coredns/coredns/plugin/cache	2.487s
ok  	github.com/coredns/coredns/plugin/cache/freq	1.077s
ok  	github.com/coredns/coredns/plugin/cancel	1.124s
ok  	github.com/coredns/coredns/plugin/chaos	1.095s
ok  	github.com/coredns/coredns/plugin/clouddns	1.682s
ok  	github.com/coredns/coredns/plugin/debug	1.122s
?   	github.com/coredns/coredns/plugin/deprecated	[no test files]
ok  	github.com/coredns/coredns/plugin/dns64	1.111s
ok  	github.com/coredns/coredns/plugin/dnssec	1.158s
ok  	github.com/coredns/coredns/plugin/dnstap	4.014s
ok  	github.com/coredns/coredns/plugin/dnstap/msg	1.037s
ok  	github.com/coredns/coredns/plugin/erratic	1.045s
ok  	github.com/coredns/coredns/plugin/errors	1.182s
ok  	github.com/coredns/coredns/plugin/etcd	1.152s
ok  	github.com/coredns/coredns/plugin/etcd/msg	1.053s
FAIL  	github.com/coredns/coredns/plugin/file	1.437s
--- FAIL: TestZoneReloadByMtime (0.18s)
    --- FAIL: TestZoneReloadByMtime/FileMissingDuringReload (0.02s)
        reload_test.go:302: Failed to remove zone file: remove .\go-test-tmpfile3888801769: The process cannot access the file because it is being used by another process.
?   	github.com/coredns/coredns/plugin/file/rrutil	[no test files]
--- FAIL: TestPrint (1.64s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestPrint1857351782\001\print_test_tmp1413678545: The process cannot access the file because it is being used by another process.
FAIL	github.com/coredns/coredns/plugin/file/tree	1.708s
--- FAIL: TestSetupResolvconf (0.00s)
    setup_test.go:324: Test 1: expected error to contain: no valid upstream addresses found, found error: failed to resolve "/dev/null": lookup /dev/null: no such host, input: forward . /dev/null
FAIL
FAIL	github.com/coredns/coredns/plugin/forward	21.226s
--- FAIL: TestGeoIPParse (0.00s)
    setup_test.go:85: Test 10: expected error to contain: failed to open database file: open /invalidPath: no such file or directory, found error: Testfile:1 - Error during parsing: failed to open database file: open /invalidPath: The system cannot find the file specified., input: geoip /invalidPath
FAIL
FAIL	github.com/coredns/coredns/plugin/geoip	0.061s
--- FAIL: TestProxyUnix (0.00s)
    proxy_test.go:129: Expected to receive reply, but didn't
FAIL
FAIL	github.com/coredns/coredns/plugin/grpc	0.108s
ok  	github.com/coredns/coredns/plugin/grpc_server	1.084s
ok  	github.com/coredns/coredns/plugin/header	1.113s
ok  	github.com/coredns/coredns/plugin/health	3.329s
ok  	github.com/coredns/coredns/plugin/hosts	1.263s
ok  	github.com/coredns/coredns/plugin/https	1.121s
ok  	github.com/coredns/coredns/plugin/https3	1.696s
ok  	github.com/coredns/coredns/plugin/k8s_external	1.122s
ok  	github.com/coredns/coredns/plugin/kubernetes	2.513s
ok  	github.com/coredns/coredns/plugin/kubernetes/object	1.075s
ok  	github.com/coredns/coredns/plugin/loadbalance	1.121s
ok  	github.com/coredns/coredns/plugin/local	1.125s
ok  	github.com/coredns/coredns/plugin/log	1.126s
ok  	github.com/coredns/coredns/plugin/loop	1.119s
ok  	github.com/coredns/coredns/plugin/metadata	1.185s
ok  	github.com/coredns/coredns/plugin/metrics	9.104s
ok  	github.com/coredns/coredns/plugin/metrics/vars	1.067s
ok  	github.com/coredns/coredns/plugin/minimal	1.085s
ok  	github.com/coredns/coredns/plugin/multisocket	1.096s
ok  	github.com/coredns/coredns/plugin/nomad	1.280s
ok  	github.com/coredns/coredns/plugin/nsid	1.098s
ok  	github.com/coredns/coredns/plugin/pkg/cache	1.506s
ok  	github.com/coredns/coredns/plugin/pkg/catalog	1.106s
ok  	github.com/coredns/coredns/plugin/pkg/cidr	1.121s
ok  	github.com/coredns/coredns/plugin/pkg/dnstest	1.147s
ok  	github.com/coredns/coredns/plugin/pkg/dnsutil	1.109s
ok  	github.com/coredns/coredns/plugin/pkg/doh	1.071s
ok  	github.com/coredns/coredns/plugin/pkg/durations	1.090s
ok  	github.com/coredns/coredns/plugin/pkg/edns	1.119s
ok  	github.com/coredns/coredns/plugin/pkg/expression	1.166s
ok  	github.com/coredns/coredns/plugin/pkg/fall	1.135s
?   	github.com/coredns/coredns/plugin/pkg/fuzz	[no test files]
ok  	github.com/coredns/coredns/plugin/pkg/log	1.164s
ok  	github.com/coredns/coredns/plugin/pkg/nonwriter	1.096s
ok  	github.com/coredns/coredns/plugin/pkg/parse	1.173s
--- FAIL: TestCoreDNSOverflow (0.00s)
    proxy_test.go:232: Failed to connect to testdnsserver: read udp 127.0.0.1:61346->127.0.0.1:50978: wsarecv: A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself.
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x1408fc922]

goroutine 154 [running]:
testing.tRunner.func1.2({0x140b0cee0, 0x140a61d10})
	C:/hostedtoolcache/windows/go/1.26.5/x64/src/testing/testing.go:1974 +0x3f7
testing.tRunner.func1()
	C:/hostedtoolcache/windows/go/1.26.5/x64/src/testing/testing.go:1977 +0x67f
panic({0x140b0cee0?, 0x140a61d10?})
	C:/hostedtoolcache/windows/go/1.26.5/x64/src/runtime/panic.go:860 +0x13a
github.com/coredns/coredns/plugin/pkg/proxy.TestCoreDNSOverflow.func2({0x140bce0ce, 0x9}, {0xe6?, 0x62?, 0x30?, {0x0?, 0x140bcbf4d?}}, 0x1)
	D:/a/coredns-private/coredns-private/plugin/pkg/proxy/proxy_test.go:226 +0x422
github.com/coredns/coredns/plugin/pkg/proxy.TestCoreDNSOverflow(0xc0002f3600)
	D:/a/coredns-private/coredns-private/plugin/pkg/proxy/proxy_test.go:232 +0x20b
testing.tRunner(0xc0002f3600, 0x140c04060)
	C:/hostedtoolcache/windows/go/1.26.5/x64/src/testing/testing.go:2036 +0x1cb
created by testing.(*T).Run in goroutine 1
	C:/hostedtoolcache/windows/go/1.26.5/x64/src/testing/testing.go:2101 +0xb2b
FAIL	github.com/coredns/coredns/plugin/pkg/proxy	2.905s
ok  	github.com/coredns/coredns/plugin/pkg/proxyproto	1.276s
ok  	github.com/coredns/coredns/plugin/pkg/rand	1.119s
ok  	github.com/coredns/coredns/plugin/pkg/rcode	1.080s
ok  	github.com/coredns/coredns/plugin/pkg/replacer	1.123s
ok  	github.com/coredns/coredns/plugin/pkg/response	1.130s
?   	github.com/coredns/coredns/plugin/pkg/reuseport	[no test files]
ok  	github.com/coredns/coredns/plugin/pkg/singleflight	1.153s
ok  	github.com/coredns/coredns/plugin/pkg/tls	1.086s
?   	github.com/coredns/coredns/plugin/pkg/trace	[no test files]
?   	github.com/coredns/coredns/plugin/pkg/transport	[no test files]
ok  	github.com/coredns/coredns/plugin/pkg/uniq	1.051s
ok  	github.com/coredns/coredns/plugin/pkg/up	1.052s
?   	github.com/coredns/coredns/plugin/pkg/upstream	[no test files]
ok  	github.com/coredns/coredns/plugin/pprof	1.357s
ok  	github.com/coredns/coredns/plugin/proxyproto	1.115s
ok  	github.com/coredns/coredns/plugin/quic	1.136s
ok  	github.com/coredns/coredns/plugin/ready	1.205s
ok  	github.com/coredns/coredns/plugin/reload	1.107s
ok  	github.com/coredns/coredns/plugin/rewrite	1.185s
ok  	github.com/coredns/coredns/plugin/root	1.127s
ok  	github.com/coredns/coredns/plugin/route53	1.081s
ok  	github.com/coredns/coredns/plugin/secondary	1.103s
--- FAIL: TestParse (0.00s)
    setup_test.go:56: Test 0 expected no errors, but got 'dns: bad private key'
--- FAIL: TestSign (0.00s)
    signer_test.go:21: dns: bad private key
--- FAIL: TestSignApexZone (0.00s)
    signer_test.go:63: dns: bad private key
--- FAIL: TestSignGlue (0.00s)
    signer_test.go:112: dns: bad private key
--- FAIL: TestSignDS (0.00s)
    signer_test.go:137: dns: bad private key
FAIL
FAIL	github.com/coredns/coredns/plugin/sign	0.047s
ok  	github.com/coredns/coredns/plugin/template	1.055s
ok  	github.com/coredns/coredns/plugin/test	1.042s
ok  	github.com/coredns/coredns/plugin/timeouts	1.090s
--- FAIL: TestTLS (1.34s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestTLS2013603571\001\tls.log: The process cannot access the file because it is being used by another process.
--- FAIL: TestTLSKeyLog (2.01s)
    --- FAIL: TestTLSKeyLog/Good_Path (2.00s)
        testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestTLSKeyLogGood_Path2053626100\001\tls.log: The process cannot access the file because it is being used by another process.
FAIL
FAIL	github.com/coredns/coredns/plugin/tls	3.444s
ok  	github.com/coredns/coredns/plugin/trace	1.219s
ok  	github.com/coredns/coredns/plugin/transfer	1.231s
ok  	github.com/coredns/coredns/plugin/tsig	1.115s
ok  	github.com/coredns/coredns/plugin/view	1.140s
ok  	github.com/coredns/coredns/plugin/whoami	1.288s
FAIL
</code>
</details>

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None, no change in functionality.

### 4. Does this introduce a backward incompatible change or deprecation?

No.