### PR TITLE
plugin/file: handle empty non-terminal wildcard sources

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -54,10 +54,10 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 	}
 
 	var (
-		found, shot    bool
-		parts          string
-		i              int
-		elem, wildElem *tree.Elem
+		found, shot     bool
+		parts, wildName string
+		i               int
+		elem, wildElem  *tree.Elem
 	)
 
 	loop, _ := ctx.Value(dnsserver.LoopKey{}).(int)
@@ -99,6 +99,11 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			wildcard := replaceWithAsteriskLabel(parts)
 			if wild, found := tr.Search(wildcard); found {
 				wildElem = wild
+				wildName = wild.Name()
+			} else if hasDescendant(tr, wildcard) {
+				// A wildcard domain may exist as an empty non-terminal.
+				wildElem = nil
+				wildName = wildcard
 			}
 
 			// Keep on searching, because maybe we hit an empty-non-terminal (which aren't
@@ -188,8 +193,12 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 	// Haven't found the original name.
 
-	// Found wildcard.
-	if wildElem != nil && !closerENTExists(tr, qname, wildElem.Name()) {
+	// Found a wildcard source of synthesis. It may be an empty non-terminal.
+	if wildName != "" && !closerENTExists(tr, qname, wildName) {
+		if wildElem == nil {
+			return nil, ap.soa(do), nil, NoData
+		}
+
 		// set metadata value for the wildcard record that synthesized the result
 		metadata.SetValueFunc(ctx, "zone/wildcard", func() string {
 			return wildElem.Name()
@@ -236,10 +245,8 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 
 	// Hacky way to get around empty-non-terminals. If a longer name does exist, but this qname, does not, it
 	// must be an empty-non-terminal. If so, we do the proper NXDOMAIN handling, but set the rcode to be success.
-	if x, found := tr.Next(qname); found {
-		if dns.IsSubDomain(qname, x.Name()) {
-			rcode = Success
-		}
+	if hasDescendant(tr, qname) {
+		rcode = Success
 	}
 
 	ret := ap.soa(do)
@@ -292,13 +299,18 @@ func closerENTExists(tr *tree.Tree, qname, wildcardName string) bool {
 		if name == parent || !dns.IsSubDomain(parent, name) {
 			return false
 		}
-		// An ENT exists at `name` iff tr.Next(name) returns a descendant of name.
-		if x, found := tr.Next(name); found && dns.IsSubDomain(name, x.Name()) {
+		if hasDescendant(tr, name) {
 			return true
 		}
 		offset, end = dns.NextLabel(name, 0)
 	}
 	return false
+}
+
+// hasDescendant reports whether the tree contains a name strictly below name.
+func hasDescendant(tr *tree.Tree, name string) bool {
+	x, found := tr.Next(name)
+	return found && tree.Less(x, name) != 0 && dns.IsSubDomain(name, x.Name())
 }
 
 // typeFromElem returns the type tp from e and adds signatures (if they exist) and do is true.

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -408,5 +409,95 @@ func TestLookupWildcardRespectsCloserEmptyNonTerminal(t *testing.T) {
 		if err := test.SortAndCheck(resp, tc); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+const emptyNonTerminalWildcard = `; example.org test file with an empty non-terminal wildcard
+$TTL 3600
+example.org.             IN     SOA     ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600
+example.org.             IN     NS      ns.example.org.
+f.*.e.example.org.       IN     A       192.0.2.1
+t.e.example.org.         IN     A       192.0.2.2
+real.deep.e.example.org. IN     A       192.0.2.3
+*.ordinary.example.org.  IN     A       192.0.2.4
+`
+
+var emptyNonTerminalWildcardTestCases = []test.Case{
+	{
+		Qname: "something.e.example.org.", Qtype: dns.TypeA,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600`),
+		},
+	},
+	{
+		Qname: "something.e.example.org.", Qtype: dns.TypeAAAA,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600`),
+		},
+	},
+	{
+		Qname: "something.somewhere.e.example.org.", Qtype: dns.TypeA,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600`),
+		},
+	},
+	{
+		Qname:  "f.*.e.example.org.",
+		Qtype:  dns.TypeA,
+		Answer: []dns.RR{test.A(`f.*.e.example.org. 3600 IN A 192.0.2.1`)},
+		Ns:     []dns.RR{test.NS(`example.org. 3600 IN NS ns.example.org.`)},
+	},
+	{
+		// *.e.example.org. is the closest encloser, not a source of synthesis for its own descendants.
+		Qname: "missing.*.e.example.org.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600`),
+		},
+	},
+	{
+		// deep.e.example.org. is a closer empty non-terminal, so *.e.example.org. does not apply.
+		Qname: "missing.deep.e.example.org.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA(`example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 1209600 3600`),
+		},
+	},
+	{
+		Qname:  "something.ordinary.example.org.",
+		Qtype:  dns.TypeA,
+		Answer: []dns.RR{test.A(`something.ordinary.example.org. 3600 IN A 192.0.2.4`)},
+		Ns:     []dns.RR{test.NS(`example.org. 3600 IN NS ns.example.org.`)},
+	},
+}
+
+func TestLookupEmptyNonTerminalWildcard(t *testing.T) {
+	const name = "example.org."
+	zone, err := Parse(strings.NewReader(emptyNonTerminalWildcard), name, "stdin", 0)
+	if err != nil {
+		t.Fatalf("Expect no error when reading zone, got %q", err)
+	}
+
+	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
+	ctx := context.TODO()
+
+	for _, tc := range emptyNonTerminalWildcardTestCases {
+		m := tc.Msg()
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		if _, err := fm.ServeDNS(ctx, rec, m); err != nil {
+			t.Errorf("Expected no error for %q/%d, got %v", tc.Qname, tc.Qtype, err)
+			continue
+		}
+
+		if err := test.SortAndCheck(rec.Msg, tc); err != nil {
+			t.Errorf("Test %q/%d: %v", tc.Qname, tc.Qtype, err)
+		}
+	}
+
+	tc := emptyNonTerminalWildcardTestCases[0]
+	state := request.Request{W: &test.ResponseWriter{}, Req: tc.Msg()}
+	if _, _, _, result := zone.Lookup(ctx, state, tc.Qname); result != NoData {
+		t.Errorf("Expected NoData result for empty non-terminal wildcard, got %v", result)
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The `file` plugin only recognizes a wildcard source of synthesis when the wildcard name owns an RRset stored in the zone tree. [RFC 4592 Sections 3.3.1 and 4.9](https://www.rfc-editor.org/rfc/rfc4592.html#section-3.3.1) also permit the source of synthesis to be an empty non-terminal.

For example, `f.*.e.example.org.` makes `*.e.example.org.` exist as an empty non-terminal. A query for `something.e.example.org.` should therefore return `NOERROR` with an empty answer, but CoreDNS currently returns `NXDOMAIN`.

This change tracks a wildcard name independently from its optional tree element. A wildcard name whose existence is proven by a descendant is selected using the existing canonical tree ordering, and lookup returns `NoData` when that empty non-terminal is the applicable source of synthesis. Regression tests cover the original case, multi-label synthesis, exact names containing an asterisk label, closer empty non-terminals, and ordinary wildcard answers.

Verified with:

- `go test ./plugin/file -run 'Wildcard|EmptyNonTerminal|ClosestEncloser' -count=100`
- `go test -race ./plugin/...`
- `go vet ./plugin/file ./plugin/file/tree`
- `go test ./... -run '^$' -count=1`
- `golangci-lint v2.11.4 --new-from-rev=origin/master` (`0 issues`)

### 2. Which issues (if any) are related?

Fixes #4256.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.