### PR TITLE
plugin/loadbalance: validate the response before dereferencing it in WriteMsg

### DIFF
--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -1,6 +1,8 @@
 package loadbalance
 
 import (
+	"fmt"
+
 	"github.com/miekg/dns"
 )
 
@@ -17,7 +19,18 @@ type LoadBalanceResponseWriter struct {
 
 // WriteMsg implements the dns.ResponseWriter interface.
 func (r *LoadBalanceResponseWriter) WriteMsg(res *dns.Msg) error {
+	if res == nil {
+		return fmt.Errorf("loadbalance: response message is nil")
+	}
+
 	if res.Rcode != dns.RcodeSuccess {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	// A response can arrive with no question section at all, in which case
+	// there is nothing to key the shuffle on and Question[0] below would
+	// panic. Pass it through untouched, as the transfer types do.
+	if len(res.Question) == 0 {
 		return r.ResponseWriter.WriteMsg(res)
 	}
 

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -254,3 +254,49 @@ func TestRoundRobinDoesNotMutateInput(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadBalanceWriteMsgNilResponse(t *testing.T) {
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	lw := &LoadBalanceResponseWriter{ResponseWriter: rec, shuffle: randomShuffle}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("WriteMsg panicked on a nil response: %v", r)
+		}
+	}()
+
+	if err := lw.WriteMsg(nil); err == nil {
+		t.Error("WriteMsg on a nil response: got nil error, want an error")
+	}
+}
+
+func TestLoadBalanceWriteMsgEmptyQuestion(t *testing.T) {
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	lw := &LoadBalanceResponseWriter{ResponseWriter: rec, shuffle: randomShuffle}
+
+	// A plugin further down the chain can hand back NOERROR with no question
+	// section at all. See #6051.
+	res := new(dns.Msg)
+	res.Response = true
+	res.Rcode = dns.RcodeSuccess
+	res.Answer = []dns.RR{
+		test.A("endpoint.example.org. 300 IN A 10.240.0.1"),
+		test.A("endpoint.example.org. 300 IN A 10.240.0.2"),
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("WriteMsg panicked on a response with an empty question section: %v", r)
+		}
+	}()
+
+	if err := lw.WriteMsg(res); err != nil {
+		t.Errorf("WriteMsg on a response with an empty question section: got error %v, want nil", err)
+	}
+	if rec.Msg == nil {
+		t.Fatal("WriteMsg did not pass the response on to the client")
+	}
+	if got := len(rec.Msg.Answer); got != 2 {
+		t.Errorf("answer section has %d records, want 2", got)
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`LoadBalanceResponseWriter.WriteMsg` reads `res.Rcode` and then `res.Question[0]`
without validating either. A plugin further down the chain that writes a nil
response, or a response with an empty question section, panics here.

Minimal reproduction of the second case, which fails with an index out of range
before this change:

    rec := dnstest.NewRecorder(&test.ResponseWriter{})
    lw := &LoadBalanceResponseWriter{ResponseWriter: rec, shuffle: randomShuffle}

    res := new(dns.Msg)
    res.Response = true
    res.Rcode = dns.RcodeSuccess

    lw.WriteMsg(res)   // panic: index out of range [0] with length 0

The scope is slightly wider than the function itself. `weightedShuffle` in
`weighted.go` dereferences `Question[0]` a second time, and is only reachable
through `r.shuffle(res)` on the last line of `WriteMsg`, so the guard covers it
too. `r.shuffle` has no other call site.

This is not hypothetical. `plugin/cache`'s `key()` has the identical
`Question[0]` dereference and crashes on it, and `loadbalance` sits immediately
after `cache` on the write path: `plugin.cfg` orders loadbalance before cache,
so cache's response writer wraps this one. Once the cache side is guarded, the
same message continues down to this writer.

Precedent in tree: `plugin/cache` (#8512) and `plugin/rewrite` (#8519) added the
same nil guard to their `WriteMsg` in the last week, and `plugin/nsid` and
`plugin/tsig` already had one. This writer never did.

Two decisions worth naming, since they are deliberately not symmetric. Nil
returns an error, matching #8512 and #8519, because there is no message to pass
on. An empty question section returns `r.ResponseWriter.WriteMsg(res)` instead,
passing the message through unshuffled, which is exactly what the AXFR/IXFR
branch three lines below already does for messages that must not be reordered.

Both paths are covered by tests and both fail without the change: one on a nil
response, one on a NOERROR response with an empty question section, which also
asserts the message still reaches the client with its answer section intact.

### 2. Which issues (if any) are related?

Related to #6051, which reports the same class of crash in `plugin/cache`. That
one is being addressed separately in #8467; this PR neither fixes nor closes it.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No. Responses that carry a question section are handled exactly as before.
