### PR TITLE
plugin/tsig: expose validated request status to downstream plugins

### DIFF
--- a/plugin/tsig/README.md
+++ b/plugin/tsig/README.md
@@ -12,6 +12,10 @@ respective plugins sending those requests to sign them using the keys defined by
 
 The *tsig* plugin can also require that incoming requests be signed for certain query types, refusing requests that do not comply.
 
+After successfully validating a TSIG record, the plugin marks the request context. Downstream Go plugins can call
+`tsig.Validated(ctx)` to distinguish validated requests from unsigned requests. The marker is not set for requests outside the
+configured zones because the *tsig* plugin does not validate them.
+
 ## Syntax
 
 ~~~

--- a/plugin/tsig/context.go
+++ b/plugin/tsig/context.go
@@ -1,0 +1,16 @@
+package tsig
+
+import "context"
+
+type validatedKey struct{}
+
+// Validated reports whether the tsig plugin successfully validated a TSIG
+// record on the request.
+func Validated(ctx context.Context) bool {
+	validated, _ := ctx.Value(validatedKey{}).(bool)
+	return validated
+}
+
+func withValidatedTSIG(ctx context.Context) context.Context {
+	return context.WithValue(ctx, validatedKey{}, true)
+}

--- a/plugin/tsig/tsig.go
+++ b/plugin/tsig/tsig.go
@@ -71,6 +71,7 @@ func (t *TSIGServer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	}
 
 	tsigRR.Error = dns.RcodeSuccess
+	ctx = withValidatedTSIG(ctx)
 	rcode, err := plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
 	if err != nil {
 		log.Errorf("request handler returned an error: %v\n", err)

--- a/plugin/tsig/tsig_test.go
+++ b/plugin/tsig/tsig_test.go
@@ -329,6 +329,7 @@ func TestServeDNSTsigNext(t *testing.T) {
 		reqSigned    bool
 		expectExtra  []uint16
 		expectNext   int
+		expectValid  bool
 	}{
 		{
 			desc:         "Optional TSIG",
@@ -338,6 +339,7 @@ func TestServeDNSTsigNext(t *testing.T) {
 			reqSigned:    false,
 			expectExtra:  []uint16{dns.TypeOPT},
 			expectNext:   1,
+			expectValid:  false,
 		},
 		{
 			desc:         "Missing TSIG",
@@ -355,6 +357,7 @@ func TestServeDNSTsigNext(t *testing.T) {
 			reqSigned:   true,
 			expectExtra: []uint16{dns.TypeOPT, dns.TypeTSIG},
 			expectNext:  1,
+			expectValid: false,
 		},
 		{
 			desc:         "Bad Status",
@@ -373,6 +376,7 @@ func TestServeDNSTsigNext(t *testing.T) {
 			reqSigned:    true,
 			expectExtra:  []uint16{dns.TypeOPT},
 			expectNext:   1,
+			expectValid:  true,
 		},
 	}
 
@@ -385,6 +389,9 @@ func TestServeDNSTsigNext(t *testing.T) {
 				allTypes: tc.tsigRequired,
 				Next: test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 					nextCalled++
+					if got := Validated(_ctx); got != tc.expectValid {
+						t.Errorf("Validated() = %t, want %t", got, tc.expectValid)
+					}
 					if !slices.EqualFunc(r.Extra, tc.expectExtra, func(rr dns.RR, t uint16) bool { return rr.Header().Rrtype == t }) {
 						t.Errorf("expected %v, got %v", tc.expectExtra, r.Extra)
 					}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `tsig` plugin removes the TSIG record before invoking downstream plugins, while `dns.ResponseWriter.TsigStatus()` returns `nil` for both an unsigned request and a valid signature. Downstream plugins therefore cannot distinguish those cases when TSIG is optional.

This change marks the request context only after the plugin successfully validates a TSIG record and exposes `tsig.Validated(ctx)` for downstream plugins. Unsigned requests, failed validation, and signed requests outside the plugin's configured zones are not marked. Tests cover each of those paths.

### 2. Which issues (if any) are related?

Closes #7830.

### 3. Which documentation changes (if any) need to be made?

The `tsig` plugin README documents the new `tsig.Validated(ctx)` helper and its scope.

### 4. Does this introduce a backward incompatible change or deprecation?

No.