### PR TITLE
test: fix flaky tests that don't check dns.Exchange response is non-nil

### DIFF
--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -212,7 +212,7 @@ func TestSecondaryZoneTransfer(t *testing.T) {
 	// This is now async; we need to wait for it to be transferred.
 	for range 10 {
 		r, _ = dns.Exchange(m, udp)
-		if len(r.Answer) != 0 {
+		if r != nil && len(r.Answer) != 0 {
 			break
 		}
 		time.Sleep(100 * time.Microsecond)
@@ -424,7 +424,7 @@ func TestSecondaryZoneNotify(t *testing.T) {
 	// This is now async; we need to wait for it to be transferred.
 	for range 10 {
 		r, _ = dns.Exchange(m, udp)
-		if len(r.Answer) != 0 {
+		if r != nil && len(r.Answer) != 0 {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -436,7 +436,7 @@ func TestSecondaryZoneNotify(t *testing.T) {
 	m = new(dns.Msg)
 	m.SetQuestion("www.example.org.", dns.TypeA)
 	r, _ = dns.Exchange(m, udp)
-	if len(r.Answer) != 0 {
+	if r != nil && len(r.Answer) != 0 {
 		t.Fatalf("Expected no answer section, got %d answers", len(r.Answer))
 	}
 
@@ -457,7 +457,7 @@ www    IN A    127.0.0.1
 	// This is now async; we need to wait for it to be transferred.
 	for range 10 {
 		r, _ = dns.Exchange(m, udp)
-		if len(r.Answer) != 0 {
+		if r != nil && len(r.Answer) != 0 {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/test/server_reverse_test.go
+++ b/test/server_reverse_test.go
@@ -40,7 +40,7 @@ func TestClasslessReverse(t *testing.T) {
 
 		r, e := dns.Exchange(m, udp)
 		if e != nil {
-			t.Errorf("Test %d, expected no error, got %q", i, e)
+			t.Fatalf("Test %d, expected no error, got %q", i, e)
 		}
 		if r.Rcode != tc.rcode {
 			t.Errorf("Test %d, expected %d, got %d for %s", i, tc.rcode, r.Rcode, tc.addr)
@@ -86,7 +86,7 @@ func TestReverse(t *testing.T) {
 
 		r, e := dns.Exchange(m, udp)
 		if e != nil {
-			t.Errorf("Test %d, expected no error, got %q", i, e)
+			t.Fatalf("Test %d, expected no error, got %q", i, e)
 		}
 		if r.Rcode != tc.rcode {
 			t.Errorf("Test %d, expected %d, got %d for %s", i, tc.rcode, r.Rcode, tc.addr)
@@ -132,7 +132,7 @@ func TestReverseInAddr(t *testing.T) {
 
 		r, e := dns.Exchange(m, udp)
 		if e != nil {
-			t.Errorf("Test %d, expected no error, got %q", i, e)
+			t.Fatalf("Test %d, expected no error, got %q", i, e)
 		}
 		if r.Rcode != tc.rcode {
 			t.Errorf("Test %d, expected %d, got %d for %s", i, tc.rcode, r.Rcode, tc.addr)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

dns.Exchange can fail due to backend timeout. When this happens returned response is nil and some tests don't account for that.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/pull/8499

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A
