### PR TITLE
plugin/kubernetes: pre-evaluate endpointHostname in findServices endpoint loops

### DIFF
--- a/plugin/kubernetes/bench_test.go
+++ b/plugin/kubernetes/bench_test.go
@@ -1,0 +1,159 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+)
+
+// The fixtures behind BenchmarkServices and BenchmarkServicesHeadless give every
+// endpoint address a single port, which is not what a headless service in a real
+// cluster looks like. A StatefulSet or a Deployment behind a headless service
+// commonly has tens to hundreds of ready endpoints spread over several
+// EndpointSlices, each exposing the handful of ports its containers declare, and
+// no per-address Hostname unless the workload sets one.
+//
+// APIConnBench models that: one headless service with benchEndpoints addresses
+// spread over benchSlices slices, each subset exposing benchPorts ports. It is
+// the shape that makes the per-port work in the endpoint loops visible.
+const (
+	benchEndpoints = 100
+	benchSlices    = 4
+	benchPorts     = 3
+)
+
+type APIConnBench struct {
+	APIConnServiceTest
+}
+
+func (APIConnBench) SvcIndex(string) []*object.Service { return benchServices }
+func (APIConnBench) ServiceList() []*object.Service    { return benchServices }
+func (APIConnBench) EpIndex(string) []*object.Endpoints {
+	return benchEndpointSlices
+}
+func (APIConnBench) EndpointsList() []*object.Endpoints { return benchEndpointSlices }
+
+var benchServices = []*object.Service{
+	{
+		Name:       "hdlsbench",
+		Namespace:  "testns",
+		ClusterIPs: []string{api.ClusterIPNone},
+	},
+}
+
+var benchEndpointSlices = makeBenchEndpoints()
+
+// makeBenchEndpoints spreads benchEndpoints addresses over benchSlices slices,
+// each subset carrying benchPorts ports. The addresses carry no Hostname, so
+// endpointHostname falls through to rewriting the IP, which is what an
+// EndpointSlice for a plain Deployment looks like.
+func makeBenchEndpoints() []*object.Endpoints {
+	ports := make([]object.EndpointPort, 0, benchPorts)
+	for _, p := range []struct {
+		name string
+		port int32
+	}{{"http", 80}, {"https", 443}, {"metrics", 9153}} {
+		ports = append(ports, object.EndpointPort{Port: p.port, Protocol: "tcp", Name: p.name})
+	}
+
+	eps := make([]*object.Endpoints, 0, benchSlices)
+	per := benchEndpoints / benchSlices
+	for s := range benchSlices {
+		addrs := make([]object.EndpointAddress, 0, per)
+		for i := range per {
+			n := s*per + i
+			addrs = append(addrs, object.EndpointAddress{IP: fmt.Sprintf("172.16.%d.%d", n/256, n%256)})
+		}
+		eps = append(eps, &object.Endpoints{
+			Subsets:   []object.EndpointSubset{{Addresses: addrs, Ports: ports}},
+			Name:      fmt.Sprintf("hdlsbench-slice%d", s),
+			Namespace: "testns",
+			Index:     object.EndpointsKey("hdlsbench", "testns"),
+		})
+	}
+	return eps
+}
+
+func benchKubernetes() *Kubernetes {
+	k := New([]string{"inter.webs.tests."})
+	k.APIConn = APIConnBench{}
+	return k
+}
+
+func benchState(k *Kubernetes, qname string, qtype uint16) request.Request {
+	m := new(dns.Msg)
+	m.SetQuestion(qname, qtype)
+	return request.Request{Zone: k.Zones[0], Req: m}
+}
+
+// BenchmarkServicesHeadlessMultiPort resolves every endpoint of a headless
+// service that exposes several ports, so the answer is benchEndpoints*benchPorts
+// records and the endpoint loops run their full length.
+func BenchmarkServicesHeadlessMultiPort(b *testing.B) {
+	k := benchKubernetes()
+	ctx := context.TODO()
+	state := benchState(k, "hdlsbench.testns.svc.inter.webs.tests.", dns.TypeA)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = k.Services(ctx, state, false, plugin.Options{})
+	}
+}
+
+// BenchmarkServicesEndpointMultiPort resolves a single endpoint of that service,
+// which walks every address to find the match rather than emitting them all.
+func BenchmarkServicesEndpointMultiPort(b *testing.B) {
+	k := benchKubernetes()
+	ctx := context.TODO()
+	state := benchState(k, "172-16-0-77.hdlsbench.testns.svc.inter.webs.tests.", dns.TypeA)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = k.Services(ctx, state, false, plugin.Options{})
+	}
+}
+
+// BenchmarkServicesSRVMultiPort resolves one named port across every endpoint.
+func BenchmarkServicesSRVMultiPort(b *testing.B) {
+	k := benchKubernetes()
+	ctx := context.TODO()
+	state := benchState(k, "_http._tcp.hdlsbench.testns.svc.inter.webs.tests.", dns.TypeSRV)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = k.Services(ctx, state, false, plugin.Options{})
+	}
+}
+
+// TestBenchFixtureSanity guards the benchmarks above: a fixture that stops
+// matching the query would leave them measuring an empty result set rather
+// than the endpoint loops they exist to measure.
+func TestBenchFixtureSanity(t *testing.T) {
+	k := benchKubernetes()
+	ctx := context.TODO()
+	for _, tc := range []struct {
+		name  string
+		qname string
+		qtype uint16
+		want  int
+	}{
+		{"headless, every port", "hdlsbench.testns.svc.inter.webs.tests.", dns.TypeA, benchEndpoints * benchPorts},
+		{"one endpoint", "172-16-0-77.hdlsbench.testns.svc.inter.webs.tests.", dns.TypeA, benchPorts},
+		{"SRV, one named port", "_http._tcp.hdlsbench.testns.svc.inter.webs.tests.", dns.TypeSRV, benchEndpoints},
+	} {
+		svcs, err := k.Services(ctx, benchState(k, tc.qname, tc.qtype), false, plugin.Options{})
+		if err != nil {
+			t.Fatalf("%s: %s", tc.name, err)
+		}
+		if len(svcs) != tc.want {
+			t.Errorf("%s: got %d services, want %d", tc.name, len(svcs), tc.want)
+		}
+	}
+}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -519,9 +519,10 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
+						epHost := endpointHostname(addr, k.endpointNameMode)
 						// See comments in parse.go parseRequest about the endpoint handling.
 						if r.endpoint != "" {
-							if !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {
+							if !match(r.endpoint, epHost) {
 								continue
 							}
 						}
@@ -531,7 +532,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 								continue
 							}
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
-							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, endpointHostname(addr, k.endpointNameMode)}, "/")
+							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, epHost}, "/")
 
 							err = nil
 
@@ -623,9 +624,10 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
+						epHost := endpointHostname(addr, k.endpointNameMode)
 						// See comments in parse.go parseRequest about the endpoint handling.
 						if r.endpoint != "" {
-							if !match(r.cluster, ep.ClusterId) || !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {
+							if !match(r.cluster, ep.ClusterId) || !match(r.endpoint, epHost) {
 								continue
 							}
 						}
@@ -635,7 +637,7 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 								continue
 							}
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
-							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, ep.ClusterId, endpointHostname(addr, k.endpointNameMode)}, "/")
+							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, ep.ClusterId, epHost}, "/")
 
 							err = nil
 

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -552,8 +552,9 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 							if topoZone != "" && ep.Zones[addr.IP] != topoZone {
 								continue
 							}
+							epHost := endpointHostname(addr, k.endpointNameMode)
 							if r.endpoint != "" {
-								if !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {
+								if !match(r.endpoint, epHost) {
 									continue
 								}
 							}
@@ -563,7 +564,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 									continue
 								}
 								s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
-								s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, endpointHostname(addr, k.endpointNameMode)}, "/")
+								s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, epHost}, "/")
 
 								err = nil
 
@@ -664,9 +665,10 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 
 				for _, eps := range ep.Subsets {
 					for _, addr := range eps.Addresses {
+						epHost := endpointHostname(addr, k.endpointNameMode)
 						// See comments in parse.go parseRequest about the endpoint handling.
 						if r.endpoint != "" {
-							if !match(r.cluster, ep.ClusterId) || !match(r.endpoint, endpointHostname(addr, k.endpointNameMode)) {
+							if !match(r.cluster, ep.ClusterId) || !match(r.endpoint, epHost) {
 								continue
 							}
 						}
@@ -676,7 +678,7 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 								continue
 							}
 							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
-							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, ep.ClusterId, endpointHostname(addr, k.endpointNameMode)}, "/")
+							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, ep.ClusterId, epHost}, "/")
 
 							err = nil
 


### PR DESCRIPTION
### Summary

Hoists `endpointHostname(addr, k.endpointNameMode)` out of the inner port loops in `findServices` and `findMultiClusterServices`, evaluating it once per endpoint address instead of once per matching port plus once per endpoint match test.

`endpointHostname` is not free: unless the address carries a `Hostname` or a target ref, it derives one from the IP with `strings.ReplaceAll`, which allocates. An endpoint exposing several ports repeats that work per port today.

In `findServices` the call sits below the topology zone check added by #8388, so addresses filtered out by a zone-scoped query do not pay for a hostname that is never used.

### A benchmark that can see it

The existing `BenchmarkServices` and `BenchmarkServicesHeadless` fixtures give every endpoint address a single port, so the innermost loop body runs once per address and this change is a no-op there by construction — on those two benchmarks it measures as ~1% slower, which is the added bookkeeping and nothing else.

The first commit adds a fixture with the shape a headless service actually has in a cluster: 100 ready endpoints spread over 4 EndpointSlices, 3 ports each, no per-address `Hostname` — what an EndpointSlice for a plain Deployment looks like. Three benchmarks run over it, covering the paths through the endpoint loops that differ in how often they need a hostname: resolving the whole service, resolving a single endpoint, and resolving one named port via SRV. `TestBenchFixtureSanity` pins the answer sizes so a fixture that drifts out of matching the query fails the build instead of quietly leaving the benchmarks measuring an empty result set.

### Benchmark

`go test -run '^$' -bench 'MultiPort' -benchmem ./plugin/kubernetes/`, benchstat vs `master` with the same fixture, Go 1.27.0, Intel i7-1065G7.

| benchmark | `master` | this PR | delta |
|---|---|---|---|
| `ServicesHeadlessMultiPort` | 91.85 µs · 87.29 KiB · 625 allocs | **66.10 µs · 84.17 KiB · 425 allocs** | **-28.0% time, -32.0% allocs** (p=0.000, n=10) |
| `ServicesEndpointMultiPort` | 13.27 µs · 3.073 KiB · 126 allocs | **12.54 µs · 3.026 KiB · 123 allocs** | **-5.5% time, -3 allocs** (p=0.007, n=20) |
| `ServicesSRVMultiPort` | 57.62 µs · 72.75 KiB · 334 allocs | 62.17 µs · 72.75 KiB · 334 allocs | ~ (p=0.052, n=10) |

The 200 allocations removed from `ServicesHeadlessMultiPort` are exactly 100 addresses x 2 redundant `endpointHostname` calls: three ports per address means three calls today and one here.

`ServicesSRVMultiPort` matches a single named port per address, so both sides make one call per address and the change cannot help — it is included to show it does not hurt.

On the pre-existing single-port benchmarks, unchanged in allocations:

| benchmark | `master` | this PR | delta |
|---|---|---|---|
| `Services` | 1.889 µs · 1768 B · 29 allocs | 1.906 µs · 1768 B · 29 allocs | +0.9% time (p=0.001, n=10) |
| `ServicesHeadless` | 2.768 µs · 2656 B · 44 allocs | 2.812 µs · 2656 B · 44 allocs | +1.6% time (p=0.000, n=10) |

`plugin/kubernetes` and `plugin/kubernetes/object` pass.
