### PR TITLE
plugin/cache: don't cache or panic on responses with no question

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -90,6 +90,13 @@ func key(qname string, m *dns.Msg, t response.Type, do, cd bool) (bool, uint64) 
 	if m.Truncated {
 		return false, 0
 	}
+	// A response with no question cannot be keyed or cached and would panic
+	// on m.Question[0] below. Some plugins can emit such a malformed message
+	// (e.g. during prefetch); warn and skip it rather than crash the server.
+	if len(m.Question) == 0 {
+		log.Warningf("Not caching malformed response with an empty question section for %q", qname)
+		return false, 0
+	}
 	// Nor errors or Meta or Update.
 	if t == response.OtherError || t == response.Meta || t == response.Update {
 		return false, 0

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -1975,3 +1975,16 @@ func TestServeFromStaleCacheFetchVerifyTimeoutMetadataIsolation(t *testing.T) {
 		t.Fatalf("background verifier mutated foreground metadata: %q", f())
 	}
 }
+
+func TestKeyEmptyQuestion(t *testing.T) {
+	// A response with an empty question section must be reported as
+	// non-cacheable instead of panicking on m.Question[0]. Some plugins can
+	// emit such a message (e.g. during prefetch). Regression test for #6051.
+	m := new(dns.Msg)
+	m.Response = true
+	m.Rcode = dns.RcodeSuccess
+
+	if ok, _ := key("example.org.", m, response.NoError, false, false); ok {
+		t.Fatal("expected a response with an empty question section to be non-cacheable")
+	}
+}


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?

An upstream may return a NOERROR message with an empty question section (some plugins emit this during prefetch). response.Typify classifies it as NoError, so key falls through to m.Question[0] and panics, taking down the server.

Skip caching such a malformed response and log a warning instead.


### 2. Which issues (if any) are related?

Fixes #6051

### 3. Which documentation changes (if any) need to be made?


### 4. Does this introduce a backward incompatible change or deprecation?
