### PR TITLE
plugin/file: return SERVFAIL on self-referential CNAME loops

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -385,6 +385,11 @@ func (z *Zone) externalLookup(ctx context.Context, state request.Request, tr *tr
 Redo:
 	cname := elem.Type(dns.TypeCNAME)
 	if len(cname) > 0 {
+		// A CNAME that points to its own owner name can only loop.
+		if dns.CanonicalName(cname[0].Header().Name) == dns.CanonicalName(cname[0].(*dns.CNAME).Target) {
+			return nil, nil, nil, ServerFailure
+		}
+
 		rrs = append(rrs, cname...)
 
 		if do {

--- a/test/file_loop_test.go
+++ b/test/file_loop_test.go
@@ -14,7 +14,10 @@ a.example.com. 500 IN CNAME b.example.com.
 alias.example.com. 500 IN DNAME alias.example.com.
 redirect.example.com. 500 IN DNAME target.example.com.
 www.target.example.com. 500 IN A 192.0.2.1
-*.foo.example.com. 500 IN CNAME bar.foo.example.com.`
+*.foo.example.com. 500 IN CNAME bar.foo.example.com.
+self.example.com. 500 IN CNAME self.example.com.
+c.example.com. 500 IN CNAME d.example.com.
+d.example.com. 500 IN CNAME d.example.com.`
 
 func TestFileLoop(t *testing.T) {
 	name, rm, err := test.TempFile(".", loopDB)
@@ -43,6 +46,8 @@ func TestFileLoop(t *testing.T) {
 	}{
 		{"wildcard CNAME", "something.foo.example.com.", dns.RcodeServerFailure, false, nil},
 		{"self-referential DNAME", "www.alias.example.com.", dns.RcodeServerFailure, true, nil},
+		{"self-referential CNAME", "self.example.com.", dns.RcodeServerFailure, true, nil},
+		{"CNAME chain into self-referential CNAME", "c.example.com.", dns.RcodeServerFailure, true, nil},
 		{"non-looping DNAME", "www.redirect.example.com.", dns.RcodeSuccess, true, []uint16{dns.TypeDNAME, dns.TypeCNAME, dns.TypeA}},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The CNAME chase in `externalLookup` has no loop detection of its own. When a
CNAME points at its own owner name, every pass of the chase re-appends the same
record and the loop exits at the depth cap with `Success`, so the server answers
NOERROR with one record repeated ten times instead of reporting the loop.

Reproduction:

    self.example.com. 500 IN CNAME self.example.com.

    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 28328
    ;; flags: qr aa; QUERY: 1, ANSWER: 10, AUTHORITY: 1, ADDITIONAL: 1

    ;; ANSWER SECTION:
    self.example.com. 500 IN CNAME self.example.com.
    [ the same record, nine more times ]

    (expected: SERVFAIL with an empty answer section)

The issue reports the direct case, but the same code path also affects a chain
that ends in one: `c CNAME d` plus `d CNAME d` produces the same ten-record
NOERROR. The check therefore goes inside the chase loop rather than at its
entry, which covers both.

`plugin/file/lookup.go` already returns SERVFAIL for a self-referential DNAME,
and wildcard CNAME loops already return SERVFAIL through the depth guard in
`Lookup`. The direct CNAME path never had it.

Two details worth naming. `dns.CanonicalName` is applied to both sides, matching
the DNAME check a few lines above. And the comparison only runs when a CNAME is
already being chased, so responses that do not involve a CNAME chain are
unaffected.

Multi-record loops (`c -> d -> c`) are deliberately left alone: detecting those
needs visited-set tracking, which costs something on every chase.

`TestFileLoop` gains two cases, the direct self-reference and the chain into
one. They fail without the change.

### 2. Which issues (if any) are related?

Fixes #6421

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
