### PR TITLE
plugin/kubernetes: skip zone serial bump on DNS neutral pod updates

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -87,8 +87,10 @@ kubernetes [ZONES...] {
      is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This
      option is provided for backward compatibility with kube-dns.
    * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This
-     option requires substantially more memory than in insecure mode, since it will maintain a watch
-     on all pods.
+     option maintains a watch on all pods in the cluster. CoreDNS only keeps a small subset of
+     each pod in memory (IP, name, namespace and labels), so the memory overhead is modest, but
+     the watch itself adds load to the Kubernetes API server, since every pod state change in
+     the cluster is streamed to CoreDNS.
 
 * `endpoint_pod_names` uses the pod name of the pod targeted by the endpoint as
    the endpoint name in A records, e.g.,

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -87,10 +87,9 @@ kubernetes [ZONES...] {
      is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This
      option is provided for backward compatibility with kube-dns.
    * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This
-     option maintains a watch on all pods in the cluster. CoreDNS only keeps a small subset of
-     each pod in memory (IP, name, namespace and labels), so the memory overhead is modest, but
-     the watch itself adds load to the Kubernetes API server, since every pod state change in
-     the cluster is streamed to CoreDNS.
+     option maintains a watch on all pods in the cluster, which requires additional memory in
+     CoreDNS (it keeps the IP, name, namespace and labels of every pod) and adds load to the
+     Kubernetes API server, since every pod state change in the cluster is streamed to CoreDNS.
 
 * `endpoint_pod_names` uses the pod name of the pod targeted by the endpoint as
    the endpoint name in A records, e.g.,

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -693,7 +693,9 @@ func (dns *dnsControl) detectChanges(oldObj, newObj any) {
 			dns.updateMultiClusterModified()
 		}
 	case *object.Pod:
-		dns.updateModified()
+		if podModified(oldObj, newObj) {
+			dns.updateModified()
+		}
 	case *object.Endpoints:
 		if !endpointsEquivalent(oldObj.(*object.Endpoints), newObj.(*object.Endpoints)) {
 			dns.updateModified()
@@ -744,6 +746,19 @@ func subsetsEquivalent(sa, sb object.EndpointSubset) bool {
 		}
 	}
 	return true
+}
+
+// podModified checks if an update to a pod changes anything that is visible in
+// DNS. Pod records and the pod IP index only depend on the pod IP, so all
+// other pod status churn (conditions, container statuses, labels) does not
+// need to bump the zone serial.
+func podModified(oldObj, newObj any) bool {
+	oldPod, okOld := oldObj.(*object.Pod)
+	newPod, okNew := newObj.(*object.Pod)
+	if !okOld || !okNew {
+		return true
+	}
+	return oldPod.PodIP != newPod.PodIP
 }
 
 // endpointsEquivalent checks if the update to an endpoint is something

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -355,3 +355,51 @@ func TestServiceModified(t *testing.T) {
 		}
 	}
 }
+
+func TestPodModified(t *testing.T) {
+	var tests = []struct {
+		oldPod  *object.Pod
+		newPod  *object.Pod
+		changed bool
+	}{
+		{
+			oldPod:  &object.Pod{Version: "1", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"},
+			newPod:  &object.Pod{Version: "2", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"},
+			changed: false,
+		},
+		{
+			oldPod:  &object.Pod{Version: "1", PodIP: "", Name: "dns-test", Namespace: "testns"},
+			newPod:  &object.Pod{Version: "2", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"},
+			changed: true,
+		},
+		{
+			oldPod:  &object.Pod{Version: "1", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"},
+			newPod:  &object.Pod{Version: "2", PodIP: "10.240.0.2", Name: "dns-test", Namespace: "testns"},
+			changed: true,
+		},
+	}
+
+	for i, test := range tests {
+		changed := podModified(test.oldPod, test.newPod)
+		if test.changed != changed {
+			t.Errorf("Expected %v for test %v. Got %v", test.changed, i, changed)
+		}
+	}
+}
+
+func TestDetectChangesPodUpdate(t *testing.T) {
+	dns := &dnsControl{}
+
+	p1 := &object.Pod{Version: "1", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"}
+	p2 := &object.Pod{Version: "2", PodIP: "10.240.0.1", Name: "dns-test", Namespace: "testns"}
+	dns.detectChanges(p1, p2)
+	if dns.Modified(ModifiedInternal) != 0 {
+		t.Fatal("pod update with an unchanged IP should not update the modified timestamp")
+	}
+
+	p3 := &object.Pod{Version: "3", PodIP: "10.240.0.2", Name: "dns-test", Namespace: "testns"}
+	dns.detectChanges(p2, p3)
+	if dns.Modified(ModifiedInternal) == 0 {
+		t.Fatal("pod update with a changed IP should update the modified timestamp")
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

In `pods verified` mode, every pod update event bumps the zone modified timestamp, which is used as the SOA serial. Pod records only depend on the pod IP, so routine pod status churn (readiness flaps, condition updates, container statuses, label changes) causes spurious SOA serial changes and needless zone transfer activity, even though pod records are not part of zone transfers at all.

Service and Endpoint updates are already filtered for DNS relevance (`serviceModified`, `endpointsEquivalent`) before bumping the serial. This PR applies the same treatment to pods: the serial is only bumped when the pod IP actually changes. Unit tests are included.

It also updates the `pods verified` documentation. The current text says verified "requires substantially more memory" than insecure mode, without describing where the cost comes from. The new text names both costs: the watch on all pods requires additional memory in CoreDNS (it keeps the IP, name, namespace and labels of every pod), and it adds load to the Kubernetes API server, since every pod state change in the cluster is streamed to CoreDNS, as discussed in #8043.

### 2. Which issues (if any) are related?

#8043. This is a first step toward making `pods verified` cheaper and better documented, in support of the discussion there about deprecating `pods insecure`.

### 3. Which documentation changes (if any) need to be made?

Included: the `pods verified` bullet in `plugin/kubernetes/README.md` now describes the actual overhead.

### 4. Does this introduce a backward incompatible change or deprecation?

No. The SOA serial still changes whenever DNS visible pod data changes. Updates that do not change the pod IP no longer bump the serial, which only removes spurious zone change signals.
