### PR TITLE
Support IPv6 service endpoints in trace plugin

### DIFF
--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +39,7 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 
 	cfg := dnsserver.GetConfig(c)
 	if len(cfg.ListenHosts) > 0 && cfg.ListenHosts[0] != "" {
-		tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
+		tr.serviceEndpoint = net.JoinHostPort(cfg.ListenHosts[0], cfg.Port)
 	}
 
 	for c.Next() { // trace

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
 )
 
 func TestTraceParse(t *testing.T) {
@@ -85,5 +86,58 @@ func TestTraceParse(t *testing.T) {
 		if test.zipkinMaxBatchInterval != m.zipkinMaxBatchInterval {
 			t.Errorf("Test %v: Expected zipkin_max_batch_interval %v but found: %v", i, test.zipkinMaxBatchInterval, m.zipkinMaxBatchInterval)
 		}
+	}
+}
+
+func TestParseServiceEndpoint(t *testing.T) {
+	tests := []struct {
+		name                    string
+		listenHosts             []string
+		port                    string
+		expectedServiceEndpoint string
+	}{
+		{
+			name:                    "IPv4 address",
+			listenHosts:             []string{"127.0.0.1"},
+			port:                    "8053",
+			expectedServiceEndpoint: "127.0.0.1:8053",
+		},
+		{
+			name:                    "IPv6 address",
+			listenHosts:             []string{"3d47:98c0:b113::3"},
+			port:                    "8853",
+			expectedServiceEndpoint: "[3d47:98c0:b113::3]:8853",
+		},
+		{
+			name:                    "Hostname",
+			listenHosts:             []string{"localhost"},
+			port:                    "8053",
+			expectedServiceEndpoint: "localhost:8053",
+		},
+		{
+			name:                    "Multiple addresses",
+			listenHosts:             []string{"3d47:98c0:b113::3", "127.0.0.1"},
+			port:                    "8853",
+			expectedServiceEndpoint: "[3d47:98c0:b113::3]:8853",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := caddy.NewTestController("dns", "trace")
+			cfg := dnsserver.GetConfig(c)
+			cfg.ListenHosts = tc.listenHosts
+			cfg.Port = tc.port
+
+			tr, err := traceParse(c)
+			if err != nil {
+				t.Errorf("Error parsing test input: %s", err)
+				return
+			}
+
+			if tr.serviceEndpoint != tc.expectedServiceEndpoint {
+				t.Errorf("Expected serviceEndpoint %s, got %s", tc.expectedServiceEndpoint, tr.serviceEndpoint)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Use net.JoinHostPort rather than string concatenation to support both ipv4, ipv6, and hostname service endpoints for the trace plugin. Previously, ipv6 bind addresses in the coredns configuration would fail to be parsed, as the ipv6 address was not surrounded in brackets.

Closes #8409

Thanks for taking a look!

### 1. Why is this pull request needed and what does it do?
The trace plugin does not currently support service endpoints which use ipv6 addresses due to direct string concatenation. This uses the go standard library function JoinHostPort to correctly bracket the ipv6 address

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/8409

### 3. Which documentation changes (if any) need to be made?
N/A

### 4. Does this introduce a backward incompatible change or deprecation?
Not that I can think of