### PR TITLE
pkg/nonwriter: fix inversion of TsigTimersOnly and WriteMsg order

### DIFF
--- a/plugin/pkg/nonwriter/nonwriter.go
+++ b/plugin/pkg/nonwriter/nonwriter.go
@@ -19,3 +19,9 @@ func (w *Writer) WriteMsg(res *dns.Msg) error {
 	w.Msg = res
 	return nil
 }
+
+func (w *Writer) TsigTimersOnly(b bool) {
+	if w.Msg == nil {
+		w.ResponseWriter.TsigTimersOnly(b)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

TsigTimersOnly must be set prior to writing as it affects generation of TSIG RR. Downstream users unaware of nonwriter may inadvertently modify wrong write.

### 2. Which issues (if any) are related?

#8391

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
