### PR TITLE
plugin/forward ensure forward sets the DOH host

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -237,7 +237,8 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 
 		// Only set this for proxies that need it.
-		if transports[i] == transport.TLS {
+		if transports[i] == transport.TLS || transports[i] == transport.HTTPS {
+			f.proxies[i].SetDOHHost(f.tlsConfig.ServerName)
 			if tlsConfig, ok := perServerNameTlsConfig[tlsServerNames[i]]; ok {
 				f.proxies[i].SetTLSConfig(tlsConfig)
 			} else {


### PR DESCRIPTION
1. Why is this pull request needed and what does it do? 

the previous PR was missing this code that is required to populate the host header from the tls_servername. In testing the same behavior that #8233 was supposed to resolve persisted. This is unique to certain DoH providers so the tests did not catch the fault

2. Which issues (if any) are related? n/a

3. Which documentation changes (if any) need to be made? none

4. Does this introduce a backward incompatible change or deprecation? no
