### PR TITLE
plugin/tsig: use Name.Matches instead of Zones.Matches

### DIFF
--- a/plugin/tsig/tsig.go
+++ b/plugin/tsig/tsig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"slices"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -39,7 +40,7 @@ func (t *TSIGServer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	switch {
 	case tsigRR == nil && !t.tsigRequired(state.QType(), r.Opcode):
 		fallthrough
-	case plugin.Zones(t.Zones).Matches(state.Name()) == "":
+	case !slices.ContainsFunc(t.Zones, func(z string) bool { return plugin.Name(z).Matches(state.Name()) }):
 		return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
 	case tsigRR == nil:
 		log.Debugf("rejecting '%s' request without TSIG\n", dns.TypeToString[state.QType()])


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Zones.Matches iterates over all zones to find most specific match, but tsig doesn't care about that. Simpler lookup is faster.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
