### PR TITLE
request: resolve IP and Port from net.Addr directly instead of formatting and re-splitting

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -3,6 +3,7 @@ package request
 
 import (
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
@@ -46,9 +47,19 @@ func (r *Request) IP() string {
 		return r.ip
 	}
 
-	ip, _, err := net.SplitHostPort(r.W.RemoteAddr().String())
+	addr := r.W.RemoteAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.ip = udp.IP.String()
+		return r.ip
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.ip = tcp.IP.String()
+		return r.ip
+	}
+
+	ip, _, err := net.SplitHostPort(addr.String())
 	if err != nil {
-		r.ip = r.W.RemoteAddr().String()
+		r.ip = addr.String()
 		return r.ip
 	}
 
@@ -62,9 +73,19 @@ func (r *Request) LocalIP() string {
 		return r.localIP
 	}
 
-	ip, _, err := net.SplitHostPort(r.W.LocalAddr().String())
+	addr := r.W.LocalAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.localIP = udp.IP.String()
+		return r.localIP
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.localIP = tcp.IP.String()
+		return r.localIP
+	}
+
+	ip, _, err := net.SplitHostPort(addr.String())
 	if err != nil {
-		r.localIP = r.W.LocalAddr().String()
+		r.localIP = addr.String()
 		return r.localIP
 	}
 
@@ -78,7 +99,17 @@ func (r *Request) Port() string {
 		return r.port
 	}
 
-	_, port, err := net.SplitHostPort(r.W.RemoteAddr().String())
+	addr := r.W.RemoteAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.port = strconv.Itoa(udp.Port)
+		return r.port
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.port = strconv.Itoa(tcp.Port)
+		return r.port
+	}
+
+	_, port, err := net.SplitHostPort(addr.String())
 	if err != nil {
 		r.port = "0"
 		return r.port
@@ -94,7 +125,17 @@ func (r *Request) LocalPort() string {
 		return r.localPort
 	}
 
-	_, port, err := net.SplitHostPort(r.W.LocalAddr().String())
+	addr := r.W.LocalAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.localPort = strconv.Itoa(udp.Port)
+		return r.localPort
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.localPort = strconv.Itoa(tcp.Port)
+		return r.localPort
+	}
+
+	_, port, err := net.SplitHostPort(addr.String())
 	if err != nil {
 		r.localPort = "0"
 		return r.localPort
@@ -103,6 +144,7 @@ func (r *Request) LocalPort() string {
 	r.localPort = port
 	return r.localPort
 }
+
 
 // RemoteAddr returns the net.Addr of the client that sent the current request.
 func (r *Request) RemoteAddr() string { return r.W.RemoteAddr().String() }

--- a/request/request.go
+++ b/request/request.go
@@ -145,7 +145,6 @@ func (r *Request) LocalPort() string {
 	return r.localPort
 }
 
-
 // RemoteAddr returns the net.Addr of the client that sent the current request.
 func (r *Request) RemoteAddr() string { return r.W.RemoteAddr().String() }
 

--- a/request/request.go
+++ b/request/request.go
@@ -3,6 +3,7 @@ package request
 
 import (
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
@@ -40,15 +41,44 @@ func (r *Request) NewWithQuestion(name string, typ uint16) Request {
 	return req1
 }
 
+// hostFromIP formats ip and zone the way net.SplitHostPort would return them for
+// the address they came from, so the type assertion fast paths below stay a pure
+// optimization.
+//
+// Two details make this more than ip.String(). A zone is part of the host, and
+// dropping it would merge fe80::1%eth0 and fe80::1%eth1 into one address for
+// everything that matches on IP, such as acl and metrics labels. And an address
+// with no IP prints as the empty string, where ip.String() would give "<nil>".
+func hostFromIP(ip net.IP, zone string) string {
+	host := ""
+	if len(ip) != 0 {
+		host = ip.String()
+	}
+	if zone != "" {
+		return host + "%" + zone
+	}
+	return host
+}
+
 // IP gets the (remote) IP address of the client making the request.
 func (r *Request) IP() string {
 	if r.ip != "" {
 		return r.ip
 	}
 
-	ip, _, err := net.SplitHostPort(r.W.RemoteAddr().String())
+	addr := r.W.RemoteAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.ip = hostFromIP(udp.IP, udp.Zone)
+		return r.ip
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.ip = hostFromIP(tcp.IP, tcp.Zone)
+		return r.ip
+	}
+
+	ip, _, err := net.SplitHostPort(addr.String())
 	if err != nil {
-		r.ip = r.W.RemoteAddr().String()
+		r.ip = addr.String()
 		return r.ip
 	}
 
@@ -62,9 +92,19 @@ func (r *Request) LocalIP() string {
 		return r.localIP
 	}
 
-	ip, _, err := net.SplitHostPort(r.W.LocalAddr().String())
+	addr := r.W.LocalAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.localIP = hostFromIP(udp.IP, udp.Zone)
+		return r.localIP
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.localIP = hostFromIP(tcp.IP, tcp.Zone)
+		return r.localIP
+	}
+
+	ip, _, err := net.SplitHostPort(addr.String())
 	if err != nil {
-		r.localIP = r.W.LocalAddr().String()
+		r.localIP = addr.String()
 		return r.localIP
 	}
 
@@ -78,7 +118,17 @@ func (r *Request) Port() string {
 		return r.port
 	}
 
-	_, port, err := net.SplitHostPort(r.W.RemoteAddr().String())
+	addr := r.W.RemoteAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.port = strconv.Itoa(udp.Port)
+		return r.port
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.port = strconv.Itoa(tcp.Port)
+		return r.port
+	}
+
+	_, port, err := net.SplitHostPort(addr.String())
 	if err != nil {
 		r.port = "0"
 		return r.port
@@ -94,7 +144,17 @@ func (r *Request) LocalPort() string {
 		return r.localPort
 	}
 
-	_, port, err := net.SplitHostPort(r.W.LocalAddr().String())
+	addr := r.W.LocalAddr()
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		r.localPort = strconv.Itoa(udp.Port)
+		return r.localPort
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		r.localPort = strconv.Itoa(tcp.Port)
+		return r.localPort
+	}
+
+	_, port, err := net.SplitHostPort(addr.String())
 	if err != nil {
 		r.localPort = "0"
 		return r.localPort

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
@@ -399,5 +400,54 @@ func BenchmarkRequestPort(b *testing.B) {
 	for b.Loop() {
 		st.Clear()
 		_ = st.Port()
+	}
+}
+
+// addrResponseWriter serves a fixed pair of addresses so IP, LocalIP, Port and
+// LocalPort can be exercised against address shapes the test package does not
+// build, such as a zoned link-local address.
+type addrResponseWriter struct {
+	dns.ResponseWriter
+	remote, local net.Addr
+}
+
+func (w *addrResponseWriter) RemoteAddr() net.Addr { return w.remote }
+func (w *addrResponseWriter) LocalAddr() net.Addr  { return w.local }
+
+// TestRequestIPPortMatchSplitHostPort checks that the type assertion fast paths
+// in IP, LocalIP, Port and LocalPort return what net.SplitHostPort returns for
+// the same address. A zone belongs to the host, and an address carrying no IP
+// has an empty host rather than "<nil>".
+func TestRequestIPPortMatchSplitHostPort(t *testing.T) {
+	addrs := []net.Addr{
+		&net.UDPAddr{IP: net.ParseIP("10.240.0.1"), Port: 40212},
+		&net.TCPAddr{IP: net.ParseIP("10.240.0.1"), Port: 40212},
+		&net.UDPAddr{IP: net.ParseIP("::1"), Port: 53},
+		&net.TCPAddr{IP: net.ParseIP("::1"), Port: 53},
+		&net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 53, Zone: "eth0"},
+		&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 53, Zone: "eth0"},
+		&net.UDPAddr{Port: 53},
+		&net.TCPAddr{Port: 53},
+	}
+
+	for _, addr := range addrs {
+		wantHost, wantPort, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			t.Fatalf("%s: %s", addr, err)
+		}
+
+		st := Request{W: &addrResponseWriter{remote: addr, local: addr}, Req: new(dns.Msg)}
+		if got := st.IP(); got != wantHost {
+			t.Errorf("%s: IP() = %q, expected %q", addr, got, wantHost)
+		}
+		if got := st.LocalIP(); got != wantHost {
+			t.Errorf("%s: LocalIP() = %q, expected %q", addr, got, wantHost)
+		}
+		if got := st.Port(); got != wantPort {
+			t.Errorf("%s: Port() = %q, expected %q", addr, got, wantPort)
+		}
+		if got := st.LocalPort(); got != wantPort {
+			t.Errorf("%s: LocalPort() = %q, expected %q", addr, got, wantPort)
+		}
 	}
 }


### PR DESCRIPTION
### Summary

`IP()`, `LocalIP()`, `Port()` and `LocalPort()` each resolved their value by rendering the
whole address to a string and splitting it back apart:

```go
ip, _, err := net.SplitHostPort(r.W.RemoteAddr().String())
```

`net.UDPAddr.String()` builds that string with `IP.String()`, an integer conversion and a
`JoinHostPort`, so three allocations are made to recover a value the address already
holds. This takes the value directly for the `*net.UDPAddr` and `*net.TCPAddr` cases and
keeps `SplitHostPort` as the fallback for any other `net.Addr`.

The four accessors are called from 29 sites across the plugins, and the memo on
`Request` does not span a query: plugins build their own `request.Request` in 55 places,
so a chain like log + metrics + forward resolves the address several times per query.

### Matching the previous results exactly

Taking the IP directly is only sound if it produces what `SplitHostPort` produced, and
two cases differ:

- **A zone is part of the host.** `fe80::1` with zone `eth0` prints as
  `[fe80::1%eth0]:53`, and `SplitHostPort` returns `fe80::1%eth0`, where `IP.String()`
  returns `fe80::1`. Dropping the zone would make `fe80::1%eth0` and `fe80::1%eth1` the
  same address to everything matching on `IP()` — `acl`, metrics labels, log.
- **An address with no IP has an empty host.** It prints as `:53`, so `SplitHostPort`
  returns `""`, where `IP.String()` returns `"<nil>"`.

Both go through `hostFromIP`, which reproduces `SplitHostPort`'s result. The extra
concatenation only runs for a zoned address; the common case still allocates once.

`TestRequestIPPortMatchSplitHostPort` checks all four accessors against `SplitHostPort`
over v4, v6, zoned and IP-less addresses in UDP and TCP form. It fails on the zoned and
IP-less cases without `hostFromIP`.

### Benchmark

`go test -run '^$' -bench 'BenchmarkRequestIP|BenchmarkRequestPort' -benchmem -count=10
./request/`, benchstat vs `master`, Go 1.27.0, Intel i7-1065G7.

| Benchmark | `master` | this PR | Change |
|---|---|---|---|
| `RequestIP` | 215.6 ns · 96 B · 5 allocs | **116.3 ns · 80 B · 3 allocs** | -46.1% time, -2 allocs |
| `RequestPort` | 212.7 ns · 96 B · 5 allocs | **97.16 ns · 69 B · 3 allocs** | -54.3% time, -2 allocs |

All deltas p=0.000, n=10.

Two of the three remaining allocations belong to the test `ResponseWriter`, which builds
a fresh `net.UDPAddr` and parses the IP on every `RemoteAddr()` call. The accessors
themselves go from three allocations to one.

`request` passes.
