### PR TITLE
feat(core): make non-dns:// transports optional to reduce binary size

### DIFF
--- a/core/dnsserver/https.go
+++ b/core/dnsserver/https.go
@@ -1,3 +1,5 @@
+//go:build !nohttps || !nohttps3
+
 package dnsserver
 
 import (

--- a/core/dnsserver/https_test.go
+++ b/core/dnsserver/https_test.go
@@ -1,3 +1,5 @@
+//go:build !nohttps || !nohttps3
+
 package dnsserver
 
 import (

--- a/core/dnsserver/quic.go
+++ b/core/dnsserver/quic.go
@@ -1,3 +1,5 @@
+//go:build !noquic
+
 package dnsserver
 
 import (

--- a/core/dnsserver/quic_test.go
+++ b/core/dnsserver/quic_test.go
@@ -1,3 +1,5 @@
+//go:build !noquic
+
 package dnsserver
 
 import (

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -90,6 +90,8 @@ func (h *dnsContext) InspectServerBlocks(_sourceFile string, serverBlocks []cadd
 					port = transport.HTTPSPort
 				case transport.HTTPS3:
 					port = transport.HTTPSPort
+				default:
+					port = transport.Ports[trans]
 				}
 			}
 
@@ -324,13 +326,14 @@ var transportServers = make(map[string]func(string, []*Config) (caddy.Server, er
 
 type NewServerFunc[T caddy.Server] func(string, []*Config) (T, error)
 
-func Register[T caddy.Server](tr string, action NewServerFunc[T]) {
+func Register[T caddy.Server](tr string, action NewServerFunc[T], port string) {
 	if tr == "" {
 		panic("server must have a transport")
 	}
 	if _, dup := transportServers[tr]; dup {
 		panic("server for " + tr + ":// already registered")
 	}
+	transport.Register(tr, port)
 	transportServers[tr] = func(addr string, group []*Config) (caddy.Server, error) {
 		s, err := action(addr, group)
 		return s, err

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -320,6 +320,23 @@ func groupConfigsByListenAddr(configs []*Config) (map[string][]*Config, error) {
 	return groups, nil
 }
 
+var transportServers = make(map[string]func(string, []*Config) (caddy.Server, error))
+
+type NewServerFunc[T caddy.Server] func(string, []*Config) (T, error)
+
+func Register[T caddy.Server](tr string, action NewServerFunc[T]) {
+	if tr == "" {
+		panic("server must have a transport")
+	}
+	if _, dup := transportServers[tr]; dup {
+		panic("server for " + tr + ":// already registered")
+	}
+	transportServers[tr] = func(addr string, group []*Config) (caddy.Server, error) {
+		s, err := action(addr, group)
+		return s, err
+	}
+}
+
 // makeServersForGroup creates servers for a specific transport and group.
 // It creates as many servers as specified in the NumSockets configuration.
 // If the NumSockets param is not specified, one server is created by default.
@@ -336,50 +353,16 @@ func makeServersForGroup(addr string, group []*Config) ([]caddy.Server, error) {
 
 	var servers []caddy.Server
 	for range numSockets {
-		// switch on addr
-		switch tr, _ := parse.Transport(addr); tr {
-		case transport.DNS:
-			s, err := NewServer(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-
-		case transport.TLS:
-			s, err := NewServerTLS(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-
-		case transport.QUIC:
-			s, err := NewServerQUIC(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-
-		case transport.GRPC:
-			s, err := NewServergRPC(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-
-		case transport.HTTPS:
-			s, err := NewServerHTTPS(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
-
-		case transport.HTTPS3:
-			s, err := NewServerHTTPS3(addr, group)
-			if err != nil {
-				return nil, err
-			}
-			servers = append(servers, s)
+		tr, _ := parse.Transport(addr)
+		f, ok := transportServers[tr]
+		if !ok {
+			continue
 		}
+		s, err := f(addr, group)
+		if err != nil {
+			return nil, err
+		}
+		servers = append(servers, s)
 	}
 	return servers, nil
 }

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -39,7 +39,7 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
-func init() { Register(transport.DNS, NewServer) }
+func init() { Register(transport.DNS, NewServer, transport.Port) }
 
 // Server represents an instance of a server, which serves
 // DNS requests at a particular address (host and port). A

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -39,6 +39,8 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
+func init() { Register(transport.DNS, NewServer) }
+
 // Server represents an instance of a server, which serves
 // DNS requests at a particular address (host and port). A
 // server is capable of serving numerous zones on

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-func init() { Register(transport.GRPC, NewServergRPC) }
+func init() { Register(transport.GRPC, NewServergRPC, transport.GRPCPort) }
 
 const (
 	// maxDNSMessageBytes is the maximum size of a DNS message on the wire.

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -1,3 +1,5 @@
+//go:build !nogrpc
+
 package dnsserver
 
 import (
@@ -21,6 +23,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 )
+
+func init() { Register(transport.GRPC, NewServergRPC) }
 
 const (
 	// maxDNSMessageBytes is the maximum size of a DNS message on the wire.

--- a/core/dnsserver/server_grpc_test.go
+++ b/core/dnsserver/server_grpc_test.go
@@ -1,3 +1,5 @@
+//go:build !nogrpc
+
 package dnsserver
 
 import (

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -1,3 +1,5 @@
+//go:build !nohttps
+
 package dnsserver
 
 import (
@@ -23,6 +25,8 @@ import (
 	"github.com/pires/go-proxyproto"
 	"golang.org/x/net/netutil"
 )
+
+func init() { Register(transport.HTTPS, NewServerHTTPS) }
 
 const (
 	// DefaultHTTPSMaxConnections is the default maximum number of concurrent connections.

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/netutil"
 )
 
-func init() { Register(transport.HTTPS, NewServerHTTPS) }
+func init() { Register(transport.HTTPS, NewServerHTTPS, transport.HTTPSPort) }
 
 const (
 	// DefaultHTTPSMaxConnections is the default maximum number of concurrent connections.

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -26,7 +26,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 )
 
-func init() { Register(transport.HTTPS3, NewServerHTTPS3) }
+func init() { Register(transport.HTTPS3, NewServerHTTPS3, transport.HTTPSPort) }
 
 const (
 	// DefaultHTTPS3MaxStreams is the default maximum number of concurrent QUIC streams per connection.

--- a/core/dnsserver/server_https3.go
+++ b/core/dnsserver/server_https3.go
@@ -1,3 +1,5 @@
+//go:build !nohttps3
+
 package dnsserver
 
 import (
@@ -23,6 +25,8 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 )
+
+func init() { Register(transport.HTTPS3, NewServerHTTPS3) }
 
 const (
 	// DefaultHTTPS3MaxStreams is the default maximum number of concurrent QUIC streams per connection.

--- a/core/dnsserver/server_https3_test.go
+++ b/core/dnsserver/server_https3_test.go
@@ -1,3 +1,5 @@
+//go:build !nohttps3
+
 package dnsserver
 
 import (

--- a/core/dnsserver/server_https_test.go
+++ b/core/dnsserver/server_https_test.go
@@ -1,3 +1,5 @@
+//go:build !nohttps
+
 package dnsserver
 
 import (

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -1,3 +1,5 @@
+//go:build !noquic
+
 package dnsserver
 
 import (
@@ -20,6 +22,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go"
 )
+
+func init() { Register(transport.QUIC, NewServerQUIC) }
 
 const (
 	// DoQCodeNoError is used when the connection or stream needs to be

--- a/core/dnsserver/server_quic.go
+++ b/core/dnsserver/server_quic.go
@@ -23,7 +23,7 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-func init() { Register(transport.QUIC, NewServerQUIC) }
+func init() { Register(transport.QUIC, NewServerQUIC, transport.QUICPort) }
 
 const (
 	// DoQCodeNoError is used when the connection or stream needs to be

--- a/core/dnsserver/server_quic_test.go
+++ b/core/dnsserver/server_quic_test.go
@@ -1,3 +1,5 @@
+//go:build !noquic
+
 package dnsserver
 
 import (

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -1,3 +1,5 @@
+//go:build !notls
+
 package dnsserver
 
 import (
@@ -14,6 +16,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/pires/go-proxyproto"
 )
+
+func init() { Register(transport.TLS, NewServerTLS) }
 
 // ServerTLS represents an instance of a TLS-over-DNS-server.
 type ServerTLS struct {

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
-func init() { Register(transport.TLS, NewServerTLS) }
+func init() { Register(transport.TLS, NewServerTLS, transport.TLSPort) }
 
 // ServerTLS represents an instance of a TLS-over-DNS-server.
 type ServerTLS struct {

--- a/core/dnsserver/server_tls_test.go
+++ b/core/dnsserver/server_tls_test.go
@@ -1,3 +1,5 @@
+//go:build !notls
+
 package dnsserver
 
 import (

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -68,6 +68,11 @@ func HostPortOrFile(s ...string) ([]string, error) {
 				ss = transport.GRPC + "://" + net.JoinHostPort(host, transport.GRPCPort)
 			case transport.HTTPS:
 				ss = transport.HTTPS + "://" + net.JoinHostPort(host, transport.HTTPSPort)
+			default:
+				port, ok := transport.Ports[trans]
+				if ok {
+					ss = trans + "://" + net.JoinHostPort(host, port)
+				}
 			}
 			servers = append(servers, ss)
 			continue

--- a/plugin/pkg/transport/transport.go
+++ b/plugin/pkg/transport/transport.go
@@ -24,3 +24,22 @@ const (
 	// HTTPSPort is the default port for DNS-over-HTTPS.
 	HTTPSPort = "443"
 )
+
+var Ports = map[string]string{
+	DNS:    Port,
+	TLS:    TLSPort,
+	QUIC:   QUICPort,
+	GRPC:   GRPCPort,
+	HTTPS:  HTTPSPort,
+	HTTPS3: HTTPSPort,
+}
+
+func Register(name string, port string) {
+	if name == "" {
+		panic("transport must have a name")
+	}
+	if p, dup := Ports[name]; dup && p != port { // allows builtin to "re-register"
+		panic("port for " + name + ":// already registered as " + p)
+	}
+	Ports[name] = port
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I use coredns in "embedded" setting (deployed on a Router) and every MB matters. With these changes in place compiling with "nogrpc nohttps nohttps3 noquic" yields 15% reduction in uncompressed image size (22.2MiB -> 18.9MiB). Or 15% lighter binary to be loaded in RAM. Might be peanuts for many but not insignificant in my setting: extra space for cache.

Tags are to opt-out. Default behavior is unchanged.

Changes made resemble those needed to support custom transports. However, PR that specifically address that angle was rejected in 2021 (see https://github.com/coredns/coredns/pull/4974). Given that my changes are much narrower in scope, decision can be reconsidered?

### 2. Which issues (if any) are related?

Tangentially:
- https://github.com/coredns/coredns/issues/4973
- https://github.com/coredns/coredns/issues/7256

### 3. Which documentation changes (if any) need to be made?

Document tags.

Maybe document how to add custom servers, but I'd leave it aside until someone actually tries these changes for this purpose.

### 4. Does this introduce a backward incompatible change or deprecation?

No