### PR TITLE
plugin/rewrite: Fixes a nil pointer dereference panic in ResponseReverter.WriteMsg

### DIFF
--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -1,6 +1,8 @@
 package rewrite
 
 import (
+	"fmt"
+
 	"github.com/miekg/dns"
 )
 
@@ -84,6 +86,9 @@ func NewResponseReverter(w dns.ResponseWriter, r *dns.Msg, policy RevertPolicy) 
 
 // WriteMsg records the status code and calls the underlying ResponseWriter's WriteMsg method.
 func (r *ResponseReverter) WriteMsg(res1 *dns.Msg) error {
+	if res1 == nil {
+		return fmt.Errorf("rewrite: response message is nil")
+	}
 	// Deep copy 'res' as to not (e.g). rewrite a message that's also stored in the cache.
 	res := res1.Copy()
 

--- a/plugin/rewrite/reverter_test.go
+++ b/plugin/rewrite/reverter_test.go
@@ -370,3 +370,22 @@ func noQuestionMsgPrinter(_ context.Context, w dns.ResponseWriter, _ *dns.Msg) (
 
 	return dns.RcodeSuccess, nil
 }
+
+func TestResponseReverterWriteMsgNilResponse(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("service.example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	rw := NewResponseReverter(rec, req, NewRevertPolicy(false, false))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ResponseReverter.WriteMsg panicked on nil response: %v", r)
+		}
+	}()
+
+	err := rw.WriteMsg(nil)
+	if err == nil {
+		t.Error("Expected error when passing nil response to WriteMsg, got nil")
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`ResponseReverter.WriteMsg` calls `res1.Copy()` without first checking `res1` for nil (`plugin/rewrite/reverter.go:88`), so any plugin further down the chain that writes a nil response — for example a handler that returns `(dns.RcodeSuccess, nil)` after `w.WriteMsg(nil)`, the same shape covered by the tests of #8506 and #8512 — panics inside the reverter before the message reaches the underlying writer.

The reverter is installed whenever a rewrite rule matched the request, so this is a very common code path.

This PR returns an error instead, mirroring the nil guard recently added to plugin/cache's `ResponseWriter.WriteMsg` in #8512:

```go
if res1 == nil {
    return fmt.Errorf("rewrite: response message is nil")
}
```

### 2. Which issues (if any) are related?

None found (open rewrite PRs #8280/#6917 cover TTL clamping and case sensitivity).

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Behavior only changes for the case that previously panicked.

---

**Verification**

- fail-before: `TestResponseReverterWriteMsgNilResponse` (new) fails on master — `ResponseReverter.WriteMsg panicked on nil response: runtime error: invalid memory address or nil pointer dereference`
- pass-after: `go test ./plugin/rewrite/ -count=1` — all tests pass, and the new test asserts an error is returned
- `go vet ./plugin/rewrite/` clean; `gofmt` clean
- Note: `plugin/forward` `TestSetup` and `test` `TestCacheACLAuthorization` fail on pristine master `c2e309e` in my environment as well, so they are pre-existing and unrelated to this change.

**AI assistance disclosure**: the bug analysis, fix and test in this PR were prepared with the help of an AI coding agent, and were verified locally by the author as described above.