### PR TITLE
core/dnsserver: document in-process embedding

### DIFF
--- a/core/dnsserver/example_test.go
+++ b/core/dnsserver/example_test.go
@@ -1,0 +1,58 @@
+package dnsserver_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	_ "github.com/coredns/coredns/plugin/bind"
+	_ "github.com/coredns/coredns/plugin/whoami"
+
+	"github.com/miekg/dns"
+)
+
+func Example_embedding() {
+	oldDirectives := dnsserver.Directives
+	oldCaddyQuiet := caddy.Quiet
+	oldDNSQuiet := dnsserver.Quiet
+	defer func() {
+		dnsserver.Directives = oldDirectives
+		caddy.Quiet = oldCaddyQuiet
+		dnsserver.Quiet = oldDNSQuiet
+	}()
+
+	// Import only the plugins the host needs and set their execution order
+	// before starting the first server.
+	dnsserver.Directives = []string{"bind", "whoami"}
+	caddy.Quiet = true
+	dnsserver.Quiet = true
+
+	instance, err := caddy.Start(caddy.CaddyfileInput{
+		Filepath:       "Corefile",
+		Contents:       []byte(".:0 {\nbind 127.0.0.1\nwhoami\n}\n"),
+		ServerTypeName: "dns",
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		shutdownErr := errors.Join(instance.ShutdownCallbacks()...)
+		stopErr := instance.Stop()
+		instance.Wait()
+		if err := errors.Join(shutdownErr, stopErr); err != nil {
+			panic(err)
+		}
+	}()
+
+	server := instance.Servers()[0].LocalAddr().String()
+	query := new(dns.Msg)
+	query.SetQuestion("example.org.", dns.TypeA)
+	response, err := dns.Exchange(query, server)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(response.Authoritative, response.Rcode == dns.RcodeSuccess)
+	// Output: true true
+}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -1,4 +1,15 @@
-// Package dnsserver implements all the interfaces from Caddy, so that CoreDNS can be a servertype plugin.
+// Package dnsserver implements CoreDNS as a Caddy server type.
+//
+// Importing this package registers the "dns" server type with Caddy. Programs
+// embedding CoreDNS can import only the plugins they need, set Directives before
+// starting a server, and pass an in-memory Corefile to [caddy.Start]. They should
+// not call coremain.Run, which provides the command-line program behavior such
+// as flag parsing, signal handling, and blocking until shutdown.
+// Before stopping an embedded instance, run its shutdown callbacks so that
+// plugins can release resources.
+//
+// Directives and Caddy's plugin registry are process-wide. Configure them
+// before starting any servers and do not mutate them while servers are running.
 package dnsserver
 
 import (


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

CoreDNS can be embedded in another Go program, but the supported startup and shutdown path is not documented in the `dnsserver` package.

This updates the package documentation and adds an executable example that:

- imports only the required plugins;
- sets their directive order before startup;
- starts CoreDNS from an in-memory Corefile without invoking `coremain.Run`;
- sends a real DNS query to the embedded server; and
- runs plugin shutdown callbacks before stopping and waiting for the instance.

The example also documents that directives and Caddy's plugin registry are process-wide and must not be mutated while servers are running.

Validation:

- `go test ./core/dnsserver -count=10`
- `go test -race ./core/... -count=1`
- `go vet ./core/dnsserver`
- `go test -run '^$' ./...`

### 2. Which issues (if any) are related?

Related to #5853.

The flag-registration part was already addressed by #5865. This PR documents the compatible embedding path without removing the existing server-type registration relied on by downstream applications.

### 3. Which documentation changes (if any) need to be made?

The `core/dnsserver` package documentation and executable Go example are updated in this PR. No external documentation changes are required.

### 4. Does this introduce a backward incompatible change or deprecation?

No. This does not change runtime behavior or registration APIs.