### PR TITLE
plugin/hosts: only open hosts file when it changed

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -121,15 +121,11 @@ type Hostsfile struct {
 
 // readHosts determines if the cached data needs to be updated based on the size and modification time of the hostsfile.
 func (h *Hostsfile) readHosts() {
-	file, err := os.Open(h.path)
+	// Only stat the file to check for changes; the file is opened for parsing
+	// only when it actually changed.
+	pstat, err := os.Stat(h.path)
 	if err != nil {
 		// We already log a warning if the file doesn't exist or can't be opened on setup. No need to return the error here.
-		return
-	}
-	defer file.Close()
-
-	stat, err := file.Stat()
-	if err != nil {
 		return
 	}
 	h.RLock()
@@ -137,7 +133,20 @@ func (h *Hostsfile) readHosts() {
 	mtime := h.mtime
 	h.RUnlock()
 
-	if mtime.Equal(stat.ModTime()) && size == stat.Size() {
+	if mtime.Equal(pstat.ModTime()) && size == pstat.Size() {
+		return
+	}
+
+	file, err := os.Open(h.path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	// Stat the opened file so the recorded mtime/size always match the content
+	// that was parsed, even if the file is replaced between the stat and open.
+	stat, err := file.Stat()
+	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`readHosts()` currently opens and closes the hosts file on every reload tick just to read its metadata (open / fstat / close per tick). This PR stats the path first and only opens the file when mtime/size actually changed — restoring the fast path the plugin originally had (#695) before it was incidentally dropped in the #1180 refactor.

With the default 5s reload interval the savings are small, but for deployments using short reload intervals (we are looking into using 250ms in Home Assistant's supervisor DNS, where a freshly started container's hosts entry must become resolvable quickly) this reduces the steady-state cost per tick from three syscalls plus fd churn to a single stat.

To stay safe against the file being replaced between the initial stat and the open, the change path still stats the opened fd and records *its* mtime/size, so the cached metadata always matches the content that was parsed. Worst case a concurrent replace causes one extra re-parse on the next tick — same eventual-consistency behavior as today.

### 2. Which issues (if any) are related?

None filed; discussed in home-assistant/plugin-dns#201.

### 3. Which documentation changes (if any) need to be made?

None — no behavior change, error handling is unchanged (missing file is still silently ignored here; setup already warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)