### PR TITLE
plugin/file: revert #7402

### DIFF
--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -81,10 +81,7 @@ func (z *Zone) CopyWithoutApex() *Zone {
 
 // Insert inserts r into z.
 func (z *Zone) Insert(r dns.RR) error {
-	// r.Header().Name = strings.ToLower(r.Header().Name)
-	if r.Header().Rrtype != dns.TypeSRV {
-		r.Header().Name = strings.ToLower(canonicalEscape(r.Header().Name))
-	}
+	r.Header().Name = strings.ToLower(canonicalEscape(r.Header().Name))
 
 	switch h := r.Header().Rrtype; h {
 	case dns.TypeNS:
@@ -119,7 +116,7 @@ func (z *Zone) Insert(r dns.RR) error {
 	case dns.TypeMX:
 		r.(*dns.MX).Mx = strings.ToLower(r.(*dns.MX).Mx)
 	case dns.TypeSRV:
-		// r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
+		r.(*dns.SRV).Target = strings.ToLower(r.(*dns.SRV).Target)
 	case dns.TypeSVCB:
 		r.(*dns.SVCB).Target = strings.ToLower(r.(*dns.SVCB).Target)
 	case dns.TypeHTTPS:

--- a/plugin/file/zone_test.go
+++ b/plugin/file/zone_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coredns/coredns/plugin/file/tree"
-
 	"github.com/miekg/dns"
 )
 
@@ -120,43 +118,5 @@ func BenchmarkNameFromRightRandomized(b *testing.B) {
 	}
 	if sink == 43 {
 		b.Log(sink)
-	}
-}
-
-func TestInsertPreservesSRVCase(t *testing.T) {
-	z := NewZone("home.arpa.", "stdin")
-
-	// SRV with mixed case and space-escaped instance name
-	srv, err := dns.NewRR(`Home\032Media._smb._tcp.home.arpa. 5 IN SRV 0 0 445 samba.home.arpa.`)
-	if err != nil {
-		t.Fatalf("Failed to parse SRV RR: %v", err)
-	}
-
-	if err := z.Insert(srv); err != nil {
-		t.Fatalf("Insert failed: %v", err)
-	}
-
-	found := false
-	err = z.Walk(func(_elem *tree.Elem, rrsets map[uint16][]dns.RR) error {
-		for _, rrs := range rrsets {
-			for _, rr := range rrs {
-				if srvRR, ok := rr.(*dns.SRV); ok {
-					if srvRR.Hdr.Name == "Home\\032Media._smb._tcp.home.arpa." {
-						found = true
-						if srvRR.Target != "samba.home.arpa." {
-							t.Errorf("Expected SRV target to be 'samba.home.arpa.', got %q", srvRR.Target)
-						}
-					}
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("Tree walk failed: %v", err)
-	}
-
-	if !found {
-		t.Errorf("SRV record with original case not found in tree")
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

#7237 incorrectly stated that owner name of SRV resource records needs to be preserved. It's not as DNS-SD clients use RDATA for corresponding PTR records to extract presentation name of the advertised service.

### 2. Which issues (if any) are related?

#7237 

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A