### PR TITLE
plugin/rewrite: drop the per-record dot-prefixed temporary in remapStringRewriter

### DIFF
--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -53,20 +53,21 @@ func (r *regexStringRewriter) rewriteString(src string) string {
 // it also maps a the domain of a sub domain.
 type remapStringRewriter struct {
 	orig        string
+	dotOrig     string
 	replacement string
 }
 
 var _ stringRewriter = &remapStringRewriter{}
 
 func newRemapStringRewriter(orig, replacement string) stringRewriter {
-	return &remapStringRewriter{orig, replacement}
+	return &remapStringRewriter{orig, "." + orig, replacement}
 }
 
 func (r *remapStringRewriter) rewriteString(src string) string {
 	if src == r.orig {
 		return r.replacement
 	}
-	if strings.HasSuffix(src, "."+r.orig) {
+	if strings.HasSuffix(src, r.dotOrig) {
 		return src[0:len(src)-len(r.orig)] + r.replacement
 	}
 	return src

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -66,8 +66,14 @@ func (r *remapStringRewriter) rewriteString(src string) string {
 	if src == r.orig {
 		return r.replacement
 	}
-	if strings.HasSuffix(src, "."+r.orig) {
-		return src[0:len(src)-len(r.orig)] + r.replacement
+	// src is a sub domain of orig when orig sits at the end of src with a label
+	// boundary right before it. Checking that boundary by index matches exactly
+	// what strings.HasSuffix(src, "."+r.orig) matches, without building the
+	// dot-prefixed string. Caching that string on the rewriter is not an option:
+	// responseRuleFor constructs a rewriter per rewritten request, so the cost
+	// would land on every request to save work on every record.
+	if i := len(src) - len(r.orig); i > 0 && src[i-1] == '.' && src[i:] == r.orig {
+		return src[:i] + r.replacement
 	}
 	return src
 }

--- a/plugin/rewrite/name_test.go
+++ b/plugin/rewrite/name_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -379,3 +380,135 @@ func TestNewNameRuleLargeRegex(t *testing.T) {
 		t.Errorf("Expected 'too long' error, got: %v", err)
 	}
 }
+
+func TestRemapStringRewriter(t *testing.T) {
+	r := newRemapStringRewriter("example.com.", "example.org.")
+
+	tests := []struct {
+		src      string
+		expected string
+	}{
+		{"example.com.", "example.org."},         // the name itself
+		{"sub.example.com.", "sub.example.org."}, // a sub domain
+		{"a.b.example.com.", "a.b.example.org."},
+		{"notexample.com.", "notexample.com."}, // same suffix, no label boundary
+		{".example.com.", ".example.org."},
+		{"example.net.", "example.net."},
+		{"com.", "com."}, // shorter than orig
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := r.rewriteString(tc.src); got != tc.expected {
+			t.Errorf("rewriteString(%q) = %q, expected %q", tc.src, got, tc.expected)
+		}
+	}
+}
+
+// k8sName is a Kubernetes service name of the length these routinely reach. It
+// matters because it is longer than 31 bytes: Go concatenates short strings into
+// a 32-byte stack buffer, so "."+orig stayed off the heap for a name like
+// example.com. but had to be allocated for one this long, once per call.
+const k8sName = "my-service.my-namespace.svc.cluster.local." // 42 bytes
+
+// BenchmarkRemapStringRewriter measures a single rewriteString call on a rewriter
+// that already exists. An auto rule builds a fresh rewriter per matching request
+// and then calls it once per record, so this is the per-record cost only — see
+// BenchmarkAutoNameRuleResponse for what one whole request costs.
+//
+// orig is the name the question was rewritten to, so its length is a property of
+// the Corefile, and it decides whether the old "."+orig temporary allocated.
+func BenchmarkRemapStringRewriter(b *testing.B) {
+	cases := []struct{ name, orig, src string }{
+		{"short/match", "example.com.", "sub.example.com."},
+		{"short/nomatch", "example.com.", "sub.example.net."},
+		{"long/match", k8sName, "pod-1234." + k8sName},
+		// Same length as orig, so this reaches the byte comparison rather than
+		// being rejected on length alone.
+		{"long/nomatch", k8sName, "my-service.my-namespace.svc.cluster.zzzzz."},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			r := newRemapStringRewriter(tc.orig, "example.org.")
+			b.ReportAllocs()
+			for b.Loop() {
+				remapSink = r.rewriteString(tc.src)
+			}
+		})
+	}
+}
+
+// BenchmarkAutoNameRuleResponse measures one whole request through an auto name
+// rule: rewrite the question, build the response rules for it — which is where the
+// rewriter is constructed — and apply them to the answer a backend would return.
+// This is the shape that decides whether an optimization in rewriteString is worth
+// what it costs newRemapStringRewriter, since neither survives the request.
+//
+// The sub cases are the paths a record owner can take through the rewriter. Only
+// the sub domain ones reach the label boundary check; an owner equal to the
+// rewritten question name returns the replacement without comparing anything, so
+// that case measures construction and nothing else. The k8s cases rewrite to a
+// name past the 32-byte concat buffer, where the old temporary had to allocate.
+func BenchmarkAutoNameRuleResponse(b *testing.B) {
+	subdomains := func(to string, n int) []string {
+		owners := make([]string, n)
+		for i := range owners {
+			owners[i] = string(rune('a'+i)) + "." + to
+		}
+		return owners
+	}
+
+	cases := []struct {
+		name  string
+		from  string
+		to    string
+		owner []string
+	}{
+		{"exact", "example.com.", "example.org.", []string{"example.org."}},
+		{"subdomain", "example.com.", "example.org.", []string{"sub.example.org."}},
+		{"nomatch", "example.com.", "example.org.", []string{"sub.example.net."}},
+		{"subdomain-8", "example.com.", "example.org.", subdomains("example.org.", 8)},
+		{"k8s/subdomain", "svc.example.com.", k8sName, []string{"pod-1234." + k8sName}},
+		{"k8s/subdomain-8", "svc.example.com.", k8sName, subdomains(k8sName, 8)},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			rule, err := newNameRule("stop", "exact", tc.from, tc.to, "answer", "auto")
+			if err != nil {
+				b.Fatal(err)
+			}
+			ctx := b.Context()
+			m := new(dns.Msg)
+			m.SetQuestion(tc.from, dns.TypeA)
+			answer := make([]dns.RR, len(tc.owner))
+			for i, owner := range tc.owner {
+				answer[i] = test.A(owner + " 3600 IN A 127.0.0.1")
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				// Both rules rewrite in place, so restore the request and the
+				// answer the backend would have returned for it.
+				m.Question[0].Name = tc.from
+				for i, rr := range answer {
+					rr.Header().Name = tc.owner[i]
+				}
+
+				rules, _ := rule.Rewrite(ctx, request.Request{Req: m})
+				for _, rr := range answer {
+					for _, rule := range rules {
+						rule.RewriteResponse(m, rr)
+					}
+				}
+				rulesSink = rules
+			}
+		})
+	}
+}
+
+// remapSink keeps the rewritten string live; assigning to _ lets the compiler
+// drop the concatenation and the benchmark then reports work it never did.
+var (
+	remapSink string
+	rulesSink ResponseRules
+)

--- a/plugin/rewrite/name_test.go
+++ b/plugin/rewrite/name_test.go
@@ -379,3 +379,14 @@ func TestNewNameRuleLargeRegex(t *testing.T) {
 		t.Errorf("Expected 'too long' error, got: %v", err)
 	}
 }
+
+func BenchmarkRemapStringRewriter(b *testing.B) {
+	r := newRemapStringRewriter("example.com.", "example.org.")
+	src := "sub.example.com."
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = r.rewriteString(src)
+	}
+}
+


### PR DESCRIPTION
### Summary

`remapStringRewriter` matches a record name against `orig` and its sub domains. The sub
domain check was `strings.HasSuffix(src, "."+r.orig)`, which built the dot-prefixed
string on every call and threw it away. This replaces it with an index comparison: `src`
is a sub domain of `orig` when `orig` sits at the end of `src` with a `.` immediately
before it, which is exactly what the `HasSuffix` call tested.

```go
if i := len(src) - len(r.orig); i > 0 && src[i-1] == '.' && src[i:] == r.orig {
	return src[:i] + r.replacement
}
```

**Where this matters.** Go concatenates short strings into a 32-byte stack buffer, so
`"."+orig` only reaches the heap once `orig` passes 31 bytes. Below that the temporary
was free and this change saves a few ns per record. Above it, master allocated 48 B per
record. Kubernetes service names are comfortably past the threshold —
`my-service.my-namespace.svc.cluster.local.` is 42 bytes — and those are the names an
auto rule rewrites to when a Corefile maps an external name onto an in-cluster one.

`orig` is the name the question was rewritten *to*, so whether a deployment sees the
allocation is a property of its Corefile, not of the query.

This applies to `exact`, `prefix`, `substring` and `regex` name rules with `answer auto`.
`suffix` rules build a `suffixStringRewriter` instead and are not affected.

### Why not cache the string on the rewriter

That was this PR's original approach and it was wrong. The rewriter is not long-lived:
`responseRuleFor` constructs a new one for every request an auto name rule rewrites, so
the concatenation ran once per request rather than once per rule, and escaped to the heap
from there:

```
$ go build -gcflags=-m ./plugin/rewrite/
plugin/rewrite/name.go:63:40: "." + orig escapes to heap
```

It bought per-record work with a per-request allocation, which regressed every response
short enough not to amortize it. The `cached` column below is that version.

### Benchmark

`go test -run '^$' -bench 'Remap|AutoNameRule' -benchmem -benchtime=200000x -count=8
./plugin/rewrite/`, benchstat over 8 runs, Intel i7-1065G7, linux/amd64.

Per record — one `rewriteString` call on an existing rewriter:

| Benchmark | `master` | cached `"."+orig` | this PR |
|---|---|---|---|
| `/short/match` | 186.6 ns · 16 B/1 | 128.9 ns · 16 B/1 | 120.4 ns (-35%) · 16 B/1 |
| `/short/nomatch` | 61.5 ns · 0 B/0 | 17.8 ns · 0 B/0 | 16.5 ns (-73%) · 0 B/0 |
| `/long/match` | 381.9 ns · 72 B/**2** | 164.0 ns · 24 B/1 | 165.3 ns (-57%) · 24 B/**1** |
| `/long/nomatch` | 219.1 ns · 48 B/**1** | 18.9 ns · 0 B/0 | 18.7 ns (-91%) · 0 B/**0** |

Per request — rewrite the question, build the response rules, apply them to the answer:

| Benchmark | `master` | cached `"."+orig` | this PR |
|---|---|---|---|
| `/exact` | 935 ns · 96 B/4 | 1267 ns (+36%) · 128 B/5 | 945 ns (~) · 96 B/4 |
| `/subdomain` | 1.248 µs · 112 B/5 | 1.478 µs (+18%) · 144 B/6 | 1.242 µs (~) · 112 B/5 |
| `/nomatch` | 1.016 µs · 96 B/4 | 1.320 µs (+30%) · 128 B/5 | 945 ns (-7%) · 96 B/4 |
| `/subdomain-8` | 3.376 µs · 224 B/12 | 3.183 µs (-6%) · 256 B/13 | 2.891 µs (**-14%**) · 224 B/12 |
| `/k8s/subdomain` | 1.611 µs · 176 B/6 | 1.666 µs (~) · 192 B/6 | 1.380 µs (**-14%**) · 128 B/**5** |
| `/k8s/subdomain-8` | 5.144 µs · 672 B/20 | 3.480 µs (-32%) · 352 B/13 | 3.305 µs (**-36%**) · 288 B/**12** |

Being straight about the scope: with short names this is flat at the request level —
`/exact`, `/subdomain` and `/nomatch` are within noise of master, because one
`rewriteString` call is small next to the four allocations that building the rules
costs. The saving is per record and per byte of name, so it appears where responses
carry several records and the rewritten-to name is long: 8 records of a Kubernetes name
is -36% time, -57% bytes and 8 fewer allocations per request.

The `cached` column never reaches master's allocation counts on the short cases and only
stops losing at 8 records.

### Tests

`TestRemapStringRewriter` pins the label boundary semantics the index arithmetic now
carries, notably that `notexample.com.` is not a sub domain of `example.com.`. It passes
against the previous implementation as well, so it documents existing behaviour rather
than the new code.
