### PR TITLE
plugin/rewrite: apply rcode rewrites to responses with no records

### DIFF
--- a/plugin/rewrite/edns0_test.go
+++ b/plugin/rewrite/edns0_test.go
@@ -26,8 +26,17 @@ func serveEdns0Rewrite(t *testing.T, rule Rule, next plugin.Handler, req *dns.Ms
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 	// The server wraps the client writer in a ScrubWriter; reproduce that here.
 	sw := request.NewScrubWriter(req, rec)
-	if _, err := rw.ServeDNS(context.Background(), sw, req); err != nil {
+	rcode, err := rw.ServeDNS(context.Background(), sw, req)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !plugin.ClientWrite(rcode) {
+		state := request.Request{W: sw, Req: req}
+		resp := new(dns.Msg).SetRcode(req, rcode)
+		state.SizeAndDo(resp)
+		if err := sw.WriteMsg(resp); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return rec.Msg
 }

--- a/plugin/rewrite/rcode.go
+++ b/plugin/rewrite/rcode.go
@@ -24,6 +24,10 @@ func (r *rcodeResponseRule) RewriteResponse(res *dns.Msg, _rr dns.RR) {
 	}
 }
 
+// rewriteMsg marks rcodeResponseRule as a message-level rule so it is applied
+// even when the response carries no resource records.
+func (r *rcodeResponseRule) rewriteMsg() {}
+
 type rcodeRuleBase struct {
 	nextAction string
 	response   rcodeResponseRule

--- a/plugin/rewrite/rcode_test.go
+++ b/plugin/rewrite/rcode_test.go
@@ -81,24 +81,35 @@ func TestRCodeRewrite(t *testing.T) {
 // reply has no answer, authority or additional records, so the rewrite must be
 // applied at the message level rather than only per record.
 func TestRCodeRewriteEmptyResponse(t *testing.T) {
-	rule, err := newRCodeRule("stop", "exact", "srv1.coredns.rocks", "SERVFAIL", "NOERROR")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Downstream plugin fails without writing a response of its own.
-	next := plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
-		return dns.RcodeServerFailure, nil
-	})
-	req := new(dns.Msg)
-	req.SetQuestion("srv1.coredns.rocks.", dns.TypeA) // no EDNS OPT record
+	for _, mode := range []string{"stop", "continue"} {
+		for _, oldRcode := range []int{
+			dns.RcodeFormatError,
+			dns.RcodeServerFailure,
+			dns.RcodeRefused,
+			dns.RcodeNotImplemented,
+		} {
+			t.Run(mode+"/"+dns.RcodeToString[oldRcode], func(t *testing.T) {
+				rule, err := newRCodeRule(mode, "exact", "srv1.coredns.rocks", dns.RcodeToString[oldRcode], "NOERROR")
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Downstream plugin fails without writing a response of its own.
+				next := plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
+					return oldRcode, nil
+				})
+				req := new(dns.Msg)
+				req.SetQuestion("srv1.coredns.rocks.", dns.TypeA) // no EDNS OPT record
 
-	resp := serveEdns0Rewrite(t, rule, next, req)
-	if resp == nil {
-		t.Fatal("no response was written to the client")
-	}
-	if resp.Rcode != dns.RcodeSuccess {
-		t.Fatalf("expected RCODE rewritten to NOERROR (%d), got %s (%d)",
-			dns.RcodeSuccess, dns.RcodeToString[resp.Rcode], resp.Rcode)
+				resp := serveEdns0Rewrite(t, rule, next, req)
+				if resp == nil {
+					t.Fatal("no response was written to the client")
+				}
+				if resp.Rcode != dns.RcodeSuccess {
+					t.Fatalf("expected RCODE rewritten to NOERROR (%d), got %s (%d)",
+						dns.RcodeSuccess, dns.RcodeToString[resp.Rcode], resp.Rcode)
+				}
+			})
+		}
 	}
 }
 

--- a/plugin/rewrite/rcode_test.go
+++ b/plugin/rewrite/rcode_test.go
@@ -1,9 +1,11 @@
 package rewrite
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
@@ -69,6 +71,34 @@ func TestRCodeRewrite(t *testing.T) {
 	rcRule.response.RewriteResponse(request.Req, rr)
 	if request.Req.Rcode != dns.RcodeFormatError {
 		t.Fatalf("RCode rewrite did not apply changes, request=%#v, err=%v", request.Req, err)
+	}
+}
+
+// TestRCodeRewriteEmptyResponse drives an rcode rewrite end-to-end through
+// ServeDNS for a response that carries no resource records, such as a bare
+// SERVFAIL from a downstream plugin. Rewriting SERVFAIL to NOERROR is the
+// plugin's documented use case (see README.md), and a non-EDNS client's failure
+// reply has no answer, authority or additional records, so the rewrite must be
+// applied at the message level rather than only per record.
+func TestRCodeRewriteEmptyResponse(t *testing.T) {
+	rule, err := newRCodeRule("stop", "exact", "srv1.coredns.rocks", "SERVFAIL", "NOERROR")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Downstream plugin fails without writing a response of its own.
+	next := plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
+		return dns.RcodeServerFailure, nil
+	})
+	req := new(dns.Msg)
+	req.SetQuestion("srv1.coredns.rocks.", dns.TypeA) // no EDNS OPT record
+
+	resp := serveEdns0Rewrite(t, rule, next, req)
+	if resp == nil {
+		t.Fatal("no response was written to the client")
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected RCODE rewritten to NOERROR (%d), got %s (%d)",
+			dns.RcodeSuccess, dns.RcodeToString[resp.Rcode], resp.Rcode)
 	}
 }
 

--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -49,6 +49,14 @@ type requestExtraRevertRule interface {
 	revertRequestExtra()
 }
 
+// msgResponseRule is a ResponseRule that rewrites message-level fields, which
+// are independent of any resource record (for example the RCODE). Such a rule
+// must still be applied when the response carries no records.
+type msgResponseRule interface {
+	ResponseRule
+	rewriteMsg()
+}
+
 // ResponseRules describes an ordered list of response rules to apply
 // after a name rewrite
 type ResponseRules = []ResponseRule
@@ -95,6 +103,13 @@ func (r *ResponseReverter) WriteMsg(res1 *dns.Msg) error {
 		}
 		for _, rr := range res.Extra {
 			r.rewriteResourceRecord(res, rr)
+		}
+		// Message-level response rules (e.g. rcode) rewrite header fields that
+		// are independent of any resource record. The per-record loops above
+		// never run them when the response carries no records (e.g. a bare
+		// SERVFAIL from a downstream plugin), so apply them once here.
+		if len(res.Ns) == 0 && len(res.Answer) == 0 && len(res.Extra) == 0 {
+			r.rewriteMsg(res)
 		}
 	}
 	return r.writeWithRevertedRequestExtra(res)
@@ -143,6 +158,19 @@ func (r *ResponseReverter) rewriteResourceRecord(res *dns.Msg, rr dns.RR) {
 	// The reverting rules need to be done in reversed order.
 	for i := len(r.ResponseRules) - 1; i >= 0; i-- {
 		r.ResponseRules[i].RewriteResponse(res, rr)
+	}
+}
+
+// rewriteMsg applies the message-level response rules once, in reversed order.
+// It is used for responses that carry no resource records, where the per-record
+// loops in WriteMsg would otherwise never apply them.
+func (r *ResponseReverter) rewriteMsg(res *dns.Msg) {
+	// The reverting rules need to be done in reversed order.
+	for i := len(r.ResponseRules) - 1; i >= 0; i-- {
+		if _, ok := r.ResponseRules[i].(msgResponseRule); !ok {
+			continue
+		}
+		r.ResponseRules[i].RewriteResponse(res, nil)
 	}
 }
 

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -57,24 +57,28 @@ func (rw Rewrite) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 				if !rw.DoRevert() {
 					return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, w, r)
 				}
-				rcode, err := plugin.NextOrFailure(rw.Name(), rw.Next, ctx, wr, r)
-				if plugin.ClientWrite(rcode) {
-					return rcode, err
-				}
-				// The next plugins didn't write a response, so write one now with the ResponseReverter.
-				// If server.ServeDNS does this then it will create an answer mismatch.
-				res := new(dns.Msg).SetRcode(r, rcode)
-				state.SizeAndDo(res)
-				wr.WriteMsg(res)
-				// return success, so server does not write a second error response to client
-				return dns.RcodeSuccess, err
+				return rw.serveWithResponseReverter(ctx, wr, r, state)
 			}
 		}
 	}
 	if !rw.DoRevert() || len(wr.ResponseRules) == 0 {
 		return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, w, r)
 	}
-	return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, wr, r)
+	return rw.serveWithResponseReverter(ctx, wr, r, state)
+}
+
+func (rw Rewrite) serveWithResponseReverter(ctx context.Context, wr *ResponseReverter, r *dns.Msg, state request.Request) (int, error) {
+	rcode, err := plugin.NextOrFailure(rw.Name(), rw.Next, ctx, wr, r)
+	if plugin.ClientWrite(rcode) {
+		return rcode, err
+	}
+	// The next plugins didn't write a response, so write one now with the ResponseReverter.
+	// If server.ServeDNS does this then it will bypass response rewrite rules.
+	res := new(dns.Msg).SetRcode(r, rcode)
+	state.SizeAndDo(res)
+	wr.WriteMsg(res)
+	// Return success so server does not write a second error response to the client.
+	return dns.RcodeSuccess, err
 }
 
 // Name implements the Handler interface.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

An `rcode` rewrite changes the message-level RCODE, but `ResponseReverter.WriteMsg` only ran response rules from inside its per-record loops over `res.Ns`, `res.Answer` and `res.Extra`. When a response has no records in any of those sections none of the loops iterate, so the rcode rewrite was silently skipped and the client kept the original RCODE.

This breaks the plugin's documented SERVFAIL-to-NOERROR use case (README: "rewrites all the *.coredns.rocks domain SERVFAIL errors to NOERROR"). A downstream plugin that fails returns a bare SERVFAIL, and for a non-EDNS client the reply that `rewrite` writes has no answer, authority or additional records, so `rcode SERVFAIL NOERROR` never took effect. An EDNS client happened to work only because its OPT record in the additional section gave the per-record loop one record to iterate over.

The fix applies message-level response rules once when the response has no records, with a small marker interface (`msgResponseRule`) that mirrors the existing `requestExtraRevertRule` pattern. Responses that carry records are unchanged. Only `rcode` opts in: its `RewriteResponse` targets the message-level RCODE and ignores the record argument, while the `ttl` and name rewrites read a record header (`rr.Header()`) and so stay per-record.

I added `TestRCodeRewriteEmptyResponse`, which drives `ServeDNS` end-to-end with a downstream handler that returns SERVFAIL without writing a record and a non-EDNS query. It fails before this change (the client gets SERVFAIL) and passes after.

Tests:

- `go test ./plugin/rewrite/ -run TestRCodeRewriteEmptyResponse -v`
- `go test -race -count=1 ./plugin/rewrite/`
- `go test ./request/...`
- `go vet ./plugin/rewrite/`
- `go build ./...`

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. It only affects a response that has no records and matches a configured rcode rule: the RCODE rewrite now applies where it previously did not.
