### PR TITLE
fix TestReadme failed cleanup between runs

### DIFF
--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -88,6 +88,7 @@ func TestReadme(t *testing.T) {
 				t.Errorf("Failed to start server with %s, for input %q:\n%s", readme, err, in.Body())
 			}
 			server.Stop()
+			server.ShutdownCallbacks()
 			port++
 		}
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Plugins that rely on shutdown callbacks may fail README tests because 
they didn't have an opportunity to timely release associated resources.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A