### PR TITLE
plugin/cache: add prefer_positive stale policy

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -41,6 +41,7 @@ cache [TTL] [ZONES...] {
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
     serve_stale [DURATION] [REFRESH_MODE [VERIFY_TIMEOUT]]
+    serve_stale_policy prefer_positive
     servfail DURATION
     disable success|denial [ZONES...]
     keepttl
@@ -78,6 +79,13 @@ cache [TTL] [ZONES...] {
   verify before falling back to the stale entry. The verify continues in the background and refreshes the
   cache when it eventually succeeds, so subsequent queries see the fresh entry. The default of `0` means
   wait until the upstream's own timeout (the original `verify` behavior). Example: `serve_stale 1h verify 100ms`.
+* `serve_stale_policy` controls cache selection while `serve_stale` is enabled. The only supported policy is
+  `prefer_positive`. It checks the success cache before the denial cache and returns an eligible positive response
+  when it actually answers the question, even when a cached NXDOMAIN, NODATA, SERVFAIL, or NOTIMP response also
+  exists. The positive response must be unexpired or within the configured `serve_stale` duration. This policy is
+  disabled by default because it can mask legitimate record deletion or removal until the positive response exceeds
+  the stale duration or is evicted. In `immediate` mode, the stale positive response is returned first and the cache
+  refreshes in the background. In `verify` mode, only a refreshed positive answer replaces the stale response.
 * `servfail` cache SERVFAIL responses for **DURATION**.  Setting **DURATION** to 0 will disable caching of SERVFAIL
   responses.  If this option is not set, SERVFAIL responses will be cached for 5 seconds.  **DURATION** may not be
   greater than 5 minutes.

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -511,10 +511,10 @@ func (w *verifyStaleResponseWriter) WriteMsg(res *dns.Msg) error {
 			w.refreshed = true
 			return w.ResponseWriter.WriteMsg(res)
 		}
-		prefetch := w.ResponseWriter.prefetch
-		w.ResponseWriter.prefetch = true
+		prefetch := w.prefetch
+		w.prefetch = true
 		err := w.ResponseWriter.WriteMsg(res)
-		w.ResponseWriter.prefetch = prefetch
+		w.prefetch = prefetch
 		return err
 	}
 	if res.Rcode == dns.RcodeSuccess || res.Rcode == dns.RcodeNameError {

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -46,6 +46,7 @@ type Cache struct {
 	staleUpTo          time.Duration
 	verifyStale        bool
 	verifyStaleTimeout time.Duration // 0 means wait for upstream until its own timeout (current default).
+	preferPositive     bool
 
 	// Positive/negative zone exceptions
 	pexcept []string
@@ -122,6 +123,52 @@ func hasSOA(m *dns.Msg) bool {
 	return false
 }
 
+// cacheResponseType returns the response type used by the cache. Typify treats
+// any NOERROR response with a non-empty answer section as NoError, but RFC 2308
+// NODATA responses may contain a CNAME chain. Reclassify those responses when
+// an SOA provides the negative cache TTL.
+func cacheResponseType(m *dns.Msg, now time.Time) response.Type {
+	t, _ := response.Typify(m, now)
+	if t == response.NoError && hasSOA(m) && isNODATA(m) {
+		return response.NoData
+	}
+	return t
+}
+
+// answersQuestion reports whether a NOERROR response contains an answer to its
+// question. For types other than CNAME and ANY, the queried type must exist at
+// the terminal owner reached by following the CNAME chain from QNAME.
+func answersQuestion(m *dns.Msg) bool {
+	if m == nil || m.Rcode != dns.RcodeSuccess || len(m.Question) == 0 || len(m.Answer) == 0 {
+		return false
+	}
+	q := m.Question[0]
+	return answerHasType(m.Answer, q.Name, q.Qtype)
+}
+
+func answerHasType(answer []dns.RR, name string, qtype uint16) bool {
+	if len(answer) == 0 {
+		return false
+	}
+	if qtype == dns.TypeANY {
+		return true
+	}
+	if qtype != dns.TypeCNAME {
+		terminal, ok := canonicalName(answer, name)
+		if !ok {
+			return false
+		}
+		name = terminal
+	}
+	for _, r := range answer {
+		h := r.Header()
+		if h.Rrtype == qtype && strings.EqualFold(h.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // isNODATA reports whether a NOERROR response with a non-empty answer section
 // does not answer the question. Following RFC 1034 section 3.6.2 and RFC 2308
 // sections 1 and 2.2, a query of any type other than CNAME (and ANY) is
@@ -144,32 +191,7 @@ func isNODATA(m *dns.Msg) bool {
 	if len(m.Answer) == 0 {
 		return false
 	}
-	qtype := m.Question[0].Qtype
-	if qtype == dns.TypeANY {
-		return false
-	}
-	// A CNAME query is answered by the CNAME itself, so the chain is not
-	// followed; otherwise resolve it to the terminal owner name.
-	name := m.Question[0].Name
-	if qtype != dns.TypeCNAME {
-		terminal, ok := canonicalName(m.Answer, name)
-		if !ok {
-			// The CNAME chain is malformed (an owner with more than one
-			// distinct target, or a loop) and therefore has no well-defined
-			// QNAME per RFC 2181 section 10.1 and RFC 1034 section 3.6.2. Such
-			// a response cannot be shown to answer the question, so treat it as
-			// NODATA and (being SOA-less) leave it uncacheable.
-			return true
-		}
-		name = terminal
-	}
-	for _, r := range m.Answer {
-		h := r.Header()
-		if h.Rrtype == qtype && strings.EqualFold(h.Name, name) {
-			return false
-		}
-	}
-	return true
+	return !answersQuestion(m)
 }
 
 // canonicalName follows the owner-linked CNAME chain in answer starting at name
@@ -362,7 +384,7 @@ func (w *ResponseWriter) Hijack() {
 // WriteMsg implements the dns.ResponseWriter interface.
 func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	res = res.Copy()
-	mt, _ := response.Typify(res, w.now().UTC())
+	mt := cacheResponseType(res, w.now().UTC())
 
 	// key returns empty string for anything we don't want to cache.
 	hasKey, key := key(w.state.Name(), res, mt, w.do, w.cd)
@@ -425,8 +447,10 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 		if w.pcache.Add(key, i) {
 			evictions.WithLabelValues(w.server, Success, w.zonesMetricLabel, w.viewMetricLabel).Inc()
 		}
-		// when pre-fetching, remove the negative cache entry if it exists
-		if w.prefetch {
+		// A positive refresh is the newest state for this key. Under the
+		// prefer_positive policy, only remove the denial when this response
+		// actually answers the question.
+		if w.prefetch || (w.preferPositive && answersQuestion(m)) {
 			w.ncache.Remove(key)
 		}
 
@@ -468,8 +492,10 @@ type verifyStaleResponseWriter struct {
 }
 
 // newVerifyStaleResponseWriter returns a ResponseWriter to be used when verifying stale cache
-// entries. It only forward writes if an entry was successfully refreshed according to RFC8767,
-// section 4 (response is NoError or NXDomain), and ignores any other response.
+// entries. By default it only forward writes if an entry was successfully refreshed according
+// to RFC8767, section 4 (response is NoError or NXDomain). With prefer_positive, only a response
+// that answers the question is forwarded; other cacheable responses are stored without being
+// sent to the client.
 func newVerifyStaleResponseWriter(w *ResponseWriter) *verifyStaleResponseWriter {
 	return &verifyStaleResponseWriter{
 		w,
@@ -480,6 +506,17 @@ func newVerifyStaleResponseWriter(w *ResponseWriter) *verifyStaleResponseWriter 
 // WriteMsg implements the dns.ResponseWriter interface.
 func (w *verifyStaleResponseWriter) WriteMsg(res *dns.Msg) error {
 	w.refreshed = false
+	if w.preferPositive {
+		if answersQuestion(res) {
+			w.refreshed = true
+			return w.ResponseWriter.WriteMsg(res)
+		}
+		prefetch := w.ResponseWriter.prefetch
+		w.ResponseWriter.prefetch = true
+		err := w.ResponseWriter.WriteMsg(res)
+		w.ResponseWriter.prefetch = prefetch
+		return err
+	}
 	if res.Rcode == dns.RcodeSuccess || res.Rcode == dns.RcodeNameError {
 		w.refreshed = true
 		return w.ResponseWriter.WriteMsg(res) // stores to the cache and send to client

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -1335,6 +1335,120 @@ func TestServfailDoesNotShadowPositiveCache(t *testing.T) {
 	}
 }
 
+func TestPreferPositiveCachePolicy(t *testing.T) {
+	c := New()
+	c.staleUpTo = time.Hour
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	state := request.Request{W: &test.ResponseWriter{}, Req: req}
+	k := hash(state.Name(), state.QType(), state.QClass(), state.Do(), state.Req.CheckingDisabled)
+
+	positive := new(dns.Msg)
+	positive.SetReply(req)
+	positive.Answer = []dns.RR{test.A("example.org. 60 IN A 192.0.2.1")}
+	c.pcache.Add(k, newItem(positive, now.Add(-2*time.Minute), time.Minute))
+
+	negative := new(dns.Msg)
+	negative.SetRcode(req, dns.RcodeNameError)
+	negative.Ns = []dns.RR{test.SOA("example.org. 300 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 300")}
+	c.ncache.Add(k, newItem(negative, now, 5*time.Minute))
+
+	if got := c.getIfNotStale(now, state, "test"); got == nil || got.Rcode != dns.RcodeNameError {
+		t.Fatalf("default policy should prefer ncache NXDOMAIN, got %+v", got)
+	}
+
+	c.preferPositive = true
+	if got := c.getIfNotStale(now, state, "test"); got == nil || got.Rcode != dns.RcodeSuccess {
+		t.Fatalf("prefer_positive should prefer eligible pcache answer, got %+v", got)
+	}
+}
+
+func TestPreferPositiveRejectsNonAnswer(t *testing.T) {
+	c := New()
+	c.staleUpTo = time.Hour
+	c.preferPositive = true
+	now := time.Now()
+
+	req := new(dns.Msg)
+	req.SetQuestion("alias.example.org.", dns.TypeA)
+	state := request.Request{W: &test.ResponseWriter{}, Req: req}
+	k := hash(state.Name(), state.QType(), state.QClass(), state.Do(), state.Req.CheckingDisabled)
+
+	incomplete := new(dns.Msg)
+	incomplete.SetReply(req)
+	incomplete.Answer = []dns.RR{test.CNAME("alias.example.org. 60 IN CNAME missing.example.org.")}
+	c.pcache.Add(k, newItem(incomplete, now, time.Minute))
+
+	negative := new(dns.Msg)
+	negative.SetRcode(req, dns.RcodeNameError)
+	negative.Ns = []dns.RR{test.SOA("example.org. 300 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 300")}
+	c.ncache.Add(k, newItem(negative, now, 5*time.Minute))
+
+	if got := c.getIfNotStale(now, state, "test"); got == nil || got.Rcode != dns.RcodeNameError {
+		t.Fatalf("non-answer pcache item must not shadow ncache, got %+v", got)
+	}
+}
+
+func TestPreferPositiveVerifyKeepsStaleOnNXDOMAIN(t *testing.T) {
+	c := New()
+	c.staleUpTo = time.Hour
+	c.verifyStale = true
+	c.preferPositive = true
+	c.Next = ttlBackend(60)
+
+	req := new(dns.Msg)
+	req.SetQuestion("cached.org.", dns.TypeA)
+	ctx := context.Background()
+	c.ServeDNS(ctx, &test.ResponseWriter{}, req)
+
+	c.now = func() time.Time { return time.Now().Add(2 * time.Minute) }
+	c.Next = nxDomainBackend(300)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	ret, err := c.ServeDNS(ctx, rec, req.Copy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ret != dns.RcodeSuccess || rec.Msg == nil || rec.Msg.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected stale positive response, got ret=%d msg=%+v", ret, rec.Msg)
+	}
+	if got := rec.Msg.Answer[0].Header().Ttl; got != 0 {
+		t.Fatalf("expected stale TTL 0, got %d", got)
+	}
+	if c.ncache.Len() != 1 {
+		t.Fatalf("expected verified NXDOMAIN to be retained in ncache, got %d entries", c.ncache.Len())
+	}
+}
+
+func TestCNAMEWithSOAStoredAsNODATA(t *testing.T) {
+	c := New()
+	req := new(dns.Msg)
+	req.SetQuestion("alias.example.org.", dns.TypeA)
+	crr := &ResponseWriter{
+		Cache:    c,
+		state:    request.Request{Req: req},
+		prefetch: true,
+	}
+
+	res := new(dns.Msg)
+	res.SetReply(req)
+	res.Answer = []dns.RR{test.CNAME("alias.example.org. 300 IN CNAME missing.example.net.")}
+	res.Ns = []dns.RR{test.SOA("example.org. 300 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 300")}
+
+	if err := crr.WriteMsg(res); err != nil {
+		t.Fatal(err)
+	}
+	if c.ncache.Len() != 1 {
+		t.Fatalf("expected NODATA in ncache, got %d entries", c.ncache.Len())
+	}
+	if c.pcache.Len() != 0 {
+		t.Fatalf("expected no positive cache entry, got %d", c.pcache.Len())
+	}
+}
+
 func TestServeFromStaleCacheFetchVerifyTimeoutMetadataIsolation(t *testing.T) {
 	c := New()
 	c.staleUpTo = time.Hour

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -132,10 +132,10 @@ func (c *Cache) doRefresh(ctx context.Context, state request.Request, cw dns.Res
 
 // verifyWithTimeout runs the upstream verify in a background goroutine and races it
 // against verifyStaleTimeout. If the verify completes within the timeout and the
-// response is cacheable (NoError or NXDomain), the freshly cached entry is served
-// to the client and served is true. Otherwise served is false and the caller falls
-// through to serve stale; the goroutine continues to run and any successful response
-// will update the cache without writing to the (now-detached) client connection.
+// response is accepted by verifyStaleResponseWriter, the freshly cached entry is
+// served to the client and served is true. Otherwise served is false and the caller
+// falls through to serve stale; the goroutine continues to run and any cacheable
+// response updates the cache without writing to the detached client connection.
 func (c *Cache) verifyWithTimeout(ctx context.Context, state request.Request, w dns.ResponseWriter, cw *verifyStaleResponseWriter, r *dns.Msg, do, ad bool) (served bool, code int, err error) {
 	type result struct {
 		code int
@@ -192,6 +192,16 @@ func (c *Cache) Name() string { return "cache" }
 func (c *Cache) getIfNotStale(now time.Time, state request.Request, server string) *item {
 	k := hash(state.Name(), state.QType(), state.QClass(), state.Do(), state.Req.CheckingDisabled)
 	cacheRequests.WithLabelValues(server, c.zonesMetricLabel, c.viewMetricLabel).Inc()
+
+	if c.preferPositive && c.staleUpTo > 0 {
+		if i, ok := c.pcache.Get(k); ok {
+			ttl := i.ttl(now)
+			if i.matches(state) && i.answersQuestion(state) && (ttl > 0 || (c.staleUpTo > 0 && -ttl < int(c.staleUpTo.Seconds()))) {
+				cacheHits.WithLabelValues(server, Success, c.zonesMetricLabel, c.viewMetricLabel).Inc()
+				return i
+			}
+		}
+	}
 
 	if i, ok := c.ncache.Get(k); ok {
 		ttl := i.ttl(now)

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -114,3 +114,7 @@ func (i *item) matches(state request.Request) bool {
 	}
 	return false
 }
+
+func (i *item) answersQuestion(state request.Request) bool {
+	return i.Rcode == dns.RcodeSuccess && answerHasType(i.Answer, state.QName(), state.QType())
+}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -63,6 +63,8 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 			}
 		}
 		origins := plugin.OriginsFromArgsOrServerBlock(args, c.ServerBlockKeys)
+		serveStaleConfigured := false
+		serveStalePolicyConfigured := false
 
 		// Refinements? In an extra block.
 		for c.NextBlock() {
@@ -171,6 +173,7 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 				}
 
 			case "serve_stale":
+				serveStaleConfigured = true
 				args := c.RemainingArgs()
 				if len(args) > 3 {
 					return nil, c.ArgErr()
@@ -207,6 +210,21 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, errors.New("invalid negative timeout for serve_stale verify")
 					}
 					ca.verifyStaleTimeout = t
+				}
+			case "serve_stale_policy":
+				if serveStalePolicyConfigured {
+					return nil, errors.New("serve_stale_policy can only be specified once")
+				}
+				serveStalePolicyConfigured = true
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				switch strings.ToLower(args[0]) {
+				case "prefer_positive":
+					ca.preferPositive = true
+				default:
+					return nil, fmt.Errorf("invalid serve_stale_policy: %s", args[0])
 				}
 			case "servfail":
 				args := c.RemainingArgs()
@@ -263,6 +281,9 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 			default:
 				return nil, c.ArgErr()
 			}
+		}
+		if serveStalePolicyConfigured && !serveStaleConfigured {
+			return nil, errors.New("serve_stale_policy requires serve_stale")
 		}
 
 		ca.Zones = origins

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -170,6 +170,41 @@ func TestServeStale(t *testing.T) {
 	}
 }
 
+func TestServeStalePolicy(t *testing.T) {
+	tests := []struct {
+		input          string
+		shouldErr      bool
+		preferPositive bool
+	}{
+		{"serve_stale\nserve_stale_policy prefer_positive", false, true},
+		{"serve_stale_policy PREFER_POSITIVE\nserve_stale", false, true},
+		{"serve_stale", false, false},
+		// fails
+		{"serve_stale_policy prefer_positive", true, false},
+		{"serve_stale\nserve_stale_policy", true, false},
+		{"serve_stale\nserve_stale_policy prefer_positive extra", true, false},
+		{"serve_stale\nserve_stale_policy invalid", true, false},
+		{"serve_stale\nserve_stale_policy prefer_positive\nserve_stale_policy prefer_positive", true, false},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", fmt.Sprintf("cache {\n%s\n}", test.input))
+		ca, err := cacheParse(c)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+			continue
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			continue
+		}
+		if test.shouldErr {
+			continue
+		}
+		if ca.preferPositive != test.preferPositive {
+			t.Errorf("Test %v: Expected preferPositive %v but found %v", i, test.preferPositive, ca.preferPositive)
+		}
+	}
+}
+
 func TestServfail(t *testing.T) {
 	tests := []struct {
 		input     string


### PR DESCRIPTION
## Summary

Add an opt-in cache policy for availability-focused deployments that prefer a last-known-good positive answer while stale serving is enabled:

```corefile
cache {
    serve_stale 1h immediate
    serve_stale_policy prefer_positive
}
```

Without `serve_stale_policy prefer_positive`, cache lookup order and stale behavior remain unchanged.

## Behavior

- Check the success cache before the denial cache only when both `serve_stale` and `prefer_positive` are configured.
- Select a positive candidate only when its answer section resolves the query name/CNAME chain to the requested type.
- In `verify` mode, keep serving the stale positive answer when the refresh returns NXDOMAIN, NODATA, SERVFAIL, or another response that does not answer the question.
- Cache non-positive refresh responses without returning them over an eligible stale positive answer.
- Remove a matching denial-cache entry after a usable positive refresh.
- Classify SOA-backed CNAME responses that do not answer the requested type as NODATA in the cache rather than as positive entries.

`immediate` semantics are unchanged: the triggering request receives stale data and the asynchronous refresh affects subsequent requests.

## Tradeoff

This mode deliberately favors availability over authoritative negative answers. It can mask legitimate deletions, DNS policy changes, migration, address reuse, and DNSSEC failures for the configured stale window. It is therefore opt-in and disabled by default.

## Tests

- parser validation and backward-compatible defaults
- positive-over-NXDOMAIN/NODATA precedence
- rejection of incomplete positive answers
- verify refresh behavior
- CNAME plus SOA NODATA storage

Closes #7805