### PR TITLE
plugin/azure: don't hold zMu across zone Lookup

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -319,9 +319,14 @@ func (h *Azure) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	m.Authoritative = true
 	var result file.Result
 	for _, z := range zones {
+		// Only the zone pointer itself needs to be guarded against a
+		// concurrent swap in updateZones; Lookup can run unlocked since it
+		// may block for a while resolving external names via upstream.
 		h.zMu.RLock()
-		m.Answer, m.Ns, m.Extra, result = z.z.Lookup(ctx, state, qname)
+		zz := z.z
 		h.zMu.RUnlock()
+
+		m.Answer, m.Ns, m.Extra, result = zz.Lookup(ctx, state, qname)
 
 		// record type exists for this name (NODATA).
 		if len(m.Answer) != 0 || result == file.NoData {

--- a/plugin/azure/azure_test.go
+++ b/plugin/azure/azure_test.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -190,14 +191,25 @@ func TestAzure(t *testing.T) {
 // every query behind it queues up, so a single slow upstream response can
 // stall the whole plugin.
 func TestServeDNSDoesNotHoldLockDuringUpstreamLookup(t *testing.T) {
-	const delay = 200 * time.Millisecond
+	const timeout = 5 * time.Second
+
+	// entered signals that the upstream handler has been reached; release
+	// gates the handler's response so the test controls exactly when the
+	// in-flight query completes. releaseOnce lets every exit path (pass or
+	// fail) unblock the handler so no goroutine is left hanging.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseHandler()
 
 	cfg := &dnsserver.Config{
 		Zone: ".",
 		Plugin: []plugin.Plugin{
 			func(plugin.Handler) plugin.Handler {
 				return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-					time.Sleep(delay)
+					close(entered)
+					<-release
 					m := new(dns.Msg)
 					m.SetReply(r)
 					m.Answer = []dns.RR{test.A("external.target. 300 IN A 5.6.7.8")}
@@ -242,8 +254,13 @@ func TestServeDNSDoesNotHoldLockDuringUpstreamLookup(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the in-flight query time to reach the slow upstream lookup.
-	time.Sleep(delay / 4)
+	select {
+	case <-entered:
+		// The query has reached the upstream handler and is now blocked on
+		// release, so a subsequent zMu.Lock() genuinely races the lookup.
+	case <-time.After(timeout):
+		t.Fatal("query never reached the upstream handler")
+	}
 
 	lockAcquired := make(chan struct{})
 	go func() {
@@ -257,9 +274,15 @@ func TestServeDNSDoesNotHoldLockDuringUpstreamLookup(t *testing.T) {
 	select {
 	case <-lockAcquired:
 		// zMu.Lock() wasn't blocked by the in-flight upstream lookup.
-	case <-time.After(delay / 2):
+	case <-time.After(timeout):
 		t.Fatal("zMu.Lock() blocked while a query awaited a slow upstream lookup")
 	}
 
-	<-done
+	releaseHandler()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("ServeDNS did not complete after the upstream handler was released")
+	}
 }

--- a/plugin/azure/azure_test.go
+++ b/plugin/azure/azure_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/file"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/fall"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
@@ -177,4 +181,85 @@ func TestAzure(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestServeDNSDoesNotHoldLockDuringUpstreamLookup guards against holding
+// zMu.RLock() for the duration of a CNAME chase to an external name, which
+// can block on a slow upstream response. Holding the lock that long starves
+// the periodic zone update in updateZones (which needs zMu.Lock()), and
+// every query behind it queues up, so a single slow upstream response can
+// stall the whole plugin.
+func TestServeDNSDoesNotHoldLockDuringUpstreamLookup(t *testing.T) {
+	const delay = 200 * time.Millisecond
+
+	cfg := &dnsserver.Config{
+		Zone: ".",
+		Plugin: []plugin.Plugin{
+			func(plugin.Handler) plugin.Handler {
+				return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+					time.Sleep(delay)
+					m := new(dns.Msg)
+					m.SetReply(r)
+					m.Answer = []dns.RR{test.A("external.target. 300 IN A 5.6.7.8")}
+					w.WriteMsg(m)
+					return dns.RcodeSuccess, nil
+				})
+			},
+		},
+	}
+	srv, err := dnsserver.NewServer("", []*dnsserver.Config{cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, srv)
+
+	newZ := file.NewZone("example.org.", "")
+	newZ.Upstream = upstream.New()
+	for _, rr := range []string{
+		"example.org.	300	IN	SOA	ns1-06.azure-dns.com. azuredns-hostmaster.microsoft.com. 1 3600 300 2419200 300",
+		"cname-ext.example.org. 300 IN CNAME external.target.",
+	} {
+		r, _ := dns.NewRR(rr)
+		newZ.Insert(r)
+	}
+	zs := make(map[string][]*zone)
+	zs["example.org."] = append(zs["example.org."], &zone{zone: "example.org.", z: newZ})
+
+	az := Azure{
+		Next:      testHandler(),
+		Fall:      fall.Zero,
+		zoneNames: []string{"example.org."},
+		zones:     zs,
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion("cname-ext.example.org.", dns.TypeA)
+
+	done := make(chan struct{})
+	go func() {
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		az.ServeDNS(ctx, rec, req)
+		close(done)
+	}()
+
+	// Give the in-flight query time to reach the slow upstream lookup.
+	time.Sleep(delay / 4)
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		// Stands in for the zone swap updateZones does every minute.
+		az.zMu.Lock()
+		zs["example.org."][0].z = file.NewZone("example.org.", "")
+		az.zMu.Unlock()
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+		// zMu.Lock() wasn't blocked by the in-flight upstream lookup.
+	case <-time.After(delay / 2):
+		t.Fatal("zMu.Lock() blocked while a query awaited a slow upstream lookup")
+	}
+
+	<-done
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Reports describe the `azure` plugin locking up (queries time out) and memory growing until
OOM under sustained load. A maintainer's heap analysis pointed at goroutine accumulation and
lock contention on the plugin's `zMu` `RWMutex`, shared between `ServeDNS` (readers) and the
periodic `updateZones` background refresh (writer).

`ServeDNS` held `zMu.RLock()` for the full duration of `zone.Lookup(...)`. For a CNAME whose
target is outside the zone, `Lookup` calls into `Upstream.Lookup`, which re-enters the entire
CoreDNS plugin chain (e.g. `forward`) and can block on real network I/O. Go's `sync.RWMutex`
blocks new `RLock()` calls once a `Lock()` is pending, so a single slow/hanging upstream
lookup holding the read lock stalls `updateZones`'s next `Lock()` call, and every subsequent
query then queues up behind that pending writer — even for unrelated zones. That matches the
reported symptoms: queries timing out and goroutines (hence memory) piling up, worse without
caching (every query re-enters `Lookup`, maximizing exposure to the slow path).

This PR narrows the critical section in `ServeDNS` to only snapshot the `*file.Zone` pointer
under `zMu.RLock()`, then calls `Lookup` unlocked. This is safe because `updateZones` replaces
a zone by pointer swap, never in-place mutation, so reading a (possibly slightly stale)
pointer without holding the lock is a standard copy-on-write pattern — the same pattern
`file.Zone` already uses internally for its own apex/tree data.

A regression test (`TestServeDNSDoesNotHoldLockDuringUpstreamLookup`) builds a minimal real
`dnsserver.Server` with a deliberately slow plugin chain and a CNAME record pointing outside
the zone, then verifies a concurrent `zMu.Lock()` (standing in for `updateZones`'s zone swap)
is not blocked by the in-flight slow query.

### 2. Which issues (if any) are related?

Report: https://github.com/coredns/coredns/issues/7316

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.

Fixes #7316