### PR TITLE
plugin/kubernetes: precompute msg.Path for configured zones

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -54,6 +54,7 @@ type Kubernetes struct {
 	apiQPS           float32       // Maximum queries per second from the client to the API server
 	apiBurst         int           // Maximum burst for throttle
 	apiMaxInflight   int           // Maximum number of concurrent requests in flight to the API server
+	zonePaths        map[string]string
 }
 
 // Upstreamer is used to resolve CNAME or other external targets
@@ -69,8 +70,32 @@ func New(zones []string) *Kubernetes {
 	k.Namespaces = make(map[string]struct{})
 	k.podMode = podModeDisabled
 	k.ttl = defaultTTL
+	k.initZonePaths()
 
 	return k
+}
+
+// initZonePaths precomputes msg.Path for every configured zone. It must be called
+// after Zones has been set, and before the plugin starts answering queries: the
+// map is read-only from then on.
+func (k *Kubernetes) initZonePaths() {
+	paths := make(map[string]string, len(k.Zones))
+	for _, z := range k.Zones {
+		paths[z] = msg.Path(z, coredns)
+	}
+	k.zonePaths = paths
+}
+
+// zonePath returns msg.Path(zone, coredns) for a zone served by this plugin.
+// Queries for a configured zone are answered from the precomputed table. A zone
+// that is not in the table - a query that arrived with different casing, which
+// handler.go deliberately preserves - is computed as before, so the case of the
+// original query is retained in the resulting key.
+func (k *Kubernetes) zonePath(zone string) string {
+	if p, ok := k.zonePaths[zone]; ok {
+		return p
+	}
+	return msg.Path(zone, coredns)
 }
 
 const (
@@ -418,7 +443,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 		return nil, errNoItems
 	}
 
-	zonePath := msg.Path(zone, coredns)
+	zonePath := k.zonePath(zone)
 
 	var ip string
 	if strings.Count(podname, "-") == 3 && !strings.Contains(podname, "--") {
@@ -483,7 +508,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 	serviceList = k.APIConn.SvcIndex(idx)
 	endpointsListFunc = func() []*object.Endpoints { return k.APIConn.EpIndex(idx) }
 
-	zonePath := msg.Path(zone, coredns)
+	zonePath := k.zonePath(zone)
 	for _, svc := range serviceList {
 		if !match(r.namespace, svc.Namespace) || !match(r.service, svc.Name) {
 			continue
@@ -630,7 +655,7 @@ func (k *Kubernetes) findMultiClusterServices(r recordRequest, zone string) (ser
 	serviceList = k.APIConn.SvcImportIndex(idx)
 	endpointsListFunc = func() []*object.MultiClusterEndpoints { return k.APIConn.McEpIndex(idx) }
 
-	zonePath := msg.Path(zone, coredns)
+	zonePath := k.zonePath(zone)
 	for _, svc := range serviceList {
 		if !match(r.namespace, svc.Namespace) || !match(r.service, svc.Name) {
 			continue

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/request"
 
@@ -521,5 +522,31 @@ func BenchmarkServicesHeadless(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		_, _ = k.Services(ctx, state, false, plugin.Options{})
+	}
+}
+
+func TestZonePath(t *testing.T) {
+	k := New([]string{"cluster.local.", "0.10.in-addr.arpa."})
+
+	// Configured zones are served from the precomputed table, and must be
+	// identical to what msg.Path would have returned.
+	for _, z := range k.Zones {
+		if got, want := k.zonePath(z), msg.Path(z, coredns); got != want {
+			t.Errorf("zonePath(%q) = %q, want %q", z, got, want)
+		}
+	}
+
+	// Zones that are not in the table fall back to msg.Path. A query that
+	// arrives with different casing must keep that casing, see handler.go.
+	for _, z := range []string{"CLUSTER.LOCAL.", "Cluster.Local.", "example.org."} {
+		if got, want := k.zonePath(z), msg.Path(z, coredns); got != want {
+			t.Errorf("zonePath(%q) = %q, want %q", z, got, want)
+		}
+	}
+
+	// A Kubernetes value built without New must still work.
+	bare := &Kubernetes{}
+	if got, want := bare.zonePath("cluster.local."), msg.Path("cluster.local.", coredns); got != want {
+		t.Errorf("zonePath on zero value = %q, want %q", got, want)
 	}
 }

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -97,6 +97,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 	k8s.opts = opts
 
 	k8s.Zones = plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
+	k8s.initZonePaths()
 
 	k8s.primaryZoneIndex = -1
 	for i, z := range k8s.Zones {


### PR DESCRIPTION
## What this does

`msg.Path()` turns a zone name into an etcd-style key path, which costs a `dns.SplitDomainName` + label reversal + `path.Join` on every call. `findServices`, `findPods` and `findMultiClusterServices` each call it **once per query**, always with a zone the plugin is already configured for — so the same handful of results get recomputed for the lifetime of the process.

This precomputes the paths for the configured zones once at setup and looks them up by zone name.

## Why it is safe

`handler.go` deliberately preserves the casing of the original query when it sets `state.Zone`:

```go
zone = qname[len(qname)-len(zone):] // maintain case of original query
```

so a zone that is *not* byte-identical to a configured one falls back to `msg.Path` and keeps producing exactly the same case-preserved key as today. The lookup is an exact string match, never a case-folded one, so there is no behaviour change for any input. The map is built at setup and is read-only while serving.

## Numbers

Isolated, `msg.Path("cluster.local.", "coredns")` costs **393 ns / 187 B / 8 allocs**. The table lookup costs ~12 ns and does not allocate.

End to end on the existing plugin benchmarks. `go test -run '^$' -bench BenchmarkServices -benchmem -count=10 ./plugin/kubernetes/`, benchstat vs `master`, Go 1.27.0, Intel i7-1065G7:

| benchmark | metric | `master` | this PR | delta |
|---|---|---|---|---|
| `BenchmarkServices` | time/op | 1.889 µs | 1.462 µs | **-22.6%** |
| | B/op | 1768 | 1496 | **-15.4%** |
| | allocs/op | 29 | 20 | **-31.0%** |
| `BenchmarkServicesHeadless` | time/op | 2.768 µs | 2.366 µs | **-14.5%** |
| | B/op | 2656 | 2384 | **-10.2%** |
| | allocs/op | 44 | 35 | **-20.5%** |

All deltas p=0.000, n=10. The allocation counts are exact and reproduce every run.

Cross-checked against a larger fixture (100 endpoints over 4 EndpointSlices, 3 ports each — the one added in #8374): there the saving is 9 allocations and ~0.3-8.7% of bytes per query, and the time delta is not significant. That is the expected shape. `zonePath` is paid once per query, not once per record, so its share shrinks as the answer grows; the benchmarks above, which return a handful of records, are the ones where a per-query cost is visible.

Since these benchmarks use the in-tree fake API connector — which itself allocates on every `SvcIndex`/`EpIndex` call — the relative improvement against a real informer cache should be larger, not smaller.

## Notes

- `external.go` also calls `msg.Path`, but with zones that come from the `k8s_external` plugin's own configuration rather than from `Kubernetes.Zones`. It is left untouched here to keep the change focused; it would fall back correctly but gain nothing.
- Added `TestZonePath`, covering the cached path, the case-fallback path, and a zero-value `Kubernetes`.
- `plugin/kubernetes` and `plugin/kubernetes/object` pass.
