### PR TITLE
plugin/ready: release lock before server shutdown

### DIFF
--- a/plugin/ready/ready.go
+++ b/plugin/ready/ready.go
@@ -80,10 +80,12 @@ func (rd *ready) onStartup() error {
 
 func (rd *ready) onFinalShutdown() error {
 	rd.Lock()
-	defer rd.Unlock()
 	if !rd.done {
+		rd.Unlock()
 		return nil
 	}
+	rd.done = false
+	rd.Unlock()
 
 	uniqAddr.Unset(rd.Addr)
 
@@ -92,6 +94,5 @@ func (rd *ready) onFinalShutdown() error {
 	if err := rd.srv.Shutdown(ctx); err != nil {
 		log.Infof("Failed to stop ready http server: %s", err)
 	}
-	rd.done = false
 	return nil
 }

--- a/plugin/ready/ready_test.go
+++ b/plugin/ready/ready_test.go
@@ -3,8 +3,11 @@ package ready
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/erratic"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
@@ -120,4 +123,81 @@ func TestReady_Continuously(t *testing.T) {
 		t.Errorf("Invalid status code: expecting %d, got %d", 503, response.StatusCode)
 	}
 	response.Body.Close()
+}
+
+func TestReadyShutdownDoesNotHoldLockWhileWaitingForHandlers(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan struct{})
+	proceed := make(chan struct{})
+	shutdownStarted := make(chan struct{})
+	rd := &ready{Addr: ln.Addr().String(), done: true, ln: ln}
+	rd.srv = &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(accepted)
+		<-proceed
+		rd.Lock()
+		defer rd.Unlock()
+		if !rd.done {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			io.WriteString(w, "Shutting down")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})}
+	rd.srv.RegisterOnShutdown(func() { close(shutdownStarted) })
+	go rd.srv.Serve(ln)
+
+	response := make(chan *http.Response, 1)
+	requestErr := make(chan error, 1)
+	go func() {
+		res, err := http.Get("http://" + ln.Addr().String())
+		if err != nil {
+			requestErr <- err
+			return
+		}
+		response <- res
+	}()
+	select {
+	case <-accepted:
+	case err := <-requestErr:
+		t.Fatalf("readiness request failed before reaching handler: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("readiness request did not reach handler")
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- rd.onFinalShutdown() }()
+	select {
+	case <-shutdownStarted:
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown returned before reaching server: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("ready server shutdown did not start")
+	}
+	close(proceed)
+
+	select {
+	case err := <-requestErr:
+		t.Fatalf("readiness request failed: %v", err)
+	case res := <-response:
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected shutdown response %d, got %d", http.StatusServiceUnavailable, res.StatusCode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readiness request blocked behind shutdown")
+	}
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Fatalf("shutdown failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ready server shutdown blocked waiting for its handler")
+	}
 }


### PR DESCRIPTION
### Problem

`onFinalShutdown` holds the ready mutex while `http.Server.Shutdown` waits for admitted handlers to finish. A handler that then checks `rd.done` needs the same mutex, so shutdown waits until its five-second context expires.

### Change

Mark readiness false under the mutex, release it, and only then unset the address and wait for the HTTP server to shut down. This lets already-admitted handlers observe the shutdown state and complete.

### Tests

The regression admits a readiness handler before shutdown, then proves that it returns 503 and both the request and shutdown complete without waiting for the timeout.

- `go test ./plugin/ready`
- `go test -race ./plugin/ready`