### PR TITLE
plugin/tls: document that dig supports DoT

### DIFF
--- a/plugin/tls/README.md
+++ b/plugin/tls/README.md
@@ -123,7 +123,7 @@ tls://.:853 {
 }
 ~~~
 
-Only Knot DNS' `kdig` supports DNS-over-TLS queries, no command line client supports gRPC making
+Knot DNS' `kdig` as well as Bind9' `dig` (since 9.17.7, via `+tls`) can be used to make DNS-over-TLS queries. No command line client supports gRPC making
 debugging these transports harder than it should be.
 
 ## See Also


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Document that Bind9' DiG supports DoT since 2020.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

Regenerate plugin/tls doc

### 4. Does this introduce a backward incompatible change or deprecation?

N/A
