### PR TITLE
core/dnsserver: normalize server block zone names

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -100,7 +100,7 @@ func (h *dnsContext) InspectServerBlocks(_sourceFile string, serverBlocks []cadd
 				}
 			}
 			for i := range hosts {
-				zoneAddrs = append(zoneAddrs, zoneAddr{Zone: dns.Fqdn(hosts[i]), Port: port, Transport: trans})
+				zoneAddrs = append(zoneAddrs, zoneAddr{Zone: plugin.Name(hosts[i]).Normalize(), Port: port, Transport: trans})
 			}
 		}
 

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -144,6 +144,19 @@ func TestInspectServerBlocks(t *testing.T) {
 			},
 		},
 		{
+			name: "uppercase dns",
+			serverBlocks: []caddyfile.ServerBlock{
+				{Keys: []string{"EXAMPLE.ORG"}},
+			},
+			expectedServerBlocks: []caddyfile.ServerBlock{
+				{Keys: []string{"dns://example.org.:53"}},
+			},
+			expectedConfigsLen: 1,
+			expectedZoneAddrs: map[string]zoneAddr{
+				"dns://example.org.:53": {Zone: "example.org.", Port: "53", Transport: "dns"},
+			},
+		},
+		{
 			name: "dns with port",
 			serverBlocks: []caddyfile.ServerBlock{
 				{Keys: []string{"example.org:1053"}},

--- a/test/corefile_test.go
+++ b/test/corefile_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"testing"
+
+	"github.com/miekg/dns"
 )
 
 // TestCorefileParsing tests the Corefile parsing functionality.
@@ -59,5 +61,25 @@ acl
 				}
 			}()
 		})
+	}
+}
+
+func TestUppercaseServerBlockZone(t *testing.T) {
+	instance, udp, _, err := CoreDNSServerAndPorts(`EXAMPLE.ORG.:0 {
+	whoami
+}`)
+	if err != nil {
+		t.Fatalf("failed to start CoreDNS: %v", err)
+	}
+	defer CoreDNSServerStop(instance)
+
+	query := new(dns.Msg)
+	query.SetQuestion("www.example.org.", dns.TypeA)
+	response, _, err := new(dns.Client).Exchange(query, udp)
+	if err != nil {
+		t.Fatalf("DNS exchange failed: %v", err)
+	}
+	if response.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected response code %s, got %s", dns.RcodeToString[dns.RcodeSuccess], dns.RcodeToString[response.Rcode])
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Server block zones were made fully qualified but retained their original letter case, while `ServeDNS` lowercases query names before routing. A Corefile with an uppercase zone therefore created an unreachable route and returned `REFUSED` for valid queries.

This change normalizes server block zones to lowercase FQDNs during config inspection using the existing `plugin.Name.Normalize` helper. It adds a unit regression test for the normalized configuration and an integration test proving that a query reaches an uppercase-configured zone.

Tests run:
- `go test ./core/dnsserver -count=1`
- `go test ./plugin/file -count=1`
- `go test ./test -run '^TestUppercaseServerBlockZone$' -count=20`
- `go test -race ./core/dnsserver -run '^TestInspectServerBlocks$' -count=1`
- `go test -race ./test -run '^TestUppercaseServerBlockZone$' -count=1`
- `go test ./... -run '^$' -count=1`
- `go vet ./core/dnsserver ./test`
- `golangci-lint run --new ./core/dnsserver ./test`

### 2. Which issues (if any) are related?

Fixes #6624.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.