### PR TITLE
plugin/autopath: Fixes a nil pointer dereference panic in autopath during search path walk

### DIFF
--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -123,6 +123,10 @@ func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			continue
 		}
 
+		if nw.Msg == nil {
+			continue
+		}
+
 		if nw.Msg.Rcode == dns.RcodeNameError {
 			continue
 		}
@@ -135,7 +139,7 @@ func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		autoPathCount.WithLabelValues(metrics.WithServer(ctx)).Add(1)
 		return rcode, err
 	}
-	if plugin.ClientWrite(firstRcode) {
+	if plugin.ClientWrite(firstRcode) && firstReply != nil {
 		w.WriteMsg(firstReply)
 	}
 	return firstRcode, firstErr

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -111,7 +111,7 @@ func TestAutoPathNilMsgFromNext(t *testing.T) {
 	ap.Zones = []string{"."}
 	// Simulate a plugin like acl's drop action that returns success
 	// without writing a response.
-	ap.Next = test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
+	ap.Next = test.HandlerFunc(func(_ctx context.Context, _w dns.ResponseWriter, _r *dns.Msg) (int, error) {
 		return dns.RcodeSuccess, nil
 	})
 	ap.search = []string{"example.org.", "example.com.", "com.", ""}
@@ -123,6 +123,9 @@ func TestAutoPathNilMsgFromNext(t *testing.T) {
 	_, err := ap.ServeDNS(context.TODO(), rec, m)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
+	}
+	if rec.Msg != nil {
+		t.Fatalf("Expected no client write, but the recorder got a message")
 	}
 }
 

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -106,6 +106,26 @@ func TestAutoPathNoAnswer(t *testing.T) {
 	}
 }
 
+func TestAutoPathNilMsgFromNext(t *testing.T) {
+	ap := new(AutoPath)
+	ap.Zones = []string{"."}
+	// Simulate a plugin like acl's drop action that returns success
+	// without writing a response.
+	ap.Next = test.HandlerFunc(func(_ctx context.Context, w dns.ResponseWriter, _r *dns.Msg) (int, error) {
+		return dns.RcodeSuccess, nil
+	})
+	ap.search = []string{"example.org.", "example.com.", "com.", ""}
+
+	m := new(dns.Msg)
+	m.SetQuestion("b.example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	_, err := ap.ServeDNS(context.TODO(), rec, m)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}
+
 // nextHandler returns a Handler that returns an answer for the question in the
 // request per the domain->answer map. On success an RR will be returned: "qname 3600 IN A 127.0.0.53"
 func nextHandler(mm map[string]int) test.Handler {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When a plugin later in the chain returns a ClientWrite rcode **without writing a response**, autopath dereferences a nil `nw.Msg` and panics.

Concretely, `acl`'s `drop` action returns `(dns.RcodeSuccess, nil)` without calling `WriteMsg` (`plugin/acl/acl.go`), and autopath sits immediately before `acl` in `plugin.cfg`, so with

```
.:53 {
    autopath example.org {
        searchpath ...
    }
    acl {
        drop net 0.0.0.0/0
    }
}
```

an autopathed query walks the search path, `acl` drops the internal query, `plugin.ClientWrite(dns.RcodeSuccess)` is true, and `nw.Msg.Rcode` panics (`plugin/autopath/autopath.go:126`). With `debug` enabled this crashes the process; otherwise it surfaces as SERVFAIL and a `coredns_panics_total` increment.

The final fallback `w.WriteMsg(firstReply)` (`plugin/autopath/autopath.go:139`) can likewise receive a nil `firstReply` (set from `nw.Msg` when `i == 0`).

This PR:
- skips search path elements that produced no message (`if nw.Msg == nil { continue }`), and
- only writes the first reply when it is non-nil.

This mirrors the nil guards recently merged in plugin/minimal (#8506), plugin/dns64 (#8511) and plugin/cache (#8512).

### 2. Which issues (if any) are related?

None found (searched open issues/PRs for autopath panic/nil; the open autopath PRs #7178/#7122 cover host-network behavior only).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Behavior only changes for the case that previously panicked.

---

**Verification**

- fail-before: `TestAutoPathNilMsgFromNext` (new) panics on master with `runtime error: invalid memory address or nil pointer dereference` at `plugin/autopath/autopath.go:126`
- pass-after: `go test ./plugin/autopath/ -count=1` — all tests pass
- `go vet ./plugin/autopath/` clean; `gofmt` clean
- Note: `plugin/forward` `TestSetup` and `test` `TestCacheACLAuthorization` fail on pristine master `c2e309e` in my environment as well (verified via `git stash`), so they are pre-existing and unrelated to this change.

**AI assistance disclosure**: the bug analysis, fix and test in this PR were prepared with the help of an AI coding agent, and were verified locally by the author as described above.