### PR TITLE
docs(corefile): document that the Corefile is line oriented

### DIFF
--- a/corefile.5.md
+++ b/corefile.5.md
@@ -33,6 +33,15 @@ match on the query name will receive the query.
 server with no plugins will just return SERVFAIL for all queries. Each plugin can have a number of
 properties than can have arguments, see the documentation for each plugin.
 
+The Corefile is line oriented: the arguments of a plugin, or of one of its properties, run until the
+end of the line. Put each plugin, each property and each closing `}` on a line of its own. A `}` that
+shares a line with a plugin or a property can be read as part of that line. For example, this fails
+with "Unexpected '}' because no matching opening brace":
+
+~~~ txt
+. { whoami }
+~~~
+
 Comments are allowed and begin with an unquoted hash `#` and continue to the end of the line.
 Comments may be started anywhere on a line.
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

corefile.5.md never says that the Corefile is line oriented: the arguments of a plugin, or of one of its properties, run until the end of the line, and a `}` on that line can be read as one of them. A one-line server block therefore fails with an error that reads like a brace-matching problem. On master (19adcd8b9):

    . { whoami }             # Unexpected '}' because no matching opening brace
    . {
        whoami log           # Wrong argument count or unexpected line ending after 'log'
    }

This adds a short paragraph after the PLUGIN description: each plugin, each property and each closing `}` on a line of its own.

Inside a plugin block the effect depends on how the plugin reads its properties: `forward . 127.0.0.1 { max_fails 2 }` works, `cache { success 1000 }` fails. So the doc recommends the safe form rather than documenting one-line blocks, and leaves other parser leniencies (snippets, the opening brace) out. My comment on #7267 showed the forward case as working; that holds for that line only.

The failing example is marked `txt` rather than `corefile`, since `corefile` blocks are meant to be valid examples (TestReadme runs them for plugin READMEs). man/corefile.5 is left to the Make Doc workflow.

### 2. Which issues (if any) are related?

Fixes #7267

### 3. Which documentation changes (if any) need to be made?

This is the documentation change.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
