### PR TITLE
core/dnsserver: don't refuse DS request after handler is found

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -333,6 +333,9 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if z, ok := s.zones[q[off:]]; ok {
 			for _, h := range z {
 				if h.pluginChain == nil { // zone defined, but has not got any plugins
+					if dshandler != nil {
+						continue
+					}
 					errorAndMetricsFunc(s.Addr, w, r, dns.RcodeRefused)
 					return
 				}
@@ -370,7 +373,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		}
 	}
 
-	if r.Question[0].Qtype == dns.TypeDS && dshandler != nil && dshandler.pluginChain != nil {
+	if r.Question[0].Qtype == dns.TypeDS && dshandler != nil {
 		// DS request, and we found a zone, use the handler for the query.
 		rcode, _ := dshandler.pluginChain.ServeDNS(ctx, w, r)
 		if !plugin.ClientWrite(rcode) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When processing TypeDS query server uses furthest ancestor zone. However, currently it will refuse query after finding appropriate intermediate ancestor if any further grand-ancestors is plugin-less. This PR corrects this behavior.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

Users who needed to handle DS queries already put them in the furthest served ancestor, they are unaffected.