### PR TITLE
core/dnsserver: pre-initialize baseCtx on Server struct to avoid per-request context allocations

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -64,6 +64,8 @@ type Server struct {
 	// Ensure Stop is idempotent when invoked concurrently (e.g., during reload and SIGTERM).
 	stopOnce sync.Once
 	stopErr  error
+
+	baseCtx context.Context
 }
 
 // MetadataCollector is a plugin that can retrieve metadata functions from all metadata providing plugins
@@ -158,6 +160,9 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		log.D.Clear()
 	}
 
+	s.baseCtx = context.WithValue(context.Background(), Key{}, s)
+	s.baseCtx = context.WithValue(s.baseCtx, LoopKey{}, 0)
+
 	return s, nil
 }
 
@@ -179,9 +184,7 @@ func (s *Server) Serve(l net.Listener) error {
 			return s.IdleTimeout
 		},
 		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-			ctx := context.WithValue(context.Background(), Key{}, s)
-			ctx = context.WithValue(ctx, LoopKey{}, 0)
-			s.ServeDNS(ctx, w, r)
+			s.ServeDNS(s.baseCtx, w, r)
 		})}
 
 	s.m.Unlock()
@@ -199,9 +202,7 @@ func (s *Server) ServePacket(p net.PacketConn) error {
 	}
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.WithValue(context.Background(), Key{}, s)
-		ctx = context.WithValue(ctx, LoopKey{}, 0)
-		s.ServeDNS(ctx, w, r)
+		s.ServeDNS(s.baseCtx, w, r)
 	}), TsigSecret: s.tsigSecret, DecorateWriter: dw}
 	s.m.Unlock()
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -76,6 +76,8 @@ type Server struct {
 	// Ensure Stop is idempotent when invoked concurrently (e.g., during reload and SIGTERM).
 	stopOnce sync.Once
 	stopErr  error
+
+	baseCtx context.Context
 }
 
 // MetadataCollector is a plugin that can retrieve metadata functions from all metadata providing plugins
@@ -172,6 +174,9 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		log.D.Clear()
 	}
 
+	s.baseCtx = context.WithValue(context.Background(), Key{}, s)
+	s.baseCtx = context.WithValue(s.baseCtx, LoopKey{}, 0)
+
 	return s, nil
 }
 
@@ -194,9 +199,7 @@ func (s *Server) Serve(l net.Listener) error {
 			return s.IdleTimeout
 		},
 		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-			ctx := context.WithValue(context.Background(), Key{}, s)
-			ctx = context.WithValue(ctx, LoopKey{}, 0)
-			s.ServeDNS(ctx, w, r)
+			s.ServeDNS(s.baseCtx, w, r)
 		})}
 
 	s.m.Unlock()
@@ -214,9 +217,7 @@ func (s *Server) ServePacket(p net.PacketConn) error {
 	}
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.WithValue(context.Background(), Key{}, s)
-		ctx = context.WithValue(ctx, LoopKey{}, 0)
-		s.ServeDNS(ctx, w, r)
+		s.ServeDNS(s.baseCtx, w, r)
 	}), TsigSecret: s.tsigSecret, MsgAcceptFunc: s.msgAcceptFunc(), DecorateWriter: dw}
 	s.m.Unlock()
 


### PR DESCRIPTION
### Summary

Optimizes request context allocation in `core/dnsserver/server.go` by pre-initializing `s.baseCtx` once on the `Server` struct in `NewServer`, instead of calling `context.WithValue` twice per incoming packet in the handler closures installed by `Serve` (TCP) and `ServePacket` (UDP).

Both closures currently run, per request:

```go
ctx := context.WithValue(context.Background(), Key{}, s)
ctx = context.WithValue(ctx, LoopKey{}, 0)
s.ServeDNS(ctx, w, r)
```

Each `context.WithValue` heap-allocates a `valueCtx`. Both values are constant for the life of the server, so building the context once at startup removes 2 allocations and ~96 B of churn per request.

### Benchmark

There is no in-tree benchmark that exercises the handler closure — `BenchmarkCoreServeDNS` calls `s.ServeDNS` with a `context.TODO()` it builds itself, so it never touches this code. The numbers below come from an ad-hoc benchmark that reproduces the closure body verbatim on each side (`context.WithValue` x2 + `ServeDNS` on `master`, `s.ServeDNS(s.baseCtx, ...)` here), against the same `testPlugin` chain and `test.ResponseWriter`. It is not part of the diff.

`-benchmem -count=10`, benchstat vs `master`, Go 1.27.0, Intel i7-1065G7.

| Metric | `master` | this PR | Change |
|---|---|---|---|
| time/op | 227.3 ns | **159.6 ns** | **-29.8%** (p=0.000, n=10) |
| B/op | 248 | **152** | **-38.7%** |
| allocs/op | 4 | **2** | **-50.0%** |

`core/dnsserver` passes.
