### PR TITLE
test(file): stabilize mtime reload

### DIFF
--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -103,13 +103,16 @@ func TestZoneReloadByMtime(t *testing.T) {
 			t.Fatalf("Failed to write new zone data: %s", err)
 		}
 
-		// Wait for reload to trigger
-		time.Sleep(30 * time.Millisecond)
-
-		// Verify reload occurred (3 records now)
-		rrs, err = z.ApexIfDefined()
-		if err != nil {
-			t.Fatal(err)
+		// Poll until reload is observed (fixed sleeps race under -race, esp. on Windows).
+		for start := time.Now(); time.Since(start) < 2*time.Second; {
+			rrs, err = z.ApexIfDefined()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rrs) == 3 {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
 		}
 		if len(rrs) != 3 {
 			t.Fatalf("Expected 3 RRs after reload, got %d", len(rrs))
@@ -182,13 +185,16 @@ func TestZoneReloadByMtime(t *testing.T) {
 			t.Fatalf("Failed to write new zone data: %s", err)
 		}
 
-		// Wait for reload
-		time.Sleep(30 * time.Millisecond)
-
-		// Query new content
-		records, _, _, res = z.Lookup(ctx, state, "miek.nl.")
-		if res != Success {
-			t.Fatalf("Failed to lookup reloaded NS records, got %d", res)
+		// Poll until reload is observed (fixed sleeps race under -race, esp. on Windows).
+		for start := time.Now(); time.Since(start) < 2*time.Second; {
+			records, _, _, res = z.Lookup(ctx, state, "miek.nl.")
+			if res != Success {
+				t.Fatalf("Failed to lookup reloaded NS records, got %d", res)
+			}
+			if len(records) == 2 {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
 		}
 
 		// Reloaded zone has 2 NS records
@@ -261,6 +267,14 @@ func prepareMtimeZone(t *testing.T, content string) (*Zone, string, func()) {
 	fileName, rm, err := test.TempFile(".", content)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
+	}
+	// A rewrite immediately after creating the file can retain the same mtime
+	// on filesystems with coarse timestamp resolution. Start with an older
+	// mtime so the rewrite is always observable by the reload loop.
+	initialMtime := time.Now().Add(-time.Minute)
+	if err := os.Chtimes(fileName, initialMtime, initialMtime); err != nil {
+		rm()
+		t.Fatalf("Failed to set initial zone mtime: %s", err)
 	}
 
 	reader, err := os.Open(fileName)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

`TestZoneReloadByMtime` was flaky on Windows for two separate timing reasons.

It used fixed 30ms sleeps after a zone write, so `ContentVerificationAfterReload` could observe the old NS set under `-race` before the reload completed:

```
--- FAIL: TestZoneReloadByMtime (0.22s)
    --- FAIL: TestZoneReloadByMtime/ContentVerificationAfterReload (0.04s)
        reload_test.go:196: Expected 2 reloaded NS records, got 4
```

Polling for the expected apex or NS count fixed that scheduling race, matching `TestZoneReload`. Windows CI then exposed a second failure where polling timed out without observing a reload:

```
--- FAIL: TestZoneReloadByMtime (2.15s)
    --- FAIL: TestZoneReloadByMtime/ContentVerificationAfterReload (2.00s)
        reload_test.go:202: Expected 2 reloaded NS records, got 4
```

An immediate rewrite of the freshly created temporary zone can retain the same observable mtime on filesystems with coarse timestamp resolution. Because mtime-based reload only reacts to a later timestamp, waiting longer cannot trigger a reload in that case.

Set the temporary zone's initial mtime in the past before recording the reload baseline, ensuring the subsequent rewrite is observable. Continue polling for the expected record count so the assertions also tolerate slow reload scheduling.

### 2. Which issues (if any) are related?

None. Tests were refactored a bit on #8275.

### 3. Which documentation changes (if any) need to be made?

None, tests only change.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
