### PR TITLE
plugin/file: preserve case of TXT and SRV records for DNS-SD

### DIFF
--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -81,8 +81,20 @@ func (z *Zone) CopyWithoutApex() *Zone {
 
 // Insert inserts r into z.
 func (z *Zone) Insert(r dns.RR) error {
-	// r.Header().Name = strings.ToLower(r.Header().Name)
-	if r.Header().Rrtype != dns.TypeSRV {
+	switch r.Header().Rrtype {
+	case dns.TypeTXT:
+		fallthrough
+	case dns.TypeSRV:
+		name := r.Header().Name
+		labels := dns.Split(name)
+		if len(labels) > 3 {
+			if proto := name[labels[2] : labels[3]-1]; proto == "_tcp" || proto == "_udp" {
+				r.Header().Name = name[:labels[1]] + strings.ToLower(canonicalEscape(name[labels[1]:]))
+				break
+			}
+		}
+		fallthrough
+	default:
 		r.Header().Name = strings.ToLower(canonicalEscape(r.Header().Name))
 	}
 
@@ -119,7 +131,7 @@ func (z *Zone) Insert(r dns.RR) error {
 	case dns.TypeMX:
 		r.(*dns.MX).Mx = strings.ToLower(r.(*dns.MX).Mx)
 	case dns.TypeSRV:
-		// r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
+		r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
 	case dns.TypeSVCB:
 		r.(*dns.SVCB).Target = strings.ToLower(r.(*dns.SVCB).Target)
 	case dns.TypeHTTPS:

--- a/plugin/file/zone_test.go
+++ b/plugin/file/zone_test.go
@@ -127,7 +127,7 @@ func TestInsertPreservesSRVCase(t *testing.T) {
 	z := NewZone("home.arpa.", "stdin")
 
 	// SRV with mixed case and space-escaped instance name
-	srv, err := dns.NewRR(`Home\032Media._smb._tcp.home.arpa. 5 IN SRV 0 0 445 samba.home.arpa.`)
+	srv, err := dns.NewRR(`Home\032Media._smb._tcp.home.arpa. 5 IN SRV 0 0 445 SAMBA.HOME.ARPA.`)
 	if err != nil {
 		t.Fatalf("Failed to parse SRV RR: %v", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

First label of TXT and SRV resource records represents user readable part (instance name) which client software may display verbatim. Administrator of a domain with DNS-SD wants control over service names shown to users. Therefore DNS server should respect and preserve instance names as written.

But even the normative [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763) does not require case preservation, only suggests. As such changes made by https://github.com/coredns/coredns/pull/7402 are narrowed:

1. Only the first label is ever affected
2. Only if third label is either `_tcp` or `_udp` (required by DNS-SD)
3. SRV's Target case is of no importance, original behavior is restored

TXT is added to follow the same rules as in DNS-SD clients usually access both resource records.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/7237
https://github.com/coredns/coredns/pull/7402

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

It restored original mangling of SRV's Target name and restores case folding unless DNS-SD is explicitly used.