### PR TITLE
plugin/pkg/reuseport: export Enabled constant

### DIFF
--- a/plugin/pkg/reuseport/listen_no_reuseport.go
+++ b/plugin/pkg/reuseport/listen_no_reuseport.go
@@ -4,6 +4,8 @@ package reuseport
 
 import "net"
 
+const Enabled = false
+
 // Listen is a wrapper around net.Listen.
 func Listen(network, addr string) (net.Listener, error) { return net.Listen(network, addr) }
 

--- a/plugin/pkg/reuseport/listen_reuseport.go
+++ b/plugin/pkg/reuseport/listen_reuseport.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const Enabled = true
+
 func control(_network, _address string, c syscall.RawConn) error {
 	c.Control(func(fd uintptr) {
 		const maxInt = int(^uint(0) >> 1)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Plugins and tests that rely on reuseport.Listen may depend on whether SO_REUSEPORT is supported.

I have a test that uses this function to allocate unique ports. I want to skip the test when this functionality is not available.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
