### PR TITLE
plugin/hosts: don't drop entries after an over-long line

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -164,11 +164,20 @@ func (h *Hostsfile) initInline(inline []string) {
 	h.inline = h.parse(strings.NewReader(strings.Join(inline, "\n")))
 }
 
+// maxLineSize is the largest hosts file line we are willing to parse. A line
+// can legitimately be long when many names share a single address, so this is
+// well above bufio.Scanner's 64KiB default, but still bounded.
+const maxLineSize = 1024 * 1024
+
 // Parse reads the hostsfile and populates the byName and addr maps.
 func (h *Hostsfile) parse(r io.Reader) *Map {
 	hmap := newMap()
 
 	scanner := bufio.NewScanner(r)
+	// The scanner grows its buffer as needed; only raise the limit at which it
+	// gives up, otherwise a single long line aborts the scan and every entry
+	// after it is dropped.
+	scanner.Buffer(nil, maxLineSize)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if i := bytes.Index(line, []byte{'#'}); i >= 0 {
@@ -219,6 +228,10 @@ func (h *Hostsfile) parse(r io.Reader) *Map {
 			}
 			hmap.addr[addr.String()] = append(hmap.addr[addr.String()], name)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		// Entries after the failing line have not been read.
+		log.Errorf("Failed to parse hosts file %q: %v", h.path, err)
 	}
 
 	return hmap

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -290,3 +290,19 @@ func TestLookupStaticHostReloadRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestParseLineLongerThanDefaultScanBuffer(t *testing.T) {
+	// A line longer than bufio.Scanner's default 64KiB buffer must not stop
+	// the scan: the entries that follow it still have to be parsed.
+	long := strings.Repeat("a", 70*1024)
+	h := testHostsfile("127.0.0.1 before.example.org\n" +
+		"127.0.0.2 " + long + ".example.org\n" +
+		"127.0.0.3 after.example.org\n")
+
+	if addrs := h.LookupStaticHostV4("before.example.org."); len(addrs) != 1 || addrs[0].String() != "127.0.0.1" {
+		t.Errorf("LookupStaticHostV4(before.example.org.) = %v, want [127.0.0.1]", addrs)
+	}
+	if addrs := h.LookupStaticHostV4("after.example.org."); len(addrs) != 1 || addrs[0].String() != "127.0.0.3" {
+		t.Errorf("LookupStaticHostV4(after.example.org.) = %v, want [127.0.0.3]", addrs)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`Hostsfile.parse` scans the hosts file with a plain `bufio.NewScanner`, which
has a 64KiB maximum token size, and it never looks at `scanner.Err()`. So a
single line longer than 64KiB makes `Scan()` return false with
`bufio.ErrTooLong`, and the loop just ends: that line **and every entry after
it** are dropped, silently. Nothing is logged, `readHosts` only logs the entry
count at debug level, and the plugin keeps answering as if the file really were
that short. From the outside it looks like a handful of names randomly stopped
resolving.

Reproducer (added as a test):

```
127.0.0.1 before.example.org
127.0.0.2 <70000 chars>.example.org
127.0.0.3 after.example.org
```

Before this change `before.example.org` resolves and `after.example.org` does
not.

Long lines are not purely hypothetical: a hosts file with many names on one
address line, or one produced by some generator, can cross 64KiB. Whatever the
cause, losing the rest of the file without a word in the log is the wrong
failure mode.

The change is small:

* `scanner.Buffer(nil, maxLineSize)` with `maxLineSize = 1MiB`. Passing a nil
  buffer keeps the lazy growth behaviour (the scanner still starts at 4KiB and
  doubles), so this only raises the point at which it gives up; nothing is
  preallocated.
* Check `scanner.Err()` and log it. `parse` returns only a `*Map` and the
  surrounding code already prefers logging over propagating for runtime file
  problems (see the comment in `readHosts` about `os.Open` failures), so this
  logs rather than changing the signature. If you would rather have the error
  propagated, I am happy to rework it.

The limit is still bounded on purpose, so a pathological file cannot make the
parser allocate without end. If a line does exceed 1MiB the tail of the file is
still lost, but now it is reported instead of being invisible.

While looking around I noticed `parseKeyFile` in `plugin/tsig/setup.go` has the
same missing `Err()` check. I deliberately left it out of this PR: TSIG key
file lines are ~100 bytes so it is defence in depth rather than a real bug,
`plugin/tsig` has a different owner in CODEOWNERS, and CONTRIBUTING asks for
pull requests to be as small as possible. Happy to send it separately if you
want it fixed.

### 2. Which issues (if any) are related?

None that I could find.

### 3. Which documentation changes (if any) need to be made?

None. No configuration or user-visible behaviour change beyond the new log line
on a file that could not be fully parsed.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Files that parse today parse identically; files that were being truncated
are now parsed further.
