### PR TITLE
plugin/auto: fix inverted arguments in duplicate-origin warning

### DIFF
--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -43,7 +43,7 @@ func (a Auto) Walk() error {
 
 		cleanPath := filepath.Clean(path)
 		if previous, ok := seen[origin]; ok && previous != cleanPath {
-			log.Warningf("Multiple zone files match origin %q: using %q instead of %q", origin, path, previous)
+			log.Warningf("Multiple zone files match origin %q: using %q instead of %q", origin, previous, cleanPath)
 			toDelete[origin] = false
 			return nil
 		}

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -141,6 +141,15 @@ func TestWalkWarnsForDuplicateOrigin(t *testing.T) {
 			t.Fatalf("Expected log to contain %q, got %q", want, got)
 		}
 	}
+	// The warning must name the kept (first, live) file in the "using" slot and
+	// the skipped backup in the "instead of" slot — not the other way around.
+	// Walk keeps example.org.zone (visited first) and skips the .bak file.
+	if !strings.Contains(got, `example.org.zone" instead of "`) {
+		t.Errorf("Warning names the wrong file as used; want the live zone in the \"using\" slot, got %q", got)
+	}
+	if strings.Contains(got, `example.org.zone.bak-20260528" instead of "`) {
+		t.Errorf("Warning claims the skipped backup is being used, got %q", got)
+	}
 
 	logBuf.Reset()
 	a.Walk()


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The duplicate-origin warning added in #8216 has its two path arguments swapped.

`Auto.Walk` keeps the first-visited file for an origin and skips later ones, then warns with:

```go
log.Warningf("Multiple zone files match origin %q: using %q instead of %q", origin, path, previous)
```

Here `previous` is the file that is kept and `path` is the one being skipped, so the message reads `using "<skipped>" instead of "<kept>"` — the reverse of what actually happens.

For the canonical case of a live `example.org.zone` next to an `example.org.zone.bak-...` backup (the scenario in #8130), CoreDNS correctly keeps and serves `example.org.zone`, but logs:

```
[INFO]    plugin/auto: Inserting zone `example.org.' from: .../example.org.zone
[WARNING] plugin/auto: Multiple zone files match origin "example.org.": using ".../example.org.zone.bak-20260528" instead of ".../example.org.zone"
```

i.e. it tells the operator the stale backup is being served when the live file is — actively misleading when triaging why a zone looks wrong.

This swaps the arguments so the kept file is named in the "using" slot and the skipped file in the "instead of" slot, and uses `cleanPath` for both (consistent with the value stored in `seen`).

The existing `TestWalkWarnsForDuplicateOrigin` only asserted that both filenames appear somewhere in the log, so the inversion passed. It is strengthened to assert the direction (fails before this change, passes after).

### 2. Which issues (if any) are related?

Follow-up to #8216, which introduced the warning. Relevant to the scenario reported in #8130 (where the backup-file warning fires).

### 3. Which documentation changes (if any) need to be made?

None — this only changes the wording of a warning log line.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Only the text of a `[WARNING]` log line changes; zone-file selection behaviour is unchanged.
