### PR TITLE
core/dnsserver: explain that the DoH JSON API is not supported

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -3,6 +3,7 @@ package dnsserver
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	stdlog "log"
 	"net"
@@ -190,7 +191,12 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	msg, raw, err := doh.RequestToMsgWire(r)
 	if err != nil {
 		clog.Debugf("DoH request could not be parsed: %v", err)
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		body := "invalid request"
+		if errors.Is(err, doh.ErrJSONNotSupported) {
+			// Fixed string, safe to return to the client.
+			body = err.Error()
+		}
+		http.Error(w, body, http.StatusBadRequest)
 		s.countResponse(http.StatusBadRequest)
 		return
 	}

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -3,6 +3,7 @@ package dnsserver
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -236,7 +237,12 @@ func (s *ServerHTTPS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	msg, raw, err := doh.RequestToMsgWire(r)
 	if err != nil {
 		clog.Debugf("DoH3 request could not be parsed: %v", err)
-		http.Error(w, "invalid request", http.StatusBadRequest)
+		body := "invalid request"
+		if errors.Is(err, doh.ErrJSONNotSupported) {
+			// Fixed string, safe to return to the client.
+			body = err.Error()
+		}
+		http.Error(w, body, http.StatusBadRequest)
 		s.countResponse(http.StatusBadRequest)
 		return
 	}

--- a/core/dnsserver/server_https3_test.go
+++ b/core/dnsserver/server_https3_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/doh"
 
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go"
@@ -408,6 +409,42 @@ func TestServeHTTP3DoesNotLeakBodyReadError(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(body)); got != "invalid request" {
 		t.Fatalf("expected sanitized body %q, got %q", "invalid request", got)
+	}
+}
+
+func TestServeHTTP3ExplainsUnsupportedJSONAPI(t *testing.T) {
+	c := Config{
+		Zone:        "example.com.",
+		Transport:   "https",
+		TLSConfig:   &tls.Config{},
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "443",
+	}
+	s, err := NewServerHTTPS3("127.0.0.1:443", []*Config{&c})
+	if err != nil {
+		t.Fatal("could not create HTTPS3 server:", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/dns-query?name=example.com&type=A", nil)
+	r.Header.Set("Accept", "application/dns-json")
+	r.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+
+	s.ServeHTTP(w, r)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(body)); got != doh.ErrJSONNotSupported.Error() {
+		t.Fatalf("expected body %q, got %q", doh.ErrJSONNotSupported.Error(), got)
 	}
 }
 

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/doh"
 
 	"github.com/miekg/dns"
 )
@@ -660,5 +661,41 @@ func TestServeHTTPDoesNotLeakBodyReadError(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(body)); got != "invalid request" {
 		t.Fatalf("expected sanitized body %q, got %q", "invalid request", got)
+	}
+}
+
+func TestServeHTTPExplainsUnsupportedJSONAPI(t *testing.T) {
+	c := Config{
+		Zone:        "example.com.",
+		Transport:   "https",
+		TLSConfig:   &tls.Config{},
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "443",
+	}
+	s, err := NewServerHTTPS("127.0.0.1:443", []*Config{&c})
+	if err != nil {
+		t.Fatal("could not create HTTPS server:", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/dns-query?name=example.com&type=A", nil)
+	r.Header.Set("Accept", "application/dns-json")
+	r.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+
+	s.ServeHTTP(w, r)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(body)); got != doh.ErrJSONNotSupported.Error() {
+		t.Fatalf("expected body %q, got %q", doh.ErrJSONNotSupported.Error(), got)
 	}
 }

--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,8 +18,18 @@ import (
 // MimeType is the DoH mimetype that should be used.
 const MimeType = "application/dns-message"
 
+// mimeTypeJSON is the mimetype of the non-standard JSON DNS API offered by
+// some public resolvers. CoreDNS does not implement it.
+const mimeTypeJSON = "application/dns-json"
+
 // Path is the URL path that should be used.
 const Path = "/dns-query"
+
+// ErrJSONNotSupported is returned for GET requests that use the non-standard
+// JSON DNS API (application/dns-json) instead of RFC 8484. The error text is
+// a fixed string that reveals no request or server internals, so it is safe
+// to return to the client.
+var ErrJSONNotSupported = errors.New("the JSON API (" + mimeTypeJSON + ") is not supported; use RFC 8484 (" + MimeType + ")")
 
 // NewRequest returns a new DoH request given a HTTP method, URL and dns.Msg.
 //
@@ -126,6 +137,15 @@ func requestToMsgGet(req *http.Request) (*dns.Msg, []byte, error) {
 	values := req.URL.Query()
 	b64, ok := values["dns"]
 	if !ok {
+		// A 'name' parameter or an application/dns-json Accept header means
+		// the client is using the JSON DNS API as implemented by e.g. the
+		// Google and Cloudflare public resolvers, see
+		// https://developers.google.com/speed/public-dns/docs/doh/json.
+		// Return a specific error so the server can tell the client why the
+		// request is rejected.
+		if values.Has("name") || strings.Contains(req.Header.Get("Accept"), mimeTypeJSON) {
+			return nil, nil, ErrJSONNotSupported
+		}
 		return nil, nil, fmt.Errorf("no 'dns' query parameter found")
 	}
 	if len(b64) != 1 {

--- a/plugin/pkg/doh/doh_test.go
+++ b/plugin/pkg/doh/doh_test.go
@@ -1,6 +1,7 @@
 package doh
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -42,6 +43,52 @@ func TestDoH(t *testing.T) {
 				t.Errorf("Qname expected %d, got %d", x, dns.TypeDNSKEY)
 			}
 		})
+	}
+}
+
+func TestDoHGETRejectsJSONAPI(t *testing.T) {
+	tests := map[string]struct {
+		target string
+		accept string
+	}{
+		"name and type parameters": {target: "https://example.org" + Path + "?name=example.org&type=A"},
+		"accept header only":       {target: "https://example.org" + Path, accept: "application/dns-json"},
+		"parameters and accept":    {target: "https://example.org" + Path + "?name=example.org&type=A", accept: "application/dns-json"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, test.target, nil)
+			if err != nil {
+				t.Fatalf("failed to build request: %v", err)
+			}
+			if test.accept != "" {
+				req.Header.Set("Accept", test.accept)
+			}
+
+			_, err = RequestToMsg(req)
+			if !errors.Is(err, ErrJSONNotSupported) {
+				t.Fatalf("expected ErrJSONNotSupported, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDoHGETMissingDNSParameter(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.org"+Path, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	_, err = RequestToMsg(req)
+	if err == nil {
+		t.Fatal("expected GET request without 'dns' query parameter to be rejected")
+	}
+	if errors.Is(err, ErrJSONNotSupported) {
+		t.Fatalf("expected a generic error for a request without JSON API markers, got %v", err)
+	}
+	if err.Error() != "no 'dns' query parameter found" {
+		t.Fatalf("expected %q, got %v", "no 'dns' query parameter found", err)
 	}
 }
 

--- a/plugin/tls/README.md
+++ b/plugin/tls/README.md
@@ -72,9 +72,15 @@ https://. {
 }
 ~~~
 
+The DoH server implements RFC 8484: queries carry a DNS message in wire format
+(`application/dns-message`), base64url-encoded in the `dns` query parameter for GET requests or in
+the request body for POST requests. The JSON API (`application/dns-json`) offered by some public
+resolvers is not an IETF standard and is not supported; requests using it are rejected with an
+HTTP 400 error.
+
 Only Knot DNS' `kdig` supports DNS-over-TLS queries, no command line client supports gRPC making
 debugging these transports harder than it should be.
 
 ## See Also
 
-RFC 7858 and https://grpc.io.
+RFC 7858, RFC 8484 and https://grpc.io.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

CoreDNS' DoH server implements RFC 8484 only: GET requests must carry the DNS message base64url-encoded in the `dns` query parameter. Several popular clients and users instead use the non-standard JSON DNS API popularized by the Google and Cloudflare public resolvers:

```
curl -H 'accept: application/dns-json' 'https://dns.example.org/dns-query?name=example.com&type=A'
```

Today that request fails with an opaque `400` / `invalid request` (formerly `no 'dns' query parameter found`), and users repeatedly conclude their DoH/TLS setup is broken and file bugs (#3465, #7143).

This PR keeps the behavior (the JSON API stays unsupported — implementing it was declined in #4358) but makes the rejection self-explanatory:

* `plugin/pkg/doh`: when a GET request has no `dns` parameter, but has a `name` parameter or an `application/dns-json` Accept header, return the new sentinel error `doh.ErrJSONNotSupported` instead of the generic parse error.
* `core/dnsserver` (DoH and DoH3 handlers): if parsing failed with `doh.ErrJSONNotSupported`, return its text in the 400 response body:

  ```
  the JSON API (application/dns-json) is not supported; use RFC 8484 (application/dns-message)
  ```

  All other parse errors keep the sanitized generic `invalid request` body, so this does not reopen the internal-error disclosure fixed by #8254 — the new message is a fixed string that reflects no request or server internals.

Verified end-to-end against a locally built binary with an `https://` server block:

```
$ curl -sk 'https://127.0.0.1:18443/dns-query?name=google.de&type=A' -H 'accept: application/dns-json'
the JSON API (application/dns-json) is not supported; use RFC 8484 (application/dns-message)   # HTTP 400

$ curl -sk 'https://127.0.0.1:18443/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB'
# HTTP 200, application/dns-message (unchanged)

$ curl -sk 'https://127.0.0.1:18443/dns-query'
invalid request   # HTTP 400 (unchanged, still sanitized)
```

Unit tests are added for the new sentinel in `plugin/pkg/doh` and for the HTTP response body in both the DoH and DoH3 handlers; a regression test asserts a GET without any JSON API markers still gets the generic error.

### 2. Which issues (if any) are related?

Fixes #7143. Same confusion previously reported in #3465. Implementing the JSON API itself was proposed and closed in #4358; this PR intentionally does not implement it and only makes the rejection understandable.

### 3. Which documentation changes (if any) need to be made?

Included: `plugin/tls/README.md` now states that the DoH server implements RFC 8484 (`application/dns-message`) and that the JSON API (`application/dns-json`) is not supported, and adds RFC 8484 to "See Also".

### 4. Does this introduce a backward incompatible change or deprecation?

No. The status code for such requests remains 400; only the response body for this specific, previously-failing request shape changes from `invalid request` to the explanatory fixed string.
