### PR TITLE
plugin/k8s_external: Fixes a nil pointer dereference panic when upstream lookup returns no response

### DIFF
--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -70,7 +70,7 @@ func TestExternalCNAMENilUpstreamResponse(t *testing.T) {
 		Zone: ".",
 		Plugin: []plugin.Plugin{
 			func(plugin.Handler) plugin.Handler {
-				return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
+				return plugin.HandlerFunc(func(_ context.Context, _ dns.ResponseWriter, _ *dns.Msg) (int, error) {
 					return dns.RcodeSuccess, nil
 				})
 			},

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/kubernetes"
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
@@ -52,6 +55,49 @@ func TestExternal(t *testing.T) {
 		if err = test.SortAndCheck(resp, tc); err != nil {
 			t.Errorf("Test %d: %v", i, err)
 		}
+	}
+}
+
+// TestExternalCNAMENilUpstreamResponse checks that a CNAME-hosted service does not
+// panic when the internal upstream lookup returns no response, e.g. when a plugin
+// like acl's drop action returns success without writing.
+func TestExternalCNAMENilUpstreamResponse(t *testing.T) {
+	k := kubernetes.New([]string{"cluster.local."})
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	k.APIConn = &external{}
+
+	cfg := &dnsserver.Config{
+		Zone: ".",
+		Plugin: []plugin.Plugin{
+			func(plugin.Handler) plugin.Handler {
+				return plugin.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (int, error) {
+					return dns.RcodeSuccess, nil
+				})
+			},
+		},
+	}
+	srv, err := dnsserver.NewServer("", []*dnsserver.Config{cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.WithValue(context.Background(), dnsserver.Key{}, srv)
+
+	e := New()
+	e.Zones = []string{"example.com."}
+	e.headless = true
+	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	e.externalFunc = k.External
+	e.externalAddrFunc = externalAddress
+	e.externalSerialFunc = externalSerial
+	e.upstream = upstream.New()
+
+	m := new(dns.Msg)
+	m.SetQuestion("svc12.testns.example.com.", dns.TypeA)
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	_, err = e.ServeDNS(ctx, w, m)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
 	}
 }
 

--- a/plugin/k8s_external/msg_to_dns.go
+++ b/plugin/k8s_external/msg_to_dns.go
@@ -21,7 +21,7 @@ func (e *External) a(ctx context.Context, services []msg.Service, state request.
 		case dns.TypeCNAME:
 			rr := s.NewCNAME(state.QName(), s.Host)
 			records = append(records, rr)
-			if resp, err := e.upstream.Lookup(ctx, state, dns.Fqdn(s.Host), dns.TypeA); err == nil {
+			if resp, err := e.upstream.Lookup(ctx, state, dns.Fqdn(s.Host), dns.TypeA); err == nil && resp != nil {
 				records = append(records, resp.Answer...)
 				if resp.Truncated {
 					truncated = true
@@ -53,7 +53,7 @@ func (e *External) aaaa(ctx context.Context, services []msg.Service, state reque
 		case dns.TypeCNAME:
 			rr := s.NewCNAME(state.QName(), s.Host)
 			records = append(records, rr)
-			if resp, err := e.upstream.Lookup(ctx, state, dns.Fqdn(s.Host), dns.TypeAAAA); err == nil {
+			if resp, err := e.upstream.Lookup(ctx, state, dns.Fqdn(s.Host), dns.TypeAAAA); err == nil && resp != nil {
 				records = append(records, resp.Answer...)
 				if resp.Truncated {
 					truncated = true
@@ -132,10 +132,10 @@ func (e *External) srv(ctx context.Context, services []msg.Service, state reques
 				records = append(records, srv)
 			}
 			if ok := isDuplicate(dup, srv.Target, addr, 0); !ok {
-				if resp, err := e.upstream.Lookup(ctx, state, addr, dns.TypeA); err == nil {
+				if resp, err := e.upstream.Lookup(ctx, state, addr, dns.TypeA); err == nil && resp != nil {
 					extra = append(extra, resp.Answer...)
 				}
-				if resp, err := e.upstream.Lookup(ctx, state, addr, dns.TypeAAAA); err == nil {
+				if resp, err := e.upstream.Lookup(ctx, state, addr, dns.TypeAAAA); err == nil && resp != nil {
 					extra = append(extra, resp.Answer...)
 				}
 			}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When k8s_external serves a service whose host is a name rather than an IP (e.g. `ExternalIPs: ["dummy.hostname"]`), it resolves the CNAME target with internal upstream lookups (`a`, `aaaa` and `srv` in `plugin/k8s_external/msg_to_dns.go`).

`upstream.Upstream.Lookup` routes the query back through CoreDNS's own plugin chain and returns `nw.Msg, nil` (`plugin/pkg/upstream/upstream.go:34`). When a plugin in that chain returns a ClientWrite rcode **without writing a response** — for example `acl`'s `drop` action, which returns `(dns.RcodeSuccess, nil)` without calling `WriteMsg` — `Lookup` returns `(nil, nil)`. All four call sites only check `err == nil` and then dereference `resp.Answer`, panicking on a nil `resp`.

Example config:

```
.:53 {
    kubernetes cluster.local in-addr.arpa ip6.arpa {
        external example.org fallthrough
    }
    acl {
        drop type A
    }
    forward . /etc/resolv.conf
}
```

A query for a CNAME-hosted service then panics inside `a()` at `resp.Answer`.

This PR guards all four lookups with `err == nil && resp != nil`, matching the existing nil checks in `plugin/backend_lookup.go` (`if e1 != nil || m1 == nil`) and the guard recently added to plugin/dns64 (#8511). When the upstream returns no response the CNAME answer is still returned, just without the additional resolved records.

### 2. Which issues (if any) are related?

None found (searched open issues/PRs; no open PR touches k8s_external).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Behavior only changes for the case that previously panicked.

---

**Verification**

- fail-before: `TestExternalCNAMENilUpstreamResponse` (new) panics on master with a nil pointer dereference at `plugin/k8s_external/msg_to_dns.go:25` (`resp.Answer` on a nil response returned by the upstream lookup)
- pass-after: `go test ./plugin/k8s_external/ -count=1` — all tests pass
- `go vet ./plugin/k8s_external/` clean; `gofmt` clean
- Note: `plugin/forward` `TestSetup` and `test` `TestCacheACLAuthorization` fail on pristine master `c2e309e` in my environment as well, so they are pre-existing and unrelated to this change.

**AI assistance disclosure**: the bug analysis, fix and test in this PR were prepared with the help of an AI coding agent, and were verified locally by the author as described above.