### PR TITLE
plugin/kubernetes: zero-allocation domain label parsing in parseRequest

### DIFF
--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+
+	"github.com/miekg/dns"
 )
 
 type recordRequest struct {
@@ -50,6 +52,44 @@ const (
 // _port._protocol.service.namespace.pod|svc. A zone-scoped name may be longer.
 const maxSegs = 6
 
+// splitReverse returns the labels of base in reverse order, so segs[0] is the label
+// closest to the zone. The labels are sliced straight out of base into arr, so a name
+// of the length parseRequest can answer for does not allocate. A zone-scoped name may
+// carry more labels than that - the zone value may span labels - and grows off arr.
+//
+// Slicing on '.' is only correct while a dot always separates two labels. An escaped
+// dot is part of a label, and an empty label is not a label at all, so names
+// containing either are handed to dns.SplitDomainName, which splits them the way the
+// rest of CoreDNS does. Neither can name a real service, so the allocation it costs
+// is not on any path that matters.
+func splitReverse(base string, arr *[maxSegs]string) []string {
+	// A leading dot is an empty first label, which the loop below would consume
+	// without ever producing it.
+	if base == "" || base[0] == '.' || strings.IndexByte(base, '\\') >= 0 {
+		return splitReverseEscaped(base)
+	}
+
+	segs := arr[:0]
+	for end := len(base); end > 0; {
+		idx := strings.LastIndexByte(base[:end], '.')
+		label := base[idx+1 : end] // idx == -1 yields the first label
+		end = idx
+		if label == "" {
+			return splitReverseEscaped(base)
+		}
+		segs = append(segs, label)
+	}
+	return segs
+}
+
+func splitReverseEscaped(base string) []string {
+	l := dns.SplitDomainName(base)
+	for i, j := 0, len(l)-1; i < j; i, j = i+1, j-1 {
+		l[i], l[j] = l[j], l[i]
+	}
+	return l
+}
+
 // joinReverse joins segs, which is in reverse label order, back into a name that
 // reads left to right the way the query did.
 func joinReverse(segs []string) string {
@@ -88,28 +128,8 @@ func parseRequest(name, zone string, multicluster, zonal bool) (r recordRequest,
 		return r, nil
 	}
 
-	// segs holds the labels of base in reverse order, so segs[0] is the label closest
-	// to the zone. The labels are sliced straight out of base into arr, so a name of
-	// the length this can answer for does not allocate. A zone-scoped name may carry
-	// more labels than that - the zone value may span labels - and grows off arr.
 	var arr [maxSegs]string
-	segs := arr[:0]
-	end := len(base)
-	for end > 0 {
-		idx := strings.LastIndexByte(base[:end], '.')
-		var label string
-		if idx == -1 {
-			label = base[:end]
-			end = 0
-		} else {
-			label = base[idx+1 : end]
-			end = idx
-		}
-		if label == "" {
-			continue
-		}
-		segs = append(segs, label)
-	}
+	segs := splitReverse(base, &arr)
 
 	n := len(segs)
 	if n < 1 {

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
-
-	"github.com/miekg/dns"
 )
 
 type recordRequest struct {
@@ -40,45 +38,62 @@ func parseRequest(name, zone string, multicluster bool) (r recordRequest, err er
 	if base == "" || base == Svc || base == Pod {
 		return r, nil
 	}
-	segs := dns.SplitDomainName(base)
 
-	last := len(segs) - 1
-	if last < 0 {
+	var segs [6]string
+	n := 0
+	end := len(base)
+	for end > 0 {
+		idx := strings.LastIndexByte(base[:end], '.')
+		var label string
+		if idx == -1 {
+			label = base[:end]
+			end = 0
+		} else {
+			label = base[idx+1 : end]
+			end = idx
+		}
+		if label == "" {
+			continue
+		}
+		if n >= 6 {
+			return r, errInvalidRequest
+		}
+		segs[n] = label
+		n++
+	}
+
+	if n < 1 {
 		return r, nil
 	}
-	r.podOrSvc = segs[last]
+	r.podOrSvc = segs[0]
 	if r.podOrSvc != Pod && r.podOrSvc != Svc {
 		return r, errInvalidRequest
 	}
-	last--
-	if last < 0 {
+	if n < 2 {
 		return r, nil
 	}
 
-	r.namespace = segs[last]
-	last--
-	if last < 0 {
+	r.namespace = segs[1]
+	if n < 3 {
 		return r, nil
 	}
 
-	r.service = segs[last]
-	last--
-	if last < 0 {
+	r.service = segs[2]
+	if n < 4 {
 		return r, nil
 	}
 
-	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol or endpoint and clusterid.
-	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
-	switch last {
-	case 0: // endpoint only
-		r.endpoint = segs[last]
-	case 1: // service and port or endpoint and clusterid
-		if !multicluster || strings.HasPrefix(segs[last], "_") || strings.HasPrefix(segs[last-1], "_") {
-			r.protocol = stripUnderscore(segs[last])
-			r.port = stripUnderscore(segs[last-1])
+	remaining := n - 3
+	switch remaining {
+	case 1: // endpoint only
+		r.endpoint = segs[3]
+	case 2: // service and port or endpoint and clusterid
+		if !multicluster || strings.HasPrefix(segs[3], "_") || strings.HasPrefix(segs[4], "_") {
+			r.protocol = stripUnderscore(segs[3])
+			r.port = stripUnderscore(segs[4])
 		} else {
-			r.cluster = segs[last]
-			r.endpoint = segs[last-1]
+			r.cluster = segs[3]
+			r.endpoint = segs[4]
 		}
 
 	default: // too long

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
-
-	"github.com/miekg/dns"
 )
 
 type recordRequest struct {
@@ -48,6 +46,31 @@ const (
 	directivePrefer = "prefer" // zone-local endpoints, all endpoints if none
 )
 
+// maxSegs is the number of labels parseRequest can answer for without growing:
+// _port._protocol.service.namespace.pod|svc. A zone-scoped name may be longer.
+const maxSegs = 6
+
+// joinReverse joins segs, which is in reverse label order, back into a name that
+// reads left to right the way the query did.
+func joinReverse(segs []string) string {
+	if len(segs) == 1 {
+		return segs[0]
+	}
+	size := len(segs) - 1
+	for _, s := range segs {
+		size += len(s)
+	}
+	var b strings.Builder
+	b.Grow(size)
+	for i := len(segs) - 1; i >= 0; i-- {
+		if i != len(segs)-1 {
+			b.WriteByte('.')
+		}
+		b.WriteString(segs[i])
+	}
+	return b.String()
+}
+
 // parseRequest parses the qname to find all the elements we need for querying k8s. Anything
 // that is not parsed will have the wildcard "*" value (except r.endpoint).
 // Potential underscores are stripped from _port and _protocol.
@@ -64,46 +87,66 @@ func parseRequest(name, zone string, multicluster, zonal bool) (r recordRequest,
 	if base == "" || base == Svc || base == Pod {
 		return r, nil
 	}
-	segs := dns.SplitDomainName(base)
 
-	last := len(segs) - 1
-	if last < 0 {
+	// segs holds the labels of base in reverse order, so segs[0] is the label closest
+	// to the zone. The labels are sliced straight out of base into arr, so a name of
+	// the length this can answer for does not allocate. A zone-scoped name may carry
+	// more labels than that - the zone value may span labels - and grows off arr.
+	var arr [maxSegs]string
+	segs := arr[:0]
+	end := len(base)
+	for end > 0 {
+		idx := strings.LastIndexByte(base[:end], '.')
+		var label string
+		if idx == -1 {
+			label = base[:end]
+			end = 0
+		} else {
+			label = base[idx+1 : end]
+			end = idx
+		}
+		if label == "" {
+			continue
+		}
+		segs = append(segs, label)
+	}
+
+	n := len(segs)
+	if n < 1 {
 		return r, nil
 	}
-	r.podOrSvc = segs[last]
+	r.podOrSvc = segs[0]
 	if r.podOrSvc != Pod && r.podOrSvc != Svc {
 		return r, errInvalidRequest
 	}
-	last--
-	if last < 0 {
+	if n < 2 {
 		return r, nil
 	}
 
-	r.namespace = segs[last]
-	last--
-	if last < 0 {
+	r.namespace = segs[1]
+	if n < 3 {
 		return r, nil
 	}
 
-	r.service = segs[last]
-	last--
-	if last < 0 {
+	r.service = segs[2]
+	if n < 4 {
 		return r, nil
 	}
 
-	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol or endpoint
-	// and clusterid. 3 or more: a zone-scoped name (the zone value may span labels).
-	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
-	switch last {
-	case 0: // endpoint only
-		r.endpoint = segs[last]
-	case 1: // service and port or endpoint and clusterid
-		if !multicluster || strings.HasPrefix(segs[last], "_") || strings.HasPrefix(segs[last-1], "_") {
-			r.protocol = stripUnderscore(segs[last])
-			r.port = stripUnderscore(segs[last-1])
+	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol
+	// or endpoint and clusterid. 3 or more: a zone-scoped name (the zone value may span
+	// labels). Anything else is a query that is too long to answer and can safely be
+	// delegated to return an nxdomain.
+	switch remaining := n - 3; remaining {
+	case 1: // endpoint only
+		r.endpoint = segs[3]
+	case 2: // service and port or endpoint and clusterid
+		if !multicluster || strings.HasPrefix(segs[3], "_") || strings.HasPrefix(segs[4], "_") {
+			r.protocol = stripUnderscore(segs[3])
+			r.port = stripUnderscore(segs[4])
 		} else {
-			r.cluster = segs[last]
-			r.endpoint = segs[last-1]
+			r.cluster = segs[3]
+			r.endpoint = segs[4]
 		}
 
 	default: // zone-scoped name (topozone.pin|prefer._zone), or too long
@@ -112,17 +155,17 @@ func parseRequest(name, zone string, multicluster, zonal bool) (r recordRequest,
 		// multicluster zones; everything this arm rejects keeps the stock
 		// too-long NXDOMAIN, so behavior with the option off (or for
 		// unknown directives) is byte-identical to today.
-		if !zonal || multicluster || segs[last] != zoneLabel || r.podOrSvc != Svc {
+		if !zonal || multicluster || segs[3] != zoneLabel || r.podOrSvc != Svc {
 			return r, errInvalidRequest
 		}
-		switch segs[last-1] {
+		switch segs[4] {
 		case directivePin:
 		case directivePrefer:
 			r.zonePrefer = true
 		default:
 			return r, errInvalidRequest
 		}
-		r.zone = strings.Join(segs[:last-1], ".")
+		r.zone = joinReverse(segs[5:])
 	}
 
 	return r, nil

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -30,6 +30,9 @@ func TestParseRequest(t *testing.T) {
 		{"..webs.mynamespace.svc.inter.webs.tests.", "....webs.mynamespace.svc", false, false, ""},
 		// A multicluster request with a clusterid
 		{"1-2-3-4.cluster1.webs.mynamespace.svc.inter.webs.tests.", "..1-2-3-4.cluster1.webs.mynamespace.svc", true, false, ""},
+		// An escaped dot is part of the label, not a separator between two labels
+		{`foo\.bar.mynamespace.svc.inter.webs.tests.`, `....foo\.bar.mynamespace.svc`, false, false, ""},
+		{`_http._tcp.foo\.bar.mynamespace.svc.inter.webs.tests.`, `http.tcp...foo\.bar.mynamespace.svc`, false, false, ""},
 		// zone-scoped names, both directives
 		{"us-west-2a.pin._zone.webs.mynamespace.svc.inter.webs.tests.", "....webs.mynamespace.svc", false, true, "us-west-2a"},
 		{"us-west-2a.prefer._zone.webs.mynamespace.svc.inter.webs.tests.", "....webs.mynamespace.svc", false, true, "us-west-2a"},
@@ -102,4 +105,73 @@ func BenchmarkParseRequest(b *testing.B) {
 	for b.Loop() {
 		_, _ = parseRequest("1-2-3-4.webs.mynamespace.svc.inter.webs.tests.", zone, false, false)
 	}
+}
+
+func TestSplitReverse(t *testing.T) {
+	tests := []string{
+		"webs.mynamespace.svc",
+		"_http._tcp.webs.mynamespace.svc",
+		`foo\.bar.mynamespace.svc`,
+		`foo\.bar.baz\.qux.svc`,
+		`a\\.mynamespace.svc`,
+		"..webs.mynamespace.svc",
+		".mynamespace.svc",
+		"svc",
+		"",
+	}
+	for _, base := range tests {
+		var arr [maxSegs]string
+		segs := splitReverse(base, &arr)
+		want := dns.SplitDomainName(base)
+		if !equalReversed(segs, want) {
+			t.Errorf("splitReverse(%q) = %q, want the reverse of %q", base, segs, want)
+		}
+	}
+
+	// A zone-scoped name carries more labels than arr holds, and grows off it.
+	var arr [maxSegs]string
+	long := "corp.example.com.pin._zone.webs.mynamespace.svc"
+	if segs := splitReverse(long, &arr); !equalReversed(segs, dns.SplitDomainName(long)) {
+		t.Errorf("splitReverse(%q) = %q, want the reverse of %q", long, segs, dns.SplitDomainName(long))
+	}
+}
+
+// FuzzSplitReverse checks the allocation-free split against dns.SplitDomainName,
+// which is the splitter the rest of CoreDNS uses and the one this replaces.
+func FuzzSplitReverse(f *testing.F) {
+	for _, s := range []string{
+		"webs.mynamespace.svc",
+		`foo\.bar.mynamespace.svc`,
+		"..webs.mynamespace.svc",
+		"_http._tcp.webs.mynamespace.svc",
+		"a.b.c.d.e.f.g.svc",
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, base string) {
+		if _, ok := dns.IsDomainName(base); !ok {
+			t.Skip()
+		}
+
+		var arr [maxSegs]string
+		segs := splitReverse(base, &arr)
+		want := dns.SplitDomainName(base)
+
+		if !equalReversed(segs, want) {
+			t.Fatalf("splitReverse(%q) = %q, want the reverse of %q", base, segs, want)
+		}
+	})
+}
+
+func equalReversed(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[len(want)-1-i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
### Summary

Optimizes domain label parsing in `parseRequest` by replacing `dns.SplitDomainName(base)` with a reverse label scan into a stack array.

A Kubernetes name that this can answer for has at most 6 labels (`_port._protocol.service.namespace.pod|svc`), so scanning right-to-left with `strings.LastIndexByte` into a `[6]string` eliminates the heap allocation of both the `[]string` segment slice and the individual label strings. A zone-scoped name may carry more labels than that — its zone value spans every label left of the directive — so `splitReverse` grows off the stack array for those rather than rejecting them; the shapes served in the hot path still do not allocate.

Splitting on `.` is only correct while a dot always separates two labels. An escaped dot is part of a label, and an empty label is not a label at all, so names containing either are handed to `dns.SplitDomainName`, which splits them the way the rest of CoreDNS does. Neither can name a real service, so the allocation that costs is not on any path that matters.

### Correctness

- `FuzzSplitReverse` cross-checks the scan against `dns.SplitDomainName` for every input `dns.IsDomainName` accepts. 187k executions on the rebase, no mismatches.
- `TestSplitReverse` covers escaped dots, escaped backslashes, empty labels, a leading dot, and a zone-scoped name that outgrows the array.
- `TestParseRequest` gains the two escaped-dot cases; the existing zonal and multicluster cases are unchanged.

### Benchmark

`go test -run '^$' -bench BenchmarkParseRequest -benchmem -count=10 ./plugin/kubernetes/`, benchstat vs `master`, Go 1.27.0, Intel i7-1065G7.

| Metric | `master` | this PR | Change |
|---|---|---|---|
| time/op | 260.2 ns | **70.68 ns** | **-72.8%** (p=0.000, n=10) |
| B/op | 184 | **0** | **-100%** |
| allocs/op | 5 | **0** | **-100%** |

`plugin/kubernetes` and `plugin/kubernetes/object` pass.
