### PR TITLE
plugin/cache: Prevents a nil pointer dereference panic in the cache prefetch

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 
 import (
 	"encoding/binary"
+	"fmt"
 	"hash/fnv"
 	"net"
 	"strings"
@@ -413,6 +414,9 @@ func (w *ResponseWriter) Hijack() {
 
 // WriteMsg implements the dns.ResponseWriter interface.
 func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
+	if res == nil {
+		return fmt.Errorf("cache: response message is nil")
+	}
 	res = res.Copy()
 	w.lastItem = nil
 	mt := cacheResponseType(res, w.now().UTC())

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -1990,3 +1990,24 @@ func TestServeFromStaleCacheFetchVerifyTimeoutMetadataIsolation(t *testing.T) {
 		t.Fatalf("background verifier mutated foreground metadata: %q", f())
 	}
 }
+
+func TestCacheWriteMsgNilResponse(t *testing.T) {
+	c := New()
+	c.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		return dns.RcodeSuccess, nil
+	})
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	cw := &ResponseWriter{ResponseWriter: rec, Cache: c}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ResponseWriter.WriteMsg panicked on nil response: %v", r)
+		}
+	}()
+
+	err := cw.WriteMsg(nil)
+	if err == nil {
+		t.Error("Expected error when passing nil response to WriteMsg, got nil")
+	}
+}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -1993,9 +1993,6 @@ func TestServeFromStaleCacheFetchVerifyTimeoutMetadataIsolation(t *testing.T) {
 
 func TestCacheWriteMsgNilResponse(t *testing.T) {
 	c := New()
-	c.Next = test.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-		return dns.RcodeSuccess, nil
-	})
 
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 	cw := &ResponseWriter{ResponseWriter: rec, Cache: c}

--- a/plugin/minimal/minimal.go
+++ b/plugin/minimal/minimal.go
@@ -35,9 +35,6 @@ func (m *minimalHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *
 
 	// if response is Denial or Error pass through also if the type is Delegation pass through
 	if cl == response.Denial || cl == response.Error || ty == response.Delegation {
-		if nw.Msg == nil {
-			return rcode, err
-		}
 		w.WriteMsg(nw.Msg)
 		return 0, nil
 	}

--- a/plugin/minimal/minimal.go
+++ b/plugin/minimal/minimal.go
@@ -35,6 +35,9 @@ func (m *minimalHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *
 
 	// if response is Denial or Error pass through also if the type is Delegation pass through
 	if cl == response.Denial || cl == response.Error || ty == response.Delegation {
+		if nw.Msg == nil {
+			return rcode, err
+		}
 		w.WriteMsg(nw.Msg)
 		return 0, nil
 	}


### PR DESCRIPTION



<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR prevents a nil pointer dereference panic in the cache prefetch, by adding nil guards

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a