### PR TITLE
image: pin numeric uid/gid for the nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,13 @@ RUN setcap cap_net_bind_service=+ep /coredns
 
 FROM ${BASE}
 COPY --from=build /coredns /coredns
-USER nonroot:nonroot
+# Use the numeric uid/gid (distroless "nonroot" is 65532) rather than the named
+# user so Kubernetes can verify the image runs as non-root when runAsNonRoot is
+# set. A named user is rejected at admission ("container has runAsNonRoot and
+# image has non-numeric user, cannot verify user is non-root"). The binary keeps
+# cap_net_bind_service (set in the build stage), so it can still bind :53.
+# Refs #7542.
+USER 65532:65532
 # Reset the working directory inherited from the base image back to the expected default:
 # https://github.com/coredns/coredns/issues/7009#issuecomment-3124851608
 WORKDIR /


### PR DESCRIPTION
## What this does
Pin the container user to the numeric uid/gid `65532:65532` instead of the named `nonroot:nonroot`.

## Why
With `USER nonroot:nonroot`, the built image's config user is the name `nonroot`. Kubernetes rejects a pod at admission when `runAsNonRoot: true` is set and the image's user is non-numeric:

> container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root

(reported in #7542). Clusters that enforce `runAsNonRoot` therefore can't run the image without also setting an explicit `runAsUser`.

distroless `nonroot` is uid/gid `65532`, so this is the same user in numeric form — no behavioural change — and the binary keeps `cap_net_bind_service` from the build stage, so it still binds `:53`.

## Verification
Building the image before/after and inspecting the config user:

- before: `docker inspect --format '{{.Config.User}}' <image>` → `nonroot:nonroot`
- after:  `docker inspect --format '{{.Config.User}}' <image>` → `65532:65532`

Fixes #7542
