### PR TITLE
plugin/kubernetes: add ptr_hostname_only option for reverse records

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -41,6 +41,7 @@ kubernetes [ZONES...] {
     labels EXPRESSION
     pods POD-MODE
     endpoint_pod_names
+    ptr_hostname_only
     ttl TTL
     noendpoints
     fallthrough [ZONES...]
@@ -102,6 +103,15 @@ kubernetes [ZONES...] {
    follows: Use the hostname of the endpoint, or if hostname is not set, use the
    pod name of the pod targeted by the endpoint. If there is no pod targeted by
    the endpoint or pod name is longer than 63, use the dashed IP address form.
+* `ptr_hostname_only` restricts reverse (PTR) records to endpoints that have an explicit hostname
+   set, and builds the PTR from that hostname only. By default a PTR is created for every endpoint
+   address, using the dashed IP form when no hostname is set, so a pod selected by more than one
+   service (for example a StatefulSet pod behind both its headless service and an individual
+   `LoadBalancer` service) gets multiple PTR records for the same IP. With this option only the
+   hostname-based record is served, keeping a single, name-consistent PTR per IP. The trade-off is
+   that endpoints without a hostname get no PTR at all, so only enable this if your pods that need
+   reverse lookups have a hostname (e.g. StatefulSet pods behind a headless service). This restores
+   the behavior of #6898, which was reverted in #7194 as a default.
 * `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -44,6 +44,7 @@ type Kubernetes struct {
 	Namespaces       map[string]struct{}
 	podMode          string
 	endpointNameMode bool
+	ptrHostnameOnly  bool
 	Fall             fall.F
 	ttl              uint32
 	opts             dnsControlOpts

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -44,10 +44,23 @@ func (k *Kubernetes) serviceRecordForIP(ip, _name string) []msg.Service {
 		}
 		for _, eps := range ep.Subsets {
 			for _, addr := range eps.Addresses {
-				if addr.IP == ip {
-					domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Index, Svc, k.primaryZone()}, ".")
-					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
+				if addr.IP != ip {
+					continue
 				}
+				// When ptr_hostname_only is set, only endpoints with an explicit hostname get a
+				// PTR record (the behavior added in #6898 and later reverted in #7194). This keeps
+				// a single, hostname-based PTR for pods selected by more than one service, at the
+				// cost of no PTR at all for endpoints that have no hostname.
+				if k.ptrHostnameOnly {
+					if addr.Hostname == "" {
+						continue
+					}
+					domain := strings.Join([]string{addr.Hostname, ep.Index, Svc, k.primaryZone()}, ".")
+					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
+					continue
+				}
+				domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Index, Svc, k.primaryZone()}, ".")
+				svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
 			}
 		}
 	}

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -137,6 +137,90 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*object.Endpoints {
 	return nil
 }
 
+// APIConnReversePTRHostnameOnlyTest models a pod IP selected by two services, where only one of
+// the endpoints has a hostname set (e.g. a StatefulSet pod behind its headless service plus an
+// individual LoadBalancer service). It reuses APIConnReverseTest for everything but the reverse
+// endpoint lookup.
+type APIConnReversePTRHostnameOnlyTest struct{ APIConnReverseTest }
+
+func (APIConnReversePTRHostnameOnlyTest) EpIndexReverse(ip string) []*object.Endpoints {
+	if ip != "10.0.0.50" {
+		return nil
+	}
+	withHostname := object.Endpoints{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{{IP: "10.0.0.50", Hostname: "pod-0"}},
+				Ports:     []object.EndpointPort{{Port: 80, Protocol: "tcp", Name: "http"}},
+			},
+		},
+		Name:      "svca-slice1",
+		Namespace: "testns",
+		Index:     object.EndpointsKey("svca", "testns"),
+	}
+	withoutHostname := object.Endpoints{
+		Subsets: []object.EndpointSubset{
+			{
+				Addresses: []object.EndpointAddress{{IP: "10.0.0.50", Hostname: ""}},
+				Ports:     []object.EndpointPort{{Port: 80, Protocol: "tcp", Name: "http"}},
+			},
+		},
+		Name:      "svcb-slice1",
+		Namespace: "testns",
+		Index:     object.EndpointsKey("svcb", "testns"),
+	}
+	return []*object.Endpoints{&withHostname, &withoutHostname}
+}
+
+func TestReversePTRHostnameOnly(t *testing.T) {
+	zones := []string{"cluster.local.", "0.10.in-addr.arpa."}
+
+	// Default: every endpoint gets a PTR, using the IP-derived name when no hostname is set.
+	defaultCase := test.Case{
+		Qname: "50.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.PTR("50.0.0.10.in-addr.arpa.      5    IN      PTR       10-0-0-50.svcb.testns.svc.cluster.local."),
+			test.PTR("50.0.0.10.in-addr.arpa.      5    IN      PTR       pod-0.svca.testns.svc.cluster.local."),
+		},
+	}
+
+	// ptr_hostname_only: only the endpoint with a hostname gets a PTR; the IP-derived one is dropped.
+	hostnameOnlyCase := test.Case{
+		Qname: "50.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.PTR("50.0.0.10.in-addr.arpa.      5    IN      PTR       pod-0.svca.testns.svc.cluster.local."),
+		},
+	}
+
+	for _, tt := range []struct {
+		name            string
+		ptrHostnameOnly bool
+		tc              test.Case
+	}{
+		{"default", false, defaultCase},
+		{"ptr_hostname_only", true, hostnameOnlyCase},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			k := New(zones)
+			k.APIConn = &APIConnReversePTRHostnameOnlyTest{}
+			k.ptrHostnameOnly = tt.ptrHostnameOnly
+
+			w := dnstest.NewRecorder(&test.ResponseWriter{})
+			if _, err := k.ServeDNS(context.TODO(), w, tt.tc.Msg()); err != tt.tc.Error {
+				t.Fatalf("expected error %v, got %v", tt.tc.Error, err)
+			}
+			if w.Msg == nil {
+				t.Fatal("got nil message")
+			}
+			if err := test.SortAndCheck(w.Msg, tt.tc); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func (APIConnReverseTest) GetNodeByName(_ctx context.Context, _name string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -123,6 +123,13 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			}
 			k8s.endpointNameMode = true
 			continue
+		case "ptr_hostname_only":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				return nil, c.ArgErr()
+			}
+			k8s.ptrHostnameOnly = true
+			continue
 		case "pods":
 			args := c.RemainingArgs()
 			if len(args) == 1 {

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -531,6 +531,64 @@ func TestKubernetesParseEndpointPodNames(t *testing.T) {
 	}
 }
 
+func TestKubernetesParsePTRHostnameOnly(t *testing.T) {
+	tests := []struct {
+		input           string // Corefile data as string
+		shouldErr       bool   // true if test case is expected to produce an error.
+		expectedErr     string // substring from the expected error. Empty for positive cases.
+		expectedPTROnly bool
+	}{
+		{
+			`kubernetes coredns.local {
+	ptr_hostname_only
+}`,
+			false,
+			"",
+			true,
+		},
+		{
+			`kubernetes coredns.local {
+	ptr_hostname_only foo
+}`,
+			true,
+			"rong argument count or unexpected",
+			false,
+		},
+		{
+			`kubernetes coredns.local {
+}`,
+			false,
+			"",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		k8sController, err := kubernetesParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but did not find error for input '%s'. Error was: '%v'", i, test.input, err)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				continue
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
+			}
+			continue
+		}
+
+		if k8sController.ptrHostnameOnly != test.expectedPTROnly {
+			t.Errorf("Test %d: Expected ptrHostnameOnly '%v', got '%v' for input '%s'", i, test.expectedPTROnly, k8sController.ptrHostnameOnly, test.input)
+		}
+	}
+}
+
 func TestKubernetesParseNoEndpoints(t *testing.T) {
 	tests := []struct {
 		input                 string // Corefile data as string


### PR DESCRIPTION
Adds an opt-in `ptr_hostname_only` option to the kubernetes plugin that restricts reverse (PTR) records to endpoints with an explicit hostname, so a pod selected by more than one service gets a single, name-consistent PTR instead of one per endpoint. Fixes #8408.

By default a PTR is created for every endpoint address, falling back to the dashed-IP name when no hostname is set. That means a StatefulSet pod behind both its headless service and an individual `LoadBalancer` service ends up with two PTRs for the same IP: the hostname-based one and an IP-based one that doesn't match the pod hostname. Low-level reverse lookups (getnameinfo and friends) just take the first answer, so strict forward/reverse matching breaks intermittently depending on answer order. See the discussion in #8408 and #7177.

This is the behavior #6898 added and #7194 reverted, but as an opt-in rather than a default. When `ptr_hostname_only` is set, only endpoints with a hostname get a PTR, built from that hostname. Default off, so nothing changes for existing users. The trade-off (documented in the README) is that endpoints without a hostname get no PTR, so it's meant for setups where the pods needing reverse lookups have a hostname, e.g. StatefulSet pods behind a headless service.

Parsing mirrors `endpoint_pod_names` (bare boolean directive). Tests: `TestKubernetesParsePTRHostnameOnly` covers directive parsing (set / bad-arg / unset) and `TestReversePTRHostnameOnly` covers the reverse behavior with the option off (both PTRs) and on (hostname PTR only), using a pod IP selected by two services where only one endpoint has a hostname.

`go build ./...`, `go vet ./plugin/kubernetes/...`, `gofmt -l`, and `go test ./plugin/kubernetes/...` all pass.
