### PR TITLE
pkg/proxy: poll instead of fixed sleeps in health tests

### DIFF
--- a/plugin/pkg/proxy/health_test.go
+++ b/plugin/pkg/proxy/health_test.go
@@ -39,8 +39,14 @@ func TestHealth(t *testing.T) {
 		t.Errorf("check failed: %v", err)
 	}
 
-	time.Sleep(20 * time.Millisecond)
-	i1 := atomic.LoadUint32(&i)
+	i1 := uint32(0)
+	for start := time.Now(); time.Since(start) < 2*time.Second; {
+		i1 = atomic.LoadUint32(&i)
+		if i1 == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if i1 != 1 {
 		t.Errorf("Expected number of health checks with RecursionDesired==true to be %d, got %d", 1, i1)
 	}
@@ -70,8 +76,14 @@ func TestHealthTCP(t *testing.T) {
 		t.Errorf("check failed: %v", err)
 	}
 
-	time.Sleep(20 * time.Millisecond)
-	i1 := atomic.LoadUint32(&i)
+	i1 := uint32(0)
+	for start := time.Now(); time.Since(start) < 2*time.Second; {
+		i1 = atomic.LoadUint32(&i)
+		if i1 == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if i1 != 1 {
 		t.Errorf("Expected number of health checks with RecursionDesired==true to be %d, got %d", 1, i1)
 	}
@@ -116,8 +128,14 @@ func TestHealthHTTPS(t *testing.T) {
 		t.Fatalf("check failed: %v", err)
 	}
 
-	time.Sleep(20 * time.Millisecond)
-	i1 := atomic.LoadUint32(&i)
+	i1 := uint32(0)
+	for start := time.Now(); time.Since(start) < 2*time.Second; {
+		i1 = atomic.LoadUint32(&i)
+		if i1 == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if i1 != 1 {
 		t.Errorf("Expected number of health checks with RecursionDesired==true to be %d, got %d", 1, i1)
 	}
@@ -146,8 +164,14 @@ func TestHealthNoRecursion(t *testing.T) {
 		t.Errorf("check failed: %v", err)
 	}
 
-	time.Sleep(20 * time.Millisecond)
-	i1 := atomic.LoadUint32(&i)
+	i1 := uint32(0)
+	for start := time.Now(); time.Since(start) < 2*time.Second; {
+		i1 = atomic.LoadUint32(&i)
+		if i1 == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if i1 != 1 {
 		t.Errorf("Expected number of health checks with RecursionDesired==false to be %d, got %d", 1, i1)
 	}
@@ -196,8 +220,14 @@ func TestHealthDomain(t *testing.T) {
 		t.Errorf("check failed: %v", err)
 	}
 
-	time.Sleep(12 * time.Millisecond)
-	i1 := atomic.LoadUint32(&i)
+	i1 := uint32(0)
+	for start := time.Now(); time.Since(start) < 2*time.Second; {
+		i1 = atomic.LoadUint32(&i)
+		if i1 == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if i1 != 1 {
 		t.Errorf("Expected number of health checks with Domain==%s to be %d, got %d", hcDomain, 1, i1)
 	}


### PR DESCRIPTION
## What

Replace the fixed sleeps in `plugin/pkg/proxy/health_test.go` with a bounded poll of the atomic counter, mirroring the sibling `plugin/forward/health_test.go` conversion in #8275 — same flake, same idiom (2s cap, 2ms tick).

Five positive-count tests (`TestHealth`, `TestHealthTCP`, `TestHealthHTTPS`, `TestHealthNoRecursion`, `TestHealthDomain`) sleep 12–20ms then snapshot a counter the health checker increments from its own goroutine; under CI load the snapshot can read `0` before the increment lands. All five are `== 1` waits, so polling only removes the race — it can't mask a missing increment.

## Testing

Test-only, no runtime change → no CHANGELOG entry.

```
go test -race -count=20 -run TestHealth ./plugin/pkg/proxy/   # ok
go test -race ./plugin/pkg/proxy/                             # ok
gofmt -l / go vet                                             # clean
```

---
for the record: test-hardening drafted with AI assistance; reviewed and verified by me.
