### PR TITLE
plugin/kubernetes: optimize endpointHostname by removing redundant strings.Contains

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -369,9 +369,6 @@ func endpointHostname(addr object.EndpointAddress, endpointNameMode bool) string
 	if endpointNameMode && addr.TargetRefName != "" {
 		return addr.TargetRefName
 	}
-	if strings.Contains(addr.IP, ".") {
-		return strings.ReplaceAll(addr.IP, ".", "-")
-	}
 	if strings.Contains(addr.IP, ":") {
 		ipv6Hostname := strings.ReplaceAll(addr.IP, ":", "-")
 		if strings.HasSuffix(ipv6Hostname, "-") {
@@ -379,7 +376,7 @@ func endpointHostname(addr object.EndpointAddress, endpointNameMode bool) string
 		}
 		return ipv6Hostname
 	}
-	return ""
+	return strings.ReplaceAll(addr.IP, ".", "-")
 }
 
 func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service, err error) {


### PR DESCRIPTION
### Description

This PR optimizes `endpointHostname` in the `kubernetes` plugin:

- Removed redundant `strings.Contains(addr.IP, ".")` check before `strings.ReplaceAll(addr.IP, ".", "-")` for IPv4 addresses.
- `strings.ReplaceAll` already scans the string and replaces dots with dashes. By evaluating IPv6 (`:`) first and passing IPv4 directly to `strings.ReplaceAll`, we eliminate an extra byte-by-byte scanning pass over the IP address string on every fallback endpoint hostname resolution.

### Testing
All unit tests in `./plugin/kubernetes/...` pass.