### PR TITLE
plugin/minimal: do not intercept zone transfers

### DIFF
--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -68,6 +68,12 @@ type AutoPath struct {
 func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 
+	// A zone transfer is answered with a stream of messages, which a nonwriter can not
+	// capture, and walking a search path makes no sense for one either.
+	if qtype := state.QType(); qtype == dns.TypeAXFR || qtype == dns.TypeIXFR {
+		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)
+	}
+
 	zone := plugin.Zones(a.Zones).Matches(state.Name())
 	if zone == "" {
 		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -164,3 +164,48 @@ func TestInSearchPath(t *testing.T) {
 		}
 	}
 }
+
+// streamHandler implements plugin.Handler and answers with a stream of messages, the way
+// plugin/transfer answers a zone transfer.
+type streamHandler struct {
+	Envelopes int
+}
+
+func (*streamHandler) Name() string { return "stream-handler" }
+
+func (s *streamHandler) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	for range s.Envelopes {
+		d := new(dns.Msg)
+		d.SetReply(r)
+		d.Answer = []dns.RR{test.SOA("example.org. 100 IN SOA ns.example.org. hostmaster.example.org. 1 7200 1800 86400 100")}
+		if err := w.WriteMsg(d); err != nil {
+			return dns.RcodeServerFailure, err
+		}
+	}
+	return 0, nil
+}
+
+func TestAutoPathZoneTransfer(t *testing.T) {
+	const envelopes = 3
+
+	for _, qtype := range []uint16{dns.TypeAXFR, dns.TypeIXFR} {
+		t.Run(dns.TypeToString[qtype], func(t *testing.T) {
+			ap := newTestAutoPath()
+			ap.Next = &streamHandler{Envelopes: envelopes}
+
+			req := new(dns.Msg)
+			// A name that is the first element of the configured search path, so autopath
+			// would otherwise intercept it.
+			req.SetQuestion("example.org.", qtype)
+
+			rec := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
+			if _, err := ap.ServeDNS(context.TODO(), rec, req); err != nil {
+				t.Fatalf("Expected no error, but got %s", err)
+			}
+
+			if len(rec.Msgs) != envelopes {
+				t.Fatalf("Expected %d messages, but got %d", envelopes, len(rec.Msgs))
+			}
+		})
+	}
+}

--- a/plugin/minimal/README.md
+++ b/plugin/minimal/README.md
@@ -13,6 +13,8 @@ Specifically this plugin looks at successful responses (this excludes negative r
 nodata or name error). If the successful response isn't a delegation only the RRs in the answer
 section are written to the client.
 
+Zone transfers (AXFR and IXFR) are passed through untouched.
+
 ## Syntax
 
 ~~~ txt

--- a/plugin/minimal/minimal.go
+++ b/plugin/minimal/minimal.go
@@ -34,6 +34,9 @@ func (m *minimalHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *
 	if err != nil {
 		return rcode, err
 	}
+	if nw.Msg == nil { // no response was written (or raw bytes were)
+		return rcode, err
+	}
 
 	ty, _ := response.Typify(nw.Msg, time.Now().UTC())
 	cl := response.Classify(ty)

--- a/plugin/minimal/minimal.go
+++ b/plugin/minimal/minimal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/plugin/pkg/response"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -20,6 +21,13 @@ type minimalHandler struct {
 func (m *minimalHandler) Name() string { return "minimal" }
 
 func (m *minimalHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	// A zone transfer is answered with a stream of messages, which a nonwriter can not
+	// capture, so hand the real writer to the next plugin.
+	state := request.Request{W: w, Req: r}
+	if qtype := state.QType(); qtype == dns.TypeAXFR || qtype == dns.TypeIXFR {
+		return plugin.NextOrFailure(m.Name(), m.Next, ctx, w, r)
+	}
+
 	nw := nonwriter.New(w)
 
 	rcode, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, nw, r)

--- a/plugin/minimal/minimal_test.go
+++ b/plugin/minimal/minimal_test.go
@@ -151,3 +151,51 @@ func TestMinimizeResponse(t *testing.T) {
 		}
 	}
 }
+
+// streamHandler implements plugin.Handler and answers with a stream of messages, the way
+// plugin/transfer answers a zone transfer.
+type streamHandler struct {
+	Envelopes int
+}
+
+func (*streamHandler) Name() string { return "stream-handler" }
+
+func (s *streamHandler) ServeDNS(_ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	for i := range s.Envelopes {
+		d := new(dns.Msg)
+		d.SetReply(r)
+		d.Answer = []dns.RR{test.SOA("example.org. 100 IN SOA ns.example.org. hostmaster.example.org. 1 7200 1800 86400 100")}
+		if i > 0 {
+			d.Answer = []dns.RR{test.A("example.org. 100 IN A 127.0.0.1")}
+		}
+		if err := w.WriteMsg(d); err != nil {
+			return dns.RcodeServerFailure, err
+		}
+	}
+	return 0, nil
+}
+
+func TestMinimalZoneTransfer(t *testing.T) {
+	const envelopes = 4
+
+	for _, qtype := range []uint16{dns.TypeAXFR, dns.TypeIXFR} {
+		t.Run(dns.TypeToString[qtype], func(t *testing.T) {
+			m := &minimalHandler{Next: &streamHandler{Envelopes: envelopes}}
+
+			req := new(dns.Msg)
+			req.SetQuestion("example.org.", qtype)
+
+			rec := dnstest.NewMultiRecorder(&test.ResponseWriter{TCP: true})
+			if _, err := m.ServeDNS(context.TODO(), rec, req); err != nil {
+				t.Fatalf("Expected no error, but got %s", err)
+			}
+
+			if len(rec.Msgs) != envelopes {
+				t.Fatalf("Expected %d messages, but got %d", envelopes, len(rec.Msgs))
+			}
+			if rec.Msgs[0].Answer[0].Header().Rrtype != dns.TypeSOA {
+				t.Errorf("Expected the first message to start with the SOA, but got %d", rec.Msgs[0].Answer[0].Header().Rrtype)
+			}
+		})
+	}
+}

--- a/plugin/minimal/minimal_test.go
+++ b/plugin/minimal/minimal_test.go
@@ -199,3 +199,32 @@ func TestMinimalZoneTransfer(t *testing.T) {
 		})
 	}
 }
+
+// silentHandler implements plugin.Handler and returns without writing a response, the way
+// acl does when it drops a request.
+type silentHandler struct{}
+
+func (*silentHandler) Name() string { return "silent-handler" }
+
+func (*silentHandler) ServeDNS(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
+	return dns.RcodeSuccess, nil
+}
+
+func TestMinimalNoResponseWritten(t *testing.T) {
+	m := &minimalHandler{Next: &silentHandler{}}
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewMultiRecorder(&test.ResponseWriter{})
+	rcode, err := m.ServeDNS(context.TODO(), rec, req)
+	if err != nil {
+		t.Fatalf("Expected no error, but got %s", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Errorf("Expected rcode %d, but got %d", dns.RcodeSuccess, rcode)
+	}
+	if len(rec.Msgs) != 0 {
+		t.Errorf("Expected no message to be written, but got %d", len(rec.Msgs))
+	}
+}

--- a/plugin/pkg/nonwriter/nonwriter.go
+++ b/plugin/pkg/nonwriter/nonwriter.go
@@ -6,9 +6,15 @@ import (
 )
 
 // Writer is a type of ResponseWriter that captures the message, but never writes to the client.
+//
+// A Writer stands in for a single response. A handler that answers with a stream of messages, as
+// plugin/transfer does for AXFR and IXFR, must not be given one: Msg holds only the last message
+// written. When more than one message is written Msgs holds all of them in order, so a caller
+// that may see a stream can detect and forward it. It stays nil for a single write.
 type Writer struct {
 	dns.ResponseWriter
-	Msg *dns.Msg
+	Msg  *dns.Msg
+	Msgs []*dns.Msg
 }
 
 // New makes and returns a new NonWriter.
@@ -16,6 +22,12 @@ func New(w dns.ResponseWriter) *Writer { return &Writer{ResponseWriter: w} }
 
 // WriteMsg records the message, but doesn't write it itself.
 func (w *Writer) WriteMsg(res *dns.Msg) error {
+	if w.Msg != nil {
+		if w.Msgs == nil {
+			w.Msgs = append(w.Msgs, w.Msg)
+		}
+		w.Msgs = append(w.Msgs, res)
+	}
 	w.Msg = res
 	return nil
 }

--- a/plugin/pkg/nonwriter/nonwriter_test.go
+++ b/plugin/pkg/nonwriter/nonwriter_test.go
@@ -1,6 +1,7 @@
 package nonwriter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -15,5 +16,40 @@ func TestNonWriter(t *testing.T) {
 	}
 	if x := nw.Msg.Question[0].Name; x != "example.org." {
 		t.Errorf("Expacted 'example.org.' got %q:", x)
+	}
+}
+
+func TestNonWriterMultipleWrites(t *testing.T) {
+	nw := New(nil)
+	for i := range 3 {
+		m := new(dns.Msg)
+		m.SetQuestion(fmt.Sprintf("%d.example.org.", i), dns.TypeA)
+		if err := nw.WriteMsg(m); err != nil {
+			t.Fatalf("Got error when writing to nonwriter: %s", err)
+		}
+	}
+
+	if len(nw.Msgs) != 3 {
+		t.Fatalf("Expected 3 messages, but got %d", len(nw.Msgs))
+	}
+	for i, m := range nw.Msgs {
+		if x := m.Question[0].Name; x != fmt.Sprintf("%d.example.org.", i) {
+			t.Errorf("Expected message %d to be %q, but got %q", i, fmt.Sprintf("%d.example.org.", i), x)
+		}
+	}
+	if x := nw.Msg.Question[0].Name; x != "2.example.org." {
+		t.Errorf("Expected Msg to hold the last message, but got %q", x)
+	}
+}
+
+func TestNonWriterSingleWrite(t *testing.T) {
+	nw := New(nil)
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	if err := nw.WriteMsg(m); err != nil {
+		t.Fatalf("Got error when writing to nonwriter: %s", err)
+	}
+	if nw.Msgs != nil {
+		t.Errorf("Expected Msgs to stay nil for a single write, but got %d messages", len(nw.Msgs))
 	}
 }

--- a/test/file_xfr_test.go
+++ b/test/file_xfr_test.go
@@ -100,3 +100,75 @@ func TestLargeAXFR(t *testing.T) {
 		t.Fatalf("Expected a AAAA answer, but it wasn't: type %d", resp.Answer[len(resp.Answer)-1].Header().Rrtype)
 	}
 }
+
+// TestLargeAXFRWithInterceptingPlugin checks that a plugin which captures and rewrites responses
+// does not swallow the stream of messages a zone transfer is answered with. Add a plugin to the
+// table when it starts wrapping the response writer.
+func TestLargeAXFRWithInterceptingPlugin(t *testing.T) {
+	var sb strings.Builder
+	const numAAAAs = 6553
+	sb.WriteString("example.com. IN SOA . . 1 60 60 60 60\n")
+	sb.WriteString("example.com. IN NS ns.example.\n")
+	for i := range numAAAAs {
+		fmt.Fprintf(&sb, "%d.example.com. IN AAAA 2001:db8::1\n", i)
+	}
+
+	name, rm, err := test.TempFile(".", sb.String())
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	resolv, rmResolv, err := test.TempFile(".", "search example.com\nnameserver 127.0.0.1\n")
+	if err != nil {
+		t.Fatalf("Failed to create resolv.conf: %s", err)
+	}
+	defer rmResolv()
+
+	plugins := []struct {
+		name      string
+		directive string
+	}{
+		{"minimal", "minimal"},
+		{"autopath", "autopath " + resolv},
+	}
+
+	for _, p := range plugins {
+		t.Run(p.name, func(t *testing.T) {
+			directive := p.directive
+			corefile := `example.com:0 {
+				` + directive + `
+				file ` + name + `
+				transfer {
+					to *
+				}
+			}`
+
+			i, _, tcp, err := CoreDNSServerAndPorts(corefile)
+			if err != nil {
+				t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+			}
+			defer i.Stop()
+
+			tr := new(dns.Transfer)
+			m := new(dns.Msg)
+			m.SetAxfr("example.com.")
+			c, err := tr.In(m, tcp)
+			if err != nil {
+				t.Fatalf("Expected to start AXFR, but didn't: %s", err)
+			}
+
+			nrr := 0
+			for e := range c {
+				if e.Error != nil {
+					t.Fatalf("Expected a clean transfer, but got: %s", e.Error)
+				}
+				nrr += len(e.RR)
+			}
+			// 2 SOA, 1 NS and all the AAAAs.
+			if nrr != numAAAAs+3 {
+				t.Errorf("Got an unexpected number of RRs: %d, expected %d", nrr, numAAAAs+3)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

*transfer* answers AXFR and IXFR as a stream of messages, one `WriteMsg` per envelope. *minimal* handed the next plugin a `nonwriter`, whose `WriteMsg` overwrites a single field, so every envelope but the last was dropped. The surviving message is the tail envelope, which has no leading SOA, so a conformant client rejects the transfer (RFC 5936 section 2.2).

The same wrapping breaks TSIG. `nonwriter` embeds `dns.ResponseWriter`, so the `TsigTimersOnly(true)` that `Transfer.Out` issues after each envelope reaches the real writer, landing before *minimal* performs its own deferred write. The response is then signed in the abbreviated timers-only form that RFC 8945 section 4.4 allows only after the first message, and no compliant client can verify it.

With the Corefile from the issue over a 10000 record zone:

```
before: 1468 of 10000 A records
        ;; Couldn't verify signature: tsig verify failure
        ; Transfer failed.  Didn't start with SOA answer.

after:  ;; XFR size: 10004 records (messages 6, bytes 369938), signature verifies
```

*minimal* already meant to leave transfers alone. `Typify` reports `Meta` for AXFR and IXFR, `Classify` maps that to `Error`, and the `Error` branch writes the message through unmodified. That decision was just made after the wrap had already destroyed the stream, so this moves it ahead of delegation, the way *loadbalance* does in its response writer.

Four commits, each standing alone:

* *minimal* does not intercept zone transfers. This is the fix.
* *minimal* no longer calls `WriteMsg(nil)` when a plugin below returns without writing, which panicked in `ScrubWriter`. *dns64* already has this check.
* *autopath* gets the same guard. It scopes itself by zone and search path, never by type, so a transfer for the first search path element is intercepted and replayed.
* `nonwriter` keeps every message in `Msgs` instead of dropping all but the last, so this cannot fail silently again. `Msg` is unchanged.

Plus an integration test putting an intercepting plugin above *transfer* and asking for a full AXFR, which nothing covered before.

### 2. Which issues (if any) are related?

Fixes #8391.

Independent of #8412 and does not conflict with it, different method on `nonwriter`, merges in either order. #8412 suppresses the TSIG symptom for transfers that fit in a single message; multi message transfers stay broken under it because `nonwriter` still keeps only the last envelope. This covers the multiple write case noted there.

### 3. Which documentation changes (if any) need to be made?

One sentence in `plugin/minimal/README.md` recording that zone transfers are passed through untouched.

### 4. Does this introduce a backward incompatible change or deprecation?

No. `nonwriter.Writer.Msg` keeps its meaning, the last message written. *minimal* already passed transfer responses through unmodified, it just did so after the stream was gone.
