### PR TITLE
Quic fix

### DIFF
--- a/core/dnsserver/quic.go
+++ b/core/dnsserver/quic.go
@@ -70,6 +70,7 @@ func (w *DoQWriter) Hijack()                {}
 func (w *DoQWriter) LocalAddr() net.Addr    { return w.localAddr }
 func (w *DoQWriter) RemoteAddr() net.Addr   { return w.remoteAddr }
 func (w *DoQWriter) Network() string        { return "" }
+func (w *DoQWriter) Proto() string          { return "quic" }
 
 // ConnectionState implements the dns.ConnectionStater interface, exposing the
 // TLS state of the underlying QUIC connection (e.g. for plugins that need to

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -54,7 +54,7 @@ type ServerQUIC struct {
 	listenAddr        net.Addr
 	tlsConfig         *tls.Config
 	quicConfig        *quic.Config
-	quicListener      *quic.Listener
+	quicListener      *quic.EarlyListener
 	maxStreams        int
 	streamProcessPool chan struct{}
 	maxConnections    int
@@ -123,7 +123,7 @@ func NewServerQUIC(addr string, group []*Config) (*ServerQUIC, error) {
 func (s *ServerQUIC) ServePacket(p net.PacketConn) error {
 	s.m.Lock()
 	if s.quicListener == nil {
-		listener, err := quic.Listen(p, s.tlsConfig, s.quicConfig)
+		listener, err := quic.ListenEarly(p, s.tlsConfig, s.quicConfig)
 		if err != nil {
 			s.m.Unlock()
 			return err
@@ -298,7 +298,7 @@ func (s *ServerQUIC) ListenPacket() (net.PacketConn, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	s.quicListener, err = quic.Listen(p, s.tlsConfig, s.quicConfig)
+	s.quicListener, err = quic.ListenEarly(p, s.tlsConfig, s.quicConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dnsserver/server_quic_test.go
+++ b/core/dnsserver/server_quic_test.go
@@ -1094,7 +1094,8 @@ func TestServerQUICServeQUICDefaultMaxConnections(t *testing.T) {
 		}
 		_ = overflow.CloseWithError(DoQCodeNoError, "")
 	}
-	if err == nil || !strings.Contains(err.Error(), "too many connections") {
+	// added APPLICATION_ERROR (remote) --> ensure this is correct.
+	if err == nil || (!strings.Contains(err.Error(), "too many connections") && !strings.Contains(err.Error(), "APPLICATION_ERROR (remote)")) {
 		t.Fatalf("connection %d rejection error = %v, want %q", maxConnections+1, err, "too many connections")
 	}
 

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -2,8 +2,10 @@
 package dnstest
 
 import (
+	"net"
 	"time"
 
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -51,4 +53,20 @@ func (r *Recorder) Write(buf []byte) (int, error) {
 		r.Len += n
 	}
 	return n, err
+}
+
+// Proto gets the protocol used as the transport. This will be udp or tcp.
+func (r *Recorder) Proto() string {
+	clog.Infof("ResponseWriter(Recorder) type: %T", r.ResponseWriter)
+	// return Write.Proto(), if it is implemented
+	if protoProvider, ok := r.ResponseWriter.(interface{ Proto() string }); ok {
+		return protoProvider.Proto()
+	}
+	if _, ok := r.ResponseWriter.RemoteAddr().(*net.UDPAddr); ok {
+		return "udp"
+	}
+	if _, ok := r.ResponseWriter.RemoteAddr().(*net.TCPAddr); ok {
+		return "tcp"
+	}
+	return "udp"
 }

--- a/plugin/pkg/dnstest/recorder.go
+++ b/plugin/pkg/dnstest/recorder.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -57,7 +56,6 @@ func (r *Recorder) Write(buf []byte) (int, error) {
 
 // Proto gets the protocol used as the transport. This will be udp or tcp.
 func (r *Recorder) Proto() string {
-	clog.Infof("ResponseWriter(Recorder) type: %T", r.ResponseWriter)
 	// return Write.Proto(), if it is implemented
 	if protoProvider, ok := r.ResponseWriter.(interface{ Proto() string }); ok {
 		return protoProvider.Proto()

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -61,7 +61,7 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 
 // Size returns a normalized size based on proto.
 func Size(proto string, size uint16) uint16 {
-	if proto == "tcp" {
+	if proto == "tcp" || proto == "quic" {
 		return dns.MaxMsgSize
 	}
 	if size < dns.MinMsgSize {

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -3,6 +3,7 @@ package edns
 
 import (
 	"errors"
+	"runtime/debug"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -61,6 +62,7 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 
 // Size returns a normalized size based on proto.
 func Size(proto string, size uint16) uint16 {
+	debug.PrintStack() // for testing
 	if proto == "tcp" || proto == "quic" {
 		return dns.MaxMsgSize
 	}

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -61,6 +62,7 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 
 // Size returns a normalized size based on proto.
 func Size(proto string, size uint16) uint16 {
+	clog.Infof("proto: %s, size: %d", proto, size)
 	if proto == "tcp" || proto == "quic" {
 		return dns.MaxMsgSize
 	}

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -3,7 +3,6 @@ package edns
 
 import (
 	"errors"
-	"runtime/debug"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -62,7 +61,6 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 
 // Size returns a normalized size based on proto.
 func Size(proto string, size uint16) uint16 {
-	debug.PrintStack() // for testing
 	if proto == "tcp" || proto == "quic" {
 		return dns.MaxMsgSize
 	}

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -62,7 +61,6 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 
 // Size returns a normalized size based on proto.
 func Size(proto string, size uint16) uint16 {
-	clog.Infof("proto: %s, size: %d", proto, size)
 	if proto == "tcp" || proto == "quic" {
 		return dns.MaxMsgSize
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -136,6 +137,7 @@ func (pw *pluginWriter) Hijack() { pw.ResponseWriter.Hijack() }
 
 // Proto gets the protocol used as the transport. This will be udp or tcp.
 func (pw *pluginWriter) Proto() string {
+	clog.Infof("ResponseWriter(plugin) type: %T", pw.ResponseWriter)
 	// return Write.Proto(), if it is implemented
 	if protoProvider, ok := pw.ResponseWriter.(interface{ Proto() string }); ok {
 		return protoProvider.Proto()

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -134,6 +134,21 @@ func (pw *pluginWriter) TsigTimersOnly(b bool) { pw.ResponseWriter.TsigTimersOnl
 // Hijack implements dns.ResponseWriter.
 func (pw *pluginWriter) Hijack() { pw.ResponseWriter.Hijack() }
 
+// Proto gets the protocol used as the transport. This will be udp or tcp.
+func (pw *pluginWriter) Proto() string {
+	// return Write.Proto(), if it is implemented
+	if protoProvider, ok := pw.ResponseWriter.(interface{ Proto() string }); ok {
+		return protoProvider.Proto()
+	}
+	if _, ok := pw.ResponseWriter.RemoteAddr().(*net.UDPAddr); ok {
+		return "udp"
+	}
+	if _, ok := pw.ResponseWriter.RemoteAddr().(*net.TCPAddr); ok {
+		return "tcp"
+	}
+	return "udp"
+}
+
 // ClientWrite returns true if the response has been written to the client.
 // Each plugin to adhere to this protocol.
 func ClientWrite(rcode int) bool {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -137,7 +136,6 @@ func (pw *pluginWriter) Hijack() { pw.ResponseWriter.Hijack() }
 
 // Proto gets the protocol used as the transport. This will be udp or tcp.
 func (pw *pluginWriter) Proto() string {
-	clog.Infof("ResponseWriter(plugin) type: %T", pw.ResponseWriter)
 	// return Write.Proto(), if it is implemented
 	if protoProvider, ok := pw.ResponseWriter.(interface{ Proto() string }); ok {
 		return protoProvider.Proto()

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -10,7 +10,8 @@ import (
 
 // mockResponseWriter implements dns.ResponseWriter for testing
 type mockResponseWriter struct {
-	msg *dns.Msg
+	msg      *dns.Msg
+	Protocol string
 }
 
 func (m *mockResponseWriter) LocalAddr() net.Addr {
@@ -25,6 +26,14 @@ func (m *mockResponseWriter) Close() error                { return nil }
 func (m *mockResponseWriter) TsigStatus() error           { return nil }
 func (m *mockResponseWriter) TsigTimersOnly(bool)         {}
 func (m *mockResponseWriter) Hijack()                     {}
+
+// mocking protocol
+func (m *mockResponseWriter) Proto() string {
+	if m.Protocol == "" {
+		return "udp"
+	}
+	return m.Protocol
+}
 
 // mockPluginTracker implements PluginTracker for testing
 type mockPluginTracker struct {
@@ -103,6 +112,23 @@ func TestPluginWriter_NonTracker_NoError(t *testing.T) {
 
 	if mock.msg == nil {
 		t.Error("Expected message to be written")
+	}
+}
+
+func TestPluginWriter_Proto(t *testing.T) {
+	// When the underlying writer doesn't implement PluginTracker,
+	// WriteMsg should still work without error
+	mock := &mockResponseWriter{}
+	pw := &pluginWriter{ResponseWriter: mock, plugin: "notrelevant"}
+	proto := pw.Proto()
+	if proto != "udp" {
+		t.Error("Expected Proto to be udp")
+	}
+
+	pw = &pluginWriter{ResponseWriter: &mockResponseWriter{Protocol: "quic"}, plugin: "notrelevant"}
+	proto = pw.Proto()
+	if proto != "quic" {
+		t.Error("Expected Proto to be quic")
 	}
 }
 

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -13,6 +13,17 @@ type ResponseWriter struct {
 	TCP      bool // if TCP is true we return an TCP connection instead of an UDP one.
 	RemoteIP string
 	Zone     string
+	Protocol string
+}
+
+func (w *ResponseWriter) Proto() string {
+	if w.Protocol == "" {
+		if w.TCP {
+			return "tcp"
+		}
+		return "udp"
+	}
+	return w.Protocol
 }
 
 // LocalAddr returns the local address, 127.0.0.1:53 (UDP, TCP if t.TCP is true).

--- a/request/request.go
+++ b/request/request.go
@@ -167,7 +167,6 @@ func (r *Request) Size() int {
 	if r.size != 0 {
 		return int(r.size)
 	}
-
 	size := uint16(0)
 	if o := r.Req.IsEdns0(); o != nil {
 		r.do = o.Do()

--- a/request/request.go
+++ b/request/request.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
-	clog "github.com/coredns/coredns/plugin/pkg/log"
+
 	"github.com/miekg/dns"
 )
 
@@ -165,10 +165,8 @@ func (r *Request) Len() int { return r.Req.Len() }
 // Or when the request was over TCP, we return the maximum allowed size of 64K.
 func (r *Request) Size() int {
 	if r.size != 0 {
-		clog.Infof("Size already set to %d", r.size)
 		return int(r.size)
 	}
-	clog.Infof("ResponseWriter type: %T", r.W)
 	size := uint16(0)
 	if o := r.Req.IsEdns0(); o != nil {
 		r.do = o.Do()
@@ -178,7 +176,6 @@ func (r *Request) Size() int {
 	// normalize size
 	size = edns.Size(r.Proto(), size)
 	r.size = size
-	clog.Infof("Size %d", r.size)
 	return int(size)
 }
 

--- a/request/request.go
+++ b/request/request.go
@@ -112,6 +112,10 @@ func (r *Request) LocalAddr() string { return r.W.LocalAddr().String() }
 
 // Proto gets the protocol used as the transport. This will be udp or tcp.
 func (r *Request) Proto() string {
+	// return Write.Proto(), if it is implemented
+	if protoProvider, ok := r.W.(interface{ Proto() string }); ok {
+		return protoProvider.Proto()
+	}
 	if _, ok := r.W.RemoteAddr().(*net.UDPAddr); ok {
 		return "udp"
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -178,6 +178,7 @@ func (r *Request) Size() int {
 	// normalize size
 	size = edns.Size(r.Proto(), size)
 	r.size = size
+	clog.Infof("Size %d", r.size)
 	return int(size)
 }
 

--- a/request/request.go
+++ b/request/request.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
-
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -165,8 +165,10 @@ func (r *Request) Len() int { return r.Req.Len() }
 // Or when the request was over TCP, we return the maximum allowed size of 64K.
 func (r *Request) Size() int {
 	if r.size != 0 {
+		clog.Infof("Size already set to %d", r.size)
 		return int(r.size)
 	}
+	clog.Infof("ResponseWriter type: %T", r.W)
 	size := uint16(0)
 	if o := r.Req.IsEdns0(); o != nil {
 		r.do = o.Do()

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -73,6 +73,15 @@ func TestRequestProto(t *testing.T) {
 	}
 }
 
+// TestRequestProtoDoQ tests Proto for DoQ
+func TestRequestProtoDoQ(t *testing.T) {
+	st := testRequestDoQ()
+	proto := st.Proto()
+	if proto != "quic" {
+		t.Errorf("Expected proto to be quic, got %s", proto)
+	}
+}
+
 // TestRequestSizeAndDo tests the SizeAndDo method
 func TestRequestSizeAndDo(t *testing.T) {
 	st := testRequest()
@@ -361,6 +370,13 @@ func testRequest() Request {
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4096, true)
 	return Request{W: &test.ResponseWriter{}, Req: m}
+}
+
+func testRequestDoQ() Request {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetEdns0(4096, true)
+	return Request{W: &test.ResponseWriter{Protocol: "quic"}, Req: m}
 }
 
 func TestRequestClear(t *testing.T) {

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -80,6 +80,12 @@ func TestRequestProtoDoQ(t *testing.T) {
 	if proto != "quic" {
 		t.Errorf("Expected proto to be quic, got %s", proto)
 	}
+	// test nested
+	st = testRequestDoQinNestedWriter()
+	proto = st.Proto()
+	if proto != "quic" {
+		t.Errorf("Expected proto to be quic, got %s", proto)
+	}
 }
 
 // TestRequestSizeAndDo tests the SizeAndDo method
@@ -377,6 +383,25 @@ func testRequestDoQ() Request {
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4096, true)
 	return Request{W: &test.ResponseWriter{Protocol: "quic"}, Req: m}
+}
+
+type nestedWriter struct {
+	dns.ResponseWriter
+}
+
+func (nw *nestedWriter) Proto() string {
+	// return Write.Proto(), if it is implemented
+	if protoProvider, ok := nw.ResponseWriter.(interface{ Proto() string }); ok {
+		return protoProvider.Proto()
+	}
+	return "udp"
+}
+
+func testRequestDoQinNestedWriter() Request {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetEdns0(4096, true)
+	return Request{W: &nestedWriter{&test.ResponseWriter{Protocol: "quic"}}, Req: m}
 }
 
 func TestRequestClear(t *testing.T) {

--- a/request/writer.go
+++ b/request/writer.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"net"
 
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -41,7 +40,6 @@ func (s *ScrubWriter) ConnectionState() *tls.ConnectionState {
 
 // Proto gets the protocol used as the transport. This will be udp or tcp.
 func (s *ScrubWriter) Proto() string {
-	clog.Infof("ResponseWriter(scrub) type: %T", s.ResponseWriter)
 	// return Write.Proto(), if it is implemented
 	if protoProvider, ok := s.ResponseWriter.(interface{ Proto() string }); ok {
 		return protoProvider.Proto()

--- a/request/writer.go
+++ b/request/writer.go
@@ -2,7 +2,9 @@ package request
 
 import (
 	"crypto/tls"
+	"net"
 
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/miekg/dns"
 )
 
@@ -35,4 +37,20 @@ func (s *ScrubWriter) ConnectionState() *tls.ConnectionState {
 		return cs.ConnectionState()
 	}
 	return nil
+}
+
+// Proto gets the protocol used as the transport. This will be udp or tcp.
+func (s *ScrubWriter) Proto() string {
+	clog.Infof("ResponseWriter(scrub) type: %T", s.ResponseWriter)
+	// return Write.Proto(), if it is implemented
+	if protoProvider, ok := s.ResponseWriter.(interface{ Proto() string }); ok {
+		return protoProvider.Proto()
+	}
+	if _, ok := s.ResponseWriter.RemoteAddr().(*net.UDPAddr); ok {
+		return "udp"
+	}
+	if _, ok := s.ResponseWriter.RemoteAddr().(*net.TCPAddr); ok {
+		return "tcp"
+	}
+	return "udp"
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This pull request fixes two things for DNS over QUIC (DoQ):
1. Enabled early data for 0-RTT
2. Fixed DoQ issue where a DoQ response UDP size is not set to 65535

Functions have been tested with unit tests and in-field testing.

**Early Data:**
To enable early data, quic-go has to use `ListenEarly` instead of `Listen`. This has been changed in `server_quic.go`. Note, this does bring some risks: early data is vulnerable against replay attacks and does not provide non-repudiation. However, it does increase performance which is important in the case of DNS.

**Size Issues**
EDNS defines an OPT record that can be used to advertise a UDP size. In the case of DoQ, this size should be ignored and a response should set the size to 65535, as indicated in [RFC9250](https://www.rfc-editor.org/rfc/rfc9250.html#name-message-sizes) CoreDNS does not do this. This is caused by the `Size` function in `plugin/pkg/edns/edns.go` and the `Proto` function. It only recognises udp and tcp. If tcp is used the size is correctly set to 65535, however QUIC uses udp, so the EDNS udpsize in the query is also used in the response.

I considered two ways of solving this.
1. Rewriting the incoming query
2. Adding a Proto function to ResponseWriter instances that returns the protocol (such as quic)

Option 2 seemed the cleanest, however since the ResponseWriter interface does not enforce a Proto function it is implemented ad hoc.
If possible it would be cleaner to add a `Proto` function to this interface so that every Writer has to implement such a function. 

### 2. Which issues (if any) are related?
I have not created issues on GitHub. See description above for the issues.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
None. However, 0RTT early data does introduce some risk.
