### PR TITLE
plugin/dns64: Fixes a nil pointer dereference panic in dns64 during response

### DIFF
--- a/plugin/dns64/dns64.go
+++ b/plugin/dns64/dns64.go
@@ -6,6 +6,7 @@ package dns64
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"time"
 
@@ -121,6 +122,9 @@ func (d *DNS64) DoDNS64(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, o
 	resp, err := d.Upstream.Lookup(ctx, req, req.Name(), dns.TypeA)
 	if err != nil {
 		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("dns64: upstream returned no response")
 	}
 	out := d.Synthesize(r, origResponse, resp)
 	return out, nil

--- a/plugin/dns64/dns64_test.go
+++ b/plugin/dns64/dns64_test.go
@@ -554,3 +554,30 @@ func (fu *fakeUpstream) Lookup(_ context.Context, _ request.Request, name string
 
 	return fu.resp, nil
 }
+
+type nilUpstream struct{}
+
+func (n *nilUpstream) Lookup(_ context.Context, _ request.Request, _ string, _ uint16) (*dns.Msg, error) {
+	return nil, nil
+}
+func TestDNS64NilUpstreamResponse(t *testing.T) {
+	_, pfx, _ := net.ParseCIDR("64:ff9b::/96")
+
+	d := DNS64{
+		Prefix:   pfx,
+		Upstream: &nilUpstream{},
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeAAAA)
+
+	origResponse := new(dns.Msg)
+	origResponse.SetReply(req)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{RemoteIP: "::1"})
+
+	_, err := d.DoDNS64(context.Background(), rec, req, origResponse)
+	if err == nil {
+		t.Error("Expected error when upstream returns nil response, got nil")
+	}
+}


### PR DESCRIPTION




<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR fixes a nil pointer dereference panic in dns64 during response, when the internal A-record upstream re-lookup returns a nil response.
### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a