### PR TITLE
plugin/view: document server_ip() for UDP

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -105,7 +105,7 @@ key exchange mechanisms use the Go `crypto/tls` defaults.
   being able to man-in-the-middle your connection to the DNS server you are forwarding to. Because of this,
   it is strongly recommended to set this value when using TLS forwarding.
 
-  Per destination endpoint TLS server name indication is possible in the form of `tls://9.9.9.9%dns.quad9.net`.
+  Per destination endpoint TLS server name indication is possible in the form of `tls://9.9.9.9%dns.quad9.net` and `tls://[2620:fe::9%dns.quad9.net]`.
   `tls_servername` must not be specified when using per destination endpoint TLS server name indication
   as it would introduce clash between the server name indication spectifications. If destination endpoint
   is to be reached via a port other than 853 then the port must be appended to the end of the destination

--- a/plugin/view/README.md
+++ b/plugin/view/README.md
@@ -131,14 +131,14 @@ functions defined below.
 
 * `bufsize() int`: the EDNS0 buffer size advertised in the query
 * `class() string`: class of the request (IN, CH, ...)
-* `client_ip() string`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
+* `client_ip() string`: client's IP address
 * `do() bool`: the EDNS0 DO (DNSSEC OK) bit set in the query
 * `id() int`: query ID
 * `name() string`: name of the request (the domain name requested ending with a dot): `example.com.`
 * `opcode() int`: query OPCODE
 * `port() string`: client's port
 * `proto() string`: protocol used (tcp or udp)
-* `server_ip() string`: server's IP address; for IPv6 addresses these are enclosed in brackets: `[::1]`
+* `server_ip() string`: server's IP address
 * `server_port() string` : server's port
 * `size() int`: request size in bytes
 * `type() string`: type of the request (A, AAAA, TXT, ...)

--- a/plugin/view/README.md
+++ b/plugin/view/README.md
@@ -154,3 +154,7 @@ The view plugin will publish the following metadata, if the *metadata*
 plugin is also enabled:
 
 * `view/name`: the name of the view handling the current request
+
+## Bugs
+
+For requests over UDP `server_ip()` returns bound address, which can be the wildcard address (`0.0.0.0` or `::`), rather than local address the datagram was actually sent to.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fix inaccuracies in the plugin/view doc:

- IPv6 does not need brackets
- `server_ip()` may produce unexpected result over UDP

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/8497

### 3. Which documentation changes (if any) need to be made?

The patch is the documentation change for plugin/view

### 4. Does this introduce a backward incompatible change or deprecation?

No