### PR TITLE
plugin/loadbalance: match weighted domain names case-insensitively

### DIFF
--- a/plugin/loadbalance/weighted.go
+++ b/plugin/loadbalance/weighted.go
@@ -180,7 +180,7 @@ func (w *weightedRR) topAddressIndex(address []dns.RR) int {
 		case dns.TypeAAAA:
 			ip = ar.(*dns.AAAA).AAAA
 		}
-		ws := w.domains[ar.Header().Name]
+		ws := w.domains[dns.CanonicalName(ar.Header().Name)]
 		for _, w := range ws {
 			if w.address.Equal(ip) {
 				wa.weight = w.value
@@ -288,12 +288,7 @@ func (w *weightedRR) parseWeights(scanner *bufio.Scanner) (map[string]weights, e
 				return nil, fmt.Errorf("wrong domain name:\"%s\" in weight file %s. (Maybe a missing weight value?)",
 					fields[0], w.fileName)
 			}
-			dname = fields[0]
-
-			// add the root domain if it is missing
-			if dname[len(dname)-1] != '.' {
-				dname += "."
-			}
+			dname = dns.CanonicalName(fields[0])
 			var ok bool
 			ws, ok = domains[dname]
 			if !ok {

--- a/plugin/loadbalance/weighted_test.go
+++ b/plugin/loadbalance/weighted_test.go
@@ -1,6 +1,7 @@
 package loadbalance
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"net"
@@ -19,6 +20,39 @@ w1,example.org
 192.168.1.15 10
 192.168.1.14 20
 `
+
+func TestWeightedDomainCase(t *testing.T) {
+	for _, configured := range []string{"example.org", "ExAmPlE.ORG"} {
+		for _, owner := range []string{"example.org.", "EXAMPLE.org."} {
+			t.Run(configured+"/"+owner, func(t *testing.T) {
+				w := &weightedRR{randomGen: &fakeRandomGen{t: t, expectedLimit: 11}}
+				var err error
+				w.domains, err = w.parseWeights(bufio.NewScanner(strings.NewReader(configured + "\n192.0.2.1 1\n192.0.2.2 10\n")))
+				if err != nil {
+					t.Fatal(err)
+				}
+				m := new(dns.Msg)
+				m.SetQuestion(owner, dns.TypeA)
+				m.Response = true
+				m.Answer = []dns.RR{
+					testutil.A(owner + " 60 IN A 192.0.2.1"),
+					testutil.A(owner + " 60 IN A 192.0.2.2"),
+				}
+				rec := dnstest.NewRecorder(&testutil.ResponseWriter{})
+				rw := &LoadBalanceResponseWriter{ResponseWriter: rec, shuffle: func(m *dns.Msg) *dns.Msg { return weightedShuffle(m, w) }}
+				if err := rw.WriteMsg(m); err != nil {
+					t.Fatal(err)
+				}
+				if got := rec.Msg.Answer[0].(*dns.A).A.String(); got != "192.0.2.2" {
+					t.Errorf("first address = %s, want 192.0.2.2", got)
+				}
+				if got := rec.Msg.Answer[0].Header().Name; got != owner {
+					t.Errorf("owner = %q, want original %q", got, owner)
+				}
+			})
+		}
+	}
+}
 
 var testOneDomainWRR = map[string]weights{
 	"w1,example.org.": {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The weighted policy matches domain names with case-sensitive map keys. Weights configured for `example.org` are ignored when the response owner is `EXAMPLE.org.`; addresses fall back to weight 1. Mixed-case names in the weight file have the same problem.

Canonicalize names when reading the weight file and looking up response owners, using `dns.CanonicalName` for DNS ASCII case folding. Keep the original owner names in the response.

The regression runs the response writer with a deterministic random generator and weights 1 and 10. Three of the four configuration/response casing combinations fail before the fix. The complete loadbalance package passes with `go test -race ./plugin/loadbalance -count=1`; `go vet ./plugin/loadbalance` also passes on Windows with Go 1.27.1. The full repository and end-to-end suites were not run.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

Names differing only in ASCII case now share a weight configuration, consistent with DNS name matching. No configuration syntax changes.
