### PR TITLE
plugin/file: map REFUSED from CNAME chasing to NXDOMAIN

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -466,7 +466,11 @@ func (z *Zone) doLookup(ctx context.Context, state request.Request, target strin
 	if m == nil {
 		return nil, Success
 	}
-	if m.Rcode == dns.RcodeNameError {
+	if m.Rcode == dns.RcodeNameError || m.Rcode == dns.RcodeRefused {
+		// A CNAME chasing lookup that lands outside any zone served by this
+		// process comes back REFUSED (see core/dnsserver's no-zone-matched
+		// handler), which otherwise fell through to Success below and turned
+		// a non-existent CNAME target into a bogus NOERROR response.
 		return m.Answer, NameError
 	}
 	if m.Rcode == dns.RcodeServerFailure {

--- a/test/file_upstream_test.go
+++ b/test/file_upstream_test.go
@@ -172,6 +172,55 @@ nodata   3600 IN CNAME nodata.example.net.
 	}
 }
 
+// TestFileUpstreamRefused verifies that chasing a CNAME to a target outside
+// any zone served by this process is reported as NXDOMAIN, not NOERROR. The
+// self-lookup used to chase the CNAME comes back REFUSED (core/dnsserver's
+// no-zone-matched handler), which previously fell through to a Success
+// result. See https://github.com/coredns/coredns/issues/6625.
+func TestFileUpstreamRefused(t *testing.T) {
+	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
+@	3600 IN	SOA   sns.dns.icann.org. noc.dns.icann.org. (
+        2017042745 ; serial
+        7200       ; refresh (2 hours)
+        3600       ; retry (1 hour)
+        1209600    ; expire (2 weeks)
+        3600       ; minimum (1 hour)
+)
+
+    3600 IN NS    a.iana-servers.net.
+    3600 IN NS    b.iana-servers.net.
+
+www 3600 IN CNAME www.unserved-zone.invalid.
+`)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Only example.org is served here; www.unserved-zone.invalid. matches no
+	// zone in this Corefile at all.
+	corefile := `example.org:0 {
+		file ` + name + `
+	}`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("www.example.org.", dns.TypeA)
+
+	r, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Could not exchange msg: %s", err)
+	}
+	if r.Rcode != dns.RcodeNameError {
+		t.Errorf("Expected rcode %v (NXDOMAIN), got %v", dns.RcodeNameError, r.Rcode)
+	}
+}
+
 // TestFileUpstreamAdditional runs two CoreDNS servers that serve example.org and foo.example.org.
 // example.org contains a cname to foo.example.org; this should be resolved via upstream.Self.
 func TestFileUpstreamAdditional(t *testing.T) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When the `file` plugin chases a CNAME chain and the target lands outside any
zone served by this CoreDNS process, the response code is `NOERROR` instead
of `NXDOMAIN`/`REFUSED`, even though the target doesn't exist anywhere this
server can resolve it.

Repro from the issue — zone `a.` with `b.a. CNAME c.`, and no other zone
configured for `c.`:

```
$ dig @127.0.0.1 -p 1053 b.a. A
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, ...
;; ANSWER SECTION:
b.a.  500  IN  CNAME  c.
```

BIND9 replies `NXDOMAIN` for the same setup.

**Root cause**: `externalLookup` chases the CNAME target via a self-lookup
(`z.Upstream.Lookup`, which re-enters the plugin chain through
`server.ServeDNS`). Since no zone in the Corefile matches `c.`,
`core/dnsserver`'s no-zone-matched handler returns `dns.RcodeRefused`
(`core/dnsserver/server.go:399`). `doLookup` (`plugin/file/lookup.go`) only
special-cases `RcodeNameError`, `RcodeServerFailure`, and
`RcodeSuccess`-with-empty-answer — `RcodeRefused` falls through to the final
`return m.Answer, Success`, so a CNAME to a non-existent target gets reported
as a successful, empty-of-further-records `NOERROR`.

This is the same class of bug as #4288 / #4303: `file.Result` doesn't map
1:1 to DNS response codes, and the mapping in `doLookup` still isn't
exhaustive. `RcodeRefused` was the specific case missing, as the issue's own
analysis identified.

**The fix**: map `dns.RcodeRefused` to `NameError` alongside
`dns.RcodeNameError`, so it renders as `NXDOMAIN` to the client — matching
BIND9's behavior and one of the two RCODEs the issue calls out as correct
("NXDOMAIN... or REFUSED... At least it should not be NOERROR"). `NameError`
was chosen over introducing a new `Result` value because it's the smallest
change that fixes the observable bug and follows the exact pattern #4303
already established for `RcodeNameError`/`RcodeServerFailure`.

Verified against the exact zone file and Corefile from the issue (built the
binary and queried it directly): `b.a. A` now returns `NXDOMAIN` with the
`CNAME` in the answer, instead of `NOERROR`.

### 2. Which issues (if any) are related?

Fixes #6625

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. This only changes the RCODE for a case that previously returned an
incorrect `NOERROR` for a CNAME target that doesn't exist anywhere reachable
by this server — any client actually depending on the old (incorrect)
`NOERROR` behavior was, per RFC 6604 §3, already receiving a non-compliant
response.
